### PR TITLE
Add readonly project dependency table

### DIFF
--- a/src/js/views/Project/Dependencies.jsx
+++ b/src/js/views/Project/Dependencies.jsx
@@ -26,7 +26,7 @@ function Dependencies({ project, urlPath }) {
     httpGet(
       globalState.fetch,
       new URL(
-        `/projects/${project.id}/dependencies?includes=dependency`,
+        `/projects/${project.id}/dependencies?include=dependency`,
         globalState.baseURL
       ),
       ({ data }) => {

--- a/src/js/views/Project/Dependencies.jsx
+++ b/src/js/views/Project/Dependencies.jsx
@@ -1,31 +1,102 @@
 import PropTypes from 'prop-types'
-import React, { useContext, useEffect } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 
 import { Context } from '../../state'
-import { WishedFutureState } from '../../components'
+import { Alert, Table } from '../../components'
+import { httpGet, lookupNamespaceByID } from '../../utils'
+import { useTranslation } from 'react-i18next'
 
-function Dependencies({ urlPath }) {
-  const [state, dispatch] = useContext(Context)
+function Dependencies({ project, urlPath }) {
+  const [globalState, dispatch] = useContext(Context)
+  const { t } = useTranslation()
+  const [rows, setRows] = useState([])
+  const [errorMessage, setErrorMessage] = useState()
+
   useEffect(() => {
     dispatch({
       type: 'SET_CURRENT_PAGE',
       payload: {
         title: 'project.dependencies',
-        url: new URL(`${urlPath}/dependencies`, state.baseURL)
+        url: new URL(`${urlPath}/dependencies`, globalState.baseURL)
       }
     })
   }, [])
+
+  useEffect(() => {
+    httpGet(
+      globalState.fetch,
+      new URL(
+        `/projects/${project.id}/dependencies?includes=dependency`,
+        globalState.baseURL
+      ),
+      ({ data }) => {
+        setRows(
+          data
+            .map(({ dependency }) => ({
+              namespace: lookupNamespaceByID(
+                globalState.metadata.namespaces,
+                dependency.namespace_id
+              ).name,
+              name: dependency.name,
+              project_type: lookupNamespaceByID(
+                globalState.metadata.projectTypes,
+                dependency.project_type_id
+              ).name
+            }))
+            .sort((a, b) => {
+              if (a.namespace < b.namespace) return -1
+              else if (a.namespace > b.namespace) return 1
+              else return a.name < b.name ? -1 : 1
+            })
+        )
+      },
+      ({ message }) => setErrorMessage(message)
+    )
+  }, [])
+
+  const columns = [
+    {
+      title: t('terms.namespace'),
+      name: 'namespace',
+      type: 'text',
+      tableOptions: {
+        headerClassName: 'w-3/12',
+        className: 'truncate'
+      }
+    },
+    {
+      title: t('terms.name'),
+      name: 'name',
+      type: 'text',
+      tableOptions: {
+        className: 'truncate',
+        headerClassName: 'w-3/12'
+      }
+    },
+    {
+      title: t('terms.projectType'),
+      name: 'project_type',
+      type: 'text',
+      tableOptions: {
+        className: 'truncate',
+        headerClassName: 'w-3/12'
+      }
+    }
+  ]
+
   return (
-    <div className="pt-20 flex items-center justify-center">
-      <WishedFutureState>
-        This tab will provide a graph visualization of the projects that this
-        project depends upon. In addition, there will be the option to edit the
-        project&rsquo;s dependencies.
-      </WishedFutureState>
-    </div>
+    <>
+      {errorMessage && (
+        <Alert className="mt-3" level="error">
+          {errorMessage}
+        </Alert>
+      )}
+      <Table columns={columns} data={rows} />
+    </>
   )
 }
 Dependencies.propTypes = {
+  project: PropTypes.object.isRequired,
   urlPath: PropTypes.string.isRequired
 }
 export { Dependencies }

--- a/src/js/views/Project/Project.jsx
+++ b/src/js/views/Project/Project.jsx
@@ -144,7 +144,7 @@ function ProjectPage({ project, factTypes, refresh }) {
           />
           <Route
             path={`dependencies`}
-            element={<Dependencies urlPath={baseURL} />}
+            element={<Dependencies project={project} urlPath={baseURL} />}
           />
           <Route path={`logs`} element={<Logs urlPath={baseURL} />} />
           <Route


### PR DESCRIPTION
This adds a simple table to the project dependencies tab. It displays the same columns in the same order as the projects page (minus score, since that is irrelevant here). It pre-sorts by namespace, then project name.