### PR TITLE
Ops log fixes

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -272,7 +272,8 @@ export default {
         descriptionDescription: 'Single line description of the change',
         versionDescription: 'Version that the change was made for',
         linkDescription: 'Additional context to the slug',
-        notesDescription: 'Notes in markdown format'
+        notesDescription: 'Notes in markdown format',
+        requestError: 'Error making API request for Operations log ({{error}}).'
       },
       project: {
         archived: 'This project is archived and is read-only.',

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -88,7 +88,7 @@ function OperationsLog() {
         )
         setDeletedID(null)
       } else {
-        setErrorMessage(t('projects.requestError', { error: data }))
+        setErrorMessage(t('operationsLog.requestError', { error: data }))
       }
       setFetching(false)
       setOnFetch(false)

--- a/src/js/views/Projects/Projects.jsx
+++ b/src/js/views/Projects/Projects.jsx
@@ -52,6 +52,18 @@ function Projects() {
         }
   })
 
+  useEffect(() => {
+    const url = new URL('/ui/projects', globalState.baseURL)
+    url.search = searchParams.toString()
+    dispatch({
+      type: 'SET_CURRENT_PAGE',
+      payload: {
+        url: url,
+        title: 'projects.title'
+      }
+    })
+  }, [])
+
   function updateParams() {
     setSearchParams(
       new URLSearchParams({


### PR DESCRIPTION
- replace project-specific error text with ops log one
- re-add breadcrumb for projects page that was accidentally removed