### PR TITLE
Add Project Components tab

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -68,6 +68,7 @@ export default {
         links: 'Links',
         name: 'Name',
         namespace: 'Namespace',
+        package: 'Package',
         project: 'Project',
         projects: 'Projects',
         projectInfo: 'Project Information',
@@ -82,7 +83,8 @@ export default {
         score: 'Score',
         scoreHistory: 'Score History',
         stackHealthScore: 'Stack health Score',
-        slug: 'Slug'
+        slug: 'Slug',
+        version: 'Version'
       },
       error: {
         title: 'ERROR',
@@ -327,6 +329,12 @@ export default {
         archived: 'This project is archived and is read-only.',
         attributes: 'Attributes',
         automations: 'Automations',
+        components: {
+          singular: 'Component',
+          plural: 'Components',
+          packageURL: 'Package URL',
+          status: 'Status'
+        },
         configurationType: 'Configuration Type',
         configurationTypes: {
           ssm: 'AWS SSM Parameter Store'

--- a/src/js/components/Table/NavigableTable.jsx
+++ b/src/js/components/Table/NavigableTable.jsx
@@ -1,0 +1,157 @@
+import PropTypes from 'prop-types'
+import React, { useRef, useState } from 'react'
+
+import { Columns } from '../../schema'
+import { Table } from './Table'
+import { useSearchParams } from 'react-router-dom'
+import { SlideOver } from '../SlideOver/SlideOver'
+import { Icon } from '../Icon/Icon'
+
+/**
+ * Table that shows a slide over when a row is clicked
+ *
+ * @param columns passed as-is to Table
+ * @param data array of data objects, passed to Table and used for navigation
+ * @param extractSearchParam function that returns the property from data[n] used in
+ *                           the search params for tracking
+ * @param selectedIndex index of the current value in data
+ * @param setSelectedIndex setter used for next/previous
+ * @param slideOverElement element to use as the root of the content in the slide over
+ * @param title title of the slide over
+ */
+function NavigableTable({
+  columns,
+  data,
+  extractSearchParam,
+  selectedIndex,
+  setSelectedIndex,
+  slideOverElement,
+  title
+}) {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const [showArrows, setShowArrows] = useState(false)
+  const [slideOverOpen, setSlideOverOpen] = useState(false)
+  const arrowLeftRef = useRef(null)
+  const arrowRightRef = useRef(null)
+
+  if (searchParams.get('v') && !slideOverOpen && data.length > 0) {
+    setSlideOverOpen(true)
+    setShowArrows(true)
+    setSelectedIndex(
+      data.findIndex((row) => extractSearchParam(row) === searchParams.get('v'))
+    )
+  } else if (!searchParams.get('v') && slideOverOpen) {
+    setSlideOverOpen(false)
+    setShowArrows(false)
+  }
+
+  function updateSearchParamsWith(newValue) {
+    const newParams = new URLSearchParams()
+    for (const [key, value] of searchParams) {
+      newParams.set(key, value)
+    }
+    if (newValue === undefined) {
+      newParams.delete('v')
+    } else {
+      newParams.set('v', newValue)
+    }
+    setSearchParams(newParams)
+  }
+  function move(index) {
+    setSelectedIndex(index)
+    updateSearchParamsWith(extractSearchParam(data[index]))
+  }
+
+  return (
+    <div className="m0">
+      <Table
+        columns={columns}
+        data={data}
+        onRowClick={({ index }) => {
+          updateSearchParamsWith(extractSearchParam(data[index]))
+          setSlideOverOpen(true)
+          setSelectedIndex(index)
+          setShowArrows(true)
+        }}
+        checkIsHighlighted={(row) =>
+          extractSearchParam(row) === searchParams.get('v')
+        }
+      />
+      <SlideOver
+        open={slideOverOpen}
+        onClose={() => {
+          updateSearchParamsWith(undefined)
+          setSlideOverOpen(false)
+        }}
+        onKeyDown={(e) => {
+          if (!showArrows) return
+          if (selectedIndex > 0 && e.key === 'ArrowLeft') {
+            arrowLeftRef.current?.focus()
+            move(selectedIndex - 1)
+          } else if (
+            selectedIndex < data.length - 1 &&
+            e.key === 'ArrowRight'
+          ) {
+            arrowRightRef.current?.focus()
+            move(selectedIndex + 1)
+          }
+        }}
+        title={
+          <div className="flex items-center">
+            {title}
+            {selectedIndex !== undefined && showArrows && (
+              <>
+                <button
+                  ref={arrowLeftRef}
+                  className="ml-4 mr-2 h-min outline-offset-4"
+                  onClick={() => {
+                    if (selectedIndex > 0) move(selectedIndex - 1)
+                  }}
+                  tabIndex={selectedIndex === 0 ? -1 : 0}>
+                  <Icon
+                    icon="fas arrow-left"
+                    className={
+                      'h-4 select-none block' +
+                      (selectedIndex === 0 ? ' text-gray-200' : '')
+                    }
+                  />
+                </button>
+                <button
+                  ref={arrowRightRef}
+                  className="outline-offset-4"
+                  onClick={() => {
+                    if (selectedIndex < data.length - 1) move(selectedIndex + 1)
+                  }}
+                  tabIndex={selectedIndex === data.length - 1 ? -1 : 0}>
+                  <Icon
+                    icon="fas arrow-right"
+                    className={
+                      'h-4 select-none block' +
+                      (selectedIndex === data.length - 1
+                        ? ' text-gray-200'
+                        : '')
+                    }
+                  />
+                </button>
+              </>
+            )}
+          </div>
+        }>
+        {data?.length > 0 ? slideOverElement : <></>}
+      </SlideOver>
+    </div>
+  )
+}
+
+NavigableTable.propTypes = {
+  columns: Columns,
+  data: PropTypes.arrayOf(PropTypes.object),
+  extractSearchParam: PropTypes.func.isRequired,
+  selectedIndex: PropTypes.number.isRequired,
+  setSelectedIndex: PropTypes.func.isRequired,
+  slideOverElement: PropTypes.node.isRequired,
+  title: PropTypes.string.isRequired
+}
+
+export { NavigableTable }

--- a/src/js/components/Table/index.js
+++ b/src/js/components/Table/index.js
@@ -1,3 +1,4 @@
+export { NavigableTable } from './NavigableTable'
 export { Table } from './Table'
 export { Head } from './Head'
 export { Body } from './Body'

--- a/src/js/views/Project/Components/ComponentList.jsx
+++ b/src/js/views/Project/Components/ComponentList.jsx
@@ -1,0 +1,114 @@
+import React, { useContext, useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+import { Alert, Loading, ScoreBadge } from '../../../components'
+import { NavigableTable } from '../../../components/Table'
+import { useTranslation } from 'react-i18next'
+import { Context } from '../../../state'
+import { httpGet, parseLinkHeader } from '../../../utils'
+import { ViewComponent } from './ViewComponent'
+
+function ComponentList({ project, urlPath }) {
+  const [globalState, dispatch] = useContext(Context)
+  const { t } = useTranslation()
+  const [components, setComponents] = useState([])
+  const [fetching, setFetching] = useState(false)
+  const [errorMessage, setErrorMessage] = useState()
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  useEffect(() => {
+    dispatch({
+      type: 'SET_CURRENT_PAGE',
+      payload: {
+        title: t('project.components.plural'),
+        url: new URL(`${urlPath}/components`, globalState.baseURL)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    let allData = []
+    let url = new URL(`/projects/${project.id}/components`, globalState.baseURL)
+    setFetching(true)
+    do {
+      const currUrl = url
+      url = null
+      httpGet(
+        globalState.fetch,
+        currUrl,
+        ({ data, headers }) => {
+          const links = parseLinkHeader(headers.get('Link'))
+          url = Object.hasOwn(links, 'next') ? new URL(links.next[0]) : null
+          setComponents((prevState) => prevState.concat(data))
+        },
+        ({ message }) => {
+          setErrorMessage(message)
+          setFetching(false)
+        }
+      )
+    } while (url !== null)
+    setFetching(false)
+  }, [])
+
+  if (fetching) return <Loading />
+  if (errorMessage) return <Alert level="error">{errorMessage}</Alert>
+
+  return (
+    <NavigableTable
+      columns={[
+        {
+          title: '',
+          name: 'icon_class',
+          type: 'icon',
+          tableOptions: {
+            headerClassName: 'w-1/12'
+          }
+        },
+        {
+          title: t('common.name'),
+          name: 'name',
+          type: 'text'
+        },
+        {
+          title: t('terms.package'),
+          name: 'package_url',
+          type: 'text'
+        },
+        {
+          title: t('terms.version'),
+          name: 'version',
+          type: 'text'
+        },
+        {
+          title: t('project.components.status'),
+          name: 'status',
+          type: 'text'
+        },
+        {
+          title: t('terms.healthScore'),
+          name: 'score',
+          type: 'text',
+          tableOptions: {
+            lookupFunction: (value) => {
+              if (value !== null) {
+                return <ScoreBadge value={value} />
+              }
+              return null
+            }
+          }
+        }
+      ]}
+      data={components}
+      extractSearchParam={(obj) => obj.name}
+      title={t('project.components.singular')}
+      selectedIndex={selectedIndex}
+      setSelectedIndex={setSelectedIndex}
+      slideOverElement={<ViewComponent component={components[selectedIndex]} />}
+    />
+  )
+}
+
+ComponentList.propTypes = {
+  urlPath: PropTypes.string,
+  project: PropTypes.object.isRequired
+}
+export { ComponentList }

--- a/src/js/views/Project/Components/ViewComponent.jsx
+++ b/src/js/views/Project/Components/ViewComponent.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useTranslation } from 'react-i18next'
+import { DescriptionList } from '../../../components/DescriptionList/DescriptionList'
+import { Definition } from '../../../components/DescriptionList/Definition'
+
+function ViewComponent({ component }) {
+  const { t } = useTranslation()
+  return (
+    <DescriptionList>
+      <Definition term={t('common.name')}>{component.name}</Definition>
+      <Definition term={t('project.components.packageURL')}>
+        {component.package_url}
+      </Definition>
+      <Definition term={t('terms.version')}>{component.version}</Definition>
+      <Definition term={t('project.components.status')}>
+        {component.status}
+      </Definition>
+      <Definition term={t('terms.score')}>
+        {component.score || 'N/A'}
+      </Definition>
+    </DescriptionList>
+  )
+}
+
+ViewComponent.propTypes = {
+  component: PropTypes.object
+}
+export { ViewComponent }

--- a/src/js/views/Project/Project.jsx
+++ b/src/js/views/Project/Project.jsx
@@ -28,6 +28,7 @@ import { Overview } from './Overview'
 import { Settings } from './Settings'
 import { OperationsLog } from '../OperationsLog'
 import { Configuration } from './Configuration/Configuration'
+import { ComponentList } from './Components/ComponentList'
 
 function ProjectPage({ project, factTypes, refresh }) {
   const [state, dispatch] = useContext(Context)
@@ -106,6 +107,9 @@ function ProjectPage({ project, factTypes, refresh }) {
             {t('common.overview')}
           </Tab>
           <Tab to={`${baseURL}/configuration`}>{t('common.configuration')}</Tab>
+          <Tab to={`${baseURL}/components`}>
+            {t('project.components.plural')}
+          </Tab>
           <Tab to={`${baseURL}/dependencies`}>{t('project.dependencies')}</Tab>
           <Tab to={`${baseURL}/logs`}>{t('common.logs')}</Tab>
           <Tab to={`${baseURL}/notes`}>{t('common.notes')}</Tab>
@@ -133,6 +137,10 @@ function ProjectPage({ project, factTypes, refresh }) {
           <Route
             path={`configuration`}
             element={<Configuration project={project} urlPath={baseURL} />}
+          />
+          <Route
+            path={`components`}
+            element={<ComponentList project={project} urlPath={baseURL} />}
           />
           <Route
             path={`dependencies`}


### PR DESCRIPTION
This PR adds a new tab to the project detail page that contains the list of components and versions that a project depends on. The components for a project are a read-only view of the `/projects/{id}/components` endpoint added in https://github.com/AWeber-Imbi/imbi-api/pull/85. It will remain unpopulated until support is added to the API for ingesting project dependency information in a near-term effort. In other words, this is pre-work in the UI since the API already exists.

I created a new component that implements the table + slide-over that we are using in several places. It is read-only / view-only since that is all that I needed for this effort. It should be pretty easy to add edit & delete support to it via parameters. The usage is pretty simple even if the name is horrid. See [ComponentList for an example](https://github.com/AWeber-Imbi/imbi-ui/commit/d2ab1524f2a361783ac24c5c4a486b802fbc4d59#diff-a4ebc27a2b78ac57af5b41043fc18e9c6184292de3ad97d1a5734e241b672deaR56-R106). Hopefully we can add more features and replace the other cases of a table + slide-over that are floating around.