### PR TITLE
Use gitlab button

### DIFF
--- a/src/js/schema/User.js
+++ b/src/js/schema/User.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 
 export const User = {
-  authenticated: PropTypes.bool,
   created_at: PropTypes.string,
   username: PropTypes.string,
   display_name: PropTypes.string,

--- a/src/js/views/User/Profile.jsx
+++ b/src/js/views/User/Profile.jsx
@@ -4,8 +4,8 @@ import React, { Fragment, useContext, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Context } from '../../state'
+import { GitlabConnectButton } from '../../components'
 import { User } from '../../schema'
-import { Button } from '../../components'
 
 function Groups({ groups }) {
   return (
@@ -51,17 +51,6 @@ function Profile({ user }) {
   const [state, dispatch] = useContext(Context)
   const { t } = useTranslation()
 
-  function redirectToGitlab(e) {
-    e.preventDefault()
-    document.location =
-      `${state.metadata.gitlabDetails.authorizationEndpoint}` +
-      `?client_id=${state.metadata.gitlabDetails.clientId}` +
-      `&redirect_uri=${state.metadata.gitlabDetails.redirectURI}` +
-      `&response_type=code` +
-      `&state=${user.username}` +
-      `&scope=api`
-  }
-
   useEffect(() => {
     dispatch({
       type: 'SET_PAGE',
@@ -104,7 +93,9 @@ function Profile({ user }) {
             value={user.integrations.join()}
           />
           {!user.integrations.includes('gitlab') && (
-            <Button onClick={redirectToGitlab}>Connect to gitlab</Button>
+            <div className="py-3 px-5 text-sm font-medium">
+              <GitlabConnectButton user={user} />
+            </div>
           )}
         </dl>
       </div>


### PR DESCRIPTION
_User/Profile.jsx_ was using `state.metadata` instead of `globalState.integrations`.  The GitLab connection code was duplicated from the GitlabConnectButton component so we can just use the component instead.  When I switched to the component I received a type warning about the `authenticated` property not being present on the User instance so I removed it from the schema.  I'm still not sure _why_ this is working in other places.  AFAICT, the `authenticated` property was moved into the metadata (or context) a while back.