### PR TITLE
Add column sorting to Namespace KPIs table

### DIFF
--- a/src/js/components/Table/HeadColumn.jsx
+++ b/src/js/components/Table/HeadColumn.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { Column } from '../../schema'
 import { Icon } from '../'
@@ -17,25 +17,19 @@ const ColClassName =
   'align-middle px-6 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap'
 
 function HeadColumn({ column, children, className, disabled, srOnly }) {
-  const [sortDirection, setSortDirection] = useState(column.sortDirection)
-  useEffect(() => {
-    if (
-      column.sortCallback !== undefined &&
-      sortDirection !== column.sortDirection
-    ) {
-      column.sortCallback(column.name, sortDirection)
-    }
-  }, [sortDirection])
-
   function onSortClick(event) {
     event.preventDefault()
     if (disabled) return
-    if (sortDirection === null) {
-      setSortDirection(Asc)
-    } else if (sortDirection === Asc) {
-      setSortDirection(Desc)
-    } else if (sortDirection === Desc) {
-      setSortDirection(null)
+
+    if (column.sortCallback !== undefined) {
+      const direction =
+        column.sortDirection === null
+          ? Asc
+          : column.sortDirection === Asc
+          ? Desc
+          : null
+
+      column.sortCallback(column.name, direction)
     }
   }
 
@@ -68,8 +62,10 @@ function HeadColumn({ column, children, className, disabled, srOnly }) {
       onClick={onSortClick}>
       {column.sortCallback !== undefined && (
         <Icon
-          icon={SortIcon[sortDirection]}
-          className={`mr-2 ${sortDirection !== null ? 'text-blue-600' : ''}`}
+          icon={SortIcon[column.sortDirection]}
+          className={`mr-2 ${
+            column.sortDirection !== null ? 'text-blue-600' : ''
+          }`}
         />
       )}
       {children !== undefined && children}

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -78,6 +78,18 @@ function NamespaceKPIs() {
       }
     })
     history.push(`${stateURL.pathname}?${stateURL.searchParams.toString()}`)
+
+    const sortBy = columnSortOrder
+      .filter((column) => state.sort[column])
+      .map((column) => ({ column: column, order: state.sort[column] }))
+    const data = [...state.data].sort((a, b) => {
+      for (let { column, order } of sortBy) {
+        if (a[column] < b[column]) return order === 'asc' ? -1 : 1
+        if (b[column] < a[column]) return order === 'asc' ? 1 : -1
+      }
+      return 0
+    })
+    setState({ ...state, data })
   }, [state.sort])
 
   useEffect(() => {

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -1,4 +1,4 @@
-import { Link, useLocation, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import React, { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -49,7 +49,6 @@ function buildSearchParams(columnSortOrder, sortDirections) {
 function NamespaceKPIs() {
   const [globalState, dispatch] = useContext(Context)
   const [searchParams, setSearchParams] = useSearchParams()
-  const query = new URLSearchParams(useLocation().search)
   const columnSortOrder = [
     'namespace',
     'stack_health_score',
@@ -63,7 +62,7 @@ function NamespaceKPIs() {
     lookup: {},
     fetched: false,
     errorMessage: null,
-    sort: buildSortDefault(query.get('sort') || '')
+    sort: buildSortDefault(searchParams.get('sort') || '')
   })
   const { t } = useTranslation()
 

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -1,4 +1,4 @@
-import { Link, useHistory, useLocation } from 'react-router-dom'
+import { Link, useLocation, useSearchParams } from 'react-router-dom'
 import React, { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -37,10 +37,19 @@ function buildSortDefault(sort) {
   return value
 }
 
+function buildSearchParams(columnSortOrder, sortDirections) {
+  const params = new URLSearchParams()
+  const sortValues = columnSortOrder
+    .filter((column) => sortDirections[column])
+    .map((column) => `${column} ${sortDirections[column]}`)
+  if (sortValues.length > 0) params.append('sort', sortValues.join(','))
+  return params
+}
+
 function NamespaceKPIs() {
   const [globalState, dispatch] = useContext(Context)
+  const [searchParams, setSearchParams] = useSearchParams()
   const query = new URLSearchParams(useLocation().search)
-  const history = useHistory()
   const columnSortOrder = [
     'namespace',
     'stack_health_score',
@@ -63,15 +72,12 @@ function NamespaceKPIs() {
       type: 'SET_CURRENT_PAGE',
       payload: {
         title: t('reports.namespaceKPIs.title'),
-        url: buildURL()
+        url: new URL('/ui/reports/namespace-kpis', globalState.baseURL)
       }
     })
   }, [])
 
   useEffect(() => {
-    const stateURL = buildURL()
-    history.push(`${stateURL.pathname}?${stateURL.searchParams.toString()}`)
-
     const sortBy = columnSortOrder
       .filter((column) => state.sort[column])
       .map((column) => ({ column: column, order: state.sort[column] }))
@@ -83,6 +89,7 @@ function NamespaceKPIs() {
       return 0
     })
     setState({ ...state, data })
+    setSearchParams(buildSearchParams(columnSortOrder, state.sort))
   }, [state.sort])
 
   useEffect(() => {
@@ -126,16 +133,6 @@ function NamespaceKPIs() {
     if (state.sort !== sort) {
       setState({ ...state, sort: sort })
     }
-  }
-
-  function buildURL(path = '/ui/reports/namespace-kpis') {
-    const url = new URL(path, globalState.baseURL)
-    const sortValues = columnSortOrder
-      .filter((column) => state.sort[column])
-      .map((column) => `${column} ${state.sort[column]}`)
-    if (sortValues.length > 0)
-      url.searchParams.append('sort', sortValues.join(','))
-    return url
   }
 
   const columns = [

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useHistory, useLocation } from 'react-router-dom'
 import React, { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -40,6 +40,15 @@ function buildSortDefault(sort) {
 function NamespaceKPIs() {
   const [globalState, dispatch] = useContext(Context)
   const query = new URLSearchParams(useLocation().search)
+  const history = useHistory()
+  const columnSortOrder = [
+    'namespace',
+    'stack_health_score',
+    'percent_of_tpps',
+    'projects',
+    'total_possible_project_score',
+    'total_project_score'
+  ]
   const [state, setState] = useState({
     data: [],
     lookup: {},
@@ -54,10 +63,22 @@ function NamespaceKPIs() {
       type: 'SET_CURRENT_PAGE',
       payload: {
         title: t('reports.namespaceKPIs.title'),
-        url: new URL('/ui/reports/namespace-kpis', globalState.baseURL)
+        url: buildURL()
       }
     })
   }, [])
+
+  useEffect(() => {
+    const stateURL = buildURL()
+    dispatch({
+      type: 'SET_CURRENT_PAGE',
+      payload: {
+        title: t('reports.namespaceKPIs.title'),
+        url: stateURL
+      }
+    })
+    history.push(`${stateURL.pathname}?${stateURL.searchParams.toString()}`)
+  }, [state.sort])
 
   useEffect(() => {
     if (state.fetched === false) {
@@ -100,6 +121,16 @@ function NamespaceKPIs() {
     if (state.sort !== sort) {
       setState({ ...state, sort: sort })
     }
+  }
+
+  function buildURL(path = '/ui/reports/namespace-kpis') {
+    const url = new URL(path, globalState.baseURL)
+    const sortValues = columnSortOrder
+      .filter((column) => state.sort[column])
+      .map((column) => `${column} ${state.sort[column]}`)
+    if (sortValues.length > 0)
+      url.searchParams.append('sort', sortValues.join(','))
+    return url
   }
 
   const columns = [

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -1,4 +1,4 @@
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import React, { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -23,32 +23,8 @@ function formatNumber(value) {
   return value.toLocaleString()
 }
 
-function buildSortDefault(sort) {
-  const value = {}
-  const sortMatches = sort.match(
-    /(?:(namespace|projects|stack_health_score|total_project_score|total_possible_project_score|percent_of_tpps) (asc|desc))/g
-  )
-  if (sortMatches !== null) {
-    sortMatches.map((match) => {
-      const [column, direction] = match.split(' ')
-      value[column] = direction
-    })
-  }
-  return value
-}
-
-function buildSearchParams(columnSortOrder, sortDirections) {
-  const params = new URLSearchParams()
-  const sortValues = columnSortOrder
-    .filter((column) => sortDirections[column])
-    .map((column) => `${column} ${sortDirections[column]}`)
-  if (sortValues.length > 0) params.append('sort', sortValues.join(','))
-  return params
-}
-
 function NamespaceKPIs() {
   const [globalState, dispatch] = useContext(Context)
-  const [searchParams, setSearchParams] = useSearchParams()
   const columnSortOrder = [
     'namespace',
     'stack_health_score',
@@ -62,7 +38,7 @@ function NamespaceKPIs() {
     lookup: {},
     fetched: false,
     errorMessage: null,
-    sort: buildSortDefault(searchParams.get('sort') || '')
+    sort: {}
   })
   const { t } = useTranslation()
 
@@ -88,7 +64,6 @@ function NamespaceKPIs() {
       return 0
     })
     setState({ ...state, data })
-    setSearchParams(buildSearchParams(columnSortOrder, state.sort))
   }, [state.sort])
 
   useEffect(() => {

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -70,13 +70,6 @@ function NamespaceKPIs() {
 
   useEffect(() => {
     const stateURL = buildURL()
-    dispatch({
-      type: 'SET_CURRENT_PAGE',
-      payload: {
-        title: t('reports.namespaceKPIs.title'),
-        url: stateURL
-      }
-    })
     history.push(`${stateURL.pathname}?${stateURL.searchParams.toString()}`)
 
     const sortBy = columnSortOrder

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -77,20 +77,20 @@ function NamespaceKPIs() {
             result.map((row) => [row.namespace, row.namespace_id])
           )
           setState({
+            ...state,
             data: result,
             fetched: true,
             lookup: lookup,
-            errorMessage: null,
-            sort: state.sort
+            errorMessage: null
           })
         },
         (error) => {
           setState({
+            ...state,
             data: [],
             fetched: true,
             lookup: {},
-            errorMessage: error,
-            sort: state.sort
+            errorMessage: error
           })
         }
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -6304,7 +6304,7 @@ react-markdown@^6.0.3:
     unist-util-visit "^2.0.0"
     vfile "^4.0.0"
 
-react-router-dom@^6.2.1:
+react-router-dom@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
   integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==


### PR DESCRIPTION
Adds frontend sorting to the Namespace KPIs reports table. It follows many of the same patterns as the sortable DataTable component (used for projects), such as a predefined column sort order when multiple columns are sorted.

Fixes AWeber-Imbi/imbi#7