### PR TITLE
Fix the global search box on project search page

### DIFF
--- a/src/js/views/Projects/Projects.jsx
+++ b/src/js/views/Projects/Projects.jsx
@@ -84,21 +84,16 @@ function Projects() {
   // hook and update the filter appropriately.
   useEffect(() => {
     if (searchParams.get('f') && state.filter !== searchParams.get('f')) {
-      setState((prevState) => ({
-        ...prevState,
-        filter: searchParams.get('f') || '',
-        refresh: true
-      }))
+      onRefresh()
     }
   }, [location])
 
   function onRefresh() {
-    setState({
-      ...state,
-      data: [],
-      filter: searchParams.get('f') ? searchParams.get('f') : '',
+    setState((prevState) => ({
+      ...prevState,
+      filter: searchParams.get('f') || '',
       refresh: true
-    })
+    }))
   }
 
   function onSortChange(column, direction) {

--- a/src/js/views/Projects/Projects.jsx
+++ b/src/js/views/Projects/Projects.jsx
@@ -5,7 +5,7 @@ import {
   toElasticsearchQuery
 } from '@cybernetex/kbn-es-query'
 import { byString, byNumber, byValues } from 'sort-es'
-import { useSearchParams } from 'react-router-dom'
+import { useLocation, useSearchParams } from 'react-router-dom'
 
 import { Alert, ScoreBadge, Table } from '../../components'
 import { Context } from '../../state'
@@ -37,6 +37,7 @@ function Projects() {
   const [globalState, dispatch] = useContext(Context)
   const [searchParams, setSearchParams] = useSearchParams()
   const { t } = useTranslation()
+  const location = useLocation()
 
   const [state, setState] = useState({
     columns: [],
@@ -75,6 +76,21 @@ function Projects() {
       })
     )
   }
+
+  // Users can use the <ProjectSearch> component to change the filter
+  // The component changes the `f` parameter via `navigate(...)`. However,
+  // if we are already on the projects page, then the `navigate()` function
+  // does not rerender the page. We can catch this with the `useLocation()`
+  // hook and update the filter appropriately.
+  useEffect(() => {
+    if (searchParams.get('f') && state.filter !== searchParams.get('f')) {
+      setState((prevState) => ({
+        ...prevState,
+        filter: searchParams.get('f') || '',
+        refresh: true
+      }))
+    }
+  }, [location])
 
   function onRefresh() {
     setState({


### PR DESCRIPTION
Entering a search into the *global* search box navigates to the project search page with the filter added to the URL. Doing this while *on the project search page* would update the URL but not the filter since the query params are only read on initial render (eg, `useCallback({}, [])`).

Adding a small snippet that sets the filter & refresh state when the f search param is included and does not match the current filter seems to address the issue. We only want this to happen when the location is changed from the `ProjectSearch` component so I used a `useEffect()` dependent on the location (via `useLocation()`) which seems to limit the effect appropriately. Without this guard, the project search box cannot be edited.