### PR TITLE
Component table improvements

### DIFF
--- a/src/js/components/CRUD/CRUD.jsx
+++ b/src/js/components/CRUD/CRUD.jsx
@@ -13,7 +13,7 @@ import {
 } from '..'
 import { Columns } from '../../schema'
 import { Context } from '../../state'
-import { httpGet, httpDelete } from '../../utils'
+import { httpGet, httpDelete, fetchPages } from '../../utils'
 
 import { Form } from './Form'
 
@@ -131,14 +131,17 @@ function CRUD({
   // Fetch the collection data
   useEffect(() => {
     if (fetchData === true) {
+      const newData = []
       setFetchData(false)
-      const url = new URL(collectionPath, state.baseURL)
-      httpGet(
-        state.fetch,
-        url,
-        ({ data }) => {
-          setData(data)
-          setReady(true)
+      fetchPages(
+        collectionPath,
+        state,
+        (data, finished) => {
+          newData.push(...data)
+          if (finished === true) {
+            setReady(true)
+            setData(newData)
+          }
         },
         ({ message }) => {
           setErrorMessage(message)

--- a/src/js/components/Report/Report.jsx
+++ b/src/js/components/Report/Report.jsx
@@ -118,12 +118,9 @@ function Report({
         endpoint,
         state,
         (data, isComplete) => {
+          setReportData((prevState) => prevState.concat(data))
           if (isComplete) {
             setFetched(true)
-            setReportData((prevState) => prevState.concat(data))
-          } else {
-            setReportData((prevState) => prevState.concat(data))
-          }
         },
         (message) => {
           setErrorMessage(message)

--- a/src/js/components/Report/Report.jsx
+++ b/src/js/components/Report/Report.jsx
@@ -4,11 +4,11 @@ import { Column } from '../../schema'
 import { useContext } from 'react'
 import { Context } from '../../state'
 import { useTranslation } from 'react-i18next'
-import { httpGet } from '../../utils'
+import { fetchPages, httpGet } from '../../utils'
 import { Alert } from '../Alert/Alert'
 import { Loading } from '../Loading/Loading'
 import { ContentArea } from '../ContentArea/ContentArea'
-import { Table } from '../Table'
+import { NavigableTable, Table } from '../Table'
 import { Markdown } from '../Markdown/Markdown'
 
 /**
@@ -114,15 +114,20 @@ function Report({
 
   useEffect(() => {
     if (!fetched) {
-      httpGet(
-        state.fetch,
-        new URL(endpoint, state.baseURL),
-        ({ data }) => {
-          setReportData(data)
-          setErrorMessage(null)
-          setFetched(true)
+      fetchPages(
+        endpoint,
+        state,
+        (data, isComplete) => {
+          if (isComplete) {
+            setFetched(true)
+            setReportData((prevState) => prevState.concat(data))
+          } else {
+            setReportData((prevState) => prevState.concat(data))
+          }
         },
-        ({ message }) => setErrorMessage(message)
+        (message) => {
+          setErrorMessage(message)
+        }
       )
     }
   }, [fetched])

--- a/src/js/components/Report/Report.jsx
+++ b/src/js/components/Report/Report.jsx
@@ -121,6 +121,7 @@ function Report({
           setReportData((prevState) => prevState.concat(data))
           if (isComplete) {
             setFetched(true)
+          }
         },
         (message) => {
           setErrorMessage(message)

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -83,6 +83,21 @@ export async function httpRequest(fetchMethod, path, options = requestOptions) {
   }
 }
 
+export function fetchPages(path, { fetch, baseURL }, onDataReceived, onError) {
+  const localFetch = (resource) => {
+    httpGet(fetch, new URL(resource, baseURL), onSuccess, onError)
+  }
+  const onSuccess = ({ data, headers }) => {
+    const links = parseLinkHeader(headers.get('Link'))
+    const nextLink = Object.hasOwn(links, 'next') ? links.next[0] : null
+    onDataReceived(data, nextLink === null)
+    if (nextLink !== null) {
+      setTimeout(localFetch, 25, nextLink)
+    }
+  }
+  localFetch(path)
+}
+
 export function isFunction(func) {
   return func && {}.toString.call(func) === '[object Function]'
 }

--- a/src/js/views/Project/Components/ComponentList.jsx
+++ b/src/js/views/Project/Components/ComponentList.jsx
@@ -77,28 +77,44 @@ function ComponentList({ project, urlPath }) {
         {
           title: t('common.name'),
           name: 'name',
-          type: 'text'
+          type: 'text',
+          tableOptions: {
+            headerClassName: 'w-3/12',
+            className: 'truncate'
+          }
         },
         {
           title: t('terms.package'),
           name: 'package_url',
-          type: 'text'
+          type: 'text',
+          tableOptions: {
+            headerClassName: 'w-4/12',
+            className: 'truncate'
+          }
         },
         {
           title: t('terms.version'),
           name: 'version',
-          type: 'text'
+          type: 'text',
+          tableOptions: {
+            headerClassName: 'w-1/12',
+            className: 'overflow-clip'
+          }
         },
         {
           title: t('project.components.status'),
           name: 'status',
-          type: 'text'
+          type: 'text',
+          tableOptions: {
+            headerClassName: 'w-1/12'
+          }
         },
         {
           title: t('terms.healthScore'),
           name: 'score',
           type: 'text',
           tableOptions: {
+            headerClassName: 'w-2/12',
             lookupFunction: (value) => {
               if (value !== null) {
                 return <ScoreBadge value={value} />

--- a/src/js/views/Project/Components/ComponentList.jsx
+++ b/src/js/views/Project/Components/ComponentList.jsx
@@ -31,8 +31,16 @@ function ComponentList({ project, urlPath }) {
       `/projects/${project.id}/components`,
       globalState,
       (data, isComplete) => {
-        setComponents((prevState) => prevState.concat(data))
-        if (isComplete) setFetching(false)
+        if (isComplete) {
+          setFetching(false)
+          setComponents((prevState) =>
+            prevState
+              .concat(data)
+              .sort((a, b) => (a['name'] < b['name'] ? -1 : 1))
+          )
+        } else {
+          setComponents((prevState) => prevState.concat(data))
+        }
       },
       (message) => {
         setErrorMessage(message)
@@ -40,6 +48,17 @@ function ComponentList({ project, urlPath }) {
       }
     )
   }, [])
+
+  function onSortChange(column, direction) {
+    setComponents(
+      [...components].sort((a, b) => {
+        if (a[column] == null || a[column] < b[column])
+          return direction === 'asc' ? -1 : 1
+        if (b[column] === null || b[column] < a[column])
+          return direction === 'asc' ? 1 : -1
+      })
+    )
+  }
 
   if (fetching) return <Loading />
   if (errorMessage) return <Alert level="error">{errorMessage}</Alert>
@@ -90,7 +109,9 @@ function ComponentList({ project, urlPath }) {
         }
       ]}
       data={components}
+      defaultSort="name"
       extractSearchParam={(obj) => obj.name}
+      onSortChange={onSortChange}
       title={t('project.components.singular')}
       selectedIndex={selectedIndex}
       setSelectedIndex={setSelectedIndex}

--- a/src/js/views/Reports/ComponentUsage.jsx
+++ b/src/js/views/Reports/ComponentUsage.jsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import Report from '../../components/Report/Report'
 
+function createColumn(name, type, headerClassName, className) {
+  const tableOptions = { headerClassName, className }
+  return { name, type, tableOptions }
+}
+
 function ComponentUsage() {
   return (
     <Report
@@ -8,12 +13,12 @@ function ComponentUsage() {
       keyPrefix="reports.componentUsage"
       pageIcon="fas cubes"
       columns={[
-        { name: 'name', type: 'text' },
-        { name: 'package_url', type: 'text' },
-        { name: 'status', type: 'text' },
-        { name: 'active_version', type: 'text' },
-        { name: 'version_count', type: 'number' },
-        { name: 'project_count', type: 'number' }
+        createColumn('name', 'text', 'w-3/12', 'truncate'),
+        createColumn('package_url', 'text', 'w-4/12', 'truncate'),
+        createColumn('status', 'text', 'w-1/12', 'overflow-clip'),
+        createColumn('active_version', 'text', 'w-2/12', 'overflow-clip'),
+        createColumn('version_count', 'number', 'w-1/12'),
+        createColumn('project_count', 'number', 'w-1/12')
       ]}
     />
   )


### PR DESCRIPTION
Once I added some components to a project, I noticed that the multi-page fetch in `ComponentList` was broken due to my misunderstanding of how that code worked. I fixed it by adding a clean way to retrieve a paginated response from the API. 

The new `fetchPages` function in _utils_ retrieves a page, invokes a callback to inject the data, and retrieves the next page if a `next` link header is in the response. The callback is also passed a "finished" flag so that the component can update its "fetching" state. There is a little more to it, but that is the gist of the function. See the `ComponentList` changes in 743750f7eb30cba653088487b999d9d00a709cd5 for the implementation. I switched the `Report` component over to using `fetchPages` so that we can paginate them in the future.

I also added sorting to the `NavigableTable` so that the user can sort the Components table and adjusted some column widths.