### PR TITLE
SSM schema updates & add update view for SSM

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -353,7 +353,9 @@ export default {
             deleteConfirmation: {
               title: 'Delete SSM Parameters',
               button: 'Delete Checked'
-            }
+            },
+            environmentType: '<0>{{environment}}</0> Type',
+            environmentValue: '<0>{{environment}}</0> Value'
           }
         },
         components: {

--- a/src/js/views/Project/Configuration/AddSSMParam.jsx
+++ b/src/js/views/Project/Configuration/AddSSMParam.jsx
@@ -29,7 +29,9 @@ function AddSSMParam({ onClose, project, pathPrefix }) {
     if (!saving) return
 
     const data = Object.fromEntries(
-      Object.entries(values).filter(([key, value]) => !!value)
+      Object.entries(values)
+        .filter(([, value]) => !!value)
+        .map(([environment, value]) => [environment, { value, type }])
     )
 
     const create = async () => {
@@ -41,7 +43,6 @@ function AddSSMParam({ onClose, project, pathPrefix }) {
         ),
         {
           name,
-          type,
           values: data
         }
       )

--- a/src/js/views/Project/Configuration/EditSSMParam.jsx
+++ b/src/js/views/Project/Configuration/EditSSMParam.jsx
@@ -186,7 +186,7 @@ function EditSSMParam({
                   {{ environment }}
                 </Trans>
               }
-              name={`${environment}`}
+              name={environment}
               type="select"
               options={[
                 { label: 'String', value: 'String' },

--- a/src/js/views/Project/Configuration/EditSSMParam.jsx
+++ b/src/js/views/Project/Configuration/EditSSMParam.jsx
@@ -1,0 +1,248 @@
+import PropTypes from 'prop-types'
+import React, { useContext, useEffect, useState } from 'react'
+import { Form } from '../../../components'
+import { compare } from 'fast-json-patch'
+import { Trans, useTranslation } from 'react-i18next'
+import { httpDelete, httpPatch, httpPost } from '../../../utils'
+import { Context } from '../../../state'
+
+function EditSSMParam({
+  param,
+  project,
+  pathPrefix,
+  onCancel,
+  onError,
+  onSuccess
+}) {
+  const [globalState] = useContext(Context)
+  const { t, i18n } = useTranslation()
+  const [saving, setSaving] = useState(false)
+  const [name, setName] = useState(param.name.replace(pathPrefix, ''))
+  const [values, setValues] = useState(
+    Object.fromEntries(
+      project.environments.map((environment) => [
+        environment,
+        {
+          value: param.values[environment]?.value,
+          type: param.values[environment]?.type
+        }
+      ])
+    )
+  )
+
+  function deleteThenPost(nameSuffix) {
+    let exitEarly = false
+    const deleteParams = async () => {
+      setSaving(true)
+      const deleteEnvironments = []
+      for (const [environment, { value }] of Object.entries(param.values)) {
+        if (value) {
+          deleteEnvironments.push(environment)
+        }
+      }
+      const response = await httpDelete(
+        globalState.fetch,
+        new URL(
+          `/projects/${project.id}/configuration/ssm`,
+          globalState.baseURL
+        ),
+        {
+          name: nameSuffix,
+          environments: deleteEnvironments
+        }
+      )
+      if (!response.success) {
+        exitEarly = true
+        onError(
+          response?.responseBody?.detail
+            ? response.responseBody.detail
+            : response.data
+        )
+      }
+    }
+    deleteParams().catch((error) => onError(error))
+    if (exitEarly) return
+
+    const createParams = async () => {
+      const newValues = {}
+      for (const [environment, { type, value }] of Object.entries(values)) {
+        if (value) {
+          newValues[environment] = { type, value }
+        }
+      }
+      const response = await httpPost(
+        globalState.fetch,
+        new URL(
+          `/projects/${project.id}/configuration/ssm`,
+          globalState.baseURL
+        ),
+        {
+          name,
+          values: newValues
+        }
+      )
+      if (!response.success) {
+        onError(
+          response?.responseBody?.detail
+            ? response.responseBody.detail
+            : response.data
+        )
+      }
+    }
+    createParams().catch((error) => {
+      onError(error)
+    })
+
+    setSaving(false)
+    onSuccess()
+  }
+
+  function patchParams(nameSuffix) {
+    const oldValues = {}
+    for (const [environment, { type, value }] of Object.entries(param.values)) {
+      if (value) {
+        oldValues[environment] = { type, value }
+      }
+    }
+    const newValues = {}
+    for (const [environment, { type, value }] of Object.entries(values)) {
+      if (value) {
+        newValues[environment] = { type, value }
+      }
+    }
+    const patch = compare(oldValues, newValues)
+    if (patch.length === 0) {
+      onSuccess()
+      return
+    }
+    const update = async () => {
+      const response = await httpPatch(
+        globalState.fetch,
+        new URL(
+          `/projects/${project.id}/configuration/ssm/${encodeURIComponent(
+            nameSuffix
+          )}`,
+          globalState.baseURL
+        ),
+        patch
+      )
+      if (response.success) {
+        onSuccess()
+      } else {
+        onError(
+          response?.responseBody?.detail
+            ? response.responseBody.detail
+            : response.data
+        )
+      }
+    }
+    update().catch((error) => onError(error))
+  }
+
+  useEffect(() => {
+    if (!saving) return
+
+    const nameSuffix = param.name.replace(pathPrefix, '')
+    if (name !== nameSuffix) {
+      deleteThenPost(nameSuffix)
+    } else {
+      patchParams(nameSuffix)
+    }
+  }, [saving])
+
+  const ready =
+    !!name &&
+    Object.entries(values).filter(
+      ([, { type, value }]) => (value && !type) || (type && !value)
+    ).length === 0
+
+  return (
+    <Form.SimpleForm
+      errorMessage={null}
+      ready={ready}
+      onSubmit={() => {
+        setSaving(true)
+      }}
+      onCancel={onCancel}
+      saving={saving}>
+      <Form.Section name="parameter" title="Parameter">
+        <Form.Field
+          title="Name"
+          name="name"
+          type="prefix-text"
+          required={true}
+          onChange={(name, value) => setName(value)}
+          value={name}
+          prefix={pathPrefix}
+        />
+      </Form.Section>
+      <Form.Section name="values" title="Values">
+        {project.environments.map((environment) => (
+          <React.Fragment key={environment}>
+            <Form.Field
+              title={
+                <Trans
+                  i18nKey={'project.configuration.ssm.environmentType'}
+                  i18n={i18n}
+                  t={t}>
+                  {{ environment }}
+                </Trans>
+              }
+              name={`${environment}`}
+              type="select"
+              options={[
+                { label: 'String', value: 'String' },
+                { label: 'SecureString', value: 'SecureString' },
+                { label: 'StringList', value: 'StringList' }
+              ]}
+              required={false}
+              onChange={(environment, newType) =>
+                setValues((prevState) => ({
+                  ...prevState,
+                  [environment]: {
+                    ...prevState[environment],
+                    type: newType || null
+                  }
+                }))
+              }
+              value={values[environment].type}
+            />
+            <Form.Field
+              title={
+                <Trans
+                  i18nKey={'project.configuration.ssm.environmentValue'}
+                  i18n={i18n}
+                  t={t}>
+                  {{ environment }}
+                </Trans>
+              }
+              name={environment}
+              type="textarea"
+              required={false}
+              onChange={(environment, newValue) =>
+                setValues((prevState) => ({
+                  ...prevState,
+                  [environment]: {
+                    ...prevState[environment],
+                    value: newValue || null
+                  }
+                }))
+              }
+              value={values[environment].value}
+            />
+          </React.Fragment>
+        ))}
+      </Form.Section>
+    </Form.SimpleForm>
+  )
+}
+
+EditSSMParam.propTypes = {
+  param: PropTypes.object.isRequired,
+  project: PropTypes.object.isRequired,
+  pathPrefix: PropTypes.string.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func.isRequired
+}
+export { EditSSMParam }

--- a/src/js/views/Project/Configuration/EditSSMParam.jsx
+++ b/src/js/views/Project/Configuration/EditSSMParam.jsx
@@ -31,7 +31,7 @@ function EditSSMParam({
   )
 
   function deleteThenPost(nameSuffix) {
-    const createParams = async (onSuccess) => {
+    const createParams = async () => {
       const newValues = {}
       for (const [environment, { type, value }] of Object.entries(values)) {
         if (value) {
@@ -61,7 +61,7 @@ function EditSSMParam({
       }
     }
 
-    const deleteParams = async (onSuccess) => {
+    const deleteParams = async () => {
       setSaving(true)
       const deleteEnvironments = []
       for (const [environment, { value }] of Object.entries(param.values)) {
@@ -88,13 +88,11 @@ function EditSSMParam({
             : response.data
         )
       } else {
-        onSuccess()
+        await createParams()
       }
     }
 
-    deleteParams(() => {
-      createParams(() => onSuccess()).catch((error) => onError(error))
-    }).catch((error) => onError(error))
+    deleteParams().catch((error) => onError(error))
   }
 
   function patchParams(nameSuffix) {

--- a/src/js/views/Project/Configuration/SSMConfiguration.jsx
+++ b/src/js/views/Project/Configuration/SSMConfiguration.jsx
@@ -235,6 +235,7 @@ function SSMConfiguration({ project }) {
           newParams.delete('v')
           setSearchParams(newParams)
           setSlideOverOpen(false)
+          setShowSecureStrings(false)
         }}
         onKeyDown={(e) => {
           if (!showArrows) return

--- a/src/js/views/Project/Configuration/SSMConfiguration.jsx
+++ b/src/js/views/Project/Configuration/SSMConfiguration.jsx
@@ -70,13 +70,13 @@ function SSMConfiguration({ project }) {
             .sort((a, b) => (a.name > b.name ? 1 : -1))
             .map((param) => {
               const types = new Set()
-              const environments = new Set()
-              param.values.forEach((value) => {
-                types.add(value.type)
-                environments.add(value.environment)
-              })
+              const environments = []
+              for (const [environment, data] of Object.entries(param.values)) {
+                types.add(data.type)
+                environments.push(environment)
+              }
               param['type'] = Array.from(types).sort().join(', ')
-              param['environments'] = Array.from(environments).sort().join(', ')
+              param['environments'] = environments.sort().join(', ')
               return param
             })
         )

--- a/src/js/views/Project/Configuration/SSMConfiguration.jsx
+++ b/src/js/views/Project/Configuration/SSMConfiguration.jsx
@@ -58,6 +58,13 @@ function SSMConfiguration({ project }) {
     setShowSecureStrings(value)
   }
 
+  function refreshPage() {
+    const newParams = cloneParams(searchParams)
+    newParams.delete('v')
+    setSearchParams(newParams)
+    refreshParams()
+  }
+
   function refreshParams() {
     setFetching(true)
 
@@ -248,12 +255,13 @@ function SSMConfiguration({ project }) {
           param={rows[selectedIndex]}
           showSecureStrings={showSecureStrings}
           onShowSecureStringsChange={onShowSecureStringsChange}
-          onDeleteComplete={() => {
-            const newParams = cloneParams(searchParams)
-            newParams.delete('v')
-            setSearchParams(newParams)
-            refreshParams()
+          onEditComplete={refreshPage}
+          onEditOpen={() => setShowArrows(false)}
+          onEditClose={() => {
+            setShowArrows(true)
+            setSlideOverFocusTrigger({})
           }}
+          onDeleteComplete={refreshPage}
           onDeleteOpen={() => setShowArrows(false)}
           onDeleteClose={() => {
             setShowArrows(true)

--- a/src/js/views/Project/Configuration/ViewSSMParam.jsx
+++ b/src/js/views/Project/Configuration/ViewSSMParam.jsx
@@ -140,10 +140,10 @@ function ViewSSMParam({
           .sort(([environmentA], [environmentB]) =>
             environmentA > environmentB ? 1 : -1
           )
-          .map(([environment, { value, type }], i) => {
+          .map(([environment, { value, type }]) => {
             return (
               <DefinitionRow
-                key={i}
+                key={environment}
                 className="min-w-0 break-words font-mono"
                 term={
                   param.type.includes(',') ? (

--- a/src/js/views/Project/Configuration/ViewSSMParam.jsx
+++ b/src/js/views/Project/Configuration/ViewSSMParam.jsx
@@ -34,7 +34,7 @@ function ViewSSMParam({
   const [deleting, setDeleting] = useState(false)
   const [deleteChecklist, setDeleteChecklist] = useState(
     Object.fromEntries(
-      param.values.map(({ environment }) => [environment, true])
+      Object.entries(param.values).map(([environment]) => [environment, true])
     )
   )
 
@@ -100,9 +100,9 @@ function ViewSSMParam({
             {deleting ? (
               <Loading />
             ) : (
-              param.values
-                .sort((a, b) => (a.environment > b.environment ? 1 : -1))
-                .map(({ environment }) => {
+              Object.keys(param.values)
+                .sort()
+                .map((environment) => {
                   return (
                     <Checkbox
                       key={environment}
@@ -136,9 +136,11 @@ function ViewSSMParam({
       </div>
 
       <DescriptionList>
-        {param.values
-          .sort((a, b) => (a.environment > b.environment ? 1 : -1))
-          .map(({ environment, value, type }, i) => {
+        {Object.entries(param.values)
+          .sort(([environmentA], [environmentB]) =>
+            environmentA > environmentB ? 1 : -1
+          )
+          .map(([environment, { value, type }], i) => {
             return (
               <DefinitionRow
                 key={i}


### PR DESCRIPTION
Adds UI for updating existing params at a given name. Users can update exiting parameters' type and/or value, delete a param, or even update the name (which is really a delete then a post).

A few minor fixes in here too such as using the correct key for a React list, and fixing a small bug with SlideOver not resetting the toggle to hide SecureStrings by default.