### PR TITLE
Various Ops Log touch ups

### DIFF
--- a/src/js/components/DescriptionList/Definition.jsx
+++ b/src/js/components/DescriptionList/Definition.jsx
@@ -7,7 +7,7 @@ function Definition({ term, icon, children, className }) {
     <div>
       <dt className="font-medium text-gray-500 w-48">{term}</dt>
       <dd
-        className={`mt-1 items-start truncate ${
+        className={`mt-1 items-start ${
           className !== undefined ? className : ''
         }`}>
         {icon && <Icon icon={icon} className="mr-2 " />}

--- a/src/js/components/Markdown/Markdown.jsx
+++ b/src/js/components/Markdown/Markdown.jsx
@@ -7,7 +7,7 @@ class Link extends React.PureComponent {
     return (
       <a
         href={this.props.href}
-        className="text-blue-600 hover:text-blue-800 whitespace-pre-wrap"
+        className="text-blue-600 hover:text-blue-800p"
         rel="noreferrer"
         target="_blank">
         {this.props.children}
@@ -36,7 +36,7 @@ UL.propTypes = {
 
 class Paragraph extends React.PureComponent {
   render() {
-    return <p className="pb-1 whitespace-pre-wrap">{this.props.children}</p>
+    return <p className="pb-1">{this.props.children}</p>
   }
 }
 Paragraph.propTypes = {
@@ -50,29 +50,15 @@ class Heading extends React.PureComponent {
   }
   render() {
     if (this.level === 1) {
-      return (
-        <h1 className="text-xl pb-2 text-bold whitespace-pre-wrap">
-          {this.props.children}
-        </h1>
-      )
+      return <h1 className="text-xl pb-2 text-bold">{this.props.children}</h1>
     }
     if (this.level === 2) {
-      return (
-        <h2 className="text-lg pb-1 text-bold whitespace-pre-wrap">
-          {this.props.children}
-        </h2>
-      )
+      return <h2 className="text-lg pb-1 text-bold">{this.props.children}</h2>
     }
     if (this.level === 3) {
-      return (
-        <h3 className="pb-1 text-bold whitespace-pre-wrap">
-          {this.props.children}
-        </h3>
-      )
+      return <h3 className="pb-1 text-bold">{this.props.children}</h3>
     }
-    return (
-      <p className="text-bold whitespace-pre-wrap">{this.props.children}</p>
-    )
+    return <p className="text-bold">{this.props.children}</p>
   }
 }
 Heading.propTypes = {

--- a/src/js/components/Markdown/Markdown.jsx
+++ b/src/js/components/Markdown/Markdown.jsx
@@ -7,7 +7,7 @@ class Link extends React.PureComponent {
     return (
       <a
         href={this.props.href}
-        className="text-blue-600 hover:text-blue-800"
+        className="text-blue-600 hover:text-blue-800 whitespace-pre-wrap"
         rel="noreferrer"
         target="_blank">
         {this.props.children}
@@ -36,7 +36,7 @@ UL.propTypes = {
 
 class Paragraph extends React.PureComponent {
   render() {
-    return <p className="pb-1">{this.props.children}</p>
+    return <p className="pb-1 whitespace-pre-wrap">{this.props.children}</p>
   }
 }
 Paragraph.propTypes = {
@@ -50,15 +50,29 @@ class Heading extends React.PureComponent {
   }
   render() {
     if (this.level === 1) {
-      return <h1 className="text-xl pb-2 text-bold">{this.props.children}</h1>
+      return (
+        <h1 className="text-xl pb-2 text-bold whitespace-pre-wrap">
+          {this.props.children}
+        </h1>
+      )
     }
     if (this.level === 2) {
-      return <h2 className="text-lg pb-1 text-bold">{this.props.children}</h2>
+      return (
+        <h2 className="text-lg pb-1 text-bold whitespace-pre-wrap">
+          {this.props.children}
+        </h2>
+      )
     }
     if (this.level === 3) {
-      return <h3 className="pb-1 text-bold">{this.props.children}</h3>
+      return (
+        <h3 className="pb-1 text-bold whitespace-pre-wrap">
+          {this.props.children}
+        </h3>
+      )
     }
-    return <p className="text-bold">{this.props.children}</p>
+    return (
+      <p className="text-bold whitespace-pre-wrap">{this.props.children}</p>
+    )
   }
 }
 Heading.propTypes = {

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -63,7 +63,7 @@ function Display({ entry }) {
       )}
       {entry.notes && (
         <Definition term={t('operationsLog.notes')}>
-          <Markdown className="overflow-auto whitespace-pre-wrap max-h-[70vh] border-solid border-2 p-2 rounded">
+          <Markdown className="overflow-auto max-h-[70vh] border-solid border-2 p-2 rounded">
             {entry.notes}
           </Markdown>
         </Definition>

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -54,11 +54,9 @@ function Display({ entry }) {
       )}
       {entry.notes && (
         <Definition term={t('operationsLog.notes')}>
-          {
-            <Markdown className="overflow-auto max-h-[70vh] border-solid border-2 p-2 rounded">
-              {entry.notes}
-            </Markdown>
-          }
+          <Markdown className="overflow-auto max-h-[70vh] border-solid border-2 p-2 rounded">
+            {entry.notes}
+          </Markdown>
         </Definition>
       )}
     </DescriptionList>

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -11,11 +11,16 @@ function Display({ entry }) {
 
   return (
     <DescriptionList>
-      <Definition term={t('operationsLog.changeType')}>
-        {entry.change_type}
-      </Definition>
       <Definition term={t('operationsLog.environment')}>
         {entry.environment}
+      </Definition>
+      {(entry.project_name || entry.project_id) && (
+        <Definition term={t('operationsLog.project')}>
+          {entry.project_name || entry.project_id}
+        </Definition>
+      )}
+      <Definition term={t('operationsLog.changeType')}>
+        {entry.change_type}
       </Definition>
       <Definition term={t('operationsLog.recordedAt')}>
         {DateTime.fromISO(entry.recorded_at).toLocaleString(
@@ -32,11 +37,6 @@ function Display({ entry }) {
       {entry.description && (
         <Definition term={t('operationsLog.description')}>
           {entry.description}
-        </Definition>
-      )}
-      {(entry.project_name || entry.project_id) && (
-        <Definition term={t('operationsLog.project')}>
-          {entry.project_name || entry.project_id}
         </Definition>
       )}
       {entry.version && (

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -63,7 +63,7 @@ function Display({ entry }) {
       )}
       {entry.notes && (
         <Definition term={t('operationsLog.notes')}>
-          <Markdown className="overflow-auto max-h-[70vh] border-solid border-2 p-2 rounded">
+          <Markdown className="overflow-auto max-h-[30vh] border-solid border-2 p-2 rounded">
             {entry.notes}
           </Markdown>
         </Definition>

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -63,7 +63,7 @@ function Display({ entry }) {
       )}
       {entry.notes && (
         <Definition term={t('operationsLog.notes')}>
-          <Markdown className="overflow-auto max-h-[70vh] border-solid border-2 p-2 rounded">
+          <Markdown className="overflow-auto whitespace-pre-wrap max-h-[70vh] border-solid border-2 p-2 rounded">
             {entry.notes}
           </Markdown>
         </Definition>

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { DateTime } from 'luxon'
-import { Markdown } from '../../components'
+import { Icon, Markdown } from '../../components'
 import { useTranslation } from 'react-i18next'
 import { DescriptionList } from '../../components/DescriptionList/DescriptionList'
 import { Definition } from '../../components/DescriptionList/Definition'
@@ -50,7 +50,16 @@ function Display({ entry }) {
         </Definition>
       )}
       {entry.link && (
-        <Definition term={t('operationsLog.link')}>{entry.link}</Definition>
+        <Definition term={t('operationsLog.link')}>
+          <a
+            className="text-blue-800 hover:text-blue-700"
+            href={entry.link}
+            title={entry.link}
+            target="_new">
+            <Icon icon="fas external-link-alt" className="mr-2" />
+            {entry.link}
+          </a>
+        </Definition>
       )}
       {entry.notes && (
         <Definition term={t('operationsLog.notes')}>

--- a/src/js/views/OperationsLog/Edit.jsx
+++ b/src/js/views/OperationsLog/Edit.jsx
@@ -8,9 +8,10 @@ import { useTranslation } from 'react-i18next'
 import { httpGet, httpPatch, ISO8601ToDatetimeLocal } from '../../utils'
 import { compare } from 'fast-json-patch'
 
-function Edit({ onCancel, onError, onSuccess, saving, operationsLog }) {
+function Edit({ onCancel, onError, onSuccess, operationsLog }) {
   const [globalState] = useContext(Context)
   const [fieldValues, setFieldValues] = useState()
+  const [saving, setSaving] = useState(false)
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -42,6 +43,7 @@ function Edit({ onCancel, onError, onSuccess, saving, operationsLog }) {
   }, [])
 
   async function onSubmit() {
+    setSaving(true)
     const url = new URL(
       `/operations-log/${operationsLog.id}`,
       globalState.baseURL
@@ -65,10 +67,12 @@ function Edit({ onCancel, onError, onSuccess, saving, operationsLog }) {
 
     const patchValue = compare(oldValues, newValues)
     if (patchValue.length === 0) {
+      setSaving(false)
       onCancel()
       return
     }
     const response = await httpPatch(globalState.fetch, url, patchValue)
+    setSaving(false)
     if (response.success) {
       onSuccess()
     } else {
@@ -210,7 +214,6 @@ Edit.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
   onSuccess: PropTypes.func.isRequired,
-  saving: PropTypes.bool.isRequired,
   operationsLog: PropTypes.object.isRequired
 }
 export { Edit }

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -37,6 +37,7 @@ function OperationsLog() {
   const [errorMessage, setErrorMessage] = useState()
   const [showHelp, setShowHelp] = useState(false)
   const [slideOverOpen, setSlideOverOpen] = useState(false)
+  const [selectedEntry, setSelectedEntry] = useState()
   const { t } = useTranslation()
 
   if (searchParams.get('v') && !slideOverOpen) {
@@ -182,6 +183,7 @@ function OperationsLog() {
           newParams.set('v', data.id)
           setSearchParams(newParams)
           setSlideOverOpen(true)
+          setSelectedEntry(data)
         }}
         checkIsHighlighted={(row) => row.id === parseInt(searchParams.get('v'))}
       />
@@ -197,8 +199,10 @@ function OperationsLog() {
             setUpdated(false)
           }
           setSlideOverOpen(false)
+          setSelectedEntry(null)
         }}>
         <ViewOperationsLog
+          cachedEntry={selectedEntry}
           operationsLogID={parseInt(searchParams.get('v'))}
           onUpdate={() => setUpdated(true)}
           onDelete={(operationsLogID) => {

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -111,6 +111,23 @@ function OperationsLog() {
       }
     },
     {
+      title: t('operationsLog.environment'),
+      name: 'environment',
+      type: 'text',
+      tableOptions: {
+        headerClassName: 'w-2/12'
+      }
+    },
+    {
+      title: t('operationsLog.project'),
+      name: 'project_name',
+      type: 'text',
+      tableOptions: {
+        headerClassName: 'w-2/12',
+        className: 'truncate'
+      }
+    },
+    {
       title: t('operationsLog.changeType'),
       name: 'change_type',
       type: 'text',
@@ -124,23 +141,6 @@ function OperationsLog() {
       type: 'text',
       tableOptions: {
         className: 'truncate'
-      }
-    },
-    {
-      title: t('operationsLog.project'),
-      name: 'project_name',
-      type: 'text',
-      tableOptions: {
-        headerClassName: 'w-2/12',
-        className: 'truncate'
-      }
-    },
-    {
-      title: t('operationsLog.environment'),
-      name: 'environment',
-      type: 'text',
-      tableOptions: {
-        headerClassName: 'w-2/12'
       }
     },
     {

--- a/src/js/views/OperationsLog/ViewOperationsLog.jsx
+++ b/src/js/views/OperationsLog/ViewOperationsLog.jsx
@@ -9,10 +9,15 @@ import { Error } from '../Error'
 import { Display } from './Display'
 import { Edit } from './Edit'
 
-function ViewOperationsLog({ operationsLogID, onUpdate, onDelete }) {
+function ViewOperationsLog({
+  cachedEntry,
+  operationsLogID,
+  onUpdate,
+  onDelete
+}) {
   const [globalState] = useContext(Context)
   const { t } = useTranslation()
-  const [entry, setEntry] = useState()
+  const [entry, setEntry] = useState(cachedEntry)
   const [error, setError] = useState()
   const [isEditing, setIsEditing] = useState(false)
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
@@ -58,7 +63,7 @@ function ViewOperationsLog({ operationsLogID, onUpdate, onDelete }) {
   }
 
   useEffect(() => {
-    loadOpsLog()
+    if (!cachedEntry) loadOpsLog()
   }, [])
 
   if (!entry) return <></>
@@ -110,6 +115,7 @@ function ViewOperationsLog({ operationsLogID, onUpdate, onDelete }) {
   )
 }
 ViewOperationsLog.propTypes = {
+  cachedEntry: PropTypes.object,
   operationsLogID: PropTypes.number.isRequired,
   onUpdate: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired

--- a/src/js/views/OperationsLog/ViewOperationsLog.jsx
+++ b/src/js/views/OperationsLog/ViewOperationsLog.jsx
@@ -34,6 +34,7 @@ function ViewOperationsLog({
         if (!data.project_id) {
           setEntry(data)
         } else {
+          setEntry({ ...data, project_name: '-' })
           const opsLog = data
           httpGet(
             globalState.fetch,

--- a/src/js/views/OperationsLog/ViewOperationsLog.jsx
+++ b/src/js/views/OperationsLog/ViewOperationsLog.jsx
@@ -83,7 +83,6 @@ function ViewOperationsLog({
       )}
       {isEditing ? (
         <Edit
-          saving={false}
           operationsLog={entry}
           onError={(error) => setError(error)}
           onCancel={() => setIsEditing(false)}


### PR DESCRIPTION
- reorder ops log table columns & view fields
- when clicking an ops log entry in the table, load the slideout data immediately by using the data already fetched for the row
- when fetching and displaying an individual ops log entry, don't wait for the second fetch for the project name to start displaying data, display a placeholder during the second request and fill it out upon response
- make ops log link field a link
- fix saving state when editing ops log entry, so the cancel/edit buttons are disabled during the saving state
- allow ops log note markdown text wrapping so there is no scroll

closes AWeber-Imbi/imbi-ui#25
closes AWeber-Imbi/imbi-ui#27