### PR TITLE
Add Operations Log occurred at

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -320,6 +320,7 @@ export default {
         ticketSlug: 'Ticket Slug',
         link: 'Link',
         project: 'Project',
+        occurredAt: 'Occurred At',
         recordedAt: 'Recorded At',
         completedAt: 'Completed At',
         recordedBy: 'Recorded By',

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -67,8 +67,8 @@ function Display({ entry }) {
       <Definition term={t('operationsLog.changeType')}>
         {entry.change_type}
       </Definition>
-      <Definition term={t('operationsLog.recordedAt')}>
-        {DateTime.fromISO(entry.recorded_at).toLocaleString(
+      <Definition term={t('operationsLog.occurredAt')}>
+        {DateTime.fromISO(entry.occurred_at).toLocaleString(
           DateTime.DATETIME_MED
         )}
       </Definition>

--- a/src/js/views/OperationsLog/Edit.jsx
+++ b/src/js/views/OperationsLog/Edit.jsx
@@ -14,7 +14,7 @@ import { normalizeTicketSlug } from './NewEntry'
 function toSchemaValues(fieldValues) {
   const values = {
     ...fieldValues,
-    recorded_at: new Date(fieldValues.recorded_at).toISOString(),
+    occurred_at: new Date(fieldValues.occurred_at).toISOString(),
     completed_at: fieldValues.completed_at
       ? new Date(fieldValues.completed_at).toISOString()
       : null,
@@ -42,7 +42,7 @@ function Edit({ onCancel, onError, onSuccess, operationsLog }) {
   useEffect(() => {
     const values = {
       ...operationsLog,
-      recorded_at: ISO8601ToDatetimeLocal(operationsLog.recorded_at),
+      occurred_at: ISO8601ToDatetimeLocal(operationsLog.occurred_at),
       completed_at: operationsLog.completed_at
         ? ISO8601ToDatetimeLocal(operationsLog.completed_at)
         : operationsLog.completed_at
@@ -80,7 +80,7 @@ function Edit({ onCancel, onError, onSuccess, operationsLog }) {
     const update = async () => {
       const oldValues = {
         ...operationsLog,
-        recorded_at: new Date(operationsLog.recorded_at).toISOString(),
+        occurred_at: new Date(operationsLog.occurred_at).toISOString(),
         completed_at: operationsLog.completed_at
           ? new Date(operationsLog.completed_at).toISOString()
           : null
@@ -156,14 +156,14 @@ function Edit({ onCancel, onError, onSuccess, operationsLog }) {
         errorMessage={errors?.environment}
       />
       <Form.Field
-        title={t('operationsLog.recordedAt')}
-        name="recorded_at"
+        title={t('operationsLog.occurredAt')}
+        name="occurred_at"
         type="datetime"
         required={true}
         onChange={onValueChange}
-        value={fieldValues.recorded_at}
+        value={fieldValues.occurred_at}
         className="text-gray-600"
-        errorMessage={errors?.recorded_at}
+        errorMessage={errors?.occurred_at}
       />
       <Form.Field
         title={t('operationsLog.completedAt')}

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -98,7 +98,7 @@ function OperationsLog({ projectID, urlPath, className }) {
         fromKueryExpression(query),
         metadataAsOptions.openSearch
       ),
-      sort: [{ recorded_at: { order: 'desc' } }],
+      sort: [{ occurred_at: { order: 'desc' } }],
       fields: globalState.fields,
       size: 1000
     }
@@ -138,8 +138,8 @@ function OperationsLog({ projectID, urlPath, className }) {
   function buildColumns() {
     const columns = [
       {
-        title: t('operationsLog.recordedAt'),
-        name: 'recorded_at',
+        title: t('operationsLog.occurredAt'),
+        name: 'occurred_at',
         type: 'datetime',
         tableOptions: {
           headerClassName: 'w-2/12 truncate',
@@ -334,6 +334,7 @@ function OperationsLog({ projectID, urlPath, className }) {
             'project_id',
             'project_name',
             'environment',
+            'occurred_at',
             'recorded_by',
             'recorded_at',
             'link',


### PR DESCRIPTION
This is the user specifiable time at which the event occurred at. The "recorded at" property is now the time at which the event was stored in the database. Both are available but the latter is not editable.