### PR TITLE
Add SSM filter search

### DIFF
--- a/src/js/views/Project/Configuration/SSMConfiguration.jsx
+++ b/src/js/views/Project/Configuration/SSMConfiguration.jsx
@@ -19,7 +19,7 @@ function cloneParams(searchParams) {
 }
 
 function SSMConfiguration({ project }) {
-  const [globalState, dispatch] = useContext(Context)
+  const [globalState] = useContext(Context)
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()


### PR DESCRIPTION
This adds a simple string-includes filter when viewing a project's
SSM parameters. The filteredRows is a separate state variable,
instead of being calculated on each render from the rows and
searchValue, both because that prevents work on each render, and
also makes keeping track of the selected index easier.