### PR TITLE
Add admin section for CRUD operations on AWS roles

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -64,6 +64,7 @@ export default {
         dataCenter: 'Data Center',
         deploymentType: 'Deployment Type',
         description: 'Description',
+        environment: 'Environment',
         environments: 'Environments',
         healthScore: 'Health Score',
         links: 'Links',
@@ -129,6 +130,14 @@ export default {
         sidebar: {
           settings: 'Settings',
           userManagement: 'User Management'
+        },
+        aws_roles: {
+          collectionName: 'AWS Roles',
+          itemName: 'AWS Role',
+          errors: {
+            uniqueViolation:
+              'A role already exists for that environment and namespace'
+          }
         },
         components: {
           activeVersion: 'Active Version',

--- a/src/js/schema/AWSRoles.js
+++ b/src/js/schema/AWSRoles.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types'
+
+export const jsonSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    id: {
+      type: 'number'
+    },
+    role_arn: {
+      type: 'string'
+    },
+    environment: {
+      type: 'string',
+      minLength: 3
+    },
+    namespace_id: {
+      type: 'number'
+    },
+    created_at: {
+      type: 'string',
+      format: 'date-time'
+    },
+    created_by: {
+      type: 'string'
+    }
+  },
+  additionalProperties: false,
+  required: ['role_arn', 'environment', 'namespace_id']
+}
+
+export const propTypes = {
+  id: PropTypes.number.isRequired,
+  description: PropTypes.string,
+  icon_class: PropTypes.string
+}

--- a/src/js/views/Admin/AWSRoles.jsx
+++ b/src/js/views/Admin/AWSRoles.jsx
@@ -19,7 +19,6 @@ export function AWSRoles() {
 
   return (
     <CRUD
-      collectionIcon="fas key"
       collectionName={t('admin.aws_roles.collectionName')}
       collectionPath="/aws-roles"
       columns={[

--- a/src/js/views/Admin/AWSRoles.jsx
+++ b/src/js/views/Admin/AWSRoles.jsx
@@ -1,0 +1,78 @@
+import React, { useContext } from 'react'
+
+import { CRUD } from '../../components'
+import { useTranslation } from 'react-i18next'
+import { jsonSchema } from '../../schema/AWSRoles'
+import { metadataAsOptions } from '../../settings'
+import { Context } from '../../state'
+
+export function AWSRoles() {
+  const [globalState] = useContext(Context)
+  const { t } = useTranslation()
+
+  const namespaceById = Object.fromEntries(
+    globalState.metadata.namespaces.map((namespace) => [
+      namespace.id,
+      namespace
+    ])
+  )
+
+  return (
+    <CRUD
+      collectionIcon="fas key"
+      collectionName={t('admin.aws_roles.collectionName')}
+      collectionPath="/aws-roles"
+      columns={[
+        {
+          title: t('id'),
+          name: 'id',
+          type: 'hidden',
+          omitOnAdd: true,
+          tableOptions: {
+            hide: true
+          }
+        },
+        {
+          title: t('common.name'),
+          name: 'role_arn',
+          type: 'text',
+          tableOptions: {
+            className: 'truncate',
+            headerClassName: 'w-6/12'
+          }
+        },
+        {
+          title: t('terms.environment'),
+          name: 'environment',
+          type: 'select',
+          options: metadataAsOptions(globalState.metadata.environments, 'name'),
+          tableOptions: {
+            className: 'truncate',
+            headerClassName: 'w-3/12'
+          }
+        },
+        {
+          title: t('terms.namespace'),
+          name: 'namespace_id',
+          type: 'select',
+          castTo: 'number',
+          options: metadataAsOptions(globalState.metadata.namespaces),
+          tableOptions: {
+            className: 'truncate',
+            headerClassName: 'w-3/12',
+            lookupFunction: (namespaceId) => namespaceById[namespaceId].slug
+          }
+        }
+      ]}
+      errorStrings={{
+        'Unique Violation': t('admin.aws_roles.errors.uniqueViolation')
+      }}
+      itemIgnore={['created_by', 'created_at']}
+      itemKey="id"
+      itemName={t('admin.aws_roles.itemName')}
+      itemPath="/aws-roles/{{value}}"
+      itemTitle="role_arn"
+      jsonSchema={jsonSchema}
+    />
+  )
+}

--- a/src/js/views/Admin/Admin.jsx
+++ b/src/js/views/Admin/Admin.jsx
@@ -30,7 +30,7 @@ function Admin({ user }) {
       <Sidebar>
         <Sidebar.Section name={t('admin.sidebar.settings')} open={true}>
           <Sidebar.MenuItem
-            value={'AWS Roles'}
+            value={t('admin.aws_roles.collectionName')}
             to="/ui/admin/aws-roles"
             icon="fas key"
           />

--- a/src/js/views/Admin/Admin.jsx
+++ b/src/js/views/Admin/Admin.jsx
@@ -19,6 +19,7 @@ import { ProjectFactTypeRanges } from './ProjectFactTypeRanges'
 import { ProjectLinkTypes } from './ProjectLinkTypes'
 import { ProjectTypes } from './ProjectTypes'
 import { Users } from './Users'
+import { AWSRoles } from './AWSRoles'
 
 function Admin({ user }) {
   const { t } = useTranslation()
@@ -28,6 +29,11 @@ function Admin({ user }) {
     <Fragment>
       <Sidebar>
         <Sidebar.Section name={t('admin.sidebar.settings')} open={true}>
+          <Sidebar.MenuItem
+            value={'AWS Roles'}
+            to="/ui/admin/aws-roles"
+            icon="fas key"
+          />
           <Sidebar.MenuItem
             value={t('admin.cookieCutters.collectionName')}
             to="/ui/admin/cookie-cutters"
@@ -90,6 +96,7 @@ function Admin({ user }) {
       <div className="flex-grow py-3 px-4">
         <Routes>
           <Route path="" exact={true} element={<Dashboard />} />
+          <Route path="aws-roles" element={<AWSRoles />} />
           <Route path="cookie-cutters" element={<CookieCutters />} />
           <Route path="components" element={<Components />} />
           <Route path="environments" element={<Environments />} />

--- a/src/js/views/Admin/Components.jsx
+++ b/src/js/views/Admin/Components.jsx
@@ -18,7 +18,6 @@ function Components() {
 
   return (
     <CRUD
-      collectionIcon="fas cog"
       collectionName={t('admin.components.collectionName')}
       collectionPath={'/components'}
       itemKey={'package_url'}

--- a/src/js/views/Admin/CookieCutters.jsx
+++ b/src/js/views/Admin/CookieCutters.jsx
@@ -17,7 +17,6 @@ export function CookieCutters() {
 
   return (
     <CRUD
-      collectionIcon="fas cookie"
       collectionName={t('admin.cookieCutters.collectionName')}
       collectionPath="/cookie-cutters"
       columns={[

--- a/src/js/views/Admin/Environments.jsx
+++ b/src/js/views/Admin/Environments.jsx
@@ -9,7 +9,6 @@ export function Environments() {
   const { t } = useTranslation()
   return (
     <CRUD
-      collectionIcon="fas tree"
       collectionName={t('admin.environments.collectionName')}
       collectionPath="/environments"
       columns={[

--- a/src/js/views/Admin/Namespaces.jsx
+++ b/src/js/views/Admin/Namespaces.jsx
@@ -12,7 +12,6 @@ export function Namespaces() {
 
   return (
     <CRUD
-      collectionIcon="fas boxes"
       collectionName={t('admin.namespaces.collectionName')}
       collectionPath="/namespaces"
       columns={[

--- a/src/js/views/Admin/ProjectFactTypeEnums.jsx
+++ b/src/js/views/Admin/ProjectFactTypeEnums.jsx
@@ -35,7 +35,6 @@ export function ProjectFactTypeEnums() {
 
   return (
     <CRUD
-      collectionIcon="fas list-ol"
       collectionName={t('admin.projectFactTypeEnums.collectionName')}
       collectionPath="/project-fact-type-enums"
       columns={[

--- a/src/js/views/Admin/ProjectFactTypeRanges.jsx
+++ b/src/js/views/Admin/ProjectFactTypeRanges.jsx
@@ -35,7 +35,6 @@ export function ProjectFactTypeRanges() {
 
   return (
     <CRUD
-      collectionIcon="fas ruler-horizontal"
       collectionName={t('admin.projectFactTypeRanges.collectionName')}
       collectionPath="/project-fact-type-ranges"
       columns={[

--- a/src/js/views/Admin/ProjectFactTypes.jsx
+++ b/src/js/views/Admin/ProjectFactTypes.jsx
@@ -28,7 +28,6 @@ export function ProjectFactTypes() {
 
   return (
     <CRUD
-      collectionIcon="fas ruler"
       collectionName={t('admin.projectFactTypes.collectionName')}
       collectionPath="/project-fact-types"
       columns={[

--- a/src/js/views/Admin/ProjectLinkTypes.jsx
+++ b/src/js/views/Admin/ProjectLinkTypes.jsx
@@ -8,7 +8,6 @@ export function ProjectLinkTypes() {
   const { t } = useTranslation()
   return (
     <CRUD
-      collectionIcon="fas external-link-alt"
       collectionName={t('admin.projectLinkTypes.collectionName')}
       collectionPath="/project-link-types"
       columns={[

--- a/src/js/views/Admin/ProjectTypes.jsx
+++ b/src/js/views/Admin/ProjectTypes.jsx
@@ -9,7 +9,6 @@ export function ProjectTypes() {
   const { t } = useTranslation()
   return (
     <CRUD
-      collectionIcon="fas cubes"
       collectionName={t('admin.projectTypes.collectionName')}
       collectionPath="/project-types"
       columns={[


### PR DESCRIPTION
This follows the pattern of our other admin sections like environment and namespace, leveraging the CRUD component table and form.