### PR TITLE
Make the ops log sortable

### DIFF
--- a/src/js/components/Header/NewMenu.jsx
+++ b/src/js/components/Header/NewMenu.jsx
@@ -1,6 +1,6 @@
-import { NavLink } from 'react-router-dom'
+import { NavLink, useLocation, useSearchParams } from 'react-router-dom'
 import { Menu } from '@headlessui/react'
-import React from 'react'
+import React, { useContext, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 
@@ -27,6 +27,15 @@ NewMenuItem.propTypes = {
 
 function NewMenu({ user }) {
   const { t } = useTranslation()
+
+  const location = useLocation()
+  const createOpsLogParams = new URLSearchParams(location.search)
+  const match = location.pathname.match('/projects/(\\d+)')
+  if (match?.length > 0) {
+    createOpsLogParams.set('project_id', match[1])
+    createOpsLogParams.set('returnTo', location.pathname)
+  }
+
   return (
     <Menu as="div" className="flex-shrink mr-3">
       <Menu.Button
@@ -40,7 +49,7 @@ function NewMenu({ user }) {
         aria-orientation="vertical"
         className="origin-top-right absolute right-20 mt-1 w-48 rounded-md shadow-lg py-1 focus:outline-none bg-white ring-1 ring-gray-300 ring-opacity-5 z-40">
         <NewMenuItem
-          to="/ui/operations-log/create"
+          to={`/ui/operations-log/create?${createOpsLogParams.toString()}`}
           value={t('headerNavItems.newOperationsLogEntry')}
         />
         <NewMenuItem

--- a/src/js/components/Table/NavigableTable.jsx
+++ b/src/js/components/Table/NavigableTable.jsx
@@ -20,7 +20,7 @@ import { createSingleColumnSorter } from '../../utils'
  *                           the search params for tracking
  * @param onSortChange function to call when the user selects a different sort order
  *                     for the table.
- * @param selectedIndex index of the current value in data
+ * @param selectedIndex index of the current value in data or undefined
  * @param setSelectedIndex setter used for next/previous
  * @param slideOverElement element to use as the root of the content in the slide over
  * @param title title of the slide over
@@ -48,15 +48,18 @@ function NavigableTable({
   const arrowLeftRef = useRef(null)
   const arrowRightRef = useRef(null)
 
-  if (searchParams.get('v') && !slideOverOpen && data.length > 0) {
-    setSlideOverOpen(true)
-    setShowArrows(true)
-    setSelectedIndex(
-      data.findIndex((row) => extractSearchParam(row) === searchParams.get('v'))
-    )
-  } else if (!searchParams.get('v') && slideOverOpen) {
+  if (!searchParams.get('v') && slideOverOpen) {
     setSlideOverOpen(false)
     setShowArrows(false)
+  }
+  if (
+    searchParams.get('v') &&
+    !slideOverOpen &&
+    data.length > 0 &&
+    selectedIndex !== undefined
+  ) {
+    setSlideOverOpen(true)
+    setShowArrows(true)
   }
 
   function updateSearchParamsWith(newValue) {
@@ -114,7 +117,7 @@ function NavigableTable({
           setSlideOverOpen(false)
         }}
         onKeyDown={(e) => {
-          if (!showArrows) return
+          if (!showArrows || selectedIndex !== undefined) return
           if (selectedIndex > 0 && e.key === 'ArrowLeft') {
             arrowLeftRef.current?.focus()
             move(selectedIndex - 1)
@@ -180,7 +183,7 @@ NavigableTable.propTypes = {
   defaultSortDirection: PropTypes.string,
   extractSearchParam: PropTypes.func.isRequired,
   onSortChange: PropTypes.func,
-  selectedIndex: PropTypes.number.isRequired,
+  selectedIndex: PropTypes.number,
   setSelectedIndex: PropTypes.func.isRequired,
   slideOverElement: PropTypes.node.isRequired,
   title: PropTypes.string.isRequired

--- a/src/js/views/OperationsLog/Display.jsx
+++ b/src/js/views/OperationsLog/Display.jsx
@@ -7,6 +7,7 @@ import { DescriptionList } from '../../components/DescriptionList/DescriptionLis
 import { Definition } from '../../components/DescriptionList/Definition'
 import { Context } from '../../state'
 import { normalizeTicketSlug } from './NewEntry'
+import { Link } from 'react-router-dom'
 
 function renderURLTemplate(urlTemplate, slug, environment) {
   return urlTemplate
@@ -54,14 +55,11 @@ function Display({ entry }) {
       </Definition>
       {(entry.project_name || entry.project_id) && (
         <Definition term={t('operationsLog.project')}>
-          <a
-            className="text-blue-800 hover:text-blue-700"
-            href={`/ui/projects/${entry.project_id}`}
-            title={entry.project_name}
-            target="_blank">
-            <Icon icon="fas external-link-alt" className="mr-2" />
+          <Link
+            to={`/ui/projects/${entry.project_id}`}
+            className="text-blue-800 hover:text-blue-700">
             {entry.project_name || entry.project_id}
-          </a>
+          </Link>
         </Definition>
       )}
       <Definition term={t('operationsLog.changeType')}>

--- a/src/js/views/OperationsLog/Edit.jsx
+++ b/src/js/views/OperationsLog/Edit.jsx
@@ -103,7 +103,7 @@ function Edit({ onCancel, onError, onSuccess, operationsLog }) {
       const response = await httpPatch(globalState.fetch, url, patchValue)
       setSaving(false)
       if (response.success) {
-        onSuccess()
+        onSuccess(response.data)
       } else {
         onError(response.data)
       }

--- a/src/js/views/OperationsLog/NewEntry.jsx
+++ b/src/js/views/OperationsLog/NewEntry.jsx
@@ -292,7 +292,11 @@ function NewEntry({ user }) {
           ]}
           onSaveComplete={(event) => {
             event.preventDefault()
-            navigate('/ui/operations-log')
+            navigate(
+              params.has('returnTo')
+                ? params.get('returnTo')
+                : '/ui/operations-log'
+            )
           }}
         />
       )}

--- a/src/js/views/OperationsLog/ViewOperationsLog.jsx
+++ b/src/js/views/OperationsLog/ViewOperationsLog.jsx
@@ -8,7 +8,7 @@ import { Button, ConfirmationDialog, Icon, Modal } from '../../components'
 import { Error } from '../Error'
 import { Display } from './Display'
 import { Edit } from './Edit'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 const IGNORE_DURING_DUP = new Set([
   'completed_at',
@@ -29,6 +29,7 @@ function ViewOperationsLog({
   onEditClose,
   onDeleteClose
 }) {
+  const location = useLocation()
   const navigate = useNavigate()
   const [globalState] = useContext(Context)
   const { t } = useTranslation()
@@ -102,7 +103,8 @@ function ViewOperationsLog({
     onDeleteClose()
   }
 
-  const duplicatesOpsLog = useCallback(() => {
+  const duplicateOpsLog = useCallback(() => {
+    const match = location.pathname.match('/projects/(\\d+)')
     const url = new URL('/ui/operations-log/create', globalState.baseURL)
     Object.keys(entry)
       .filter((k) => !IGNORE_DURING_DUP.has(k))
@@ -110,6 +112,9 @@ function ViewOperationsLog({
       .forEach((k) => {
         url.searchParams.set(k, entry[k])
       })
+    if (match?.length > 0) {
+      url.searchParams.set('returnTo', location.pathname)
+    }
     navigate(url, { replace: true })
   }, [entry])
 
@@ -156,7 +161,7 @@ function ViewOperationsLog({
             </Button>
             <Button
               className="btn-white text-s"
-              onClick={() => duplicatesOpsLog()}>
+              onClick={() => duplicateOpsLog()}>
               <Icon icon="fa clone" className="mr-2" />
               Duplicate
             </Button>

--- a/src/js/views/OperationsLog/ViewOperationsLog.jsx
+++ b/src/js/views/OperationsLog/ViewOperationsLog.jsx
@@ -138,10 +138,12 @@ function ViewOperationsLog({
           onCancel={() => {
             onEditEnd()
           }}
-          onSuccess={() => {
+          onSuccess={(newData) => {
             onEditEnd()
-            onUpdate()
             loadOpsLog()
+            // NB -- loadOpsLog has not called setEntry() yet so this is an
+            // optimistic update of our parent data
+            onUpdate(newData)
           }}
         />
       ) : (


### PR DESCRIPTION
I switched the operations log views (top-level and project-specific) to use the `NavigableTable` component created a while back. This makes the views sortable _by a single column_. If we feel that being able to sort by multiple columns is useful enough, we can add it to the `NavigableTable` component.

Closes https://github.com/AWeber-Imbi/imbi/issues/80