### PR TITLE
Add sentry automation during project creation

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -149,6 +149,11 @@ export default {
             title: 'GitLab Group Path',
             description:
               'GitLab group slug/path that new projects for this namespace will be created in'
+          },
+          sentryTeamSlug: {
+            title: 'Sentry Team Slug',
+            description:
+              'Sentry team that new projects for this namespace will be created in'
           }
         },
         projectFactTypes: {

--- a/src/js/views/Admin/Namespaces.jsx
+++ b/src/js/views/Admin/Namespaces.jsx
@@ -75,6 +75,15 @@ export function Namespaces() {
           tableOptions: {
             headerClassName: 'w-4/12'
           }
+        },
+        {
+          title: t('admin.namespaces.sentryTeamSlug.title'),
+          name: 'sentry_team_slug',
+          description: t('admin.namespaces.sentryTeamSlug.description'),
+          type: 'text',
+          tableOptions: {
+            headerClassName: 'w-2/12'
+          }
         }
       ]}
       errorStrings={{

--- a/src/js/views/Project/Create/Automations.jsx
+++ b/src/js/views/Project/Create/Automations.jsx
@@ -326,6 +326,12 @@ function Automations({ localDispatch, localState, user }) {
         </Fragment>
       </Form.Section>
     )
+  } else {
+    return (
+      <Form.Section name="automations" title={t('project.projectAutomations')}>
+        <Fragment>No automations available</Fragment>
+      </Form.Section>
+    )
   }
 }
 Automations.propTypes = {

--- a/src/js/views/Project/Create/Automations.jsx
+++ b/src/js/views/Project/Create/Automations.jsx
@@ -37,6 +37,16 @@ function Automations({ localDispatch, localState, user }) {
     'project'
   )
 
+  const namespace = localState.attributes.namespace_id
+    ? globalState.metadata.namespaces.filter(
+        (n) => n.id === localState.attributes.namespace_id
+      )[0]
+    : undefined
+  const sentryEnabled =
+    namespace &&
+    namespace.sentry_team_slug &&
+    globalState.integrations.sentry.enabled
+
   function manageAutomationLinks(automationEnabled, project_link_type_id) {
     const automationLinks = new Set(localState.automationLinks)
     if (automationEnabled && project_link_type_id !== null)
@@ -66,6 +76,7 @@ function Automations({ localDispatch, localState, user }) {
     if (localState.isSaving && localState.saved.attributes) {
       if (localState.createGitlabRepository)
         localDispatch({ type: 'SET_CREATING_GITLAB_REPOSITORY', payload: true })
+      else localDispatch({ type: 'SET_CREATING_SENTRY_PROJECT', payload: true })
     }
   }, [localState.saved.attributes])
 
@@ -230,10 +241,39 @@ function Automations({ localDispatch, localState, user }) {
     }
   }, [localState.creating.sonarqubeProject])
 
+  // Create Sentry Project
+  useEffect(() => {
+    async function createSentryProject() {
+      let result = await httpPost(
+        globalState.fetch,
+        new URL('/ui/automations/sentry/create', globalState.baseURL),
+        {
+          project_id: localState.projectId
+        }
+      )
+      if (result.success) {
+        localDispatch({ type: 'SET_CREATED_SENTRY_PROJECT', payload: true })
+        localDispatch({ type: 'SET_CREATING_SENTRY_PROJECT', payload: false })
+      } else {
+        localDispatch({ type: 'SET_CREATING_SENTRY_PROJECT', payload: false })
+        localDispatch({ type: 'SET_ERROR_MESSAGE', payload: result.data })
+        localDispatch({ type: 'SET_IS_SAVING', payload: false })
+      }
+    }
+    if (
+      localState.isSaving &&
+      localState.creating.sentryProject &&
+      !localState.created.sentryProject
+    ) {
+      createSentryProject()
+    }
+  }, [localState.creating.sentryProject])
+
   if (
     gitlabEnabled ||
     globalState.integrations.sonarqube.enabled ||
-    grafanaEnabled
+    grafanaEnabled ||
+    sentryEnabled
   ) {
     return (
       <Form.Section name="automations" title={t('project.projectAutomations')}>
@@ -267,7 +307,7 @@ function Automations({ localDispatch, localState, user }) {
               value={localState.createSonarqubeProject}
             />
           )}
-          {globalState.integrations.sentry.enabled && (
+          {sentryEnabled && (
             <Form.Field
               title={t('project.createSentryProject')}
               name="createSentryProject"

--- a/src/js/views/Project/Create/Reducer.jsx
+++ b/src/js/views/Project/Create/Reducer.jsx
@@ -124,6 +124,23 @@ function reducer(state, action) {
         ...state,
         createSentryProject: action.payload
       }
+    case 'SET_CREATING_SENTRY_PROJECT':
+      return {
+        ...state,
+        creating: {
+          ...state.creating,
+          sentryProject: action.payload
+        }
+      }
+    case 'SET_CREATED_SENTRY_PROJECT':
+      return {
+        ...state,
+        created: {
+          ...state.created,
+          sentryProject: action.payload
+        }
+      }
+
     case 'SET_CREATE_SONARQUBE_PROJECT':
       return {
         ...state,

--- a/src/js/views/Project/Settings.jsx
+++ b/src/js/views/Project/Settings.jsx
@@ -63,7 +63,7 @@ function Settings({ project, refresh, urlPath }) {
       'message',
       `${project.name} was successfully deleted.`
     )
-    history.replace(`${url.pathname}${url.search}`)
+    navigate(`${url.pathname}${url.search}`)
   }
 
   return (


### PR DESCRIPTION
This PR adds the Sentry automation during project creation if:

1. the Sentry automation is configured and enabled in Imbi
2. the Namespace has a `sentry_team_slug` attribute set

In this case, the "create project in sentry" toggle will appear in the "Project Automations" section.