### PR TITLE
Grab project fact types from settings in feed

### DIFF
--- a/src/js/views/Project/Overview.jsx
+++ b/src/js/views/Project/Overview.jsx
@@ -73,7 +73,7 @@ function Overview({ factTypes, project, refresh, urlPath }) {
         <div
           className="flex-auto lg:w-6/12 w-full"
           style={height ? { height: height } : null}>
-          <ProjectFeed factTypes={factTypes} projectID={project.id} />
+          <ProjectFeed projectID={project.id} />
         </div>
       </div>
     </Fragment>

--- a/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
+++ b/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 
 const FETCH_LIMIT = 25
 
-function ProjectFeed({ projectID, factTypes }) {
+function ProjectFeed({ projectID }) {
   const [state, dispatch] = useContext(Context)
   const [factHistory, setFactHistory] = useState({
     entries: [],
@@ -58,7 +58,9 @@ function ProjectFeed({ projectID, factTypes }) {
   }
 
   function normalizeFactHistory(entries) {
-    const factTypeById = new Map(factTypes.map((f) => [f.id, f]))
+    const factTypeById = new Map(
+      state.metadata.projectFactTypes.map((f) => [f.id, f])
+    )
     return entries.map((f) => ({
       ...f,
       project_fact_type: factTypeById.get(f.fact_type_id).name,
@@ -135,7 +137,6 @@ function ProjectFeed({ projectID, factTypes }) {
   )
 }
 ProjectFeed.propTypes = {
-  projectID: PropTypes.number.isRequired,
-  factTypes: PropTypes.arrayOf(PropTypes.object).isRequired
+  projectID: PropTypes.number.isRequired
 }
 export { ProjectFeed }


### PR DESCRIPTION
Removes an unnecessary prop.

This also fixes a bug where if you change the project's type to one with different fact types, any now-missing types would trigger reference errors in the `.name` access. Using the settings metadata always contains all types so this doesn't happen.