### PR TITLE
Markdown enhancements

### DIFF
--- a/src/js/components/Form/Field.jsx
+++ b/src/js/components/Form/Field.jsx
@@ -11,6 +11,7 @@ import { TextArea } from './TextArea'
 import { Toggle } from './Toggle'
 import { DatePicker } from './DatePicker'
 import { DateTimePicker } from './DateTimePicker'
+import { MarkdownField } from '../Markdown/MarkdownField'
 
 function Field({
   autoFocus,
@@ -101,6 +102,20 @@ function Field({
             readOnly={readOnly}
             required={required}
             type={type}
+            value={value}
+          />
+        )}
+        {type === 'markdown' && (
+          <MarkdownField
+            autoFocus={autoFocus}
+            description={description}
+            disabled={disabled}
+            errorMessage={errorMessage}
+            name={name}
+            onChange={onChange}
+            placeholder={placeholder}
+            readOnly={readOnly}
+            required={required}
             value={value}
           />
         )}
@@ -196,6 +211,7 @@ Field.propTypes = {
     'email',
     'hidden',
     'icon',
+    'markdown',
     'number',
     'select',
     'text',

--- a/src/js/components/Form/TextArea.jsx
+++ b/src/js/components/Form/TextArea.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react'
 
 function TextArea({
   autoFocus,
+  className,
   disabled,
   hasError,
   name,
@@ -20,13 +21,21 @@ function TextArea({
       ref.current.focus()
     }
   }, [])
+
+  let uiClassName = 'form-input'
+  if (className) {
+    uiClassName += ` ${className}`
+  }
+  if (hasFocus === false && hasError === true) {
+    uiClassName += ' border-red-700'
+  }
+  if (disabled || readOnly) {
+    uiClassName += ' cursor-not-allowed'
+  }
+
   return (
     <textarea
-      className={
-        'form-input' +
-        (hasFocus === false && hasError === true ? ' border-red-700' : '') +
-        (disabled || readOnly ? ' cursor-not-allowed' : '')
-      }
+      className={uiClassName}
       defaultValue={value}
       disabled={disabled}
       id={'field-' + name}
@@ -62,6 +71,7 @@ TextArea.defaultProps = {
 }
 TextArea.propTypes = {
   autoFocus: PropTypes.bool,
+  className: PropTypes.string,
   disabled: PropTypes.bool,
   hasError: PropTypes.bool,
   name: PropTypes.string.isRequired,

--- a/src/js/components/Markdown/Markdown.jsx
+++ b/src/js/components/Markdown/Markdown.jsx
@@ -19,18 +19,50 @@ Link.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
+    PropTypes.arrayOf(PropTypes.string),
     PropTypes.string
   ]),
   href: PropTypes.string
 }
+
 class UL extends React.PureComponent {
   render() {
-    return (
-      <ul className="list-disc list-inside space-y-2">{this.props.children}</ul>
-    )
+    return <ul className="list-disc list-inside">{this.props.children}</ul>
   }
 }
 UL.propTypes = {
+  children: PropTypes.any
+}
+
+class Paragraph extends React.PureComponent {
+  render() {
+    return <p className="pb-1">{this.props.children}</p>
+  }
+}
+Paragraph.propTypes = {
+  children: PropTypes.any
+}
+
+class Heading extends React.PureComponent {
+  constructor(props) {
+    super(props)
+    this.level = props.level
+  }
+  render() {
+    if (this.level === 1) {
+      return <h1 className="text-xl pb-2 text-bold">{this.props.children}</h1>
+    }
+    if (this.level === 2) {
+      return <h2 className="text-lg pb-1 text-bold">{this.props.children}</h2>
+    }
+    if (this.level === 3) {
+      return <h3 className="pb-1 text-bold">{this.props.children}</h3>
+    }
+    return <p className="text-bold">{this.props.children}</p>
+  }
+}
+Heading.propTypes = {
+  level: PropTypes.number.isRequired,
   children: PropTypes.any
 }
 
@@ -50,7 +82,11 @@ class Markdown extends React.PureComponent {
         className={this.props.className}
         components={{
           a: ({ ...props }) => <Link {...props} />,
-          ul: ({ ...props }) => <UL {...props} />
+          ul: ({ ...props }) => <UL {...props} />,
+          h1: ({ ...props }) => <Heading level={1} {...props} />,
+          h2: ({ ...props }) => <Heading level={2} {...props} />,
+          h3: ({ ...props }) => <Heading level={3} {...props} />,
+          p: ({ ...props }) => <Paragraph {...props} />
         }}>
         {this.props.children}
       </ReactMarkdown>

--- a/src/js/components/Markdown/MarkdownField.jsx
+++ b/src/js/components/Markdown/MarkdownField.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+
+import { Markdown } from './Markdown'
+import { TextArea } from '../Form/TextArea'
+import { Toggle } from '../Form/Toggle'
+
+export const MarkdownField = (props) => {
+  const className = 'overflow-auto h-[25vh] form-input'
+  const [renderMarkdown, changeRenderMarkdown] = useState(false)
+  return (
+    <div>
+      {renderMarkdown ? (
+        <Markdown className={className}>{props.value}</Markdown>
+      ) : (
+        <TextArea
+          autoFocus={props.autoFocus}
+          className={className}
+          disabled={props.disabled}
+          hasError={props.errorMessage && props.errorMessage.length > 0}
+          name={props.name}
+          onChange={props.onChange}
+          placeholder={props.placeholder}
+          readOnly={props.readOnly}
+          required={props.required}
+          value={props.value}
+        />
+      )}
+      <div className="flex">
+        <span className="grow"></span>
+        <label className="text-sm mr-1 font-medium text-gray-700">
+          Preview
+        </label>
+        <Toggle
+          onChange={(n, value) => {
+            changeRenderMarkdown(value)
+          }}
+          name="renderMarkdown"
+          title="Preview"
+          value={renderMarkdown}
+        />
+      </div>
+    </div>
+  )
+}
+MarkdownField.defaultProps = {
+  autoFocus: false,
+  disabled: false,
+  errorMessage: null,
+  readOnly: false,
+  required: false,
+  rows: 3
+}
+MarkdownField.propTypes = {
+  autoFocus: PropTypes.bool,
+  disabled: PropTypes.bool,
+  errorMessage: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  rows: PropTypes.number,
+  value: PropTypes.string
+}

--- a/src/js/schema/Columns.js
+++ b/src/js/schema/Columns.js
@@ -42,6 +42,7 @@ export const Column = {
     'hidden',
     'icon',
     'internal',
+    'markdown',
     'number',
     'select',
     'text',

--- a/src/js/views/Project/Create/Attributes.jsx
+++ b/src/js/views/Project/Create/Attributes.jsx
@@ -122,9 +122,10 @@ function Attributes({ localState, localDispatch }) {
         title={t('common.description')}
         name="description"
         description={t('project.descriptionDescription')}
-        type="textarea"
+        type="markdown"
         onChange={onChange}
         errorMessage={errors.description}
+        value={localState.attributes.description}
       />
       <Form.Field
         title={t('project.environments')}

--- a/src/js/views/Project/Edit.jsx
+++ b/src/js/views/Project/Edit.jsx
@@ -349,7 +349,7 @@ function Edit({ project, onEditFinished }) {
             title={t('common.description')}
             name="description"
             description={t('project.descriptionDescription')}
-            type="textarea"
+            type="markdown"
             onChange={onValueChange}
             errorMessage={state.projectErrors.description}
             value={state.values.description}


### PR DESCRIPTION
Tailwind CSS removes styling for headings, offsets, margins, and other similar things.  However, the Markdown implementation renders using HTML elements and expects them to be styled.  This PR adds a few styles back into the mix so that we can use them in our markdown views.

I also added a `markdown` field type to `Form.Field` which is a text area field with a toggle that will render the text as markdown in a panel.  I switched the Project description to use this component and plan on using it for the Project Notes as well.