### PR TITLE
Prepare for yarn-modern

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,5 +117,5 @@
     "*.{css,js,json,jsx}": "prettier --write",
     "*.{js,jsx}": "eslint --cache --fix"
   },
-  "dependencies": {}
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Setting the `packageManager` prop in _package.json_ to the old version of yarn ensures that we continue to get what we want. Yarn Classic (1.x) will ignore this. However, if you enable `corepack` and use a modern version of yarn, it will install and use the specified version. So, I'm going to set it to the newest in the Yarn Classic line for the time being. If we decide to adopt Yarn Modern with all of it's goodness, then we can change the version number. Did I mention that Yarn Modern doesn't require `node_modules`? 😉 

The selfish reason for doing this is that I upgraded yarn on my dev box and it took it upon itself to auto upgrade my environment when I ran `yarn install`... I haven't convinced myself that we can run in [PnP mode safely](https://yarnpkg.com/features/pnp) so I'd rather not do that now. FWIW, I did convert over to using the hooked loader file and everything _seemed to work_. This is something that we might want to examine in the future since it enables [running utilities in an isolated environment](https://yarnpkg.com/cli/dlx) which is really useful.

https://yarnpkg.com/migration/guide