### PR TITLE
Add support for "performed_by" opslog field

### DIFF
--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -323,8 +323,8 @@ export default {
         occurredAt: 'Occurred At',
         recordedAt: 'Recorded At',
         completedAt: 'Completed At',
-        recordedBy: 'Recorded By',
-        recordedByDescription: 'User name that recorded this operations log',
+        performedBy: 'Performed By',
+        performedByDescription: 'User that performed this action',
         completedAtDescription:
           'When the change completed, if it occurred over a period of time',
         descriptionDescription: 'Single line description of the change',

--- a/public/locales/en.js
+++ b/public/locales/en.js
@@ -324,6 +324,7 @@ export default {
         recordedAt: 'Recorded At',
         completedAt: 'Completed At',
         recordedBy: 'Recorded By',
+        recordedByDescription: 'User name that recorded this operations log',
         completedAtDescription:
           'When the change completed, if it occurred over a period of time',
         descriptionDescription: 'Single line description of the change',

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -46,7 +46,7 @@ function Display({ entry }) {
 
   return (
     <DescriptionList>
-      <Definition term={t('operationsLog.recordedBy')}>
+      <Definition term={t('operationsLog.performedBy')}>
         {entry.display_name}
       </Definition>
       <Definition term={t('operationsLog.environment')}>

--- a/src/js/views/OperationsLog/Edit.jsx
+++ b/src/js/views/OperationsLog/Edit.jsx
@@ -159,11 +159,11 @@ function Edit({ onCancel, onError, onSuccess, operationsLog }) {
         errorMessage={errors?.environment}
       />
       <Form.Field
-        title={t('operationsLog.recordedBy')}
+        title={t('operationsLog.performedBy')}
         name="performed_by"
         type="text"
         required={true}
-        description={t('operationsLog.recordedByDescription')}
+        description={t('operationsLog.performedByDescription')}
         onChange={onValueChange}
         value={fieldValues.performed_by || fieldValues.recorded_by}
         className="text-gray-600"

--- a/src/js/views/OperationsLog/Edit.jsx
+++ b/src/js/views/OperationsLog/Edit.jsx
@@ -21,6 +21,9 @@ function toSchemaValues(fieldValues) {
     description: fieldValues.description
       ? fieldValues.description.trim()
       : null,
+    performed_by: fieldValues.performed_by
+      ? fieldValues.performed_by.trim()
+      : null,
     project_id: fieldValues.project.project_id
       ? parseInt(fieldValues.project.project_id.trim())
       : null,
@@ -154,6 +157,17 @@ function Edit({ onCancel, onError, onSuccess, operationsLog }) {
         value={fieldValues.environment}
         className="text-gray-600"
         errorMessage={errors?.environment}
+      />
+      <Form.Field
+        title={t('operationsLog.recordedBy')}
+        name="performed_by"
+        type="text"
+        required={true}
+        description={t('operationsLog.recordedByDescription')}
+        onChange={onValueChange}
+        value={fieldValues.performed_by || fieldValues.recorded_by}
+        className="text-gray-600"
+        errorMessage={errors?.performed_by}
       />
       <Form.Field
         title={t('operationsLog.occurredAt')}

--- a/src/js/views/OperationsLog/NewEntry.jsx
+++ b/src/js/views/OperationsLog/NewEntry.jsx
@@ -34,6 +34,7 @@ function NewEntry({ user }) {
     occurred_at: ISO8601ToDatetimeLocal(new Date().toISOString()).slice(0, -7),
     completed_at: null,
     description: '',
+    performed_by: user.username,
     project: null,
     version: '',
     ticket_slug: '',
@@ -55,7 +56,7 @@ function NewEntry({ user }) {
   }, [])
 
   function values() {
-    return {
+    const fieldValues = {
       environment: fields.environment,
       change_type: fields.change_type,
       occurred_at: new Date(fields.occurred_at).toISOString(),
@@ -69,6 +70,15 @@ function NewEntry({ user }) {
       ticket_slug: normalizeTicketSlug(fields.ticket_slug),
       version: fields.version ? fields.version : null
     }
+    // only include performed_by when it differs from current user
+    // nothing depends on this ... but searching for documents in the
+    // index with the field set is possible (eg, NOT performed_by:*)
+    // whereas it is not possible to find documents where performed_by
+    // is different from recorded_by :p
+    if (fields.performed_by !== user.username) {
+      fieldValues.performed_by = fields.performed_by
+    }
+    return fieldValues
   }
 
   useEffect(() => {
@@ -109,7 +119,8 @@ function NewEntry({ user }) {
           !fields.change_type ||
           !fields.environment ||
           !fields.occurred_at ||
-          !fields.description
+          !fields.description ||
+          !fields.performed_by
         }
         sideBarTitle={t('operationsLog.create.sideBarTitle')}
         icon="fas file"
@@ -122,6 +133,15 @@ function NewEntry({ user }) {
           <div className="ml-2 text-sm">* {t('common.required')}</div>
         }
         submitButtonText={saving ? t('common.saving') : t('common.save')}>
+        <Form.Field
+          title={t('operationsLog.performedBy')}
+          name="performed_by"
+          type="text"
+          required={true}
+          onChange={onChange}
+          errorMessage={errors.performed_by}
+          value={fields.performed_by}
+        />
         <Form.Field
           title={t('operationsLog.changeType')}
           name="change_type"

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -330,15 +330,20 @@ function OperationsLog({ projectID, urlPath, className }) {
           searchHelp={t('operationsLog.searchHelp')}
           fields={[
             'change_type',
+            'completed_at',
             'description',
-            'project_id',
-            'project_name',
+            'display_name',
             'environment',
-            'occurred_at',
-            'recorded_by',
-            'recorded_at',
+            'id',
             'link',
             'notes',
+            'occurred_at',
+            'performed_by',
+            'project_id',
+            'project_name',
+            'recorded_at',
+            'recorded_by',
+            'ticket_slug',
             'version'
           ]}
         />

--- a/src/js/views/OperationsLog/OperationsLog.jsx
+++ b/src/js/views/OperationsLog/OperationsLog.jsx
@@ -186,7 +186,7 @@ function OperationsLog({ projectID, urlPath, className }) {
         }
       },
       {
-        title: t('operationsLog.recordedBy'),
+        title: t('operationsLog.performedBy'),
         name: 'display_name',
         type: 'text',
         tableOptions: {


### PR DESCRIPTION
This optional field can be set to override the display name of the user that created the log entry. I chose to not set it during creation since the creator of the entry is the authenticated user. I did expose the ability to edit it after the fact.