### PR TITLE
Implement Field.readOnly

### DIFF
--- a/src/js/components/Form/DatePicker.jsx
+++ b/src/js/components/Form/DatePicker.jsx
@@ -8,6 +8,7 @@ function DatePicker({
   name,
   onChange,
   placeholder,
+  readOnly,
   required,
   value
 }) {
@@ -46,6 +47,7 @@ function DatePicker({
         setHasFocus(true)
       }}
       placeholder={placeholder}
+      readOnly={readOnly}
       ref={ref}
       required={required}
     />
@@ -55,6 +57,7 @@ DatePicker.defaultProps = {
   autoFocus: false,
   disabled: false,
   hasError: false,
+  readOnly: false,
   required: false
 }
 DatePicker.propTypes = {
@@ -64,6 +67,7 @@ DatePicker.propTypes = {
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   value: PropTypes.string
 }

--- a/src/js/components/Form/DateTimePicker.jsx
+++ b/src/js/components/Form/DateTimePicker.jsx
@@ -8,6 +8,7 @@ function DateTimePicker({
   name,
   onChange,
   placeholder,
+  readOnly,
   required,
   value
 }) {
@@ -46,6 +47,7 @@ function DateTimePicker({
         setHasFocus(true)
       }}
       placeholder={placeholder}
+      readOnly={readOnly}
       ref={ref}
       required={required}
     />
@@ -55,6 +57,7 @@ DateTimePicker.defaultProps = {
   autoFocus: false,
   disabled: false,
   hasError: false,
+  readOnly: false,
   required: false
 }
 DateTimePicker.propTypes = {
@@ -64,6 +67,7 @@ DateTimePicker.propTypes = {
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   value: PropTypes.string
 }

--- a/src/js/components/Form/Field.jsx
+++ b/src/js/components/Form/Field.jsx
@@ -25,6 +25,7 @@ function Field({
   onChange,
   options,
   placeholder,
+  readOnly,
   required,
   step,
   title,
@@ -52,6 +53,7 @@ function Field({
             name={name}
             onChange={onChange}
             placeholder={placeholder}
+            readOnly={readOnly}
             required={required}
             value={value}
           />
@@ -66,6 +68,7 @@ function Field({
             name={name}
             onChange={onChange}
             placeholder={placeholder}
+            readOnly={readOnly}
             required={required}
             step={step}
             value={value}
@@ -82,6 +85,7 @@ function Field({
             onChange={onChange}
             options={options}
             placeholder={placeholder}
+            readOnly={readOnly}
             required={required}
             value={value}
           />
@@ -94,6 +98,7 @@ function Field({
             name={name}
             onChange={onChange}
             placeholder={placeholder}
+            readOnly={readOnly}
             required={required}
             type={type}
             value={value}
@@ -107,6 +112,7 @@ function Field({
             name={name}
             onChange={onChange}
             placeholder={placeholder}
+            readOnly={readOnly}
             required={required}
             value={value}
           />
@@ -117,6 +123,7 @@ function Field({
             className="mt-2"
             disabled={disabled}
             onChange={onChange}
+            readOnly={readOnly}
             value={value}
           />
         )}
@@ -128,6 +135,7 @@ function Field({
             name={name}
             onChange={onChange}
             placeholder={placeholder}
+            readOnly={readOnly}
             required={required}
             value={value}
           />
@@ -140,6 +148,7 @@ function Field({
             name={name}
             onChange={onChange}
             placeholder={placeholder}
+            readOnly={readOnly}
             required={required}
             value={value}
           />
@@ -179,6 +188,7 @@ Field.propTypes = {
   onChange: PropTypes.func,
   options: SelectOptions,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   step: PropTypes.string,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,

--- a/src/js/components/Form/IconSelect.jsx
+++ b/src/js/components/Form/IconSelect.jsx
@@ -11,6 +11,7 @@ function IconSelect({
   name,
   onChange,
   placeholder,
+  readOnly,
   required,
   value
 }) {
@@ -31,7 +32,7 @@ function IconSelect({
           (hasFocus === false && hasError === true ? ' border-red-700' : '')
         }
         defaultValue={value}
-        disabled={disabled}
+        disabled={disabled || readOnly}
         id={'field-' + name}
         onBlur={(event) => {
           event.preventDefault()
@@ -65,6 +66,7 @@ IconSelect.defaultProps = {
   autoFocus: false,
   disabled: false,
   hasError: false,
+  readOnly: false,
   required: false
 }
 IconSelect.propTypes = {
@@ -74,6 +76,7 @@ IconSelect.propTypes = {
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   value: PropTypes.string.isRequired
 }

--- a/src/js/components/Form/NumericInput.jsx
+++ b/src/js/components/Form/NumericInput.jsx
@@ -10,6 +10,7 @@ function NumericInput({
   name,
   onChange,
   placeholder,
+  readOnly,
   required,
   step,
   value
@@ -58,6 +59,7 @@ function NumericInput({
         setHasFocus(true)
       }}
       placeholder={placeholder}
+      readOnly={readOnly}
       ref={ref}
       required={required}
       step={step}
@@ -69,6 +71,7 @@ NumericInput.defaultProps = {
   autoFocus: false,
   disabled: false,
   hasError: false,
+  readOnly: false,
   required: false,
   step: '1'
 }
@@ -81,6 +84,7 @@ NumericInput.propTypes = {
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   step: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])

--- a/src/js/components/Form/Select.jsx
+++ b/src/js/components/Form/Select.jsx
@@ -13,6 +13,7 @@ function Select({
   onChange,
   options,
   placeholder,
+  readOnly,
   required,
   value
 }) {
@@ -48,7 +49,7 @@ function Select({
         (hasFocus === false && hasError === true ? ' border-red-700' : '')
       }
       defaultValue={currentValue === null ? '' : currentValue}
-      disabled={disabled}
+      disabled={disabled || readOnly}
       id={'field-' + name}
       multiple={multiple}
       name={name}
@@ -100,6 +101,7 @@ Select.defaultProps = {
   disabled: false,
   hasError: false,
   multiple: false,
+  readOnly: false,
   required: false
 }
 Select.propTypes = {
@@ -112,6 +114,7 @@ Select.propTypes = {
   onChange: PropTypes.func,
   options: SelectOptions,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   value: PropTypes.oneOfType([
     PropTypes.array,

--- a/src/js/components/Form/TextArea.jsx
+++ b/src/js/components/Form/TextArea.jsx
@@ -8,6 +8,7 @@ function TextArea({
   name,
   onChange,
   placeholder,
+  readOnly,
   required,
   rows,
   value
@@ -44,6 +45,7 @@ function TextArea({
         setHasFocus(true)
       }}
       placeholder={placeholder}
+      readOnly={readOnly}
       ref={ref}
       required={required}
       rows={rows}
@@ -54,6 +56,7 @@ TextArea.defaultProps = {
   autoFocus: false,
   disabled: false,
   hasError: false,
+  readOnly: false,
   required: false,
   rows: 3
 }
@@ -64,6 +67,7 @@ TextArea.propTypes = {
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   rows: PropTypes.number,
   value: PropTypes.string

--- a/src/js/components/Form/TextInput.jsx
+++ b/src/js/components/Form/TextInput.jsx
@@ -8,6 +8,7 @@ function TextInput({
   name,
   onChange,
   placeholder,
+  readOnly,
   required,
   type,
   value
@@ -44,6 +45,7 @@ function TextInput({
         setHasFocus(true)
       }}
       placeholder={placeholder}
+      readOnly={readOnly}
       ref={ref}
       required={required}
       type={type}
@@ -55,6 +57,7 @@ TextInput.defaultProps = {
   autoFocus: false,
   disabled: false,
   hasError: false,
+  readOnly: false,
   required: false
 }
 TextInput.propTypes = {
@@ -64,6 +67,7 @@ TextInput.propTypes = {
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   type: PropTypes.oneOf(['email', 'text', 'url']),
   value: PropTypes.string

--- a/src/js/components/Form/Toggle.jsx
+++ b/src/js/components/Form/Toggle.jsx
@@ -2,7 +2,15 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-function Toggle({ name, className, disabled, onChange, title, value }) {
+function Toggle({
+  name,
+  className,
+  disabled,
+  onChange,
+  readOnly,
+  title,
+  value
+}) {
   const { t } = useTranslation()
   return (
     <button
@@ -11,7 +19,7 @@ function Toggle({ name, className, disabled, onChange, title, value }) {
         value ? 'bg-blue-600' : 'bg-gray-400'
       } relative inline-flex flex-shrink-0 h-5 w-9 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none ${className}`}
       aria-pressed="false"
-      disabled={disabled}
+      disabled={disabled || readOnly}
       onClick={(event) => {
         event.preventDefault()
         onChange(name, !value)
@@ -35,9 +43,11 @@ function Toggle({ name, className, disabled, onChange, title, value }) {
     </button>
   )
 }
+
 Toggle.defaultProps = {
   className: '',
   disabled: false,
+  readOnly: false,
   value: false
 }
 Toggle.propTypes = {
@@ -45,6 +55,7 @@ Toggle.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
   title: PropTypes.string,
   value: PropTypes.bool
 }


### PR DESCRIPTION
We refer to the property in Columns schema which is forwarded along to the various form fields. I forwarded the property along to the underlying field implementations where it made sense and disabled fields when there was nowhere to forward to (e.g., `<select>`).