### PR TITLE
Add wildcards to single word project searches

### DIFF
--- a/src/js/views/Projects/Projects.jsx
+++ b/src/js/views/Projects/Projects.jsx
@@ -163,13 +163,14 @@ function Projects() {
   function search() {
     if (state.fetching === false) {
       let filter = state.filter
+      if (filter.match(/^[^\s:]+$/)) filter = `*${state.filter}*`
       if (state.filter === '' || state.filter === '*')
         filter = 'NOT archived:true'
       else if (
         state.filter.length > 0 &&
         state.filter.includes('archived:') !== true
       )
-        filter = `(${state.filter}) AND NOT archived:true`
+        filter = `(${filter}) AND NOT archived:true`
 
       let ast
 

--- a/src/js/views/Projects/Projects.jsx
+++ b/src/js/views/Projects/Projects.jsx
@@ -22,6 +22,9 @@ const sortMap = {
   project_type: byString
 }
 
+// These are used to detect that a query isn't "simple". See the "search" function for usage.
+const searchStopWords = new Set(['NOT', 'AND', 'OR'])
+
 function sortTableData(data, columns) {
   const sortSettings = []
   for (const [column, direction] of Object.entries(columns)) {
@@ -163,7 +166,17 @@ function Projects() {
   function search() {
     if (state.fetching === false) {
       let filter = state.filter
-      if (filter.match(/^[^\s:]+$/)) filter = `*${state.filter}*`
+
+      // Make simple searches do what the user expects ... "foo bar" is converted to a
+      // search for `*foo* OR *bar*`. We need to be careful here since the search could
+      // have `AND`, `OR`, or `NOT` included. We want to leave these alone.
+      if (filter.match(/^[\w\s]+$/)) {
+        const words = filter.split(/\s+/).map((word) => word.trim())
+        if (!words.some((word) => searchStopWords.has(word.toUpperCase())))
+          filter = `${words.map((word) => `*${word}*`).join(' OR ')}`
+      }
+
+      // We also want to filter out archived projects unless the user asks for them
       if (state.filter === '' || state.filter === '*')
         filter = 'NOT archived:true'
       else if (


### PR DESCRIPTION
This PR adds wildcards around each word in the project search so that things like `nav` match `navigation` as well as `component-navigation`. Each word is wrapped with wildcards and then joined with the `OR` operation since that is what people generally want. However, if the query contains a Boolean operator or a non-word / non-space character, then it is passed along like it was before. This removes some unexpected behavior from escaped characters (eg, `-<>*...`). If you include an escaped character, you are probably doing something specific anyway.

This changes the Opensearch query from doing a [multi_match search](https://opensearch.org/docs/latest/query-dsl/full-text/multi-match/) to doing a [query_string search](https://opensearch.org/docs/latest/query-dsl/full-text/query-string/). I was careful to retain the automatic filtering of archived projects.