### PR TITLE
Fix ProjectFeed scroll

### DIFF
--- a/src/js/views/Project/Facts.jsx
+++ b/src/js/views/Project/Facts.jsx
@@ -63,39 +63,41 @@ function Display({ project, onEditClick }) {
   const { t } = useTranslation()
   let lastUpdated = 0
   return (
-    <Card className="flex flex-col">
-      <h2 className="font-medium mb-2">{t('project.projectFacts')}</h2>
-      <dl className="lg:ml-4 my-3">
-        {project.facts.map((fact, offset) => {
-          const updated = Date.parse(fact.recorded_at)
-          if (updated > lastUpdated) lastUpdated = updated
-          return (
-            <Fact
-              key={`fact-${fact.fact_type_id}`}
-              fact={fact}
-              offset={offset}
-            />
-          )
-        })}
-      </dl>
-      <div className="flex flex-row items-end mt-2">
-        {lastUpdated > 0 && (
-          <div className="flex-1 text-xs italic">
-            {t('common.lastUpdated', {
-              date: new Intl.DateTimeFormat('en-US').format(lastUpdated)
-            })}
-          </div>
-        )}
-        {project.archived === false && (
-          <div className="flex-1 text-xs text-right">
-            <Button onClick={onEditClick}>
-              <Icon icon="fas edit" className="mr-2" />
-              {t('project.updateFacts')}
-            </Button>
-          </div>
-        )}
-      </div>
-    </Card>
+    <div>
+      <Card className="flex flex-col">
+        <h2 className="font-medium mb-2">{t('project.projectFacts')}</h2>
+        <dl className="lg:ml-4 my-3">
+          {project.facts.map((fact, offset) => {
+            const updated = Date.parse(fact.recorded_at)
+            if (updated > lastUpdated) lastUpdated = updated
+            return (
+              <Fact
+                key={`fact-${fact.fact_type_id}`}
+                fact={fact}
+                offset={offset}
+              />
+            )
+          })}
+        </dl>
+        <div className="flex flex-row items-end mt-2">
+          {lastUpdated > 0 && (
+            <div className="flex-1 text-xs italic">
+              {t('common.lastUpdated', {
+                date: new Intl.DateTimeFormat('en-US').format(lastUpdated)
+              })}
+            </div>
+          )}
+          {project.archived === false && (
+            <div className="flex-1 text-xs text-right">
+              <Button onClick={onEditClick}>
+                <Icon icon="fas edit" className="mr-2" />
+                {t('project.updateFacts')}
+              </Button>
+            </div>
+          )}
+        </div>
+      </Card>
+    </div>
   )
 }
 Display.propTypes = {

--- a/src/js/views/Project/Overview.jsx
+++ b/src/js/views/Project/Overview.jsx
@@ -21,7 +21,7 @@ function Overview({ factTypes, project, refresh, urlPath }) {
 
   return (
     <Fragment>
-      <div className="grid grid-cols-1 space-y-3 space-x-0 lg:grid-cols-3 lg:space-y-0 lg:space-x-3 text-left text-gray-600 items-start">
+      <div className="grid grid-cols-1 space-y-3 space-x-0 lg:grid-cols-3 lg:space-y-0 lg:space-x-3 text-left text-gray-600">
         <Details
           project={project}
           editing={editing.details}


### PR DESCRIPTION
This keeps the ProjectFacts Card to only grow to the size of its content while retaining the scroll of the project feed. The items-start was correcting the Facts height but inadvertently removed the feed scroll. This is fixed by merely wrapping the facts component in a div that takes up the full height, instead of its content, which now grows only to its normal size, per usual.