### PR TITLE
Component usage report

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -11,6 +11,7 @@ export default {
         configuration: 'Configuration',
         createdAt: 'Created At',
         createdBy: 'Created By',
+        definitions: 'Definitions',
         description: 'Description',
         delete: 'Delete',
         done: 'Done',
@@ -463,6 +464,42 @@ export default {
       },
       reports: {
         available: 'Available Reports',
+        componentUsage: {
+          title: 'Component Usage',
+          columns: {
+            active_version: {
+              title: 'Active Version',
+              description:
+                'Version range that is "active". When empty, this component does not impact project scores.' +
+                " When set, the score of a project that uses this component is impacted based on whether the project's" +
+                ' version *matches* this value.'
+            },
+            name: {
+              title: 'Name',
+              description: 'Human-readable name for the component (informative)'
+            },
+            package_url: {
+              title: 'Package URL',
+              description:
+                'Unique package URL as defined in the [purl-spec](https://github.com/package-url/purl-spec)'
+            },
+            project_count: {
+              title: 'Project Count',
+              description:
+                'Number of projects using some version of this component'
+            },
+            status: {
+              title: 'Status',
+              description:
+                'Administrative status for **all** versions of this component. "Forbidden"' +
+                'or "Deprecated" components always impact the score of project\'s that use any version of the component.'
+            },
+            version_count: {
+              title: 'Version Count',
+              description: 'Number of versions recorded for this component'
+            }
+          }
+        },
         lastUpdated: 'Last Updated: {{lastUpdated}}',
         namespaceKPIs: {
           title: 'Namespace KPIs',

--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -503,12 +503,30 @@ export default {
         lastUpdated: 'Last Updated: {{lastUpdated}}',
         namespaceKPIs: {
           title: 'Namespace KPIs',
-          projects: 'Projects',
-          avgProjectScore: 'Avg Project Score',
-          stackHealthScore: 'Stack Health Score',
-          totalProjectScore: 'Total Project Score',
-          totalPossibleProjectScore: 'Total Possible Score',
-          totalProjectScorePercentage: 'TPS %'
+          columns: {
+            namespace: { title: 'Namespace' },
+            percent_of_tpps: {
+              title: 'TPS %',
+              description:
+                'Total Project Score percentage of the Total Possible Score'
+            },
+            projects: { title: 'Projects' },
+            stack_health_score: {
+              title: 'Stack Health Score',
+              description:
+                'The calculated score indicating the overall health of projects in the namespace'
+            },
+            total_possible_project_score: {
+              title: 'Total Possible Score',
+              description:
+                'The sum of the maximum possible project scores for all projects in the namespace'
+            },
+            total_project_score: {
+              title: 'Total Project Score',
+              description:
+                'The sum of the project scores for all projects in the namespace'
+            }
+          }
         },
         projectTypeDefinitions: {
           title: 'Project Type Definitions'

--- a/src/js/components/Report/Report.jsx
+++ b/src/js/components/Report/Report.jsx
@@ -127,9 +127,9 @@ function Report({
     }
   }, [fetched])
 
-  useEffect(() => {
-    if (sort !== null) {
-      const [column, direction] = sort
+  function onSortDirection(column, direction) {
+    const [curCol, curDir] = sort
+    if (curCol !== column || curDir !== direction) {
       setReportData(
         [...reportData].sort((a, b) => {
           if (a[column] === null || a[column] < b[column])
@@ -138,12 +138,6 @@ function Report({
             return direction === 'asc' ? 1 : -1
         })
       )
-    }
-  }, [sort])
-
-  function onSortDirection(column, direction) {
-    const [curCol, curDir] = sort
-    if (curCol !== column || curDir !== direction) {
       setSort([column, direction])
     }
   }

--- a/src/js/components/Report/Report.jsx
+++ b/src/js/components/Report/Report.jsx
@@ -1,0 +1,221 @@
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import { Column } from '../../schema'
+import { useContext } from 'react'
+import { Context } from '../../state'
+import { useTranslation } from 'react-i18next'
+import { httpGet } from '../../utils'
+import { Alert } from '../Alert/Alert'
+import { Loading } from '../Loading/Loading'
+import { ContentArea } from '../ContentArea/ContentArea'
+import { Table } from '../Table'
+import { Markdown } from '../Markdown/Markdown'
+
+/**
+ * Sortable report table with field descriptions
+ *
+ * This component is a `Table.Table` with the textual content coming from the
+ * localization catalog properties rooted at `keyPrefix`. The title of the report
+ * is `${keyPrefix}.title` and the defaults properties for the columns are rooted
+ * at `${keyPrefix}.columns`. The component also includes a Definitions section
+ * following the table that is derived from the column titles and descriptions.
+ * If a column lacks a description, then it will be omitted from the Definitions
+ * section.
+ *
+ * The following localization entry defines a report with one column where
+ * `property_name` is the name of the property for the column **in the API
+ * response**. The only column in the table has the title *Property Title*
+ * and would be described in the Definitions section.
+ *
+ * ```
+ * {
+ *   reports: {
+ *     myReport: {
+ *       title: 'My Report',
+ *       columns: {
+ *         property_name: {
+ *           title: 'Property Title',
+ *           description: 'Long winded description of the property' +
+ *             ' that can include **markdown**'
+ *         }
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * The view definition for this is:
+ *
+ * ```
+ * function MyReport() {
+ *   return (
+ *     <Report
+ *       endpoint="/reports/my-report"
+ *       keyPrefix="reports.myReport"
+ *       columns={[
+ *         { name: 'property_name', type: 'text' }
+ *       ]}/>
+ *   )
+ * }
+ * ```
+ *
+ * The `Report` component takes care of:
+ *
+ *  1. retrieving the report data from the API at `/reports/my-report` and
+ *     passing the result as `data` to the `Table`
+ *  2. creating the `Column` collection for the `Table` based on the
+ *     localization catalog rooted at `keyPrefix`
+ *  3. implementing **single column** sorting based on simple comparison or
+ *     the optional `column.sortCallback`
+ *  4. generating the Definitions section based on the column title and
+ *     descriptions
+ *  5. dispatching `SET_CURRENT_PAGE` to update the breadcrumbs
+ *
+ * @param columns {ReportColumn} -- array of report columns in the order that
+ *  they appear in the table
+ * @param endpoint {string} -- Imbi API endpoint to retrieve the report data from
+ * @param keyPrefix {string} -- translation key prefix. This is passed to
+ *   useTranslation to retrieve the translation details for the report
+ * @param pageIcon {string} -- optional FontAwesome icon name to use on the page
+ * @param title {string} -- optional title override
+ * @param tableProps {TableProps} -- additional properties are passed to the
+ *   inner `Table` component
+ * @returns {JSX.Element}
+ * @constructor
+ */
+function Report({
+  columns,
+  endpoint,
+  keyPrefix,
+  pageIcon,
+  title,
+  ...tableProps
+}) {
+  const [state, dispatch] = useContext(Context)
+  const { t: globalT } = useTranslation()
+  const { t } = useTranslation('translation', { keyPrefix })
+
+  const [errorMessage, setErrorMessage] = useState(null)
+  const [fetched, setFetched] = useState(false)
+  const [reportData, setReportData] = useState([])
+  const [sort, setSort] = useState(['', null])
+
+  const pageTitle = title || t('title')
+
+  useEffect(() => {
+    dispatch({
+      type: 'SET_CURRENT_PAGE',
+      payload: {
+        title: pageTitle,
+        url: new URL(`/ui${endpoint}`, state.baseURL)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!fetched) {
+      httpGet(
+        state.fetch,
+        new URL(endpoint, state.baseURL),
+        ({ data }) => {
+          setReportData(data)
+          setErrorMessage(null)
+          setFetched(true)
+        },
+        ({ message }) => setErrorMessage(message)
+      )
+    }
+  }, [fetched])
+
+  useEffect(() => {
+    if (sort !== null) {
+      const [column, direction] = sort
+      setReportData(
+        [...reportData].sort((a, b) => {
+          if (a[column] === null || a[column] < b[column])
+            return direction === 'asc' ? -1 : 1
+          if (b[column] === null || b[column] < a[column])
+            return direction === 'asc' ? 1 : -1
+        })
+      )
+    }
+  }, [sort])
+
+  function onSortDirection(column, direction) {
+    const [curCol, curDir] = sort
+    if (curCol !== column || curDir !== direction) {
+      setSort([column, direction])
+    }
+  }
+
+  if (errorMessage !== null) {
+    return <Alert level="error" message={errorMessage} />
+  }
+  if (fetched === false) {
+    return <Loading />
+  }
+
+  const augmentedColumns = columns.map((column) => ({
+    description: t(`columns.${column.name}.description`, ''),
+    title: t(`columns.${column.name}.title`, ''),
+    sortCallback: onSortDirection,
+    ...column,
+    sortDirection: sort[0] === column.name ? sort[1] : null
+  }))
+
+  return (
+    <ContentArea
+      pageTitle={title || t(`title`)}
+      className="flex-grow"
+      pageIcon={pageIcon}>
+      <Table {...tableProps} data={reportData} columns={augmentedColumns} />
+      <div className="italic text-gray-600 text-right text-xs">
+        {globalT('reports.lastUpdated', { lastUpdated: new Date().toString() })}
+      </div>
+      <div className="ml-4 text-gray-600">
+        <h1 className="font-medium my-2">{globalT('common.definitions')}</h1>
+        <dl className="ml-2 text-sm">
+          {augmentedColumns
+            .filter((c) => c.description)
+            .map((column, idx) => (
+              <div key={`${column.name}-term`}>
+                <dt
+                  key={`term-${idx}`}
+                  className={'font-medium' + (idx > 0 ? ' mt-2' : '')}>
+                  {column.title}
+                </dt>
+                <dd>
+                  <Markdown>{column.description}</Markdown>
+                </dd>
+              </div>
+            ))}
+        </dl>
+      </div>
+    </ContentArea>
+  )
+}
+
+const ReportColumn = Object.fromEntries(
+  Object.entries(Column).map(([k, v]) => {
+    if (k === 'title' || k === 'description') {
+      // we will provide these from translation if defined
+      return [k, PropTypes.string]
+    }
+    return [k, v]
+  })
+)
+const TableProps = Object.fromEntries(
+  Object.entries(Table.propTypes).filter(
+    ([k]) => k !== 'columns' && k !== 'data'
+  )
+)
+Report.propTypes = {
+  columns: PropTypes.arrayOf(PropTypes.exact(ReportColumn)).isRequired,
+  endpoint: PropTypes.string.isRequired,
+  keyPrefix: PropTypes.string.isRequired,
+  pageIcon: PropTypes.string,
+  title: PropTypes.string,
+  ...TableProps
+}
+
+export default Report

--- a/src/js/views/Main.jsx
+++ b/src/js/views/Main.jsx
@@ -11,6 +11,7 @@ import { NewEntry, OperationsLog } from './OperationsLog/'
 import { Project } from './Project/'
 import { Projects } from './Projects/'
 import {
+  ComponentUsage,
   NamespaceKPIs,
   ProjectTypeDefinitions,
   Reports
@@ -19,6 +20,7 @@ import { UserProfile, UserSettings } from './User'
 
 import { useSettings } from '../settings'
 import { User as UserSchema } from '../schema'
+import { Components } from './Admin/Components'
 
 function Main({ user }) {
   const [globalState] = useContext(Context)
@@ -67,6 +69,10 @@ function Main({ user }) {
                 />
                 <Route path="/ui/projects" element={<Projects user={user} />} />
                 <Route path="/ui/reports" element={<Reports />} />
+                <Route
+                  path="/ui/reports/component-usage"
+                  element={<ComponentUsage />}
+                />
                 <Route
                   path="/ui/reports/namespace-kpis"
                   element={<NamespaceKPIs />}

--- a/src/js/views/Reports/ComponentUsage.jsx
+++ b/src/js/views/Reports/ComponentUsage.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import Report from '../../components/Report/Report'
+
+function ComponentUsage() {
+  return (
+    <Report
+      endpoint="/reports/component-usage"
+      keyPrefix="reports.componentUsage"
+      pageIcon="fas cubes"
+      columns={[
+        { name: 'name', type: 'text' },
+        { name: 'package_url', type: 'text' },
+        { name: 'status', type: 'text' },
+        { name: 'active_version', type: 'text' },
+        { name: 'version_count', type: 'number' },
+        { name: 'project_count', type: 'number' }
+      ]}
+    />
+  )
+}
+
+export { ComponentUsage }

--- a/src/js/views/Reports/NamespaceKPIs.jsx
+++ b/src/js/views/Reports/NamespaceKPIs.jsx
@@ -1,11 +1,9 @@
 import { Link } from 'react-router-dom'
-import React, { useContext, useEffect, useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import React, { useContext } from 'react'
 
 import { Context } from '../../state'
-import { httpGet } from '../../utils'
-import { Alert, Badge, ContentArea, Loading, Table } from '../../components'
-import { lookupNamespaceByID } from '../../utils'
+import { Badge } from '../../components'
+import Report from '../../components/Report/Report'
 
 function colorizeValue(value) {
   value = parseInt(value)
@@ -25,221 +23,83 @@ function formatNumber(value) {
 }
 
 function NamespaceKPIs() {
-  const [globalState, dispatch] = useContext(Context)
-  const columnSortOrder = [
-    'namespace',
-    'stack_health_score',
-    'percent_of_tpps',
-    'projects',
-    'total_possible_project_score',
-    'total_project_score'
-  ]
-  const [state, setState] = useState({
-    data: [],
-    lookup: {},
-    fetched: false,
-    errorMessage: null,
-    sort: {}
-  })
-  const { t } = useTranslation()
+  const [globalState] = useContext(Context)
+  const namespaceNameToSlug = new Map(
+    globalState.metadata.namespaces.map((namespace) => [
+      namespace.name,
+      namespace.slug
+    ])
+  )
 
-  useEffect(() => {
-    dispatch({
-      type: 'SET_CURRENT_PAGE',
-      payload: {
-        title: t('reports.namespaceKPIs.title'),
-        url: new URL('/ui/reports/namespace-kpis', globalState.baseURL)
-      }
-    })
-  }, [])
-
-  useEffect(() => {
-    const sortBy = columnSortOrder
-      .filter((column) => state.sort[column])
-      .map((column) => ({ column: column, order: state.sort[column] }))
-    const data = [...state.data].sort((a, b) => {
-      for (let { column, order } of sortBy) {
-        if (a[column] < b[column]) return order === 'asc' ? -1 : 1
-        if (b[column] < a[column]) return order === 'asc' ? 1 : -1
-      }
-      return 0
-    })
-    setState({ ...state, data })
-  }, [state.sort])
-
-  useEffect(() => {
-    if (state.fetched === false) {
-      const url = new URL('/reports/namespace-kpis', globalState.baseURL)
-      httpGet(
-        globalState.fetch,
-        url,
-        ({ data }) => {
-          const lookup = Object.fromEntries(
-            data.map((row) => [row.namespace, row.namespace_id])
-          )
-          setState({
-            ...state,
-            data: data,
-            fetched: true,
-            lookup: lookup,
-            errorMessage: null
-          })
-        },
-        ({ message }) => {
-          setState({
-            ...state,
-            data: [],
-            fetched: true,
-            lookup: {},
-            errorMessage: message
-          })
-        }
-      )
-    }
-  }, [state.fetched])
-
-  function onSortDirection(column, direction) {
-    const sort = { ...state.sort }
-    if (direction === null) {
-      if (sort[column] !== undefined) delete sort[column]
-    } else if (state.sort[column] !== direction) {
-      sort[column] = direction
-    }
-    if (state.sort !== sort) {
-      setState({ ...state, sort: sort })
-    }
-  }
-
-  const columns = [
-    {
-      title: t('terms.namespace'),
-      name: 'namespace',
-      sortCallback: onSortDirection,
-      sortDirection: state.sort.namespace ? state.sort.namespace : null,
-      type: 'text',
-      tableOptions: {
-        className: 'truncate',
-        headerClassName: 'w-3/12',
-        lookupFunction: (namespace) => {
-          const filter =
-            'namespace_slug:' +
-            lookupNamespaceByID(
-              globalState.metadata.namespaces,
-              state.lookup[namespace]
-            ).slug
-          return (
-            <Link to={`/ui/projects?f=${encodeURIComponent(filter)}`}>
-              {namespace}
-            </Link>
-          )
-        }
-      }
-    },
-    {
-      title: t('reports.namespaceKPIs.projects'),
-      name: 'projects',
-      sortCallback: onSortDirection,
-      sortDirection: state.sort.projects ? state.sort.projects : null,
-      type: 'text',
-      tableOptions: {
-        className: 'text-right',
-        headerClassName: 'pl-2 text-right',
-        lookupFunction: formatNumber
-      }
-    },
-    {
-      title: t('reports.namespaceKPIs.stackHealthScore'),
-      name: 'stack_health_score',
-      sortCallback: onSortDirection,
-      sortDirection: state.sort.stack_health_score
-        ? state.sort.stack_health_score
-        : null,
-      type: 'text',
-      tableOptions: {
-        className: 'text-center',
-        headerClassName: 'pl-2 text-center',
-        lookupFunction: colorizeValue
-      }
-    },
-    {
-      title: t('reports.namespaceKPIs.totalProjectScore'),
-      name: 'total_project_score',
-      sortCallback: onSortDirection,
-      sortDirection: state.sort.total_project_score
-        ? state.sort.total_project_score
-        : null,
-      type: 'text',
-      tableOptions: {
-        className: 'text-right',
-        headerClassName: 'pl-2 text-right',
-        lookupFunction: formatNumber
-      }
-    },
-    {
-      title: t('reports.namespaceKPIs.totalPossibleProjectScore'),
-      name: 'total_possible_project_score',
-      sortCallback: onSortDirection,
-      sortDirection: state.sort.total_possible_project_score
-        ? state.sort.total_possible_project_score
-        : null,
-      type: 'text',
-      tableOptions: {
-        className: 'text-right',
-        headerClassName: 'pl-2 text-right',
-        lookupFunction: formatNumber
-      }
-    },
-    {
-      title: t('reports.namespaceKPIs.totalProjectScorePercentage'),
-      name: 'percent_of_tpps',
-      sortCallback: onSortDirection,
-      sortDirection: state.sort.percent_of_tpps
-        ? state.sort.percent_of_tpps
-        : null,
-      type: 'text',
-      tableOptions: {
-        className: 'text-right',
-        headerClassName: 'pl-2 text-right'
-      }
-    }
-  ]
-
-  if (state.errorMessage !== null)
-    return <Alert level="error">{state.errorMessage}</Alert>
-  if (state.fetched === false) return <Loading />
   return (
-    <ContentArea
-      className="flex-grow"
+    <Report
+      endpoint="/reports/namespace-kpis"
+      keyPrefix="reports.namespaceKPIs"
       pageIcon="fas chart-line"
-      pageTitle="Namespace KPIs">
-      <Table columns={columns} data={state.data} />
-      <div className="italic text-gray-600 text-right text-xs">
-        {t('reports.lastUpdated', { lastUpdated: new Date().toString() })}
-      </div>
-      <div className="ml-4 text-gray-600">
-        <h1 className="font-medium my-2">Definitions</h1>
-        <dl className="ml-2 text-sm">
-          <dt className="font-medium">Stack Health Score</dt>
-          <dd>
-            The calculated score indicating the overall health of projects in
-            the namespace
-          </dd>
-          <dt className="font-medium mt-2">Total Project Score</dt>
-          <dd>
-            The sum of the project scores for all projects in the namespace
-          </dd>
-          <dt className="font-medium mt-2">Total Possible Score</dt>
-          <dd>
-            The sum of the maximum possible project score for all projects in
-            the namespace
-          </dd>
-          <dt className="font-medium mt-2">TPS %</dt>
-          <dd>
-            The Total Project Score percentage of the Total Possible Score
-          </dd>
-        </dl>
-      </div>
-    </ContentArea>
+      columns={[
+        {
+          name: 'namespace',
+          type: 'text',
+          tableOptions: {
+            className: 'truncate',
+            headerClassName: 'w-3/12',
+            lookupFunction: (namespace) => {
+              const filter =
+                'namespace_slug:' + namespaceNameToSlug.get(namespace)
+              return (
+                <Link to={`/ui/projects?f=${encodeURIComponent(filter)}`}>
+                  {namespace}
+                </Link>
+              )
+            }
+          }
+        },
+        {
+          name: 'projects',
+          type: 'text',
+          tableOptions: {
+            className: 'text-right',
+            headerClassName: 'pl-2 text-right',
+            lookupFunction: formatNumber
+          }
+        },
+        {
+          name: 'stack_health_score',
+          type: 'text',
+          tableOptions: {
+            className: 'text-center',
+            headerClassName: 'pl-2 text-center',
+            lookupFunction: colorizeValue
+          }
+        },
+        {
+          name: 'total_project_score',
+          type: 'text',
+          tableOptions: {
+            className: 'text-right',
+            headerClassName: 'pl-2 text-right',
+            lookupFunction: formatNumber
+          }
+        },
+        {
+          name: 'total_possible_project_score',
+          type: 'text',
+          tableOptions: {
+            className: 'text-right',
+            headerClassName: 'pl-2 text-right',
+            lookupFunction: formatNumber
+          }
+        },
+        {
+          name: 'percent_of_tpps',
+          type: 'text',
+          tableOptions: {
+            className: 'text-right',
+            headerClassName: 'pl-2 text-right'
+          }
+        }
+      ]}
+    />
   )
 }
 export { NamespaceKPIs }

--- a/src/js/views/Reports/Reports.jsx
+++ b/src/js/views/Reports/Reports.jsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Card } from '../../components'
 import { Context } from '../../state'
 
+export { ComponentUsage } from './ComponentUsage'
 export { NamespaceKPIs } from './NamespaceKPIs'
 export { ProjectTypeDefinitions } from './ProjectTypeDefinitions'
 
@@ -25,6 +26,11 @@ function Reports() {
       <Card className="space-y-3">
         <h1 className="text-gray-700 text-lg">{t('reports.available')}</h1>
         <ul className="list-disc list-inside ml-4 text-gray-600">
+          <li>
+            <Link to="/ui/reports/component-usage">
+              {t('reports.componentUsage.title')}
+            </Link>
+          </li>
           <li>
             <Link to="/ui/reports/namespace-kpis">
               {t('reports.namespaceKPIs.title')}


### PR DESCRIPTION
This PR adds a new report that lists the known software components and their usage.

I extracted the essence of the Namespace KPI report into a reusable component called `Report` (see [Report/Report.jsx](https://github.com/dave-shawley/imbi-ui/blob/842561fbb0b6831dae6ddec435740555d828abc6/src/js/components/Report/Report.jsx)). It takes care of the implementing sorting, fetching data from the API, displaying a localized definition list for interesting columns, and other such sundry details. The [second commit](https://github.com/AWeber-Imbi/imbi-ui/commit/842561fbb0b6831dae6ddec435740555d828abc6) migrates the Namespace KPI report to use the reusable component.  There is also a decent-sized docblock on the new component.

See https://github.com/AWeber-Imbi/imbi-api/pull/91 for the API that backs the new table.

![image](https://github.com/AWeber-Imbi/imbi-ui/assets/350812/d3a01293-a339-4f07-b4f7-cd9ff42ada42)