### PR TITLE
Exit early when comparing facts to fields if equal

### DIFF
--- a/src/js/views/Project/EditFacts.jsx
+++ b/src/js/views/Project/EditFacts.jsx
@@ -15,6 +15,10 @@ function ISO8601ToDatetimeLocal(isoDate) {
 }
 
 function isDifferent(factValue, fieldValue, factDataType) {
+  if (factValue === fieldValue) {
+    return false
+  }
+
   function normalizedFact() {
     if (factDataType === 'timestamp') return ISO8601ToDatetimeLocal(factValue)
     if (factDataType === 'decimal') return parseFloat(factValue)


### PR DESCRIPTION
This fixes a bug where decimal fact/fields were converted to NaN via parseFloat, and then compared, but NaN !== NaN, so it would (wrongly) consider them different.