### PR TITLE
Fix closing/opening modal dialogs

### DIFF
--- a/src/js/components/ConfirmationDialog/ConfirmationDialog.jsx
+++ b/src/js/components/ConfirmationDialog/ConfirmationDialog.jsx
@@ -21,7 +21,7 @@ function ConfirmationDialog({
 }) {
   const { t } = useTranslation()
   return (
-    <Modal>
+    <Modal onClose={onCancel}>
       <Modal.Title onClose={onCancel} showClose={true}>
         {title}
       </Modal.Title>

--- a/src/js/components/Form/ModalForm.jsx
+++ b/src/js/components/Form/ModalForm.jsx
@@ -84,7 +84,7 @@ function ModalForm({
   }
 
   return (
-    <Modal>
+    <Modal onClose={onClose}>
       <form onSubmit={handleSubmit}>
         <Modal.Title>{saving ? savingTitle : title}</Modal.Title>
         <div className="text-gray-500">

--- a/src/js/components/Modal/Modal.jsx
+++ b/src/js/components/Modal/Modal.jsx
@@ -10,15 +10,16 @@ class Modal extends React.PureComponent {
   constructor(props) {
     super(props)
     this.dialogRef = React.createRef()
-    this.state = { isOpen: true }
   }
 
   render() {
     return (
       <Dialog
         initialFocus={this.dialogRef}
-        open={this.state.isOpen}
-        onClose={() => this.setState({ isOpen: false })}
+        open={true}
+        onClose={() => {
+          this.props.onClose && this.props.onClose()
+        }}
         className="fixed font-sans z-10 inset-0 overflow-y-auto text-base">
         <div className="flex items-center justify-center min-h-screen">
           <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />


### PR DESCRIPTION
This refactors the state/prop management for Modal components so that they close properly (and can be re-opened) when you click outside the modal, hit escape, etc. Modals are all conditionally rendered, so we don't need the isOpen boolean state, just always be true.