### PR TITLE
Fix ProjectPicker not clearing project list on change

### DIFF
--- a/src/js/components/Form/ProjectPicker.jsx
+++ b/src/js/components/Form/ProjectPicker.jsx
@@ -44,7 +44,9 @@ function ProjectPicker({
       globalState.fetch,
       projectURL,
       ({ data }) => {
-        setProjects((prevState) => prevState.concat(data.data))
+        setProjects((prevState) =>
+          offset === 0 ? data.data : prevState.concat(data.data)
+        )
         if (data.rows > offset + limit) {
           fetchProjects(offset + limit)
         }


### PR DESCRIPTION
Quick fix where the project list for the projects select dropdown wasn't being cleared out when the user changed the namespace or project type. This means project options in the dropdown would just continue accumulating if you changed the namespace or project type.