### PR TITLE
Search exact project type slug from dashboard

### DIFF
--- a/src/js/views/Dashboard/Stats/ProjectTypes.jsx
+++ b/src/js/views/Dashboard/Stats/ProjectTypes.jsx
@@ -64,7 +64,7 @@ function ProjectTypes({ onReady }) {
                 icon={row.icon}
                 url={
                   '/ui/projects?f=' +
-                  encodeURIComponent('project_type_slug:' + row.slug)
+                  encodeURIComponent('project_type_slug.keyword:' + row.slug)
                 }
                 value={row.count}
               />


### PR DESCRIPTION
This updates the search to use the DQL syntax `.keyword` for exact matches when users click on one of the project type cards on the dashboard.