### PR TITLE
Project search updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "prettier": "^2.0.4",
     "prop-types": "^15.7.2",
     "react": "17.0.2",
-    "react-chartjs-2": "^4.0.0",
+    "react-chartjs-2": "^4.3.1",
     "react-circular-progressbar": "^2.0.3",
     "react-dom": "17.0.2",
     "react-gravatar": "^2.6.3",

--- a/src/js/components/Header/Header.jsx
+++ b/src/js/components/Header/Header.jsx
@@ -4,6 +4,7 @@ import React, { Fragment } from 'react'
 
 import { NavMenu } from './NavMenu'
 import { NewMenu } from './NewMenu'
+import { ProjectSearch } from './ProjectSearch'
 import { UserMenu } from './UserMenu'
 import { User } from '../../schema'
 
@@ -31,6 +32,7 @@ function Header({ logo, service, authenticated, user }) {
         {authenticated === true && (
           <Fragment>
             <NavMenu user={user} />
+            <ProjectSearch />
             <NewMenu user={user} />
             <UserMenu user={user} />
           </Fragment>

--- a/src/js/components/Header/ProjectSearch.jsx
+++ b/src/js/components/Header/ProjectSearch.jsx
@@ -6,10 +6,8 @@ import { Context } from '../../state'
 
 function ProjectSearch() {
   const [globalState] = useContext(Context)
-  const location = useLocation()
   const navigate = useNavigate()
   const { t } = useTranslation()
-  const [hidden, setHidden] = useState(true)
   const [value, setValue] = useState('')
 
   function handleSubmit(event) {
@@ -24,26 +22,20 @@ function ProjectSearch() {
     }
   }
 
-  useEffect(() => {
-    setHidden(location.pathname === '/ui/projects')
-  }, [location])
-
   return (
     <div className="w-64 mr-2">
       <form onSubmit={handleSubmit}>
-        {hidden === false && (
-          <input
-            className="form-input border-blue-600 mb-0 focus:outline-0"
-            type="text"
-            autoComplete="off"
-            name="search"
-            placeholder={t('common.search')}
-            onChange={(event) => {
-              setValue(event.target.value)
-            }}
-            value={value}
-          />
-        )}
+        <input
+          className="form-input border-blue-600 mb-0 focus:outline-0"
+          type="text"
+          autoComplete="off"
+          name="search"
+          placeholder={t('common.search')}
+          onChange={(event) => {
+            setValue(event.target.value)
+          }}
+          value={value}
+        />
       </form>
     </div>
   )

--- a/src/js/components/Header/ProjectSearch.jsx
+++ b/src/js/components/Header/ProjectSearch.jsx
@@ -1,0 +1,52 @@
+import React, { useContext, useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+import { Context } from '../../state'
+
+function ProjectSearch() {
+  const [globalState] = useContext(Context)
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+  const [hidden, setHidden] = useState(true)
+  const [value, setValue] = useState('')
+
+  function handleSubmit(event) {
+    event.preventDefault()
+    if (value !== '') {
+      const url = new URL(
+        `/ui/projects?f=${encodeURIComponent(value)}`,
+        globalState.baseURL
+      )
+      navigate(url, { replace: true })
+      setValue('')
+    }
+  }
+
+  useEffect(() => {
+    setHidden(location.pathname === '/ui/projects')
+  }, [location])
+
+  return (
+    <div className="w-64 mr-2">
+      <form onSubmit={handleSubmit}>
+        {hidden === false && (
+          <input
+            className="form-input border-blue-600 mb-0 focus:outline-0"
+            type="text"
+            autoComplete="off"
+            name="search"
+            placeholder={t('common.search')}
+            onChange={(event) => {
+              setValue(event.target.value)
+            }}
+            value={value}
+          />
+        )}
+      </form>
+    </div>
+  )
+}
+
+export { ProjectSearch }

--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter } from 'react-router-dom'
+import { Chart, registerables } from 'chart.js'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import { render } from 'react-dom'
@@ -13,6 +14,8 @@ import { httpGet, isURL } from './utils'
 import { Header, Footer } from './components'
 import { Error, Initializing, Login, Main } from './views'
 import State from './state'
+
+Chart.register(...registerables)
 
 export const loggedOutUser = {
   username: null,

--- a/src/js/schema/User.js
+++ b/src/js/schema/User.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 
 export const User = {
-  authenticated: PropTypes.bool,
   created_at: PropTypes.string,
   username: PropTypes.string,
   display_name: PropTypes.string,

--- a/src/js/state.jsx
+++ b/src/js/state.jsx
@@ -115,7 +115,7 @@ const initialState = {
   openSearch: undefined,
   projects: {
     filter: '',
-    fields: ['id', 'namespace', 'type', 'name', 'project_score'],
+    fields: ['id', 'namespace', 'project_type', 'name', 'project_score'],
     sort: {
       namespace: 'asc',
       name: 'asc'

--- a/src/js/state.jsx
+++ b/src/js/state.jsx
@@ -59,38 +59,6 @@ const Reducer = (state, action) => {
         ...state,
         projectURLTemplate: action.payload
       }
-    case 'SET_PROJECTS_FIELDS':
-      return {
-        ...state,
-        projects: {
-          ...state.projects,
-          fields: action.payload
-        }
-      }
-    case 'SET_PROJECTS_FILTER':
-      return {
-        ...state,
-        projects: {
-          ...state.projects,
-          filter: action.payload
-        }
-      }
-    case 'SET_PROJECTS_INCLUDE_ARCHIVED':
-      return {
-        ...state,
-        projects: {
-          ...state.projects,
-          includeArchived: action.payload
-        }
-      }
-    case 'SET_PROJECTS_SORT':
-      return {
-        ...state,
-        projects: {
-          ...state.projects,
-          sort: action.payload
-        }
-      }
     case 'SET_REFRESH_SETTINGS':
       return {
         ...state,
@@ -113,14 +81,6 @@ const initialState = {
   integrations: undefined,
   metadata: undefined,
   openSearch: undefined,
-  projects: {
-    filter: '',
-    fields: ['id', 'namespace', 'project_type', 'name', 'project_score'],
-    sort: {
-      namespace: 'asc',
-      name: 'asc'
-    }
-  },
   projectURLTemplate: '',
   refreshSettings: true
 }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -79,6 +79,10 @@ export function isURL(value) {
   return urlRegexp.test(value)
 }
 
+export function lookupNamespaceByID(namespaces, namespace_id) {
+  return namespaces.find((e) => e.id === namespace_id)
+}
+
 export function setDocumentTitle(value) {
   document.title = 'Imbi - ' + value
 }

--- a/src/js/views/Dashboard/ActivityFeed/Entry.jsx
+++ b/src/js/views/Dashboard/ActivityFeed/Entry.jsx
@@ -2,11 +2,16 @@ import { DateTime } from 'luxon'
 import Gravatar from 'react-gravatar'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useContext } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+
+import { Context } from '../../../state'
+import { lookupNamespaceByID } from '../../../utils'
 
 function Entry({ entry }) {
   const { t, i18n } = useTranslation()
+  const [globalState] = useContext(Context)
+
   let action = t('dashboard.activityFeed.created')
   if (entry.what === 'updated') action = t('dashboard.activityFeed.updated')
   if (entry.what === 'updated facts')
@@ -15,6 +20,12 @@ function Entry({ entry }) {
   const namespace = entry.namespace
   const project = entry.project_name
   const displayName = entry.display_name
+  const filter = encodeURIComponent(
+    `namespace_slug:${
+      lookupNamespaceByID(globalState.metadata.namespaces, entry.namespace_id)
+        .slug
+    }`
+  )
   return (
     <li className="flex p-2 space-x-3 border-b border-gray-200">
       <Gravatar
@@ -35,7 +46,7 @@ function Entry({ entry }) {
             </Link>{' '}
             project in the{' '}
             <Link
-              to={`/ui/projects?namespace_id=${entry.namespace_id}`}
+              to={`/ui/projects?f=${filter}`}
               className="font-medium text-blue-700 hover:text-blue-800">
               {{ namespace }}
             </Link>{' '}

--- a/src/js/views/Dashboard/ActivityFeed/Feed.jsx
+++ b/src/js/views/Dashboard/ActivityFeed/Feed.jsx
@@ -41,26 +41,26 @@ function Feed({ onReady }) {
 
   return (
     <ErrorBoundary>
-      {state.fetched && (
-        <ContentArea
-          className="flex flex-col lg:h-full pl-0"
-          pageIcon="fas rss"
-          pageTitle={t('dashboard.activityFeed.recentActivity')}
-          setPageTitle={false}>
-          <Panel className="flex-grow overflow-hidden pb-5">
-            {state.errorMessage !== null && (
-              <Alert level="error">{state.errorMessage}</Alert>
-            )}
-            <div className="h-full overflow-y-scroll">
-              <ul className="space-y-3">
-                {state.data.map((entry, offset) => {
+      <ContentArea
+        className="flex flex-col lg:h-full pl-0"
+        pageIcon="fas rss"
+        pageTitle={t('dashboard.activityFeed.recentActivity')}
+        setPageTitle={false}>
+        <Panel className="flex-grow overflow-hidden pb-5">
+          {state.errorMessage !== null && (
+            <Alert level="error">{state.errorMessage}</Alert>
+          )}
+          <div className="h-full overflow-y-scroll">
+            <ul className="space-y-3">
+              {state.data
+                .filter((e) => e.display_name !== 'SonarQube')
+                .map((entry, offset) => {
                   return <Entry key={`entry-${offset}`} entry={entry} />
                 })}
-              </ul>
-            </div>
-          </Panel>
-        </ContentArea>
-      )}
+            </ul>
+          </div>
+        </Panel>
+      </ContentArea>
     </ErrorBoundary>
   )
 }

--- a/src/js/views/Dashboard/Dashboard.jsx
+++ b/src/js/views/Dashboard/Dashboard.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 import React, { Fragment, useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { Icon, Loading } from '../../components/'
+import { Icon } from '../../components/'
 import { Context } from '../../state'
 
 import { Feed } from './ActivityFeed/'
@@ -28,14 +28,9 @@ export function Dashboard() {
     })
   }, [])
   setDocumentTitle(t('dashboard.title'))
-  const loading =
-    state.feedReady !== true &&
-    state.namespacesReady !== true &&
-    state.projectTypesReady !== true
   return (
     <Fragment>
-      {loading && <Loading />}
-      <div className={`flex-1 ${loading ? 'hidden' : ''}`}>
+      <div className="flex-1">
         <div className="flex flex-col lg:flex-row lg:items-stretch lg:h-screen-1/2 space-x-0 lg:space-x-3 space-y-3 lg:space-y-0">
           <div className="flex-auto lg:h-full lg:w-8/12 w-full">
             <Namespaces

--- a/src/js/views/Dashboard/Namespaces/Namespaces.jsx
+++ b/src/js/views/Dashboard/Namespaces/Namespaces.jsx
@@ -13,6 +13,7 @@ import {
 import { Head } from '../../../components/Table/'
 import { Context } from '../../../state'
 import { httpGet } from '../../../utils'
+import { lookupNamespaceByID } from '../../../utils'
 
 import { PopupGraph } from './PopupGraph'
 
@@ -161,9 +162,6 @@ function Namespaces({ onReady }) {
       }
     })
   }
-
-  if (state.fetchedNamespaces !== true || state.fetchedKPIHistory !== true)
-    return <div />
   return (
     <ErrorBoundary>
       {state.chart !== null && (
@@ -201,7 +199,15 @@ function Namespaces({ onReady }) {
                 ).map((entry) => entry.value)
                 const handleClick = () =>
                   navigate(
-                    `/ui/projects?namespace_id=${namespace.namespace_id}`
+                    '/ui/projects?f=' +
+                      encodeURIComponent(
+                        `namespace_slug:${
+                          lookupNamespaceByID(
+                            globalState.metadata.namespaces,
+                            namespace.namespace_id
+                          ).slug
+                        }`
+                      )
                   )
                 return (
                   <tr

--- a/src/js/views/Dashboard/Stats/ProjectTypes.jsx
+++ b/src/js/views/Dashboard/Stats/ProjectTypes.jsx
@@ -11,7 +11,9 @@ import PropTypes from 'prop-types'
 
 function ProjectTypes({ onReady }) {
   const [state, setState] = useState({
-    data: [],
+    data: {
+      project_types: []
+    },
     fetched: false,
     errorMessage: null
   })
@@ -31,7 +33,11 @@ function ProjectTypes({ onReady }) {
           })
         },
         (error) => {
-          setState({ data: [], fetched: true, errorMessage: error })
+          setState({
+            data: { project_types: [] },
+            fetched: true,
+            errorMessage: error
+          })
         }
       )
     } else {
@@ -41,30 +47,31 @@ function ProjectTypes({ onReady }) {
 
   return (
     <ErrorBoundary>
-      {state.fetched && (
-        <ContentArea
-          className="flex-grow pt-0"
-          pageIcon="fas cubes"
-          pageTitle={t('dashboard.projectTypes')}
-          setPageTitle={false}>
-          {state.errorMessage !== null && (
-            <Alert level="error">{state.errorMessage}</Alert>
-          )}
-          <Container>
-            {state.data.project_types.map((row) => {
-              return (
-                <Value
-                  key={`stats-${row.name}`}
-                  title={row.count === 1 ? row.name : row.plural}
-                  icon={row.icon}
-                  url={`/ui/projects?project_type_id=${row.project_type_id}`}
-                  value={row.count}
-                />
-              )
-            })}
-          </Container>
-        </ContentArea>
-      )}
+      <ContentArea
+        className="flex-grow pt-0"
+        pageIcon="fas cubes"
+        pageTitle={t('dashboard.projectTypes')}
+        setPageTitle={false}>
+        {state.errorMessage !== null && (
+          <Alert level="error">{state.errorMessage}</Alert>
+        )}
+        <Container>
+          {state.data.project_types.map((row) => {
+            return (
+              <Value
+                key={`stats-${row.name}`}
+                title={row.count === 1 ? row.name : row.plural}
+                icon={row.icon}
+                url={
+                  '/ui/projects?f=' +
+                  encodeURIComponent('project_type_slug:' + row.slug)
+                }
+                value={row.count}
+              />
+            )
+          })}
+        </Container>
+      </ContentArea>
     </ErrorBoundary>
   )
 }

--- a/src/js/views/Projects/Filter.jsx
+++ b/src/js/views/Projects/Filter.jsx
@@ -11,7 +11,8 @@ function Filter({ disabled, onChange, onRefresh, onShowHelp, value }) {
     <form className="flex flex-row items-center md:space-x-2 mr-2 text-gray-500 sm:w-full md:w-full">
       <div className="relative flex items-stretch rounded-md shadow-sm flex-grow focus-within:z-10">
         <input
-          className="block w-full rounded-none rounded-l-md pl-10 sm:text-sm border-gray-300 focus:outline-0"
+          autoFocus={true}
+          className="block w-full rounded-none rounded-l-md pl-10 sm:text-sm border-gray-300 focus:border-gray-300 focus:outline-0 focus:ring-0"
           type="text"
           autoComplete="off"
           defaultValue={value !== '' ? value : undefined}

--- a/src/js/views/Projects/Filter.jsx
+++ b/src/js/views/Projects/Filter.jsx
@@ -1,34 +1,47 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 import { Icon } from '../../components'
 
 function Filter({ disabled, onChange, onRefresh, onShowHelp, value }) {
+  const [filter, setFilter] = useState(value)
+  const location = useLocation()
+  const params = new Proxy(new URLSearchParams(window.location.search), {
+    get: (searchParams, prop) => searchParams.get(prop)
+  })
   const { t } = useTranslation()
 
+  function handleSubmit(event) {
+    event.preventDefault()
+    onChange(filter)
+  }
+
+  // Change the filter if the top search box changes it
+  useEffect(() => {
+    const filterParam = decodeURIComponent(params.f)
+    if (filterParam !== filter) setFilter(filterParam)
+  }, [location])
+
   return (
-    <form className="flex flex-row items-center md:space-x-2 mr-2 text-gray-500 sm:w-full md:w-full">
+    <form
+      className="flex flex-row items-center md:space-x-2 mr-2 text-gray-500 sm:w-full md:w-full"
+      onSubmit={handleSubmit}>
       <div className="relative flex items-stretch rounded-md shadow-sm flex-grow focus-within:z-10">
         <input
           autoFocus={true}
           className="block w-full rounded-none rounded-l-md pl-10 sm:text-sm border-gray-300 focus:border-gray-300 focus:outline-0 focus:ring-0"
           type="text"
           autoComplete="off"
-          defaultValue={value !== '' ? value : undefined}
           disabled={disabled}
           name="search"
+          onChange={(event) => {
+            setFilter(event.target.value)
+          }}
           placeholder={t('common.search')}
           style={{ padding: '.575rem' }}
-          onBlur={(event) => {
-            onChange(event.target.value)
-          }}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault()
-              onChange(event.target.value)
-            }
-          }}
+          value={filter}
         />
         <button
           type="button"

--- a/src/js/views/Projects/HelpDialog.jsx
+++ b/src/js/views/Projects/HelpDialog.jsx
@@ -25,7 +25,7 @@ function HelpDialog({ onClose }) {
         />
         <h1 className="my-4 font-bold">{t('projects.searchHelpFields')}</h1>
         <ul className="list-disc list-inside max-h-36 ml-5 font-mono overflow-scroll">
-          {fields.sort(byValue((f) => f, byString())).map((field) => {
+          {fields.sort(byString()).map((field) => {
             return <li key={`field-` + field}>{field}</li>
           })}
         </ul>

--- a/src/js/views/Projects/HelpDialog.jsx
+++ b/src/js/views/Projects/HelpDialog.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
+import { byString, byValue } from 'sort-es'
 
 import { Modal } from '../../components'
 import { Context } from '../../state'
@@ -24,7 +25,7 @@ function HelpDialog({ onClose }) {
         />
         <h1 className="my-4 font-bold">{t('projects.searchHelpFields')}</h1>
         <ul className="list-disc list-inside max-h-36 ml-5 font-mono overflow-scroll">
-          {fields.map((field) => {
+          {fields.sort(byValue((f) => f, byString())).map((field) => {
             return <li key={`field-` + field}>{field}</li>
           })}
         </ul>

--- a/src/js/views/Projects/Projects.jsx
+++ b/src/js/views/Projects/Projects.jsx
@@ -18,17 +18,7 @@ const sortMap = {
   namespace: byString,
   name: byString,
   project_score: byNumber,
-  type: byString
-}
-
-function slugToName(items, slug) {
-  let value = slug
-  items.forEach((item) => {
-    if (item.slug === slug) {
-      value = item.name
-    }
-  })
-  return value
+  project_type: byString
 }
 
 function sortTableData(data, columns) {
@@ -109,11 +99,11 @@ function Projects() {
       },
       {
         title: t('terms.projectType'),
-        name: 'type',
+        name: 'project_type',
         sortCallback: onSortChange,
         sortDirection:
-          globalState.projects.sort.type !== undefined
-            ? globalState.projects.sort.type
+          globalState.projects.sort.project_type !== undefined
+            ? globalState.projects.sort.project_type
             : null,
         type: 'text',
         tableOptions: {
@@ -139,11 +129,6 @@ function Projects() {
         }
       }
     ]
-  }
-
-  const slugToNameMap = {
-    namespace: globalState.metadata.namespaces,
-    type: globalState.metadata.projectTypes
   }
 
   const [state, setState] = useState({
@@ -196,11 +181,7 @@ function Projects() {
             data.hits.hits.forEach((row) => {
               const values = {}
               for (const [key, value] of Object.entries(row.fields)) {
-                if (slugToNameMap[key] !== undefined) {
-                  values[key] = slugToName(slugToNameMap[key], value[0])
-                } else {
-                  values[key] = value[0]
-                }
+                values[key] = value[0]
               }
               tableData.push(values)
             })

--- a/src/js/views/Projects/Projects.jsx
+++ b/src/js/views/Projects/Projects.jsx
@@ -5,6 +5,7 @@ import {
   toElasticsearchQuery
 } from '@cybernetex/kbn-es-query'
 import { byString, byNumber, byValues } from 'sort-es'
+import { useNavigate } from 'react-router-dom'
 
 import { Alert, ScoreBadge, Table } from '../../components'
 import { Context } from '../../state'
@@ -32,19 +33,41 @@ function sortTableData(data, columns) {
 function Projects() {
   const [errorMessage, setErrorMessage] = useState(null)
   const [globalState, dispatch] = useContext(Context)
+  const navigate = useNavigate()
   const { t } = useTranslation()
+  const params = new Proxy(new URLSearchParams(window.location.search), {
+    get: (searchParams, prop) => searchParams.get(prop)
+  })
 
-  function buildURL(path) {
-    return new URL(path, globalState.baseURL)
-  }
+  const [state, setState] = useState({
+    columns: [],
+    data: [],
+    fetching: false,
+    fields: ['id', 'namespace', 'project_type', 'name', 'project_score'],
+    filter: params.f !== null ? decodeURIComponent(params.f) : '',
+    refresh: false,
+    showHelp: false,
+    sort:
+      params.s !== null
+        ? JSON.parse(decodeURIComponent(params.s))
+        : {
+            namespace: 'asc',
+            name: 'asc'
+          }
+  })
 
   function onFilterChange(value) {
-    if (value !== globalState.projects.filter) {
-      setState({ ...state, data: [] })
-      dispatch({
-        type: 'SET_PROJECTS_FILTER',
-        payload: value
-      })
+    if (value !== state.filter) {
+      setState((prevState) => ({
+        ...prevState,
+        data: [],
+        filter: value
+      }))
+      setURL(
+        `/ui/projects?f=${encodeURIComponent(value)}&s=${encodeURIComponent(
+          JSON.stringify(state.sort)
+        )}`
+      )
     }
   }
 
@@ -53,17 +76,17 @@ function Projects() {
   }
 
   function onSortChange(column, direction) {
-    const sort = { ...globalState.projects.sort }
+    const sort = { ...state.sort }
     if (direction === null) {
       if (sort[column] !== undefined) delete sort[column]
-    } else if (globalState.projects.sort[column] !== direction) {
+    } else if (state.sort[column] !== direction) {
       sort[column] = direction
     }
-    if (JSON.stringify(globalState.projects.sort) !== JSON.stringify(sort)) {
-      dispatch({
-        type: 'SET_PROJECTS_SORT',
-        payload: sort
-      })
+    if (JSON.stringify(state.sort) !== JSON.stringify(sort)) {
+      setState((prevState) => ({
+        ...prevState,
+        sort: sort
+      }))
     }
   }
 
@@ -74,9 +97,7 @@ function Projects() {
         name: 'namespace',
         sortCallback: onSortChange,
         sortDirection:
-          globalState.projects.sort.namespace !== undefined
-            ? globalState.projects.sort.namespace
-            : null,
+          state.sort.namespace !== undefined ? state.sort.namespace : null,
         type: 'text',
         tableOptions: {
           className: 'truncate',
@@ -87,10 +108,7 @@ function Projects() {
         title: t('terms.name'),
         name: 'name',
         sortCallback: onSortChange,
-        sortDirection:
-          globalState.projects.sort.name !== undefined
-            ? globalState.projects.sort.name
-            : null,
+        sortDirection: state.sort.name !== undefined ? state.sort.name : null,
         type: 'text',
         tableOptions: {
           className: 'truncate',
@@ -102,8 +120,8 @@ function Projects() {
         name: 'project_type',
         sortCallback: onSortChange,
         sortDirection:
-          globalState.projects.sort.project_type !== undefined
-            ? globalState.projects.sort.project_type
+          state.sort.project_type !== undefined
+            ? state.sort.project_type
             : null,
         type: 'text',
         tableOptions: {
@@ -116,8 +134,8 @@ function Projects() {
         name: 'project_score',
         sortCallback: onSortChange,
         sortDirection:
-          globalState.projects.sort.project_score !== undefined
-            ? globalState.projects.sort.project_score
+          state.sort.project_score !== undefined
+            ? state.sort.project_score
             : null,
         type: 'text',
         tableOptions: {
@@ -131,46 +149,45 @@ function Projects() {
     ]
   }
 
-  const [state, setState] = useState({
-    columns: buildColumns(),
-    data: [],
-    fetching: false,
-    refresh: false,
-    showHelp: false
-  })
+  function buildURL(path) {
+    return new URL(path, globalState.baseURL)
+  }
 
-  useEffect(() => {
+  function setURL(path) {
+    const url = buildURL(path)
     dispatch({
       type: 'SET_CURRENT_PAGE',
       payload: {
-        url: buildURL('/ui/projects'),
+        url: url,
         title: 'projects.title'
       }
     })
-  }, [])
+    navigate(url)
+  }
+
+  useEffect(() => {
+    setState({ ...state, columns: buildColumns() })
+  }, [state.fields])
 
   useEffect(() => {
     if (state.fetching === false) {
       setState({ ...state, fetching: true })
 
-      let filter = globalState.projects.filter
-      if (
-        globalState.projects.filter === '' ||
-        globalState.projects.filter === '*'
-      )
+      let filter = state.filter
+      if (state.filter === '' || state.filter === '*')
         filter = 'NOT archived:true'
       else if (
-        globalState.projects.filter.length > 0 &&
-        globalState.projects.filter.includes('archived:') !== true
+        state.filter.length > 0 &&
+        state.filter.includes('archived:') !== true
       )
-        filter = `(${globalState.projects.filter}) AND NOT archived:true`
+        filter = `(${state.filter}) AND NOT archived:true`
 
       const query = {
         query: toElasticsearchQuery(
           fromKueryExpression(filter),
           metadataAsOptions.openSearch
         ),
-        fields: globalState.projects.fields,
+        fields: state.fields,
         size: 1000
       }
 
@@ -187,7 +204,7 @@ function Projects() {
             })
             setState((prevState) => ({
               ...prevState,
-              data: sortTableData(tableData, globalState.projects.sort),
+              data: sortTableData(tableData, state.sort),
               fetching: false,
               refresh: false
             }))
@@ -202,16 +219,21 @@ function Projects() {
         }
       )
     }
-  }, [globalState.projects.fields, globalState.projects.filter, state.refresh])
+  }, [state.fields, state.filter, state.refresh])
 
   // Re-sort the table data when the sort settings change
   useEffect(() => {
     setState({
       ...state,
       columns: buildColumns(),
-      data: sortTableData(state.data, globalState.projects.sort)
+      data: sortTableData(state.data, state.sort)
     })
-  }, [globalState.projects.sort])
+    setURL(
+      `/ui/projects?f=${encodeURIComponent(
+        state.filter
+      )}&s=${encodeURIComponent(JSON.stringify(state.sort))}`
+    )
+  }, [state.sort])
 
   // Remove the error message after 30 seconds
   useEffect(() => {
@@ -238,7 +260,7 @@ function Projects() {
           onChange={onFilterChange}
           onRefresh={onRefresh}
           onShowHelp={() => setState({ ...state, showHelp: true })}
-          value={globalState.projects.filter}
+          value={state.filter}
         />
       </div>
       <Table

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Context } from '../../state'
 import { httpGet } from '../../utils'
 import { Alert, Badge, ContentArea, Loading, Table } from '../../components'
+import { lookupNamespaceByID } from '../../utils'
 
 function colorizeValue(value) {
   value = parseInt(value)
@@ -120,8 +121,14 @@ function NamespaceKPIs() {
         className: 'truncate',
         headerClassName: 'w-3/12',
         lookupFunction: (namespace) => {
+          const filter =
+            'namespace_slug:' +
+            lookupNamespaceByID(
+              globalState.metadata.namespaces,
+              state.lookup[namespace]
+            ).slug
           return (
-            <Link to={`/ui/projects?namespace_id=${state.lookup[namespace]}`}>
+            <Link to={`/ui/projects?f=${encodeURIComponent(filter)}`}>
               {namespace}
             </Link>
           )

--- a/yarn.lock
+++ b/yarn.lock
@@ -6224,7 +6224,7 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-chartjs-2@^4.0.0:
+react-chartjs-2@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-4.3.1.tgz#9941e7397fb963f28bb557addb401e9ff96c6681"
   integrity sha512-5i3mjP6tU7QSn0jvb8I4hudTzHJqS8l00ORJnVwI2sYu0ihpj83Lv2YzfxunfxTZkscKvZu2F2w9LkwNBhj6xA==


### PR DESCRIPTION
This PR is primarily focused around cleaning up the ability to link to the Projects page and carry the settings in the URL

- Refactor to use local state for Projects instead of Global State
- Fix the links to the Projects page from various places in the project
- Remove an unused attribute from the User schema
- Use the proper names for fields (namespace_slug, project_type_slug) so there's no confusion in searching
- Removes the loading state from the Dashboard due to use feedback
- Adds a search input box to the header when not on the Projects page