### PR TITLE
Add external identifier management for a project

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -357,6 +357,9 @@ export default {
             externalId: 'Identifier'
           },
           addIdentifier: 'Add Identifier',
+          deleteTitle: 'Delete {{integrationName}} identifier',
+          deleteConfirmation:
+            'Are you sure you would like to delete this identifier?',
           externalId: 'External ID',
           integrationName: 'Integration Name',
           identifierTitle: 'Identifier for {{integrationName}}',

--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -65,6 +65,7 @@ export default {
         projects: 'Projects',
         projectInfo: 'Project Information',
         projectFacts: 'Project Facts',
+        projectIdentifiers: 'Project Identifiers',
         projectNote: 'Note',
         projectNotes: 'Notes',
         projectType: 'Project Type',
@@ -347,6 +348,12 @@ export default {
           repoCreated: 'GitLab Repository Created'
         },
         id: 'Project ID',
+        identifiers: {
+          columns: {
+            owner: 'Identifier Owner',
+            externalId: 'Identifier'
+          }
+        },
         links: 'Links',
         linksSaved: 'Links Saved',
         logs: 'Logs',

--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -6,6 +6,7 @@ export default {
         cancel: 'Cancel',
         close: 'Close',
         configuration: 'Configuration',
+        createdAt: 'Created At',
         createdBy: 'Created By',
         description: 'Description',
         delete: 'Delete',
@@ -21,6 +22,8 @@ export default {
         initializing: 'Initializing',
         invalidURL: 'Value does not appear to be a URL',
         lastUpdated: 'Last Updated: {{date}}',
+        lastUpdatedBy: 'Last Updated By',
+        lastUpdatedTitle: 'Last Updated',
         loading: 'Loading',
         logs: 'Logs',
         name: 'Name',
@@ -352,7 +355,10 @@ export default {
           columns: {
             owner: 'Identifier Owner',
             externalId: 'Identifier'
-          }
+          },
+          externalId: 'External ID',
+          identifierTitle: 'Identifier for {{integrationName}}',
+          integrationName: 'Integration Name'
         },
         links: 'Links',
         linksSaved: 'Links Saved',

--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -356,9 +356,11 @@ export default {
             owner: 'Identifier Owner',
             externalId: 'Identifier'
           },
+          addIdentifier: 'Add Identifier',
           externalId: 'External ID',
+          integrationName: 'Integration Name',
           identifierTitle: 'Identifier for {{integrationName}}',
-          integrationName: 'Integration Name'
+          newIdentifier: 'New Identifier'
         },
         links: 'Links',
         linksSaved: 'Links Saved',

--- a/src/js/components/Form/Select.jsx
+++ b/src/js/components/Form/Select.jsx
@@ -48,7 +48,7 @@ function Select({
         (multiple === false ? ' truncate pr-6' : '') +
         (hasFocus === false && hasError === true ? ' border-red-700' : '')
       }
-      defaultValue={currentValue === null ? '' : currentValue}
+      value={currentValue === null ? '' : currentValue}
       disabled={disabled || readOnly}
       id={'field-' + name}
       multiple={multiple}

--- a/src/js/views/Identifiers/Display.jsx
+++ b/src/js/views/Identifiers/Display.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { DateTime } from 'luxon'
+import { Definition } from '../../components/DescriptionList/Definition'
+import { DescriptionList } from '../../components/DescriptionList/DescriptionList'
+import { useTranslation } from 'react-i18next'
+
+function Display({ entry }) {
+  const { t } = useTranslation()
+  return (
+    <DescriptionList>
+      <Definition term={t('project.identifiers.integrationName')}>
+        {entry.integration_name}
+      </Definition>
+      <Definition term={t('project.identifiers.externalId')}>
+        {entry.external_id}
+      </Definition>
+      <Definition term={t('common.createdAt')}>
+        {DateTime.fromISO(entry.created_at).toLocaleString(
+          DateTime.DATETIME_MED
+        )}
+      </Definition>
+      <Definition term={t('common.createdBy')}>{entry.created_by}</Definition>
+      <Definition term={t('common.lastUpdatedTitle')}>
+        {entry.last_modified_at === null
+          ? ''
+          : DateTime.fromISO(entry.last_modified_at).toLocaleString(
+              DateTime.DATETIME_MED
+            )}
+      </Definition>
+      <Definition term={t('common.lastUpdatedBy')}>
+        {entry.last_modified_by === null ? '' : entry.last_modified_by}
+      </Definition>
+    </DescriptionList>
+  )
+}
+
+Display.propTypes = {
+  entry: PropTypes.object.isRequired
+}
+export { Display }

--- a/src/js/views/Identifiers/Edit.jsx
+++ b/src/js/views/Identifiers/Edit.jsx
@@ -1,0 +1,118 @@
+import React, { useContext, useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import { ErrorBoundary, Form } from '../../components'
+import { httpPatch, ISO8601ToDatetimeLocal } from '../../utils'
+import { Context } from '../../state'
+import { useTranslation } from 'react-i18next'
+
+function Edit({ integrations, entry, onError, onCancel, onSuccess }) {
+  const { t } = useTranslation()
+  const [globalState] = useContext(Context)
+  const [fieldValues, setFieldValues] = useState()
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    const values = {
+      ...entry,
+      created_at: ISO8601ToDatetimeLocal(entry.created_at),
+      last_modified_at: entry.last_modified_at
+        ? ISO8601ToDatetimeLocal(entry.last_modified_at)
+        : entry.last_modified_at
+    }
+    setFieldValues(values)
+  }, [])
+
+  useEffect(() => {
+    if (!saving) return
+
+    let changes = []
+    if (fieldValues.external_id !== entry.external_id) {
+      changes = changes.concat([
+        {
+          op: 'replace',
+          path: '/external_id',
+          value: fieldValues.external_id
+        }
+      ])
+    }
+    if (fieldValues.integration_name !== entry.integration_name) {
+      changes = changes.concat([
+        {
+          op: 'replace',
+          path: '/integration_name',
+          value: fieldValues.integration_name
+        }
+      ])
+    }
+    if (changes.length === 0) {
+      setSaving(false)
+      onSuccess()
+      return
+    }
+
+    const update = async () => {
+      const response = await httpPatch(
+        globalState.fetch,
+        new URL(
+          `/projects/${entry.project_id}/identifiers/${entry.integration_name}`,
+          globalState.baseURL
+        ),
+        changes
+      )
+      if (response.success) {
+        setSaving(false)
+        onSuccess()
+      } else {
+        onError(response.data)
+      }
+    }
+    update().catch((error) => onError(error))
+  }, [saving])
+
+  function onValueChange(key, value) {
+    setFieldValues((prevState) => ({
+      ...prevState,
+      [key]: value
+    }))
+  }
+
+  if (!fieldValues) return <></>
+  return (
+    <ErrorBoundary>
+      <Form.SimpleForm
+        errorMessage={null}
+        onCancel={onCancel}
+        onSubmit={() => {
+          setSaving(true)
+        }}
+        ready={true}
+        saving={saving}>
+        <Form.Field
+          title={t('project.identifiers.columns.owner')}
+          name="integration_name"
+          type="select"
+          options={integrations.map((name) => ({ label: name, value: name }))}
+          value={fieldValues.integration_name}
+          required={true}
+          onChange={onValueChange}
+        />
+        <Form.Field
+          title={t('project.identifiers.columns.externalId')}
+          name="external_id"
+          type="text"
+          value={fieldValues.external_id}
+          required={true}
+          onChange={onValueChange}
+        />
+      </Form.SimpleForm>
+    </ErrorBoundary>
+  )
+}
+Edit.propTypes = {
+  integrations: PropTypes.arrayOf(PropTypes.string).isRequired,
+  entry: PropTypes.object.isRequired,
+  onError: PropTypes.func,
+  onCancel: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func.isRequired
+}
+export { Edit }

--- a/src/js/views/Identifiers/Identifiers.jsx
+++ b/src/js/views/Identifiers/Identifiers.jsx
@@ -50,14 +50,18 @@ function IdentifierTable({ integrations, identifiers, projectId, onChange }) {
 
   return (
     <>
-      <Table
-        columns={buildColumns()}
-        data={identifiers}
-        onRowClick={({ index }) => {
-          setSelectedIndex(index)
-          setViewSlideOverOpen(true)
-        }}
-      />
+      {identifiers.length > 0 ? (
+        <Table
+          columns={buildColumns()}
+          data={identifiers}
+          onRowClick={({ index }) => {
+            setSelectedIndex(index)
+            setViewSlideOverOpen(true)
+          }}
+        />
+      ) : (
+        <></>
+      )}
       <SlideOver
         title={t('project.identifiers.newIdentifier')}
         open={addSlideOverOpen}
@@ -128,7 +132,7 @@ IdentifierTable.propTypes = {
   onChange: PropTypes.func.isRequired
 }
 
-function Identifiers({ project }) {
+function Identifiers({ project, setIntegrationCount }) {
   const [globalState] = useContext(Context)
   const projectId = project.id
   const [identifiers, setIdentifiers] = useState(null)
@@ -162,6 +166,9 @@ function Identifiers({ project }) {
       ).then(({ data, success }) => {
         if (success) {
           setIntegrations(data.map((elm) => elm.name))
+          if (setIntegrationCount !== undefined) {
+            setIntegrationCount(data.length)
+          }
         }
       })
     }
@@ -185,7 +192,8 @@ function Identifiers({ project }) {
   )
 }
 Identifiers.propTypes = {
-  project: PropTypes.object.isRequired
+  project: PropTypes.object.isRequired,
+  setIntegrationCount: PropTypes.func
 }
 
 export { Identifiers }

--- a/src/js/views/Identifiers/Identifiers.jsx
+++ b/src/js/views/Identifiers/Identifiers.jsx
@@ -28,12 +28,18 @@ function IdentifierTable({ integrations, identifiers, projectId, onChange }) {
 
   const [addSlideOverOpen, setAddSlideOverOpen] = useState(false)
   const [viewSlideOverOpen, setViewSlideOverOpen] = useState(false)
-  const [selectedIdentifier, setSelectedIdentifier] = useState(null)
+  const [selectedIndex, setSelectedIndex] = useState(null)
   const [availableIntegrations, setAvailableIntegrations] =
     useState(integrations)
 
   function addIdentifier() {
     setAddSlideOverOpen(true)
+  }
+
+  function onIdentifierModified() {
+    setViewSlideOverOpen(false)
+    setSelectedIndex(null)
+    onChange()
   }
 
   useEffect(() => {
@@ -48,7 +54,7 @@ function IdentifierTable({ integrations, identifiers, projectId, onChange }) {
         columns={buildColumns()}
         data={identifiers}
         onRowClick={({ index }) => {
-          setSelectedIdentifier(identifiers[index])
+          setSelectedIndex(index)
           setViewSlideOverOpen(true)
         }}
       />
@@ -66,7 +72,7 @@ function IdentifierTable({ integrations, identifiers, projectId, onChange }) {
           onCancel={() => setAddSlideOverOpen(false)}
         />
       </SlideOver>
-      {selectedIdentifier !== null ? (
+      {selectedIndex !== null ? (
         <SlideOver
           open={viewSlideOverOpen}
           onClose={() => {
@@ -78,16 +84,19 @@ function IdentifierTable({ integrations, identifiers, projectId, onChange }) {
               i18n={i18n}
               t={t}>
               <span>
-                {{ integrationName: selectedIdentifier.integration_name }}
+                {{
+                  integrationName: identifiers[selectedIndex].integration_name
+                }}
               </span>
             </Trans>
           }>
           <ViewIdentifier
-            cachedIdentifier={selectedIdentifier}
-            onDelete={() => {
-              setViewSlideOverOpen(false)
-              onChange()
-            }}
+            cachedIdentifier={identifiers[selectedIndex]}
+            integrations={availableIntegrations.concat(
+              identifiers[selectedIndex].integration_name
+            )}
+            onDelete={onIdentifierModified}
+            onUpdate={onIdentifierModified}
           />
         </SlideOver>
       ) : (

--- a/src/js/views/Identifiers/Identifiers.jsx
+++ b/src/js/views/Identifiers/Identifiers.jsx
@@ -84,6 +84,10 @@ function IdentifierTable({ integrations, identifiers, projectId, onChange }) {
           }>
           <ViewIdentifier
             cachedIdentifier={selectedIdentifier}
+            onDelete={() => {
+              setViewSlideOverOpen(false)
+              onChange()
+            }}
           />
         </SlideOver>
       ) : (

--- a/src/js/views/Identifiers/Identifiers.jsx
+++ b/src/js/views/Identifiers/Identifiers.jsx
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types'
+import React, { Fragment, useContext, useEffect, useState } from 'react'
+import { Context } from '../../state'
+import { Alert, Loading, Table } from '../../components'
+import { httpRequest, requestOptions } from '../../utils'
+import { useTranslation } from 'react-i18next'
+
+function IdentifierTable({ identifiers }) {
+  const { t } = useTranslation()
+
+  function buildColumns() {
+    return [
+      {
+        title: t('project.identifiers.columns.owner'),
+        name: 'integration_name',
+        type: 'text'
+      },
+      {
+        title: t('project.identifiers.columns.externalId'),
+        name: 'external_id',
+        type: 'text'
+      }
+    ]
+  }
+
+  return <Table columns={buildColumns()} data={identifiers} />
+}
+IdentifierTable.propTypes = {
+  identifiers: PropTypes.arrayOf(PropTypes.object).isRequired
+}
+
+function Identifiers({ project }) {
+  const [globalState] = useContext(Context)
+  const projectId = project.id
+  const [identifiers, setIdentifiers] = useState(null)
+  const [errorMessage, setErrorMessage] = useState()
+
+  useEffect(() => {
+    if (identifiers === null) {
+      httpRequest(
+        globalState.fetch,
+        new URL(`/projects/${projectId}/identifiers`, globalState.baseURL),
+        requestOptions
+      ).then(({ data, success }) => {
+        if (success) {
+          setIdentifiers(data)
+        } else {
+          setErrorMessage(data.toString())
+        }
+      })
+    }
+  }, [projectId])
+
+  return errorMessage ? (
+    <Alert className="mt-3" level="error">
+      {errorMessage}
+    </Alert>
+  ) : identifiers === null ? (
+    <Loading />
+  ) : (
+    <IdentifierTable identifiers={identifiers} />
+  )
+}
+Identifiers.propTypes = {
+  project: PropTypes.object.isRequired
+}
+
+export { Identifiers }

--- a/src/js/views/Identifiers/Identifiers.jsx
+++ b/src/js/views/Identifiers/Identifiers.jsx
@@ -4,8 +4,10 @@ import { Context } from '../../state'
 import { Alert, Loading, Table } from '../../components'
 import { httpRequest, requestOptions } from '../../utils'
 import { useTranslation } from 'react-i18next'
+import { SlideOver } from '../../components/SlideOver/SlideOver'
+import { ViewIdentifier } from './ViewIdentifier'
 
-function IdentifierTable({ identifiers }) {
+function IdentifierTable({ identifiers, projectId }) {
   const { t } = useTranslation()
 
   function buildColumns() {
@@ -23,9 +25,42 @@ function IdentifierTable({ identifiers }) {
     ]
   }
 
-  return <Table columns={buildColumns()} data={identifiers} />
+  const [viewSlideOverOpen, setViewSlideOverOpen] = useState(false)
+  const [selectedIdentifier, setSelectedIdentifier] = useState(null)
+
+  return (
+    <>
+      <Table
+        columns={buildColumns()}
+        data={identifiers}
+        onRowClick={({ index }) => {
+          setSelectedIdentifier(identifiers[index])
+          setViewSlideOverOpen(true)
+        }}
+      />
+      {selectedIdentifier !== null ? (
+        <SlideOver
+          open={viewSlideOverOpen}
+          onClose={() => {
+            setViewSlideOverOpen(false)
+          }}
+          title={
+            <div>
+              {t('project.identifiers.identifierTitle', {
+                integrationName: selectedIdentifier.integration_name
+              })}
+            </div>
+          }>
+          <ViewIdentifier cachedIdentifier={selectedIdentifier} />
+        </SlideOver>
+      ) : (
+        <></>
+      )}
+    </>
+  )
 }
 IdentifierTable.propTypes = {
+  projectId: PropTypes.number.isRequired,
   identifiers: PropTypes.arrayOf(PropTypes.object).isRequired
 }
 
@@ -58,7 +93,7 @@ function Identifiers({ project }) {
   ) : identifiers === null ? (
     <Loading />
   ) : (
-    <IdentifierTable identifiers={identifiers} />
+    <IdentifierTable identifiers={identifiers} projectId={projectId} />
   )
 }
 Identifiers.propTypes = {

--- a/src/js/views/Identifiers/NewIdentifier.jsx
+++ b/src/js/views/Identifiers/NewIdentifier.jsx
@@ -1,0 +1,84 @@
+import { ErrorBoundary, Form } from '../../components'
+import React, { useContext, useEffect, useState } from 'react'
+import { httpPost } from '../../utils'
+import { Context } from '../../state'
+import PropTypes from 'prop-types'
+import { useTranslation } from 'react-i18next'
+
+function NewIdentifier({ integrations, onCancel, onSuccess, projectId }) {
+  const [globalState] = useContext(Context)
+  const { t } = useTranslation()
+  const [fields, setFields] = useState({
+    integration_name: null,
+    external_id: null
+  })
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!saving) return
+
+    const create = async () => {
+      const response = await httpPost(
+        globalState.fetch,
+        new URL(`/projects/${projectId}/identifiers`, globalState.baseURL),
+        {
+          integration_name: fields.integration_name,
+          external_id: fields.external_id
+        }
+      )
+      if (response.success) {
+        onSuccess(response.data)
+      } else {
+        setError(response.data)
+        setSaving(false)
+      }
+    }
+    create().catch((error) => {
+      setError(error.toString())
+    })
+  }, [saving])
+
+  function onValueChange(key, value) {
+    setFields((prevState) => ({
+      ...prevState,
+      [key]: value
+    }))
+  }
+
+  return (
+    <ErrorBoundary>
+      <Form.SimpleForm
+        errorMessage={error}
+        onCancel={onCancel}
+        onSubmit={() => {
+          setSaving(true)
+        }}
+        ready={true}
+        saving={saving}>
+        <Form.Field
+          title={t('project.identifiers.columns.owner')}
+          name="integration_name"
+          type="select"
+          value={integrations[0]}
+          options={integrations.map((name) => ({ label: name, value: name }))}
+          onChange={onValueChange}
+        />
+        <Form.Field
+          title={t('project.identifiers.columns.externalId')}
+          name="external_id"
+          type="text"
+          value={fields.external_id}
+          onChange={onValueChange}
+        />
+      </Form.SimpleForm>
+    </ErrorBoundary>
+  )
+}
+NewIdentifier.propTypes = {
+  integrations: PropTypes.arrayOf(PropTypes.string).isRequired,
+  projectId: PropTypes.number.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func.isRequired
+}
+export { NewIdentifier }

--- a/src/js/views/Identifiers/ViewIdentifier.jsx
+++ b/src/js/views/Identifiers/ViewIdentifier.jsx
@@ -1,13 +1,72 @@
-import React from 'react'
+import React, { useContext, useState } from 'react'
 import PropTypes from 'prop-types'
+import { Context } from '../../state'
+import { Error } from '../Error'
 import { Display } from './Display'
+import { httpDelete } from '../../utils'
+import { Button, ConfirmationDialog, Icon, Modal } from '../../components'
+import { useTranslation } from 'react-i18next'
 
-function ViewIdentifier({ cachedIdentifier }) {
+function ViewIdentifier({ cachedIdentifier, onDelete }) {
+  const { t } = useTranslation()
+  const [globalState] = useContext(Context)
+  const projectId = cachedIdentifier.project_id
+  const integrationName = cachedIdentifier.integration_name
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
+  const [error, setError] = useState()
+
+  async function onConfirmDelete() {
+    const response = await httpDelete(
+      globalState.fetch,
+      new URL(
+        `/projects/${projectId}/identifiers/${integrationName}`,
+        globalState.baseURL
+      )
+    )
+    if (response.success) {
+      setShowDeleteConfirmation(false)
+      if (onDelete) {
+        onDelete()
+      }
+    } else {
+      setError(response.data)
+    }
+  }
+
+  function onDeleteStart() {
+    setShowDeleteConfirmation(true)
+  }
+  function onDeleteEnd() {
+    setShowDeleteConfirmation(false)
+  }
+
   if (!cachedIdentifier) return <></>
-  return <Display entry={cachedIdentifier} />
+  if (error) return <Error>{error}</Error>
+  return (
+    <>
+      {showDeleteConfirmation && (
+        <ConfirmationDialog
+          title={t('project.identifiers.deleteTitle', { integrationName })}
+          mode="error"
+          onCancel={onDeleteEnd}
+          onConfirm={onConfirmDelete}
+          confirmationButtonText={t('common.delete')}>
+          {t('project.identifiers.deleteConfirmation')}
+        </ConfirmationDialog>
+      )}
+      <Display entry={cachedIdentifier} />
+      <Modal.Footer>
+        <Button className="btn-red text-s" onClick={onDeleteStart}>
+          <Icon icon="fas trash" className="mr-2" />
+          {t('common.delete')}
+        </Button>
+      </Modal.Footer>
+    </>
+  )
 }
 ViewIdentifier.propTypes = {
-  cachedIdentifier: PropTypes.object
+  cachedIdentifier: PropTypes.object,
+  onDelete: PropTypes.func
 }
 
 export { ViewIdentifier }

--- a/src/js/views/Identifiers/ViewIdentifier.jsx
+++ b/src/js/views/Identifiers/ViewIdentifier.jsx
@@ -6,14 +6,21 @@ import { Display } from './Display'
 import { httpDelete } from '../../utils'
 import { Button, ConfirmationDialog, Icon, Modal } from '../../components'
 import { useTranslation } from 'react-i18next'
+import { Edit } from './Edit'
 
-function ViewIdentifier({ cachedIdentifier, onDelete }) {
+function ViewIdentifier({
+  cachedIdentifier,
+  integrations,
+  onDelete,
+  onUpdate
+}) {
   const { t } = useTranslation()
   const [globalState] = useContext(Context)
-  const projectId = cachedIdentifier.project_id
-  const integrationName = cachedIdentifier.integration_name
+  const projectId = cachedIdentifier?.project_id
+  const integrationName = cachedIdentifier?.integration_name
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const [error, setError] = useState()
+  const [isEditing, setIsEditing] = useState(false)
 
   async function onConfirmDelete() {
     const response = await httpDelete(
@@ -40,6 +47,13 @@ function ViewIdentifier({ cachedIdentifier, onDelete }) {
     setShowDeleteConfirmation(false)
   }
 
+  function onEditStart() {
+    setIsEditing(true)
+  }
+  function onEditEnd() {
+    setIsEditing(false)
+  }
+
   if (!cachedIdentifier) return <></>
   if (error) return <Error>{error}</Error>
   return (
@@ -54,19 +68,40 @@ function ViewIdentifier({ cachedIdentifier, onDelete }) {
           {t('project.identifiers.deleteConfirmation')}
         </ConfirmationDialog>
       )}
-      <Display entry={cachedIdentifier} />
-      <Modal.Footer>
-        <Button className="btn-red text-s" onClick={onDeleteStart}>
-          <Icon icon="fas trash" className="mr-2" />
-          {t('common.delete')}
-        </Button>
-      </Modal.Footer>
+      {isEditing ? (
+        <Edit
+          entry={cachedIdentifier}
+          integrations={integrations}
+          onError={(error) => setError(error)}
+          onCancel={onEditEnd}
+          onSuccess={() => {
+            onEditEnd()
+            onUpdate()
+          }}
+        />
+      ) : (
+        <>
+          <Display entry={cachedIdentifier} />
+          <Modal.Footer>
+            <Button className="btn-red text-s" onClick={onDeleteStart}>
+              <Icon icon="fas trash" className="mr-2" />
+              {t('common.delete')}
+            </Button>
+            <Button className="btn-white text-s" onClick={onEditStart}>
+              <Icon icon="fas edit" className="mr-2" />
+              {t('common.edit')}
+            </Button>
+          </Modal.Footer>
+        </>
+      )}
     </>
   )
 }
 ViewIdentifier.propTypes = {
+  integrations: PropTypes.arrayOf(PropTypes.string).isRequired,
   cachedIdentifier: PropTypes.object,
-  onDelete: PropTypes.func
+  onDelete: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired
 }
 
 export { ViewIdentifier }

--- a/src/js/views/Identifiers/ViewIdentifier.jsx
+++ b/src/js/views/Identifiers/ViewIdentifier.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Display } from './Display'
+
+function ViewIdentifier({ cachedIdentifier }) {
+  if (!cachedIdentifier) return <></>
+  return <Display entry={cachedIdentifier} />
+}
+ViewIdentifier.propTypes = {
+  cachedIdentifier: PropTypes.object
+}
+
+export { ViewIdentifier }

--- a/src/js/views/Identifiers/index.js
+++ b/src/js/views/Identifiers/index.js
@@ -1,0 +1,1 @@
+export { Identifiers } from './Identifiers'

--- a/src/js/views/Project/Details.jsx
+++ b/src/js/views/Project/Details.jsx
@@ -7,73 +7,83 @@ import { useTranslation } from 'react-i18next'
 import { Edit } from './Edit'
 import { DescriptionList } from '../../components/DescriptionList/DescriptionList'
 import { Definition } from '../../components/DescriptionList/Definition'
+import { Identifiers } from '../Identifiers'
 
 function Display({ project, onEditClick, shouldGrow }) {
   const { t } = useTranslation()
   return (
-    <Card className={`flex flex-col ${shouldGrow ? 'h-full' : ''}`}>
-      <h2 className="font-medium mb-2">{t('terms.projectInfo')}</h2>
-      <DescriptionList className="my-3">
-        <Definition term={t('terms.namespace')} icon={project.namespace_icon}>
-          {project.namespace}
-        </Definition>
-        <Definition term={t('terms.projectType')} icon={project.project_icon}>
-          {project.project_type}
-        </Definition>
-        <Definition term={t('terms.slug')} className="font-mono">
-          {project.slug}
-        </Definition>
-        {project.environments && project.environments.length > 0 && (
-          <Definition term={t('terms.environments')}>
-            {project.environments.join(', ')}
+    <>
+      <Card className={`flex flex-col ${shouldGrow ? 'h-full' : ''}`}>
+        <h2 className="font-medium mb-2">{t('terms.projectInfo')}</h2>
+        <DescriptionList className="my-3">
+          <Definition term={t('terms.namespace')} icon={project.namespace_icon}>
+            {project.namespace}
           </Definition>
-        )}
-        {project.environments &&
-          project.environments.map((environment) => {
-            if (project.urls[environment] === undefined) return null
+          <Definition term={t('terms.projectType')} icon={project.project_icon}>
+            {project.project_type}
+          </Definition>
+          <Definition term={t('terms.slug')} className="font-mono">
+            {project.slug}
+          </Definition>
+          {project.environments && project.environments.length > 0 && (
+            <Definition term={t('terms.environments')}>
+              {project.environments.join(', ')}
+            </Definition>
+          )}
+          {project.environments &&
+            project.environments.map((environment) => {
+              if (project.urls[environment] === undefined) return null
+              return (
+                <Definition
+                  key={`display-${environment}-url`}
+                  term={`${environment} URL`}>
+                  <a
+                    className="text-blue-800 hover:text-blue-700"
+                    title={project.urls[environment]}
+                    href={project.urls[environment]}
+                    target="_new">
+                    <Icon icon="fas external-link-alt" className="mr-2" />
+                    {project.urls[environment]}{' '}
+                  </a>
+                </Definition>
+              )
+            })}
+          {project.links.map((link, index) => {
             return (
-              <Definition
-                key={`display-${environment}-url`}
-                term={`${environment} URL`}>
+              <Definition key={`display-link-${index}`} term={link.title}>
                 <a
                   className="text-blue-800 hover:text-blue-700"
-                  title={project.urls[environment]}
-                  href={project.urls[environment]}
+                  href={link.url}
+                  title={link.url}
                   target="_new">
                   <Icon icon="fas external-link-alt" className="mr-2" />
-                  {project.urls[environment]}{' '}
+                  {link.url}{' '}
                 </a>
               </Definition>
             )
           })}
-        {project.links.map((link, index) => {
-          return (
-            <Definition key={`display-link-${index}`} term={link.title}>
-              <a
-                className="text-blue-800 hover:text-blue-700"
-                href={link.url}
-                title={link.url}
-                target="_new">
-                <Icon icon="fas external-link-alt" className="mr-2" />
-                {link.url}{' '}
-              </a>
-            </Definition>
-          )
-        })}
-      </DescriptionList>
-      {project.archived === false && (
-        <div className="flex-grow flex flex-row items-end">
-          <div className="flex-grow text-right mt-2">
-            <Button className="btn-white text-xs" onClick={onEditClick}>
-              <Icon icon="fas edit" className="mr-2" />
-              {t('project.editProject')}
-            </Button>
+        </DescriptionList>
+        {project.archived === false && (
+          <div className="flex-grow flex flex-row items-end">
+            <div className="flex-grow text-right mt-2">
+              <Button className="btn-white text-xs" onClick={onEditClick}>
+                <Icon icon="fas edit" className="mr-2" />
+                {t('project.editProject')}
+              </Button>
+            </div>
           </div>
+        )}
+      </Card>
+      <Card className="flex flex-col mt-3">
+        <h2 className="font-medium mb-2">{t('terms.projectIdentifiers')}</h2>
+        <div className="mt-3 mb-2">
+          <Identifiers project={project} />
         </div>
-      )}
-    </Card>
+      </Card>
+    </>
   )
 }
+
 Display.propTypes = {
   project: PropTypes.object.isRequired,
   onEditClick: PropTypes.func.isRequired,

--- a/src/js/views/Project/Details.jsx
+++ b/src/js/views/Project/Details.jsx
@@ -105,7 +105,7 @@ function Details({ project, editing, onEditing, refresh, shouldGrow }) {
     <Display
       project={project}
       onEditClick={() => onEditing(true)}
-      shouldGrow={shouldGrow}
+      shouldGrow={false}
     />
   )
 }

--- a/src/js/views/Project/Details.jsx
+++ b/src/js/views/Project/Details.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { Button, Card, Icon } from '../../components'
 import { useTranslation } from 'react-i18next'
@@ -11,6 +11,17 @@ import { Identifiers } from '../Identifiers'
 
 function Display({ project, onEditClick, shouldGrow }) {
   const { t } = useTranslation()
+  const [integrationCount, setIntegrationCount] = useState()
+  const [displayIdentifiers, setDisplayIdentifiers] = useState()
+
+  useEffect(() => {
+    if (integrationCount === 0) {
+      setDisplayIdentifiers(false)
+    } else if (integrationCount > 0) {
+      setDisplayIdentifiers(true)
+    }
+  }, [integrationCount, setDisplayIdentifiers])
+
   return (
     <>
       <Card className={`flex flex-col ${shouldGrow ? 'h-full' : ''}`}>
@@ -74,12 +85,17 @@ function Display({ project, onEditClick, shouldGrow }) {
           </div>
         )}
       </Card>
-      <Card className="flex flex-col mt-3">
-        <h2 className="font-medium mb-2">{t('terms.projectIdentifiers')}</h2>
-        <div className="mt-3 mb-2">
-          <Identifiers project={project} />
-        </div>
-      </Card>
+      {displayIdentifiers !== false && (
+        <Card className="flex flex-col mt-3">
+          <h2 className="font-medium mb-2">{t('terms.projectIdentifiers')}</h2>
+          <div className="mt-3 mb-2">
+            <Identifiers
+              project={project}
+              setIntegrationCount={setIntegrationCount}
+            />
+          </div>
+        </Card>
+      )}
     </>
   )
 }


### PR DESCRIPTION
This PR adds a new panel to the Project view for a project's external identifiers. See https://github.com/AWeber-Imbi/imbi-api/pull/61 for the API changes. The empty state for a project without identifiers present is:

![image](https://github.com/AWeber-Imbi/imbi-ui/assets/350812/5f6e19ec-8a4a-4dc9-a7b5-72d0488c0b51)

After adding an identifier, the table of identifiers appears above the button.

![image](https://github.com/AWeber-Imbi/imbi-ui/assets/350812/55c15991-4556-4616-8fe6-cf52da844665)

The `(Add Identifier)` button is shown when there are integrations registered in Imbi that the project does not already have an identifier for.

Identifiers are edited in a flyover that is initiated by clicking on the project row.

![image](https://github.com/AWeber-Imbi/imbi-ui/assets/350812/b7ac9d42-8fb6-476a-8db1-6dc59c10e9c8)

Editing has an interesting wrinkle in that the pop-up for available "Identifier Owner"s is limited to the integrations that the project does not have an identifier for. The following screenshot shows this behavior 

![image](https://github.com/AWeber-Imbi/imbi-ui/assets/350812/f749498f-8ad8-4d00-8d73-a64e5fb6a3ea)

If I remove the `sonarqube` identifier, then the pop-up contains both `gitlab` and `sonarqube`. There were some changes required in the `Form.Select` code to make this work (a2a2141). I haven't seen any problems with this change but it does strike me as something that might break stuff.
