### PR TITLE
Simplify Project Overview Card heights

### DIFF
--- a/src/js/views/Project/Facts.jsx
+++ b/src/js/views/Project/Facts.jsx
@@ -78,24 +78,22 @@ function Display({ project, onEditClick }) {
           )
         })}
       </dl>
-      <div className="flex-grow flex flex-row items-end">
-        <div className="flex-grow flex items-center mt-2">
-          {lastUpdated > 0 && (
-            <div className="flex-1 text-xs italic">
-              {t('common.lastUpdated', {
-                date: new Intl.DateTimeFormat('en-US').format(lastUpdated)
-              })}
-            </div>
-          )}
-          {project.archived === false && (
-            <div className="flex-1 text-xs text-right">
-              <Button onClick={onEditClick}>
-                <Icon icon="fas edit" className="mr-2" />
-                {t('project.updateFacts')}
-              </Button>
-            </div>
-          )}
-        </div>
+      <div className="flex flex-row items-end mt-2">
+        {lastUpdated > 0 && (
+          <div className="flex-1 text-xs italic">
+            {t('common.lastUpdated', {
+              date: new Intl.DateTimeFormat('en-US').format(lastUpdated)
+            })}
+          </div>
+        )}
+        {project.archived === false && (
+          <div className="flex-1 text-xs text-right">
+            <Button onClick={onEditClick}>
+              <Icon icon="fas edit" className="mr-2" />
+              {t('project.updateFacts')}
+            </Button>
+          </div>
+        )}
       </div>
     </Card>
   )

--- a/src/js/views/Project/Overview.jsx
+++ b/src/js/views/Project/Overview.jsx
@@ -21,7 +21,7 @@ function Overview({ factTypes, project, refresh, urlPath }) {
 
   return (
     <Fragment>
-      <div className="grid grid-cols-1 space-y-3 space-x-0 lg:grid-cols-3 lg:space-y-0 lg:space-x-3 text-left text-gray-600">
+      <div className="grid grid-cols-1 space-y-3 space-x-0 lg:grid-cols-3 lg:space-y-0 lg:space-x-3 text-left text-gray-600 items-start">
         <Details
           project={project}
           editing={editing.details}

--- a/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
+++ b/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
@@ -138,7 +138,7 @@ function ProjectFeed({ projectID }) {
 
   return (
     <ErrorBoundary>
-      <Card className="flow-root max-h-screen">
+      <Card className="flow-root max-h-[900px]">
         <h2 className="font-medium mb-2">{t('project.feed.title')}</h2>
         {content}
       </Card>


### PR DESCRIPTION
This ensures that the Cards shown on the Project Overview page only grow to their maximum height based on content. Except the ProjectFeed, which can grow indefinitely, and so is capped to 900px.