### PR TITLE
Truncate the display of long project links

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -140,3 +140,23 @@ export function camelCase(s) {
     .toLowerCase()
     .replace(/(_[a-z])/g, (group) => group.toUpperCase().replace('_', ''))
 }
+
+export function truncateUrl(url, maxLen) {
+  const attrs = ['hash', 'search']
+  const working = new URL(url)
+  attrs.forEach((attr) => {
+    if (working.toString().length > maxLen) {
+      working[attr] = ''
+    }
+  })
+  while (working.toString().length > maxLen && working.pathname.length > 1) {
+    working.pathname = working.pathname.substring(
+      0,
+      working.pathname.lastIndexOf('/')
+    )
+  }
+  const rendered = working.toString()
+  return rendered.length <= maxLen
+    ? rendered
+    : working.toString().substring(0, maxLen - 3) + '...'
+}

--- a/src/js/views/Project/Details.jsx
+++ b/src/js/views/Project/Details.jsx
@@ -8,6 +8,7 @@ import { Edit } from './Edit'
 import { DescriptionList } from '../../components/DescriptionList/DescriptionList'
 import { Definition } from '../../components/DescriptionList/Definition'
 import { Identifiers } from '../Identifiers'
+import { truncateUrl } from '../../utils'
 
 function Display({ project, onEditClick, shouldGrow }) {
   const { t } = useTranslation()
@@ -73,7 +74,7 @@ function Display({ project, onEditClick, shouldGrow }) {
                   title={link.url}
                   target="_new">
                   <Icon icon="fas external-link-alt" className="mr-2" />
-                  {link.url}{' '}
+                  {truncateUrl(link.url, 100)}{' '}
                 </a>
               </Definition>
             )


### PR DESCRIPTION
Something in the UI model is breaking the use of tailwind's truncate class for our project links. This commit adds a helper function that intelligently truncates a URL for display. The "intelligent" part is to:

1. remove the fragment first
2. remove the query if it is still too long
3. iteratively remove path segments until we are under the limit or run out of segments
4. truncate and add ellipsis if we are still over the limit