### PR TITLE
Filter out unexpected project feed entries

### DIFF
--- a/src/js/views/Dashboard/ActivityFeed/Feed.jsx
+++ b/src/js/views/Dashboard/ActivityFeed/Feed.jsx
@@ -24,8 +24,11 @@ function Feed({ onReady }) {
         globalState.fetch,
         url,
         (result) => {
+          // defaulting 'type' to 'ProjectFeedType' for backwards compatibility
           setState({
-            data: result,
+            data: result.filter(
+              (f) => (f.type || 'ProjectFeedEntry') === 'ProjectFeedEntry'
+            ),
             fetched: true,
             errorMessage: null
           })

--- a/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
+++ b/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
@@ -61,13 +61,16 @@ function ProjectFeed({ projectID }) {
     const factTypeById = new Map(
       state.metadata.projectFactTypes.map((f) => [f.id, f])
     )
-    return entries.map((f) => ({
-      ...f,
-      project_fact_type: factTypeById.get(f.fact_type_id).name,
-      recorded_at: DateTime.fromISO(f.recorded_at).toLocaleString(
-        DateTime.DATETIME_MED
-      )
-    }))
+    // defaulting 'type' to 'ProjectFeedType' for backwards compatibility
+    return entries
+      .filter((f) => (f.type || 'ProjectFeedEntry') === 'ProjectFeedEntry')
+      .map((f) => ({
+        ...f,
+        project_fact_type: factTypeById.get(f.fact_type_id).name,
+        recorded_at: DateTime.fromISO(f.recorded_at).toLocaleString(
+          DateTime.DATETIME_MED
+        )
+      }))
   }
 
   let content


### PR DESCRIPTION
This ensures that we are not going to render feed entries that we do not understand.  Currently the only feed type that we recognize is `ProjectFeedEntry`.  This is the first step in adding support for ops log entries in the project feed (#30) and the dashboard activity feed (#31).  Once this is in place, the server and client can be developed independently.