### PR TITLE
Project ops log tab

### DIFF
--- a/src/js/views/Main.jsx
+++ b/src/js/views/Main.jsx
@@ -51,7 +51,7 @@ function Main({ user }) {
                 />
                 <Route
                   path="/ui/operations-log"
-                  element={<OperationsLog user={user} />}
+                  element={<OperationsLog user={user} className="px-4 py-3" />}
                 />
                 <Route
                   path="/ui/projects/create"

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -108,59 +108,67 @@ function OperationsLog({ projectID, className }) {
     return new URL(path, globalState.baseURL)
   }
 
-  const columns = [
-    {
-      title: t('operationsLog.recordedAt'),
-      name: 'recorded_at',
-      type: 'datetime',
-      tableOptions: {
-        headerClassName: 'w-2/12 truncate',
-        className: 'truncate'
+  function buildColumns() {
+    const columns = [
+      {
+        title: t('operationsLog.recordedAt'),
+        name: 'recorded_at',
+        type: 'datetime',
+        tableOptions: {
+          headerClassName: 'w-2/12 truncate',
+          className: 'truncate'
+        }
+      },
+      {
+        title: t('operationsLog.environment'),
+        name: 'environment',
+        type: 'text',
+        tableOptions: {
+          headerClassName: 'w-2/12'
+        }
       }
-    },
-    {
-      title: t('operationsLog.environment'),
-      name: 'environment',
-      type: 'text',
-      tableOptions: {
-        headerClassName: 'w-2/12'
-      }
-    },
-    {
-      title: t('operationsLog.project'),
-      name: 'project_name',
-      type: 'text',
-      tableOptions: {
-        headerClassName: 'w-2/12',
-        className: 'truncate'
-      }
-    },
-    {
-      title: t('operationsLog.changeType'),
-      name: 'change_type',
-      type: 'text',
-      tableOptions: {
-        headerClassName: 'w-2/12 truncate'
-      }
-    },
-    {
-      title: t('operationsLog.description'),
-      name: 'description',
-      type: 'text',
-      tableOptions: {
-        className: 'truncate'
-      }
-    },
-    {
-      title: t('operationsLog.recordedBy'),
-      name: 'recorded_by',
-      type: 'text',
-      tableOptions: {
-        headerClassName: 'w-2/12 truncate',
-        className: 'truncate'
-      }
+    ]
+
+    if (!projectID) {
+      columns.push({
+        title: t('operationsLog.project'),
+        name: 'project_name',
+        type: 'text',
+        tableOptions: {
+          headerClassName: 'w-2/12',
+          className: 'truncate'
+        }
+      })
     }
-  ]
+
+    return columns.concat([
+      {
+        title: t('operationsLog.changeType'),
+        name: 'change_type',
+        type: 'text',
+        tableOptions: {
+          headerClassName: 'w-2/12 truncate'
+        }
+      },
+      {
+        title: t('operationsLog.description'),
+        name: 'description',
+        type: 'text',
+        tableOptions: {
+          className: 'truncate'
+        }
+      },
+      {
+        title: t('operationsLog.recordedBy'),
+        name: 'recorded_by',
+        type: 'text',
+        tableOptions: {
+          headerClassName: 'w-2/12 truncate',
+          className: 'truncate'
+        }
+      }
+    ])
+  }
 
   return (
     <div className={`m-0 space-y-3 ${className}`}>
@@ -184,7 +192,7 @@ function OperationsLog({ projectID, className }) {
         value={filter}
       />
       <Table
-        columns={columns}
+        columns={buildColumns()}
         data={rows}
         onRowClick={(data) => {
           const newParams = cloneParams(searchParams)

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -24,7 +24,7 @@ function cloneParams(searchParams) {
   return newParams
 }
 
-function OperationsLog({ projectID }) {
+function OperationsLog({ projectID, className }) {
   const [globalState, dispatch] = useContext(Context)
   const [searchParams, setSearchParams] = useSearchParams()
   const [filter, setFilter] = useState(
@@ -163,7 +163,7 @@ function OperationsLog({ projectID }) {
   ]
 
   return (
-    <div className="m-0 px-4 py-3 space-y-3 grow">
+    <div className={`m-0 space-y-3 ${className}`}>
       {errorMessage && (
         <Alert className="mt-3" level="error">
           {errorMessage}

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -14,6 +14,7 @@ import { HelpDialog } from '../Projects/HelpDialog'
 import { useSearchParams } from 'react-router-dom'
 import { ViewOperationsLog } from './ViewOperationsLog'
 import { SlideOver } from '../../components/SlideOver/SlideOver'
+import PropTypes from 'prop-types'
 
 function cloneParams(searchParams) {
   const newParams = new URLSearchParams()
@@ -23,7 +24,7 @@ function cloneParams(searchParams) {
   return newParams
 }
 
-function OperationsLog() {
+function OperationsLog({ projectID }) {
   const [globalState, dispatch] = useContext(Context)
   const [searchParams, setSearchParams] = useSearchParams()
   const [filter, setFilter] = useState(
@@ -65,9 +66,16 @@ function OperationsLog() {
     if (fetching || !onFetch) return
     setFetching(true)
 
-    const query = {
+    let query = filter.trim()
+    if (projectID) {
+      query += query
+        ? ` AND project_id:${projectID}`
+        : `project_id:${projectID}`
+    }
+
+    const payload = {
       query: toElasticsearchQuery(
-        fromKueryExpression(filter),
+        fromKueryExpression(query),
         metadataAsOptions.openSearch
       ),
       sort: [{ recorded_at: { order: 'desc' } }],
@@ -78,7 +86,7 @@ function OperationsLog() {
     httpPost(
       globalState.fetch,
       buildURL('/opensearch/operations-log'),
-      query
+      payload
     ).then(({ data, success }) => {
       if (success) {
         setErrorMessage(null)
@@ -235,5 +243,8 @@ function OperationsLog() {
       )}
     </div>
   )
+}
+OperationsLog.propTypes = {
+  projectID: PropTypes.number
 }
 export { OperationsLog }

--- a/src/js/views/Project/Project.jsx
+++ b/src/js/views/Project/Project.jsx
@@ -27,6 +27,7 @@ import { Logs } from './Logs'
 import { Notes } from './Notes'
 import { Overview } from './Overview'
 import { Settings } from './Settings'
+import { OperationsLog } from '../OperationsLog'
 
 function ProjectPage({ project, factTypes, refresh }) {
   const [state, dispatch] = useContext(Context)
@@ -108,11 +109,7 @@ function ProjectPage({ project, factTypes, refresh }) {
           <Tab to={`${baseURL}/dependencies`}>{t('project.dependencies')}</Tab>
           <Tab to={`${baseURL}/logs`}>{t('common.logs')}</Tab>
           <Tab to={`${baseURL}/notes`}>{t('common.notes')}</Tab>
-          <Tab
-            to={`/ui/operations-log?f=${encodeURIComponent(
-              `project_id:${project.id}`
-            )}`}
-            isLast={project.archived}>
+          <Tab to={`${baseURL}/operations-log`} isLast={project.archived}>
             {t('operationsLog.title')}
           </Tab>
           {project.archived !== true && (
@@ -145,6 +142,10 @@ function ProjectPage({ project, factTypes, refresh }) {
           <Route
             path={`notes`}
             element={<Notes project={project} urlPath={baseURL} />}
+          />
+          <Route
+            path={`operations-log`}
+            element={<OperationsLog projectID={project.id} />}
           />
           <Route
             path={`settings`}

--- a/src/js/views/Projects/HelpDialog.jsx
+++ b/src/js/views/Projects/HelpDialog.jsx
@@ -21,7 +21,7 @@ function HelpDialog({ title, searchHelp, fields, onClose }) {
           </a>
         </span>
         <h1 className="my-4 font-bold">{t('projects.searchHelpFields')}</h1>
-        <ul className="list-disc list-inside max-h-96 ml-5 font-mono overflow-scroll">
+        <ul className="list-disc list-inside max-h-96 ml-5 font-mono overflow-auto">
           {fields.sort(byString()).map((field) => {
             return <li key={`field-` + field}>{field}</li>
           })}


### PR DESCRIPTION
- Reuses the OperationsLog component for the project-specific ops log tab. It removes the project column since it's redundant
- Removes unnecessary scrollbar padding on the help dialog if it doesn't need to scroll