### PR TITLE
Fix breadcrumbs in project-specific ops log tab

### DIFF
--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -24,7 +24,7 @@ function cloneParams(searchParams) {
   return newParams
 }
 
-function OperationsLog({ projectID, className }) {
+function OperationsLog({ projectID, urlPath, className }) {
   const [globalState, dispatch] = useContext(Context)
   const [searchParams, setSearchParams] = useSearchParams()
   const [filter, setFilter] = useState(
@@ -53,11 +53,12 @@ function OperationsLog({ projectID, className }) {
   }
 
   useEffect(() => {
+    const path = urlPath ? `${urlPath}/operations-log` : 'ui/operations-log'
     dispatch({
       type: 'SET_CURRENT_PAGE',
       payload: {
         title: 'operationsLog.title',
-        url: new URL('/ui/operations-log', globalState.baseURL)
+        url: new URL(path, globalState.baseURL)
       }
     })
   }, [])
@@ -253,6 +254,8 @@ function OperationsLog({ projectID, className }) {
   )
 }
 OperationsLog.propTypes = {
-  projectID: PropTypes.number
+  projectID: PropTypes.number,
+  urlPath: PropTypes.string,
+  className: PropTypes.string
 }
 export { OperationsLog }

--- a/src/js/views/Project/Project.jsx
+++ b/src/js/views/Project/Project.jsx
@@ -145,7 +145,7 @@ function ProjectPage({ project, factTypes, refresh }) {
           />
           <Route
             path={`operations-log`}
-            element={<OperationsLog projectID={project.id} />}
+            element={<OperationsLog projectID={project.id} urlPath={baseURL} />}
           />
           <Route
             path={`settings`}


### PR DESCRIPTION
Fixes project-specific ops log tab breadcrumbs so you see 'Projects -> Project Name -> Operations Log' instead of just 'Operations Log'