### PR TITLE
Show empty project feed when no fact history

### DIFF
--- a/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
+++ b/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
@@ -72,10 +72,12 @@ function ProjectFeed({ projectID, factTypes }) {
   if (errorMessage) {
     content = <Alert level="error">{errorMessage}</Alert>
   } else if (factHistory.entries.length === 0) {
-    content = (
+    content = factHistory.hasMore ? (
       <div className="flex flex-col justify-items-center content-center h-full">
         <Loading />
       </div>
+    ) : (
+      <></>
     )
   } else {
     const entries = factHistory.entries.map((fact, index) => (


### PR DESCRIPTION
Fixes a UI bug where the user sees an infinite loading bee if there
are no project fact history entries (such as on project creation)