### PR TITLE
Handle multiple issue comma-separated ticket slugs

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -343,7 +343,7 @@ export default {
           projectError: 'Project must either be or a number',
           versionError: 'Version must either be empty or a string',
           ticketSlugError:
-            'Ticket slug must either be empty or a string containing only letters, numbers, hyphen, and underscore',
+            'Ticket slug must either be empty or a string containing only slugs separated by spaces or commas',
           linkError: 'Link must either be empty or a string',
           notesError: 'Notes must either be empty or a string'
         }

--- a/src/js/schema/OperationsLog.js
+++ b/src/js/schema/OperationsLog.js
@@ -30,7 +30,7 @@ export const jsonSchema = {
       oneOf: [{ type: 'string' }, { type: 'null' }]
     },
     ticket_slug: {
-      oneOf: [{ type: 'string', pattern: '^[\\w-]+$' }, { type: 'null' }]
+      oneOf: [{ type: 'string', pattern: '^[\\w-, ]+$' }, { type: 'null' }]
     },
     version: {
       oneOf: [{ type: 'string' }, { type: 'null' }]

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { DescriptionList } from '../../components/DescriptionList/DescriptionList'
 import { Definition } from '../../components/DescriptionList/Definition'
 import { Context } from '../../state'
+import { normalizeTicketSlug } from './NewEntry'
 
 function renderURLTemplate(urlTemplate, slug, environment) {
   return urlTemplate
@@ -16,6 +17,32 @@ function renderURLTemplate(urlTemplate, slug, environment) {
 function Display({ entry }) {
   const [globalState] = useContext(Context)
   const { t } = useTranslation()
+
+  const renderIssueLinks = () => {
+    if (!globalState.opsLogURLTemplate) {
+      return entry.ticket_slug
+    }
+    const slugs = normalizeTicketSlug(entry.ticket_slug).split(',')
+    return slugs.map((slug, index) => (
+      <span key={`${slug}-${index}`}>
+        <a
+          title={slug}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-800 hover:text-blue-700"
+          href={renderURLTemplate(
+            globalState.opsLogURLTemplate,
+            slug,
+            entry.environment
+          )}>
+          {slug}
+        </a>
+        <React.Fragment>
+          {index !== slugs.length - 1 ? ', ' : ''}
+        </React.Fragment>
+      </span>
+    ))
+  }
 
   return (
     <DescriptionList>
@@ -64,22 +91,7 @@ function Display({ entry }) {
       )}
       {entry.ticket_slug && (
         <Definition term={t('operationsLog.ticketSlug')}>
-          {globalState.opsLogURLTemplate ? (
-            <a
-              className="text-blue-800 hover:text-blue-700"
-              href={renderURLTemplate(
-                globalState.opsLogURLTemplate,
-                entry.ticket_slug,
-                entry.environment
-              )}
-              title={entry.ticket_slug}
-              target="_blank">
-              <Icon icon="fas external-link-alt" className="mr-2" />
-              {entry.ticket_slug}
-            </a>
-          ) : (
-            entry.ticket_slug
-          )}
+          {renderIssueLinks()}
         </Definition>
       )}
       {entry.link && (

--- a/src/js/views/OperationsLog/Edit.jsx
+++ b/src/js/views/OperationsLog/Edit.jsx
@@ -9,6 +9,7 @@ import { httpGet, httpPatch, ISO8601ToDatetimeLocal } from '../../utils'
 import { compare } from 'fast-json-patch'
 import { jsonSchema } from '../../schema/OperationsLog'
 import { useValidation } from '../../components/Form/validate'
+import { normalizeTicketSlug } from './NewEntry'
 
 function toSchemaValues(fieldValues) {
   const values = {
@@ -23,9 +24,7 @@ function toSchemaValues(fieldValues) {
     project_id: fieldValues.project.project_id
       ? parseInt(fieldValues.project.project_id.trim())
       : null,
-    ticket_slug: fieldValues.ticket_slug
-      ? fieldValues.ticket_slug.trim()
-      : null,
+    ticket_slug: normalizeTicketSlug(fieldValues.ticket_slug),
     link: fieldValues.link ? fieldValues.link.trim() : null,
     notes: fieldValues.notes ? fieldValues.notes.trim() : null
   }

--- a/src/js/views/OperationsLog/NewEntry.jsx
+++ b/src/js/views/OperationsLog/NewEntry.jsx
@@ -12,6 +12,16 @@ import { Error } from '../Error'
 import { jsonSchema } from '../../schema/OperationsLog'
 import { useValidation } from '../../components/Form/validate'
 
+export function normalizeTicketSlug(ticketSlug) {
+  if (ticketSlug) {
+    return ticketSlug
+      .split(/[,\s]+/)
+      .join(',')
+      .replace(/[,\s]+$/, '')
+  }
+  return null
+}
+
 function NewEntry({ user }) {
   const [globalState, dispatch] = useContext(Context)
   const [saving, setSaving] = useState(false)
@@ -57,7 +67,7 @@ function NewEntry({ user }) {
       description: fields.description ? fields.description : null,
       link: fields.link ? fields.link : null,
       notes: fields.notes ? fields.notes : null,
-      ticket_slug: fields.ticket_slug ? fields.ticket_slug : null,
+      ticket_slug: normalizeTicketSlug(fields.ticket_slug),
       version: fields.version ? fields.version : null
     }
   }


### PR DESCRIPTION
This allows for multiple ticket slugs that are space or comma-separated. The display splits by spaces/commas and generates anchors using the configured ticket slug. Editing and creation does a similar split by space or comma but always joins with commas. The API does not allow for spaces (by design) but our users will want to insert spaces.

See https://github.com/AWeber-Imbi/imbi-openapi/pull/41 for the API spec changes