### PR TITLE
Cap ProjectFeed height at tallest sibling

### DIFF
--- a/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
+++ b/src/js/views/Project/ProjectFeed/ProjectFeed.jsx
@@ -137,12 +137,14 @@ function ProjectFeed({ projectID }) {
   }
 
   return (
-    <ErrorBoundary>
-      <Card className="flow-root max-h-[900px]">
-        <h2 className="font-medium mb-2">{t('project.feed.title')}</h2>
-        {content}
-      </Card>
-    </ErrorBoundary>
+    <div className="h-0 min-h-full">
+      <ErrorBoundary>
+        <Card className="max-h-full flex flex-col">
+          <h2 className="font-medium mb-2">{t('project.feed.title')}</h2>
+          {content}
+        </Card>
+      </ErrorBoundary>
+    </div>
   )
 }
 ProjectFeed.propTypes = {


### PR DESCRIPTION
The new outer div acts as a layout container that is exactly the height of the tallest sibling. The height: 0px and min-height: 100% trick enforces this because the height will make it ignore its own content, and then the min-height will take on the height of the parent, which is determined by the grid. Since the min-height is larger than the height, it will always be selected as the actual height of the element.

The Card is then capped at the height of the div parent with max-height: 100%. This fixes the height problems, so that a small feed will only take up as much space as needed, but a large feed will be capped at the largest sibling height.

However, this breaks scrolling the feed because the height of the parent is no longer explicit. To fix this, we switch the parent to a column flexbox to get scrolling for free.