### PR TITLE
Fix URL generation in CRUD code

### DIFF
--- a/src/js/components/CRUD/CRUD.jsx
+++ b/src/js/components/CRUD/CRUD.jsx
@@ -48,7 +48,7 @@ function CRUD({
   const { t } = useTranslation()
 
   async function deleteItem() {
-    const path = itemPath.replace(/{{value}}/, itemToDelete)
+    const path = itemPath.replace(/{{value}}/, encodeURIComponent(itemToDelete))
     const url = new URL(path, state.baseURL)
     const result = await httpDelete(state.fetch, url)
     if (result.success === true) {
@@ -74,7 +74,7 @@ function CRUD({
 
   async function onEditClick(value) {
     setFetching(true)
-    const path = itemPath.replace(/{{value}}/, value)
+    const path = itemPath.replace(/{{value}}/, encodeURIComponent(value))
     const url = new URL(path, state.baseURL)
     httpGet(
       state.fetch,

--- a/src/js/components/CRUD/Form.jsx
+++ b/src/js/components/CRUD/Form.jsx
@@ -38,7 +38,10 @@ function CrudForm({
     let result = null
     if (isEdit === true) {
       const patchValue = compare(originalValues, mapEmptyValues(formValues))
-      url.pathname = itemPath.replace(/{{value}}/, originalValues[itemKey])
+      url.pathname = itemPath.replace(
+        /{{value}}/,
+        encodeURIComponent(originalValues[itemKey])
+      )
       result = await httpPatch(state.fetch, url, patchValue)
     } else {
       url.pathname = itemPath

--- a/src/js/schema/Component.js
+++ b/src/js/schema/Component.js
@@ -4,7 +4,7 @@ export const jsonSchema = {
   properties: {
     package_url: {
       type: 'string',
-      pattern: 'pkg:[^:]+:.*'
+      pattern: 'pkg:[^/]+/.*'
     },
     name: { type: 'string' },
     status: {


### PR DESCRIPTION
Package URLs might contain slashes so we need to handle escaping `{{value}}` in the item path templates. I missed this in my initial rounds because I thought that the initial part of a [Package URL](https://github.com/package-url/purl-spec) was colon-separated -- `pkg:pypi:tornado` instead of `pkg:pypi/tornado`. I was prototyping SBoM ingestion and found out that I was wrong. _Yay for using real data but :sigh: for not doing it sooner._

I couldn't find any other place that this defect exists but I'm 99.9% sure that this will bite us again.