### PR TITLE
Add Third-Party Services and Service Applications admin UI

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ install:
     npm ci
 
 # Run development server
-dev:
+dev: install
     npm run dev
 
 # Run tests

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -33,6 +33,8 @@ import type {
   Team,
   TeamCreate,
   TeamMember,
+  ThirdPartyService,
+  ThirdPartyServiceCreate,
   Upload,
   ApiKey,
   ApiKeyCreated,
@@ -399,6 +401,24 @@ export const removeTeamMember = (slug: string, email: string) =>
   apiClient.delete<void>(
     `/teams/${encodeURIComponent(slug)}/members/${encodeURIComponent(email)}`
   )
+
+// Admin - Third-Party Services
+export const listThirdPartyServices = async (): Promise<ThirdPartyService[]> => {
+  const response = await apiClient.get<ThirdPartyService[]>('/third-party-services/')
+  return Array.isArray(response) ? response : []
+}
+
+export const getThirdPartyService = (slug: string) =>
+  apiClient.get<ThirdPartyService>(`/third-party-services/${encodeURIComponent(slug)}`)
+
+export const createThirdPartyService = (svc: ThirdPartyServiceCreate) =>
+  apiClient.post<ThirdPartyService>('/third-party-services/', svc)
+
+export const updateThirdPartyService = (slug: string, svc: ThirdPartyServiceCreate) =>
+  apiClient.put<ThirdPartyService>(`/third-party-services/${encodeURIComponent(slug)}`, svc)
+
+export const deleteThirdPartyService = (slug: string) =>
+  apiClient.delete<void>(`/third-party-services/${encodeURIComponent(slug)}`)
 
 // Uploads
 export const uploadFile = (file: File): Promise<Upload> => {

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -37,6 +37,9 @@ import type {
   ThirdPartyServiceCreate,
   ServiceApplication,
   ServiceApplicationCreate,
+  ServiceApplicationUpdate,
+  ServiceApplicationSecrets,
+  ServiceApplicationSecretsUpdate,
   Upload,
   ApiKey,
   ApiKeyCreated,
@@ -444,7 +447,7 @@ export const createServiceApplication = (serviceSlug: string, data: ServiceAppli
 export const updateServiceApplication = (
   serviceSlug: string,
   appSlug: string,
-  data: ServiceApplicationCreate
+  data: ServiceApplicationUpdate
 ) =>
   apiClient.put<ServiceApplication>(
     `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}`,
@@ -454,6 +457,22 @@ export const updateServiceApplication = (
 export const deleteServiceApplication = (serviceSlug: string, appSlug: string) =>
   apiClient.delete<void>(
     `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}`
+  )
+
+// Service Application Secrets
+export const getApplicationSecrets = (serviceSlug: string, appSlug: string) =>
+  apiClient.get<ServiceApplicationSecrets>(
+    `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}/secrets`
+  )
+
+export const updateApplicationSecrets = (
+  serviceSlug: string,
+  appSlug: string,
+  data: ServiceApplicationSecretsUpdate
+) =>
+  apiClient.put<ServiceApplicationSecrets>(
+    `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}/secrets`,
+    data
   )
 
 // Uploads

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -35,6 +35,8 @@ import type {
   TeamMember,
   ThirdPartyService,
   ThirdPartyServiceCreate,
+  ServiceApplication,
+  ServiceApplicationCreate,
   Upload,
   ApiKey,
   ApiKeyCreated,
@@ -419,6 +421,40 @@ export const updateThirdPartyService = (slug: string, svc: ThirdPartyServiceCrea
 
 export const deleteThirdPartyService = (slug: string) =>
   apiClient.delete<void>(`/third-party-services/${encodeURIComponent(slug)}`)
+
+// Service Applications (nested under Third-Party Services)
+export const listServiceApplications = async (serviceSlug: string): Promise<ServiceApplication[]> => {
+  const response = await apiClient.get<ServiceApplication[]>(
+    `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/`
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const getServiceApplication = (serviceSlug: string, appSlug: string) =>
+  apiClient.get<ServiceApplication>(
+    `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}`
+  )
+
+export const createServiceApplication = (serviceSlug: string, data: ServiceApplicationCreate) =>
+  apiClient.post<ServiceApplication>(
+    `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/`,
+    data
+  )
+
+export const updateServiceApplication = (
+  serviceSlug: string,
+  appSlug: string,
+  data: ServiceApplicationCreate
+) =>
+  apiClient.put<ServiceApplication>(
+    `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}`,
+    data
+  )
+
+export const deleteServiceApplication = (serviceSlug: string, appSlug: string) =>
+  apiClient.delete<void>(
+    `/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}`
+  )
 
 // Uploads
 export const uploadFile = (file: File): Promise<Upload> => {

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import {
   Users, Shield, FileJson, ChevronRight, ChevronLeft,
-  ExternalLink, Building2, Globe, Layers, FolderTree, UsersRound, Bot,
+  ExternalLink, Building2, Globe, Layers, FolderTree, UsersRound, Bot, Cloud,
 } from 'lucide-react'
 import { UserManagement } from './admin/UserManagement'
 import { RoleManagement } from './admin/RoleManagement'
@@ -12,6 +12,7 @@ import { ServiceAccountManagement } from './admin/ServiceAccountManagement'
 import { OAuthManagement } from './admin/OAuthManagement'
 import { EnvironmentManagement } from './admin/EnvironmentManagement'
 import { ProjectTypeManagement } from './admin/ProjectTypeManagement'
+import { ThirdPartyServiceManagement } from './admin/ThirdPartyServiceManagement'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -23,6 +24,7 @@ type AdminSection =
   | 'teams'
   | 'environments'
   | 'project-types'
+  | 'third-party-services'
   | 'blueprints'
   | 'organizations'
   | 'users'
@@ -34,6 +36,7 @@ const VALID_SECTIONS: AdminSection[] = [
   'teams',
   'environments',
   'project-types',
+  'third-party-services',
   'blueprints',
   'organizations',
   'users',
@@ -67,6 +70,7 @@ export function Admin({ isDarkMode }: AdminProps) {
     { id: 'teams', label: 'Teams', icon: UsersRound, description: `Manage teams in ${orgName}`, scope: 'org' },
     { id: 'environments', label: 'Environments', icon: Layers, description: `Manage environments in ${orgName}`, scope: 'org' },
     { id: 'project-types', label: 'Project Types', icon: FolderTree, description: `Manage project types in ${orgName}`, scope: 'org' },
+    { id: 'third-party-services', label: 'Third-Party Services', icon: Cloud, description: `Manage external SaaS services in ${orgName}`, scope: 'org' },
     { id: 'blueprints', label: 'Blueprints', icon: FileJson, description: `Configure metadata templates in ${orgName}`, scope: 'org' },
   ]
 
@@ -213,6 +217,7 @@ export function Admin({ isDarkMode }: AdminProps) {
             {currentSection === 'teams' && <TeamManagement isDarkMode={isDarkMode} />}
             {currentSection === 'environments' && <EnvironmentManagement isDarkMode={isDarkMode} />}
             {currentSection === 'project-types' && <ProjectTypeManagement isDarkMode={isDarkMode} />}
+            {currentSection === 'third-party-services' && <ThirdPartyServiceManagement isDarkMode={isDarkMode} />}
             {currentSection === 'blueprints' && <BlueprintManagement isDarkMode={isDarkMode} />}
             {currentSection === 'organizations' && <OrganizationManagement isDarkMode={isDarkMode} />}
             {currentSection === 'users' && <UserManagement isDarkMode={isDarkMode} />}

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -1,0 +1,358 @@
+import { useState, useMemo } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Plus, Search, Trash2, Cloud, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { ThirdPartyServiceForm } from './third-party-services/ThirdPartyServiceForm'
+import { ThirdPartyServiceDetail } from './third-party-services/ThirdPartyServiceDetail'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { listThirdPartyServices, deleteThirdPartyService, createThirdPartyService, updateThirdPartyService } from '@/api/endpoints'
+import type { ThirdPartyServiceCreate } from '@/types'
+
+interface ThirdPartyServiceManagementProps {
+  isDarkMode: boolean
+}
+
+type ViewMode = 'list' | 'create' | 'edit' | 'detail'
+
+const STATUS_COLORS: Record<string, { bg: string; text: string; darkBg: string; darkText: string }> = {
+  active: { bg: 'bg-green-100', text: 'text-green-700', darkBg: 'bg-green-900/30', darkText: 'text-green-400' },
+  deprecated: { bg: 'bg-yellow-100', text: 'text-yellow-700', darkBg: 'bg-yellow-900/30', darkText: 'text-yellow-400' },
+  evaluating: { bg: 'bg-blue-100', text: 'text-blue-700', darkBg: 'bg-blue-900/30', darkText: 'text-blue-400' },
+  inactive: { bg: 'bg-gray-100', text: 'text-gray-700', darkBg: 'bg-gray-700', darkText: 'text-gray-400' },
+}
+
+export function ThirdPartyServiceManagement({ isDarkMode }: ThirdPartyServiceManagementProps) {
+  const queryClient = useQueryClient()
+  const { selectedOrganization } = useOrganization()
+  const [viewMode, setViewMode] = useState<ViewMode>('list')
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const { data: services = [], isLoading, error } = useQuery({
+    queryKey: ['third-party-services'],
+    queryFn: listThirdPartyServices,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: createThirdPartyService,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['third-party-services'] })
+      setViewMode('list')
+      setSelectedSlug(null)
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({ slug, svc }: { slug: string; svc: ThirdPartyServiceCreate }) =>
+      updateThirdPartyService(slug, svc),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['third-party-services'] })
+      setViewMode('list')
+      setSelectedSlug(null)
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteThirdPartyService,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['third-party-services'] })
+    },
+    onError: (error: any) => {
+      alert(`Failed to delete service: ${error.response?.data?.detail || error.message}`)
+    },
+  })
+
+  const filteredServices = services.filter((svc) => {
+    if (selectedOrganization && svc.organization.slug !== selectedOrganization.slug) {
+      return false
+    }
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase()
+      return (
+        svc.name.toLowerCase().includes(query) ||
+        svc.slug.toLowerCase().includes(query) ||
+        svc.vendor.toLowerCase().includes(query) ||
+        (svc.category?.toLowerCase().includes(query) ?? false) ||
+        (svc.description?.toLowerCase().includes(query) ?? false)
+      )
+    }
+    return true
+  })
+
+  const selectedService = useMemo(
+    () => services.find((s) => s.slug === selectedSlug) || null,
+    [services, selectedSlug],
+  )
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = { active: 0, deprecated: 0, evaluating: 0, inactive: 0 }
+    for (const svc of filteredServices) {
+      counts[svc.status] = (counts[svc.status] || 0) + 1
+    }
+    return counts
+  }, [filteredServices])
+
+  const handleDelete = (slug: string) => {
+    const svc = services.find((s) => s.slug === slug)
+    if (svc && confirm(`Delete third-party service "${svc.name}"? This action cannot be undone.`)) {
+      deleteMutation.mutate(slug)
+    }
+  }
+
+  const handleSave = (svcData: ThirdPartyServiceCreate) => {
+    if (viewMode === 'create') {
+      createMutation.mutate(svcData)
+    } else if (selectedSlug) {
+      updateMutation.mutate({ slug: selectedSlug, svc: svcData })
+    }
+  }
+
+  const handleCancel = () => {
+    setViewMode('list')
+    setSelectedSlug(null)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+          Loading third-party services...
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className={`flex items-center gap-3 p-4 rounded-lg border ${
+        isDarkMode ? 'bg-red-900/20 border-red-700 text-red-400' : 'bg-red-50 border-red-200 text-red-700'
+      }`}>
+        <AlertCircle className="w-5 h-5 flex-shrink-0" />
+        <div>
+          <div className="font-medium">Failed to load third-party services</div>
+          <div className="text-sm mt-1">{error instanceof Error ? error.message : 'An error occurred'}</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (viewMode === 'create' || viewMode === 'edit') {
+    return (
+      <ThirdPartyServiceForm
+        service={selectedService}
+        onSave={handleSave}
+        onCancel={handleCancel}
+        isDarkMode={isDarkMode}
+        isLoading={createMutation.isPending || updateMutation.isPending}
+        error={createMutation.error || updateMutation.error}
+      />
+    )
+  }
+
+  if (viewMode === 'detail' && selectedService) {
+    return (
+      <ThirdPartyServiceDetail
+        service={selectedService}
+        onEdit={() => {
+          setSelectedSlug(selectedService.slug)
+          setViewMode('edit')
+        }}
+        onBack={handleCancel}
+        isDarkMode={isDarkMode}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <div className="relative max-w-md">
+            <Search className={`absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 ${
+              isDarkMode ? 'text-gray-400' : 'text-gray-500'
+            }`} />
+            <Input
+              placeholder="Search services..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className={`pl-10 ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
+            />
+          </div>
+        </div>
+        <Button
+          onClick={() => {
+            setSelectedSlug(null)
+            setViewMode('create')
+          }}
+          className="bg-[#2A4DD0] hover:bg-blue-700 text-white"
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          New Service
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className={`p-4 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+            Total Services
+          </div>
+          <div className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            {filteredServices.length}
+          </div>
+        </div>
+        <div className={`p-4 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Active</div>
+          <div className={`mt-1 text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}>
+            {statusCounts.active}
+          </div>
+        </div>
+        <div className={`p-4 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Evaluating</div>
+          <div className={`mt-1 text-2xl ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}>
+            {statusCounts.evaluating}
+          </div>
+        </div>
+        <div className={`p-4 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Deprecated</div>
+          <div className={`mt-1 text-2xl ${isDarkMode ? 'text-yellow-400' : 'text-yellow-600'}`}>
+            {statusCounts.deprecated}
+          </div>
+        </div>
+      </div>
+
+      {/* Services Table */}
+      <div className={`rounded-lg border ${
+        isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+      }`}>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}>
+              <tr>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Service</th>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Vendor</th>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Category</th>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Status</th>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Team</th>
+                <th className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Actions</th>
+              </tr>
+            </thead>
+            <tbody className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}>
+              {filteredServices.map((svc) => {
+                const statusColor = STATUS_COLORS[svc.status] || STATUS_COLORS.inactive
+                return (
+                  <tr
+                    key={svc.slug}
+                    onClick={() => {
+                      setSelectedSlug(svc.slug)
+                      setViewMode('detail')
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.currentTarget !== e.target) return
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        setSelectedSlug(svc.slug)
+                        setViewMode('detail')
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-label={`View service ${svc.name}`}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                  >
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <div className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${
+                          isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'
+                        }`}>
+                          {svc.icon ? (
+                            <img src={svc.icon} alt="" className="w-5 h-5 rounded object-cover" />
+                          ) : (
+                            <Cloud className={`w-4 h-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`} />
+                          )}
+                        </div>
+                        <div>
+                          <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                            {svc.name}
+                          </div>
+                          {svc.description && (
+                            <div className={`text-sm truncate max-w-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                              {svc.description}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                      {svc.vendor}
+                    </td>
+                    <td className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                      {svc.category || <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>--</span>}
+                    </td>
+                    <td className="px-6 py-4">
+                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        isDarkMode
+                          ? `${statusColor.darkBg} ${statusColor.darkText}`
+                          : `${statusColor.bg} ${statusColor.text}`
+                      }`}>
+                        {svc.status}
+                      </span>
+                    </td>
+                    <td className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                      {svc.team?.name || <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>--</span>}
+                    </td>
+                    <td className="px-6 py-4 text-right" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+                      <div className="flex items-center justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Delete service ${svc.name}`}
+                          onClick={() => handleDelete(svc.slug)}
+                          disabled={deleteMutation.isPending}
+                          className={isDarkMode ? 'text-red-400 hover:text-red-300 hover:bg-red-900/20' : 'text-red-600 hover:text-red-700 hover:bg-red-50'}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+
+          {filteredServices.length === 0 && (
+            <div className={`text-center py-12 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+              {searchQuery
+                ? 'No services found matching your search.'
+                : selectedOrganization
+                  ? `No third-party services in ${selectedOrganization.name} yet.`
+                  : 'No third-party services created yet.'}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -1,0 +1,298 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Eye, EyeOff, Copy, Check, Save, Shield, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { getApplicationSecrets, updateApplicationSecrets } from '@/api/endpoints'
+import type { ServiceApplicationSecretsUpdate } from '@/types'
+
+interface ApplicationSecretsPanelProps {
+  serviceSlug: string
+  appSlug: string
+  appType: string
+  isDarkMode: boolean
+}
+
+const TYPE_SECRET_FIELDS: Record<string, string[]> = {
+  github_app: ['client_secret', 'private_key', 'webhook_secret'],
+  pagerduty_oauth: ['client_secret'],
+  generic_oauth2: ['client_secret', 'signing_secret'],
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  client_secret: 'Client Secret',
+  webhook_secret: 'Webhook Secret',
+  private_key: 'Private Key (PEM)',
+  signing_secret: 'Signing Secret',
+}
+
+export function ApplicationSecretsPanel({
+  serviceSlug,
+  appSlug,
+  appType,
+  isDarkMode,
+}: ApplicationSecretsPanelProps) {
+  const queryClient = useQueryClient()
+  const [revealed, setRevealed] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const [editValues, setEditValues] = useState<Record<string, string>>({})
+
+  const visibleFields = TYPE_SECRET_FIELDS[appType] || ['client_secret']
+
+  const {
+    data: secrets,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['application-secrets', serviceSlug, appSlug],
+    queryFn: () => getApplicationSecrets(serviceSlug, appSlug),
+    enabled: revealed,
+    retry: false,
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: (data: ServiceApplicationSecretsUpdate) =>
+      updateApplicationSecrets(serviceSlug, appSlug, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['application-secrets', serviceSlug, appSlug],
+      })
+      setEditing(false)
+      setEditValues({})
+      refetch()
+    },
+  })
+
+  const handleReveal = () => {
+    setRevealed(true)
+  }
+
+  const handleHide = () => {
+    setRevealed(false)
+    setEditing(false)
+    setEditValues({})
+  }
+
+  const handleCopy = async (field: string, value: string) => {
+    await navigator.clipboard.writeText(value)
+    setCopiedField(field)
+    setTimeout(() => setCopiedField(null), 2000)
+  }
+
+  const handleStartEdit = () => {
+    setEditing(true)
+    setEditValues({})
+  }
+
+  const handleCancelEdit = () => {
+    setEditing(false)
+    setEditValues({})
+  }
+
+  const handleSave = () => {
+    const update: ServiceApplicationSecretsUpdate = {}
+    for (const [field, value] of Object.entries(editValues)) {
+      if (value.trim()) {
+        (update as Record<string, string>)[field] = value.trim()
+      }
+    }
+    if (Object.keys(update).length === 0) {
+      return
+    }
+    updateMutation.mutate(update)
+  }
+
+  const is403 = error && (error as any)?.response?.status === 403
+
+  return (
+    <div className={`p-6 rounded-lg border ${
+      isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+    }`}>
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Shield className={`w-5 h-5 ${isDarkMode ? 'text-yellow-400' : 'text-yellow-600'}`} />
+          <h3 className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Secrets
+          </h3>
+        </div>
+        <div className="flex items-center gap-2">
+          {revealed && !editing && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleStartEdit}
+              className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
+            >
+              Update Secrets
+            </Button>
+          )}
+          {revealed ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleHide}
+              className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
+            >
+              <EyeOff className="w-4 h-4 mr-1" />
+              Hide
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleReveal}
+              className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
+            >
+              <Eye className="w-4 h-4 mr-1" />
+              Reveal Secrets
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {!revealed && (
+        <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+          Secrets are hidden. Click &ldquo;Reveal Secrets&rdquo; to view or update them.
+          Admin privileges required.
+        </p>
+      )}
+
+      {revealed && isLoading && (
+        <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+          Loading secrets...
+        </div>
+      )}
+
+      {revealed && is403 && (
+        <div className={`flex items-center gap-3 p-4 rounded-lg border ${
+          isDarkMode ? 'bg-yellow-900/20 border-yellow-700 text-yellow-400' : 'bg-yellow-50 border-yellow-200 text-yellow-700'
+        }`}>
+          <AlertCircle className="w-5 h-5 flex-shrink-0" />
+          <div className="text-sm">Admin access required to view secrets.</div>
+        </div>
+      )}
+
+      {revealed && error && !is403 && (
+        <div className={`flex items-center gap-3 p-4 rounded-lg border ${
+          isDarkMode ? 'bg-red-900/20 border-red-700 text-red-400' : 'bg-red-50 border-red-200 text-red-700'
+        }`}>
+          <AlertCircle className="w-5 h-5 flex-shrink-0" />
+          <div className="text-sm">
+            {error instanceof Error ? error.message : 'Failed to load secrets'}
+          </div>
+        </div>
+      )}
+
+      {revealed && secrets && !editing && (
+        <div className="space-y-3">
+          {visibleFields.map((field) => {
+            const value = (secrets as unknown as Record<string, string | null>)[field]
+            if (value == null && field !== 'client_secret') return null
+            return (
+              <div key={field}>
+                <div className={`text-sm mb-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {FIELD_LABELS[field]}
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className={`flex-1 px-3 py-2 rounded text-sm font-mono break-all ${
+                    isDarkMode ? 'bg-gray-700 text-gray-200' : 'bg-gray-100 text-gray-800'
+                  }`}>
+                    {field === 'private_key' ? (
+                      <pre className="whitespace-pre-wrap text-xs">{value}</pre>
+                    ) : (
+                      value
+                    )}
+                  </code>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleCopy(field, value!)}
+                    title="Copy to clipboard"
+                    className={isDarkMode ? 'text-gray-400 hover:text-gray-200' : ''}
+                  >
+                    {copiedField === field ? (
+                      <Check className="w-4 h-4 text-green-500" />
+                    ) : (
+                      <Copy className="w-4 h-4" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {revealed && editing && (
+        <div className="space-y-4">
+          <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+            Only fill in the secrets you want to change. Empty fields will be left unchanged.
+          </p>
+
+          {updateMutation.error && (
+            <div className={`flex items-center gap-3 p-3 rounded-lg border ${
+              isDarkMode ? 'bg-red-900/20 border-red-700 text-red-400' : 'bg-red-50 border-red-200 text-red-700'
+            }`}>
+              <AlertCircle className="w-4 h-4 flex-shrink-0" />
+              <div className="text-sm">
+                {updateMutation.error instanceof Error
+                  ? updateMutation.error.message
+                  : 'Failed to update secrets'}
+              </div>
+            </div>
+          )}
+
+          {visibleFields.map((field) => (
+            <div key={field}>
+              <label className={`block text-sm font-medium mb-1 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                {FIELD_LABELS[field]}
+              </label>
+              {field === 'private_key' ? (
+                <textarea
+                  value={editValues[field] || ''}
+                  onChange={(e) => setEditValues({ ...editValues, [field]: e.target.value })}
+                  placeholder="Paste new value to update"
+                  rows={4}
+                  className={`w-full px-3 py-2 rounded-md border text-sm font-mono ${
+                    isDarkMode
+                      ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'
+                      : 'bg-white border-gray-300 text-gray-900'
+                  }`}
+                />
+              ) : (
+                <Input
+                  type="password"
+                  value={editValues[field] || ''}
+                  onChange={(e) => setEditValues({ ...editValues, [field]: e.target.value })}
+                  placeholder="Paste new value to update"
+                  className={isDarkMode ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400' : ''}
+                />
+              )}
+            </div>
+          ))}
+
+          <div className="flex items-center gap-2 pt-2">
+            <Button
+              onClick={handleSave}
+              disabled={updateMutation.isPending || Object.values(editValues).every((v) => !v.trim())}
+              className="bg-[#2A4DD0] hover:bg-blue-700 text-white"
+            >
+              <Save className="w-4 h-4 mr-1" />
+              {updateMutation.isPending ? 'Saving...' : 'Save Secrets'}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleCancelEdit}
+              disabled={updateMutation.isPending}
+              className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react'
 import { ArrowLeft, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import type { ServiceApplication, ServiceApplicationCreate } from '@/types'
+import { slugify } from '@/lib/utils'
+import type { ServiceApplication, ServiceApplicationCreate, ServiceApplicationUpdate } from '@/types'
 
 interface OAuth2ApplicationFormProps {
   application: ServiceApplication | null
-  onSave: (data: ServiceApplicationCreate) => void
+  onSave: (data: ServiceApplicationCreate | ServiceApplicationUpdate) => void
   onCancel: () => void
   isDarkMode: boolean
   isLoading: boolean
@@ -19,8 +20,8 @@ const APP_TYPES = [
   { value: 'generic_oauth2', label: 'Generic OAuth2' },
 ]
 
-// Fields to show per app type beyond the common ones
-const TYPE_FIELDS: Record<string, string[]> = {
+// Secret fields to show per app type (create mode only)
+const TYPE_SECRET_FIELDS: Record<string, string[]> = {
   github_app: ['private_key', 'webhook_secret'],
   pagerduty_oauth: [],
   generic_oauth2: ['signing_secret'],
@@ -42,26 +43,33 @@ export function OAuth2ApplicationForm({
   const [appType, setAppType] = useState(application?.app_type || 'github_app')
   const [applicationUrl, setApplicationUrl] = useState(application?.application_url || '')
   const [clientId, setClientId] = useState(application?.client_id || '')
-  const [clientSecret, setClientSecret] = useState(isEdit ? '********' : '')
   const [scopes, setScopes] = useState(application?.scopes?.join(', ') || '')
-  const [webhookSecret, setWebhookSecret] = useState(
-    application?.webhook_secret || ''
-  )
-  const [privateKey, setPrivateKey] = useState(
-    application?.private_key || ''
-  )
-  const [signingSecret, setSigningSecret] = useState(
-    application?.signing_secret || ''
-  )
   const [status, setStatus] = useState(application?.status || 'active')
   const [validationError, setValidationError] = useState<string | null>(null)
 
-  const extraFields = TYPE_FIELDS[appType] || []
+  // Secret fields (create mode only)
+  const [clientSecret, setClientSecret] = useState('')
+  const [webhookSecret, setWebhookSecret] = useState('')
+  const [privateKey, setPrivateKey] = useState('')
+  const [signingSecret, setSigningSecret] = useState('')
+
+  const extraSecretFields = TYPE_SECRET_FIELDS[appType] || []
+
+  const handleNameChange = (value: string) => {
+    setName(value)
+    if (!isEdit) {
+      setSlug(slugify(value))
+    }
+  }
 
   const handleSubmit = () => {
     setValidationError(null)
-    if (!slug || !name || !clientId || !clientSecret || !appType) {
-      setValidationError('Slug, name, app type, client ID, and client secret are required.')
+    if (!slug || !name || !clientId || !appType) {
+      setValidationError('Slug, name, app type, and client ID are required.')
+      return
+    }
+    if (!isEdit && !clientSecret) {
+      setValidationError('Client secret is required when creating an application.')
       return
     }
     if (!/^[a-z][a-z0-9-]*$/.test(slug)) {
@@ -69,21 +77,35 @@ export function OAuth2ApplicationForm({
       return
     }
 
-    const data: ServiceApplicationCreate = {
-      slug,
-      name,
-      description: description || null,
-      app_type: appType,
-      application_url: applicationUrl || null,
-      client_id: clientId,
-      client_secret: clientSecret,
-      scopes: scopes ? scopes.split(',').map((s) => s.trim()).filter(Boolean) : [],
-      webhook_secret: extraFields.includes('webhook_secret') && webhookSecret ? webhookSecret : null,
-      private_key: extraFields.includes('private_key') && privateKey ? privateKey : null,
-      signing_secret: extraFields.includes('signing_secret') && signingSecret ? signingSecret : null,
-      status,
+    if (isEdit) {
+      const data: ServiceApplicationUpdate = {
+        slug,
+        name,
+        description: description || null,
+        app_type: appType,
+        application_url: applicationUrl || null,
+        client_id: clientId,
+        scopes: scopes ? scopes.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        status,
+      }
+      onSave(data)
+    } else {
+      const data: ServiceApplicationCreate = {
+        slug,
+        name,
+        description: description || null,
+        app_type: appType,
+        application_url: applicationUrl || null,
+        client_id: clientId,
+        client_secret: clientSecret,
+        scopes: scopes ? scopes.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        webhook_secret: extraSecretFields.includes('webhook_secret') && webhookSecret ? webhookSecret : null,
+        private_key: extraSecretFields.includes('private_key') && privateKey ? privateKey : null,
+        signing_secret: extraSecretFields.includes('signing_secret') && signingSecret ? signingSecret : null,
+        status,
+      }
+      onSave(data)
     }
-    onSave(data)
   }
 
   const inputClass = isDarkMode
@@ -135,7 +157,7 @@ export function OAuth2ApplicationForm({
             <label className={labelClass}>Name *</label>
             <Input
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => handleNameChange(e.target.value)}
               placeholder="My GitHub App"
               className={inputClass}
             />
@@ -208,26 +230,14 @@ export function OAuth2ApplicationForm({
           </div>
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className={labelClass}>Client ID *</label>
-            <Input
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-              placeholder="Iv1.abc123..."
-              className={inputClass}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>Client Secret *</label>
-            <Input
-              type="password"
-              value={clientSecret}
-              onChange={(e) => setClientSecret(e.target.value)}
-              placeholder={isEdit ? '********' : 'Enter secret'}
-              className={inputClass}
-            />
-          </div>
+        <div>
+          <label className={labelClass}>Client ID *</label>
+          <Input
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            placeholder="Iv1.abc123..."
+            className={inputClass}
+          />
         </div>
 
         <div>
@@ -240,47 +250,76 @@ export function OAuth2ApplicationForm({
           />
         </div>
 
-        {/* Conditional fields based on app type */}
-        {extraFields.includes('webhook_secret') && (
-          <div>
-            <label className={labelClass}>Webhook Secret</label>
-            <Input
-              type="password"
-              value={webhookSecret}
-              onChange={(e) => setWebhookSecret(e.target.value)}
-              placeholder={isEdit && application?.webhook_secret ? '********' : 'Enter webhook secret'}
-              className={inputClass}
-            />
-          </div>
+        {/* Secret fields (create mode only) */}
+        {!isEdit && (
+          <>
+            <div className={`border-t pt-4 ${isDarkMode ? 'border-gray-600' : 'border-gray-200'}`}>
+              <h4 className={`text-sm font-medium mb-3 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                Secrets
+              </h4>
+            </div>
+
+            <div>
+              <label className={labelClass}>Client Secret *</label>
+              <Input
+                type="password"
+                value={clientSecret}
+                onChange={(e) => setClientSecret(e.target.value)}
+                placeholder="Enter client secret"
+                className={inputClass}
+              />
+            </div>
+
+            {extraSecretFields.includes('webhook_secret') && (
+              <div>
+                <label className={labelClass}>Webhook Secret</label>
+                <Input
+                  type="password"
+                  value={webhookSecret}
+                  onChange={(e) => setWebhookSecret(e.target.value)}
+                  placeholder="Enter webhook secret"
+                  className={inputClass}
+                />
+              </div>
+            )}
+
+            {extraSecretFields.includes('private_key') && (
+              <div>
+                <label className={labelClass}>Private Key (PEM)</label>
+                <textarea
+                  value={privateKey}
+                  onChange={(e) => setPrivateKey(e.target.value)}
+                  placeholder={'-----BEGIN RSA PRIVATE KEY-----\n...'}
+                  rows={4}
+                  className={`w-full px-3 py-2 rounded-md border text-sm font-mono ${
+                    isDarkMode
+                      ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'
+                      : 'bg-white border-gray-300 text-gray-900'
+                  }`}
+                />
+              </div>
+            )}
+
+            {extraSecretFields.includes('signing_secret') && (
+              <div>
+                <label className={labelClass}>Signing Secret</label>
+                <Input
+                  type="password"
+                  value={signingSecret}
+                  onChange={(e) => setSigningSecret(e.target.value)}
+                  placeholder="Enter signing secret"
+                  className={inputClass}
+                />
+              </div>
+            )}
+          </>
         )}
 
-        {extraFields.includes('private_key') && (
-          <div>
-            <label className={labelClass}>Private Key (PEM)</label>
-            <textarea
-              value={privateKey}
-              onChange={(e) => setPrivateKey(e.target.value)}
-              placeholder={isEdit && application?.private_key ? '********' : '-----BEGIN RSA PRIVATE KEY-----\n...'}
-              rows={4}
-              className={`w-full px-3 py-2 rounded-md border text-sm font-mono ${
-                isDarkMode
-                  ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'
-                  : 'bg-white border-gray-300 text-gray-900'
-              }`}
-            />
-          </div>
-        )}
-
-        {extraFields.includes('signing_secret') && (
-          <div>
-            <label className={labelClass}>Signing Secret</label>
-            <Input
-              type="password"
-              value={signingSecret}
-              onChange={(e) => setSigningSecret(e.target.value)}
-              placeholder={isEdit && application?.signing_secret ? '********' : 'Enter signing secret'}
-              className={inputClass}
-            />
+        {isEdit && (
+          <div className={`border-t pt-4 ${isDarkMode ? 'border-gray-600' : 'border-gray-200'}`}>
+            <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+              Secrets are managed separately below via the Secrets panel.
+            </p>
           </div>
         )}
       </div>

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -1,0 +1,289 @@
+import { useState } from 'react'
+import { ArrowLeft, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import type { ServiceApplication, ServiceApplicationCreate } from '@/types'
+
+interface OAuth2ApplicationFormProps {
+  application: ServiceApplication | null
+  onSave: (data: ServiceApplicationCreate) => void
+  onCancel: () => void
+  isDarkMode: boolean
+  isLoading: boolean
+  error: Error | null
+}
+
+const APP_TYPES = [
+  { value: 'github_app', label: 'GitHub App' },
+  { value: 'pagerduty_oauth', label: 'PagerDuty OAuth' },
+  { value: 'generic_oauth2', label: 'Generic OAuth2' },
+]
+
+// Fields to show per app type beyond the common ones
+const TYPE_FIELDS: Record<string, string[]> = {
+  github_app: ['private_key', 'webhook_secret'],
+  pagerduty_oauth: [],
+  generic_oauth2: ['signing_secret'],
+}
+
+export function OAuth2ApplicationForm({
+  application,
+  onSave,
+  onCancel,
+  isDarkMode,
+  isLoading,
+  error,
+}: OAuth2ApplicationFormProps) {
+  const isEdit = !!application
+
+  const [slug, setSlug] = useState(application?.slug || '')
+  const [name, setName] = useState(application?.name || '')
+  const [description, setDescription] = useState(application?.description || '')
+  const [appType, setAppType] = useState(application?.app_type || 'github_app')
+  const [applicationUrl, setApplicationUrl] = useState(application?.application_url || '')
+  const [clientId, setClientId] = useState(application?.client_id || '')
+  const [clientSecret, setClientSecret] = useState(isEdit ? '********' : '')
+  const [scopes, setScopes] = useState(application?.scopes?.join(', ') || '')
+  const [webhookSecret, setWebhookSecret] = useState(
+    application?.webhook_secret || ''
+  )
+  const [privateKey, setPrivateKey] = useState(
+    application?.private_key || ''
+  )
+  const [signingSecret, setSigningSecret] = useState(
+    application?.signing_secret || ''
+  )
+  const [status, setStatus] = useState(application?.status || 'active')
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  const extraFields = TYPE_FIELDS[appType] || []
+
+  const handleSubmit = () => {
+    setValidationError(null)
+    if (!slug || !name || !clientId || !clientSecret || !appType) {
+      setValidationError('Slug, name, app type, client ID, and client secret are required.')
+      return
+    }
+    if (!/^[a-z][a-z0-9-]*$/.test(slug)) {
+      setValidationError('Slug must start with a letter and contain only lowercase letters, numbers, and hyphens.')
+      return
+    }
+
+    const data: ServiceApplicationCreate = {
+      slug,
+      name,
+      description: description || null,
+      app_type: appType,
+      application_url: applicationUrl || null,
+      client_id: clientId,
+      client_secret: clientSecret,
+      scopes: scopes ? scopes.split(',').map((s) => s.trim()).filter(Boolean) : [],
+      webhook_secret: extraFields.includes('webhook_secret') && webhookSecret ? webhookSecret : null,
+      private_key: extraFields.includes('private_key') && privateKey ? privateKey : null,
+      signing_secret: extraFields.includes('signing_secret') && signingSecret ? signingSecret : null,
+      status,
+    }
+    onSave(data)
+  }
+
+  const inputClass = isDarkMode
+    ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'
+    : ''
+
+  const labelClass = `block text-sm font-medium mb-1 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Button variant="outline" onClick={onCancel} className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back
+          </Button>
+          <h3 className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            {isEdit ? 'Edit Application' : 'New Application'}
+          </h3>
+        </div>
+        <Button
+          onClick={handleSubmit}
+          disabled={isLoading}
+          className="bg-[#2A4DD0] hover:bg-blue-700 text-white"
+        >
+          {isLoading ? 'Saving...' : isEdit ? 'Update' : 'Create'}
+        </Button>
+      </div>
+
+      {/* Error display */}
+      {(validationError || error) && (
+        <div className={`flex items-center gap-3 p-4 rounded-lg border ${
+          isDarkMode ? 'bg-red-900/20 border-red-700 text-red-400' : 'bg-red-50 border-red-200 text-red-700'
+        }`}>
+          <AlertCircle className="w-5 h-5 flex-shrink-0" />
+          <div className="text-sm">
+            {validationError || (error instanceof Error ? error.message : 'An error occurred')}
+          </div>
+        </div>
+      )}
+
+      {/* Form */}
+      <div className={`p-6 rounded-lg border space-y-4 ${
+        isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+      }`}>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className={labelClass}>Name *</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="My GitHub App"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Slug *</label>
+            <Input
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              placeholder="my-github-app"
+              disabled={isEdit}
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className={labelClass}>Description</label>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional description"
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className={labelClass}>Application URL</label>
+          <Input
+            value={applicationUrl}
+            onChange={(e) => setApplicationUrl(e.target.value)}
+            placeholder="https://github.com/settings/apps/my-app"
+            className={inputClass}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className={labelClass}>Application Type *</label>
+            <select
+              value={appType}
+              onChange={(e) => setAppType(e.target.value)}
+              disabled={isEdit}
+              className={`w-full px-3 py-2 rounded-md border text-sm ${
+                isDarkMode
+                  ? 'bg-gray-700 border-gray-600 text-white'
+                  : 'bg-white border-gray-300 text-gray-900'
+              }`}
+            >
+              {APP_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelClass}>Status</label>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value as 'active' | 'inactive' | 'revoked')}
+              className={`w-full px-3 py-2 rounded-md border text-sm ${
+                isDarkMode
+                  ? 'bg-gray-700 border-gray-600 text-white'
+                  : 'bg-white border-gray-300 text-gray-900'
+              }`}
+            >
+              <option value="active">Active</option>
+              <option value="inactive">Inactive</option>
+              <option value="revoked">Revoked</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className={labelClass}>Client ID *</label>
+            <Input
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+              placeholder="Iv1.abc123..."
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Client Secret *</label>
+            <Input
+              type="password"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.target.value)}
+              placeholder={isEdit ? '********' : 'Enter secret'}
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className={labelClass}>Scopes</label>
+          <Input
+            value={scopes}
+            onChange={(e) => setScopes(e.target.value)}
+            placeholder="repo, read:org (comma-separated)"
+            className={inputClass}
+          />
+        </div>
+
+        {/* Conditional fields based on app type */}
+        {extraFields.includes('webhook_secret') && (
+          <div>
+            <label className={labelClass}>Webhook Secret</label>
+            <Input
+              type="password"
+              value={webhookSecret}
+              onChange={(e) => setWebhookSecret(e.target.value)}
+              placeholder={isEdit && application?.webhook_secret ? '********' : 'Enter webhook secret'}
+              className={inputClass}
+            />
+          </div>
+        )}
+
+        {extraFields.includes('private_key') && (
+          <div>
+            <label className={labelClass}>Private Key (PEM)</label>
+            <textarea
+              value={privateKey}
+              onChange={(e) => setPrivateKey(e.target.value)}
+              placeholder={isEdit && application?.private_key ? '********' : '-----BEGIN RSA PRIVATE KEY-----\n...'}
+              rows={4}
+              className={`w-full px-3 py-2 rounded-md border text-sm font-mono ${
+                isDarkMode
+                  ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'
+                  : 'bg-white border-gray-300 text-gray-900'
+              }`}
+            />
+          </div>
+        )}
+
+        {extraFields.includes('signing_secret') && (
+          <div>
+            <label className={labelClass}>Signing Secret</label>
+            <Input
+              type="password"
+              value={signingSecret}
+              onChange={(e) => setSigningSecret(e.target.value)}
+              placeholder={isEdit && application?.signing_secret ? '********' : 'Enter signing secret'}
+              className={inputClass}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -4,7 +4,8 @@ import { Plus, Trash2, Key, AlertCircle, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { listServiceApplications, deleteServiceApplication, createServiceApplication, updateServiceApplication } from '@/api/endpoints'
 import { OAuth2ApplicationForm } from './OAuth2ApplicationForm'
-import type { ServiceApplication, ServiceApplicationCreate } from '@/types'
+import { ApplicationSecretsPanel } from './ApplicationSecretsPanel'
+import type { ServiceApplication, ServiceApplicationCreate, ServiceApplicationUpdate } from '@/types'
 
 interface OAuth2ApplicationListProps {
   serviceSlug: string
@@ -37,7 +38,7 @@ export function OAuth2ApplicationList({ serviceSlug, isDarkMode }: OAuth2Applica
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ appSlug, data }: { appSlug: string; data: ServiceApplicationCreate }) =>
+    mutationFn: ({ appSlug, data }: { appSlug: string; data: ServiceApplicationUpdate }) =>
       updateServiceApplication(serviceSlug, appSlug, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['service-applications', serviceSlug] })
@@ -62,27 +63,51 @@ export function OAuth2ApplicationList({ serviceSlug, isDarkMode }: OAuth2Applica
     }
   }
 
-  const handleSave = (data: ServiceApplicationCreate) => {
+  const handleSave = (data: ServiceApplicationCreate | ServiceApplicationUpdate) => {
     if (viewMode === 'create') {
-      createMutation.mutate(data)
+      createMutation.mutate(data as ServiceApplicationCreate)
     } else if (editingApp) {
-      updateMutation.mutate({ appSlug: editingApp.slug, data })
+      updateMutation.mutate({ appSlug: editingApp.slug, data: data as ServiceApplicationUpdate })
     }
   }
 
-  if (viewMode === 'create' || viewMode === 'edit') {
+  if (viewMode === 'create') {
     return (
       <OAuth2ApplicationForm
-        application={editingApp}
+        application={null}
         onSave={handleSave}
         onCancel={() => {
           setViewMode('list')
           setEditingApp(null)
         }}
         isDarkMode={isDarkMode}
-        isLoading={createMutation.isPending || updateMutation.isPending}
-        error={createMutation.error || updateMutation.error}
+        isLoading={createMutation.isPending}
+        error={createMutation.error}
       />
+    )
+  }
+
+  if (viewMode === 'edit' && editingApp) {
+    return (
+      <div className="space-y-6">
+        <OAuth2ApplicationForm
+          application={editingApp}
+          onSave={handleSave}
+          onCancel={() => {
+            setViewMode('list')
+            setEditingApp(null)
+          }}
+          isDarkMode={isDarkMode}
+          isLoading={updateMutation.isPending}
+          error={updateMutation.error}
+        />
+        <ApplicationSecretsPanel
+          serviceSlug={serviceSlug}
+          appSlug={editingApp.slug}
+          appType={editingApp.app_type}
+          isDarkMode={isDarkMode}
+        />
+      </div>
     )
   }
 

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Plus, Trash2, Key, AlertCircle, ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { listServiceApplications, deleteServiceApplication, createServiceApplication, updateServiceApplication } from '@/api/endpoints'
+import { OAuth2ApplicationForm } from './OAuth2ApplicationForm'
+import type { ServiceApplication, ServiceApplicationCreate } from '@/types'
+
+interface OAuth2ApplicationListProps {
+  serviceSlug: string
+  isDarkMode: boolean
+}
+
+const STATUS_COLORS: Record<string, { bg: string; text: string; darkBg: string; darkText: string }> = {
+  active: { bg: 'bg-green-100', text: 'text-green-700', darkBg: 'bg-green-900/30', darkText: 'text-green-400' },
+  inactive: { bg: 'bg-gray-100', text: 'text-gray-700', darkBg: 'bg-gray-700', darkText: 'text-gray-400' },
+  revoked: { bg: 'bg-red-100', text: 'text-red-700', darkBg: 'bg-red-900/30', darkText: 'text-red-400' },
+}
+
+export function OAuth2ApplicationList({ serviceSlug, isDarkMode }: OAuth2ApplicationListProps) {
+  const queryClient = useQueryClient()
+  const [viewMode, setViewMode] = useState<'list' | 'create' | 'edit'>('list')
+  const [editingApp, setEditingApp] = useState<ServiceApplication | null>(null)
+
+  const { data: applications = [], isLoading, error } = useQuery({
+    queryKey: ['service-applications', serviceSlug],
+    queryFn: () => listServiceApplications(serviceSlug),
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (data: ServiceApplicationCreate) =>
+      createServiceApplication(serviceSlug, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['service-applications', serviceSlug] })
+      setViewMode('list')
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({ appSlug, data }: { appSlug: string; data: ServiceApplicationCreate }) =>
+      updateServiceApplication(serviceSlug, appSlug, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['service-applications', serviceSlug] })
+      setViewMode('list')
+      setEditingApp(null)
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (appSlug: string) => deleteServiceApplication(serviceSlug, appSlug),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['service-applications', serviceSlug] })
+    },
+    onError: (error: any) => {
+      alert(`Failed to delete application: ${error.response?.data?.detail || error.message}`)
+    },
+  })
+
+  const handleDelete = (app: ServiceApplication) => {
+    if (confirm(`Delete application "${app.name}"? This cannot be undone.`)) {
+      deleteMutation.mutate(app.slug)
+    }
+  }
+
+  const handleSave = (data: ServiceApplicationCreate) => {
+    if (viewMode === 'create') {
+      createMutation.mutate(data)
+    } else if (editingApp) {
+      updateMutation.mutate({ appSlug: editingApp.slug, data })
+    }
+  }
+
+  if (viewMode === 'create' || viewMode === 'edit') {
+    return (
+      <OAuth2ApplicationForm
+        application={editingApp}
+        onSave={handleSave}
+        onCancel={() => {
+          setViewMode('list')
+          setEditingApp(null)
+        }}
+        isDarkMode={isDarkMode}
+        isLoading={createMutation.isPending || updateMutation.isPending}
+        error={createMutation.error || updateMutation.error}
+      />
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+          Loading applications...
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className={`flex items-center gap-3 p-4 rounded-lg border ${
+        isDarkMode ? 'bg-red-900/20 border-red-700 text-red-400' : 'bg-red-50 border-red-200 text-red-700'
+      }`}>
+        <AlertCircle className="w-5 h-5 flex-shrink-0" />
+        <div>
+          <div className="font-medium">Failed to load applications</div>
+          <div className="text-sm mt-1">{error instanceof Error ? error.message : 'An error occurred'}</div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+          {applications.length} application{applications.length !== 1 ? 's' : ''}
+        </div>
+        <Button
+          onClick={() => {
+            setEditingApp(null)
+            setViewMode('create')
+          }}
+          size="sm"
+          className="bg-[#2A4DD0] hover:bg-blue-700 text-white"
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          Add Application
+        </Button>
+      </div>
+
+      {/* Table */}
+      {applications.length === 0 ? (
+        <div className={`text-center py-8 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+          <Key className="w-8 h-8 mx-auto mb-2 opacity-50" />
+          <div>No applications registered</div>
+          <div className="text-sm mt-1">Add an OAuth2 application to get started</div>
+        </div>
+      ) : (
+        <div className={`rounded-lg border overflow-hidden ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <table className="w-full">
+            <thead className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}>
+              <tr>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Application</th>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Type</th>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Client ID</th>
+                <th className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Status</th>
+                <th className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}>Actions</th>
+              </tr>
+            </thead>
+            <tbody className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}>
+              {applications.map((app) => {
+                const statusColor = STATUS_COLORS[app.status] || STATUS_COLORS.inactive
+                return (
+                  <tr
+                    key={app.slug}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                    onClick={() => {
+                      setEditingApp(app)
+                      setViewMode('edit')
+                    }}
+                  >
+                    <td className="px-6 py-4">
+                      <div className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                        {app.name}
+                      </div>
+                      <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                        {app.slug}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4">
+                      <code className={`px-2 py-1 rounded text-xs ${
+                        isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'
+                      }`}>
+                        {app.app_type}
+                      </code>
+                    </td>
+                    <td className={`px-6 py-4 text-sm font-mono ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                      {app.client_id}
+                    </td>
+                    <td className="px-6 py-4">
+                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        isDarkMode
+                          ? `${statusColor.darkBg} ${statusColor.darkText}`
+                          : `${statusColor.bg} ${statusColor.text}`
+                      }`}>
+                        {app.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-right" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+                      <div className="flex items-center justify-end gap-1">
+                        {app.application_url && (
+                          <a
+                            href={app.application_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={`inline-flex items-center p-1.5 rounded ${
+                              isDarkMode
+                                ? 'text-blue-400 hover:text-blue-300 hover:bg-blue-900/20'
+                                : 'text-blue-600 hover:text-blue-700 hover:bg-blue-50'
+                            }`}
+                            title="Open application"
+                          >
+                            <ExternalLink className="w-4 h-4" />
+                          </a>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Delete application ${app.name}`}
+                          onClick={() => handleDelete(app)}
+                          disabled={deleteMutation.isPending}
+                          className={isDarkMode ? 'text-red-400 hover:text-red-300 hover:bg-red-900/20' : 'text-red-600 hover:text-red-700 hover:bg-red-50'}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -1,0 +1,188 @@
+import { ArrowLeft, Edit2, ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { ThirdPartyService } from '@/types'
+
+interface ThirdPartyServiceDetailProps {
+  service: ThirdPartyService
+  onEdit: () => void
+  onBack: () => void
+  isDarkMode: boolean
+}
+
+const STATUS_COLORS: Record<string, { bg: string; text: string; darkBg: string; darkText: string }> = {
+  active: { bg: 'bg-green-100', text: 'text-green-700', darkBg: 'bg-green-900/30', darkText: 'text-green-400' },
+  deprecated: { bg: 'bg-yellow-100', text: 'text-yellow-700', darkBg: 'bg-yellow-900/30', darkText: 'text-yellow-400' },
+  evaluating: { bg: 'bg-blue-100', text: 'text-blue-700', darkBg: 'bg-blue-900/30', darkText: 'text-blue-400' },
+  inactive: { bg: 'bg-gray-100', text: 'text-gray-700', darkBg: 'bg-gray-700', darkText: 'text-gray-400' },
+}
+
+export function ThirdPartyServiceDetail({ service, onEdit, onBack, isDarkMode }: ThirdPartyServiceDetailProps) {
+  const statusColor = STATUS_COLORS[service.status] || STATUS_COLORS.inactive
+  const linkEntries = Object.entries(service.links || {})
+  const identifierEntries = Object.entries(service.identifiers || {})
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Button variant="outline" onClick={onBack} className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back
+          </Button>
+          <div>
+            <div className="flex items-center gap-3">
+              {service.icon && (
+                <img src={service.icon} alt="" className="w-8 h-8 rounded object-cover" />
+              )}
+              <h2 className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                {service.name}
+              </h2>
+              <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                isDarkMode
+                  ? `${statusColor.darkBg} ${statusColor.darkText}`
+                  : `${statusColor.bg} ${statusColor.text}`
+              }`}>
+                {service.status}
+              </span>
+            </div>
+            {service.description && (
+              <p className={`mt-1 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+                {service.description}
+              </p>
+            )}
+          </div>
+        </div>
+        <Button onClick={onEdit} className="bg-[#2A4DD0] hover:bg-blue-700 text-white">
+          <Edit2 className="w-4 h-4 mr-2" />
+          Edit Service
+        </Button>
+      </div>
+
+      {/* Service Info */}
+      <div className={`p-6 rounded-lg border ${
+        isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+      }`}>
+        <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+          Service Information
+        </h3>
+        <div className="grid grid-cols-2 gap-6">
+          <div>
+            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Slug</div>
+            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              <code className={`px-2 py-1 rounded text-sm ${
+                isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'
+              }`}>
+                {service.slug}
+              </code>
+            </div>
+          </div>
+          <div>
+            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Vendor</div>
+            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              {service.vendor}
+            </div>
+          </div>
+          <div>
+            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Organization</div>
+            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              {service.organization.name}
+            </div>
+          </div>
+          <div>
+            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Managing Team</div>
+            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              {service.team?.name || (
+                <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not assigned</span>
+              )}
+            </div>
+          </div>
+          <div>
+            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Category</div>
+            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              {service.category || (
+                <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not set</span>
+              )}
+            </div>
+          </div>
+          <div>
+            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Service URL</div>
+            <div className="mt-1">
+              {service.service_url ? (
+                <a
+                  href={service.service_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-1 text-sm ${
+                    isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'
+                  }`}
+                >
+                  {service.service_url}
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              ) : (
+                <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not set</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Links */}
+      {linkEntries.length > 0 && (
+        <div className={`p-6 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Links
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {linkEntries.map(([label, url]) => (
+              <div key={label}>
+                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>{label}</div>
+                <div className="mt-1">
+                  <a
+                    href={String(url)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`inline-flex items-center gap-1 text-sm ${
+                      isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'
+                    }`}
+                  >
+                    {String(url)}
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Identifiers */}
+      {identifierEntries.length > 0 && (
+        <div className={`p-6 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Identifiers
+          </h3>
+          <div className="grid grid-cols-2 gap-4">
+            {identifierEntries.map(([label, val]) => (
+              <div key={label}>
+                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>{label}</div>
+                <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                  <code className={`px-2 py-1 rounded text-sm ${
+                    isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'
+                  }`}>
+                    {String(val)}
+                  </code>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -1,5 +1,7 @@
-import { ArrowLeft, Edit2, ExternalLink } from 'lucide-react'
+import { useState } from 'react'
+import { ArrowLeft, Edit2, ExternalLink, Info, Key } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { OAuth2ApplicationList } from './OAuth2ApplicationList'
 import type { ThirdPartyService } from '@/types'
 
 interface ThirdPartyServiceDetailProps {
@@ -9,6 +11,8 @@ interface ThirdPartyServiceDetailProps {
   isDarkMode: boolean
 }
 
+type DetailTab = 'details' | 'applications'
+
 const STATUS_COLORS: Record<string, { bg: string; text: string; darkBg: string; darkText: string }> = {
   active: { bg: 'bg-green-100', text: 'text-green-700', darkBg: 'bg-green-900/30', darkText: 'text-green-400' },
   deprecated: { bg: 'bg-yellow-100', text: 'text-yellow-700', darkBg: 'bg-yellow-900/30', darkText: 'text-yellow-400' },
@@ -17,9 +21,15 @@ const STATUS_COLORS: Record<string, { bg: string; text: string; darkBg: string; 
 }
 
 export function ThirdPartyServiceDetail({ service, onEdit, onBack, isDarkMode }: ThirdPartyServiceDetailProps) {
+  const [activeTab, setActiveTab] = useState<DetailTab>('details')
   const statusColor = STATUS_COLORS[service.status] || STATUS_COLORS.inactive
   const linkEntries = Object.entries(service.links || {})
   const identifierEntries = Object.entries(service.identifiers || {})
+
+  const tabs: { id: DetailTab; label: string; icon: typeof Info }[] = [
+    { id: 'details', label: 'Details', icon: Info },
+    { id: 'applications', label: 'Applications', icon: Key },
+  ]
 
   return (
     <div className="space-y-6">
@@ -59,129 +69,170 @@ export function ThirdPartyServiceDetail({ service, onEdit, onBack, isDarkMode }:
         </Button>
       </div>
 
-      {/* Service Info */}
-      <div className={`p-6 rounded-lg border ${
-        isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
-      }`}>
-        <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-          Service Information
-        </h3>
-        <div className="grid grid-cols-2 gap-6">
-          <div>
-            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Slug</div>
-            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-              <code className={`px-2 py-1 rounded text-sm ${
-                isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'
-              }`}>
-                {service.slug}
-              </code>
-            </div>
-          </div>
-          <div>
-            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Vendor</div>
-            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-              {service.vendor}
-            </div>
-          </div>
-          <div>
-            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Organization</div>
-            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-              {service.organization.name}
-            </div>
-          </div>
-          <div>
-            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Managing Team</div>
-            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-              {service.team?.name || (
-                <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not assigned</span>
-              )}
-            </div>
-          </div>
-          <div>
-            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Category</div>
-            <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-              {service.category || (
-                <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not set</span>
-              )}
-            </div>
-          </div>
-          <div>
-            <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Service URL</div>
-            <div className="mt-1">
-              {service.service_url ? (
-                <a
-                  href={service.service_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`inline-flex items-center gap-1 text-sm ${
-                    isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'
-                  }`}
-                >
-                  {service.service_url}
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              ) : (
-                <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not set</span>
-              )}
-            </div>
-          </div>
+      {/* Tabs */}
+      <div className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}>
+        <div className="flex gap-0">
+          {tabs.map((tab) => {
+            const Icon = tab.icon
+            const isActive = activeTab === tab.id
+            return (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+                  isActive
+                    ? isDarkMode
+                      ? 'border-blue-400 text-blue-400'
+                      : 'border-[#2A4DD0] text-[#2A4DD0]'
+                    : isDarkMode
+                      ? 'border-transparent text-gray-400 hover:text-gray-200'
+                      : 'border-transparent text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                <Icon className="w-4 h-4" />
+                {tab.label}
+              </button>
+            )
+          })}
         </div>
       </div>
 
-      {/* Links */}
-      {linkEntries.length > 0 && (
-        <div className={`p-6 rounded-lg border ${
-          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
-        }`}>
-          <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-            Links
-          </h3>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {linkEntries.map(([label, url]) => (
-              <div key={label}>
-                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>{label}</div>
-                <div className="mt-1">
-                  <a
-                    href={String(url)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`inline-flex items-center gap-1 text-sm ${
-                      isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'
-                    }`}
-                  >
-                    {String(url)}
-                    <ExternalLink className="w-3 h-3" />
-                  </a>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Identifiers */}
-      {identifierEntries.length > 0 && (
-        <div className={`p-6 rounded-lg border ${
-          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
-        }`}>
-          <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-            Identifiers
-          </h3>
-          <div className="grid grid-cols-2 gap-4">
-            {identifierEntries.map(([label, val]) => (
-              <div key={label}>
-                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>{label}</div>
+      {/* Details Tab */}
+      {activeTab === 'details' && (
+        <div className="space-y-6">
+          {/* Service Info */}
+          <div className={`p-6 rounded-lg border ${
+            isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+          }`}>
+            <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              Service Information
+            </h3>
+            <div className="grid grid-cols-2 gap-6">
+              <div>
+                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Slug</div>
                 <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
                   <code className={`px-2 py-1 rounded text-sm ${
                     isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'
                   }`}>
-                    {String(val)}
+                    {service.slug}
                   </code>
                 </div>
               </div>
-            ))}
+              <div>
+                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Vendor</div>
+                <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                  {service.vendor}
+                </div>
+              </div>
+              <div>
+                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Organization</div>
+                <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                  {service.organization.name}
+                </div>
+              </div>
+              <div>
+                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Managing Team</div>
+                <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                  {service.team?.name || (
+                    <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not assigned</span>
+                  )}
+                </div>
+              </div>
+              <div>
+                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Category</div>
+                <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                  {service.category || (
+                    <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not set</span>
+                  )}
+                </div>
+              </div>
+              <div>
+                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>Service URL</div>
+                <div className="mt-1">
+                  {service.service_url ? (
+                    <a
+                      href={service.service_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`inline-flex items-center gap-1 text-sm ${
+                        isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'
+                      }`}
+                    >
+                      {service.service_url}
+                      <ExternalLink className="w-3 h-3" />
+                    </a>
+                  ) : (
+                    <span className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}>Not set</span>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
+
+          {/* Links */}
+          {linkEntries.length > 0 && (
+            <div className={`p-6 rounded-lg border ${
+              isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+            }`}>
+              <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                Links
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {linkEntries.map(([label, url]) => (
+                  <div key={label}>
+                    <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>{label}</div>
+                    <div className="mt-1">
+                      <a
+                        href={String(url)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`inline-flex items-center gap-1 text-sm ${
+                          isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'
+                        }`}
+                      >
+                        {String(url)}
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Identifiers */}
+          {identifierEntries.length > 0 && (
+            <div className={`p-6 rounded-lg border ${
+              isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+            }`}>
+              <h3 className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                Identifiers
+              </h3>
+              <div className="grid grid-cols-2 gap-4">
+                {identifierEntries.map(([label, val]) => (
+                  <div key={label}>
+                    <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>{label}</div>
+                    <div className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                      <code className={`px-2 py-1 rounded text-sm ${
+                        isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'
+                      }`}>
+                        {String(val)}
+                      </code>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
+      )}
+
+      {/* Applications Tab */}
+      {activeTab === 'applications' && (
+        <OAuth2ApplicationList
+          serviceSlug={service.slug}
+          isDarkMode={isDarkMode}
+        />
       )}
     </div>
   )

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -1,0 +1,410 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Save, X, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { IconUpload } from '@/components/ui/icon-upload'
+import { KeyValueEditor } from '@/components/ui/key-value-editor'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { listTeams } from '@/api/endpoints'
+import { slugify } from '@/lib/utils'
+import type { ThirdPartyService, ThirdPartyServiceCreate } from '@/types'
+
+interface ThirdPartyServiceFormProps {
+  service: ThirdPartyService | null
+  onSave: (svc: ThirdPartyServiceCreate) => void
+  onCancel: () => void
+  isDarkMode: boolean
+  isLoading?: boolean
+  error?: any
+}
+
+const STATUS_OPTIONS = [
+  { value: 'active', label: 'Active' },
+  { value: 'evaluating', label: 'Evaluating' },
+  { value: 'deprecated', label: 'Deprecated' },
+  { value: 'inactive', label: 'Inactive' },
+]
+
+export function ThirdPartyServiceForm({
+  service,
+  onSave,
+  onCancel,
+  isDarkMode,
+  isLoading = false,
+  error,
+}: ThirdPartyServiceFormProps) {
+  const isEditing = !!service
+  const { selectedOrganization, organizations } = useOrganization()
+
+  const [name, setName] = useState(service?.name || '')
+  const [slug, setSlug] = useState(service?.slug || '')
+  const [description, setDescription] = useState(service?.description || '')
+  const [icon, setIcon] = useState(service?.icon || '')
+  const [vendor, setVendor] = useState(service?.vendor || '')
+  const [serviceUrl, setServiceUrl] = useState(service?.service_url || '')
+  const [category, setCategory] = useState(service?.category || '')
+  const [status, setStatus] = useState<string>(service?.status || 'active')
+  const [links, setLinks] = useState<Record<string, string | number>>(service?.links || {})
+  const [identifiers, setIdentifiers] = useState<Record<string, string | number>>(service?.identifiers || {})
+  const [orgSlug, setOrgSlug] = useState(
+    service?.organization.slug || selectedOrganization?.slug || ''
+  )
+  const [teamSlug, setTeamSlug] = useState(service?.team?.slug || '')
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const { data: teams = [] } = useQuery({
+    queryKey: ['teams'],
+    queryFn: listTeams,
+  })
+
+  const orgTeams = teams.filter((t) => t.organization.slug === orgSlug)
+
+  const validate = () => {
+    const newErrors: Record<string, string> = {}
+    if (!name.trim()) newErrors.name = 'Service name is required'
+    if (!slug.trim()) newErrors.slug = 'Slug is required'
+    if (slug && !/^[a-z0-9_-]+$/.test(slug)) {
+      newErrors.slug = 'Slug must be lowercase and can only contain letters, numbers, hyphens, and underscores'
+    }
+    if (!orgSlug) newErrors.organization = 'Organization is required'
+    if (!vendor.trim()) newErrors.vendor = 'Vendor is required'
+    if (serviceUrl && !/^https?:\/\/.+/.test(serviceUrl)) {
+      newErrors.service_url = 'Must be a valid URL starting with http:// or https://'
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!validate()) return
+
+    onSave({
+      name: name.trim(),
+      slug: slug.trim(),
+      description: description.trim() || null,
+      icon: icon.trim() || null,
+      vendor: vendor.trim(),
+      service_url: serviceUrl.trim() || null,
+      category: category.trim() || null,
+      status,
+      links: links as Record<string, string>,
+      identifiers,
+      organization_slug: orgSlug,
+      team_slug: teamSlug || null,
+    })
+  }
+
+  const handleNameChange = (value: string) => {
+    setName(value)
+    if (!isEditing) {
+      setSlug(slugify(value))
+    }
+  }
+
+  const selectClass = `w-full px-3 py-2 rounded-lg border text-sm ${
+    isDarkMode
+      ? 'bg-gray-700 border-gray-600 text-white'
+      : 'bg-white border-gray-300 text-gray-900'
+  }`
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            {isEditing ? 'Edit Third-Party Service' : 'Add Third-Party Service'}
+          </h2>
+          <p className={`mt-1 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+            {isEditing ? 'Update service information' : 'Register a new external SaaS or managed service'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            disabled={isLoading}
+            className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
+          >
+            <X className="w-4 h-4 mr-2" />
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isLoading}
+            className="bg-[#2A4DD0] hover:bg-blue-700 text-white"
+          >
+            <Save className="w-4 h-4 mr-2" />
+            {isLoading ? 'Saving...' : isEditing ? 'Save Changes' : 'Create Service'}
+          </Button>
+        </div>
+      </div>
+
+      {/* API Error */}
+      {error && (
+        <div className={`rounded-lg border p-4 ${
+          isDarkMode ? 'bg-red-900/20 border-red-700' : 'bg-red-50 border-red-200'
+        }`}>
+          <div className="flex items-start gap-3">
+            <AlertCircle className={`w-5 h-5 flex-shrink-0 ${isDarkMode ? 'text-red-400' : 'text-red-600'}`} />
+            <div>
+              <div className={`font-medium ${isDarkMode ? 'text-red-400' : 'text-red-800'}`}>
+                Failed to save service
+              </div>
+              <div className={`text-sm mt-1 ${isDarkMode ? 'text-red-300' : 'text-red-700'}`}>
+                {error?.response?.data?.detail || error?.message || 'An error occurred'}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Form */}
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Basic Information */}
+        <div className={`p-6 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <h3 className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Service Information
+          </h3>
+
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  Organization <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={orgSlug}
+                  onChange={(e) => {
+                    setOrgSlug(e.target.value)
+                    setTeamSlug('')
+                  }}
+                  disabled={isEditing || isLoading}
+                  className={`${selectClass} ${isEditing ? 'opacity-60 cursor-not-allowed' : ''} ${
+                    errors.organization ? 'border-red-500' : ''
+                  }`}
+                >
+                  <option value="">Select organization...</option>
+                  {organizations.map((org) => (
+                    <option key={org.slug} value={org.slug}>{org.name}</option>
+                  ))}
+                </select>
+                {errors.organization && (
+                  <div className={`flex items-center gap-1 mt-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>
+                    <AlertCircle className="w-3 h-3" />
+                    {errors.organization}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  Managing Team
+                </label>
+                <select
+                  value={teamSlug}
+                  onChange={(e) => setTeamSlug(e.target.value)}
+                  disabled={isLoading || !orgSlug}
+                  className={selectClass}
+                >
+                  <option value="">No team assigned</option>
+                  {orgTeams.map((team) => (
+                    <option key={team.slug} value={team.slug}>{team.name}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  Service Name <span className="text-red-500">*</span>
+                </label>
+                <Input
+                  value={name}
+                  onChange={(e) => handleNameChange(e.target.value)}
+                  placeholder="e.g., Stripe"
+                  disabled={isLoading}
+                  className={`${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''} ${
+                    errors.name ? 'border-red-500' : ''
+                  }`}
+                />
+                {errors.name && (
+                  <div className={`flex items-center gap-1 mt-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>
+                    <AlertCircle className="w-3 h-3" />
+                    {errors.name}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  Slug <span className="text-red-500">*</span>
+                </label>
+                <Input
+                  value={slug}
+                  onChange={(e) => setSlug(e.target.value)}
+                  placeholder="e.g., stripe"
+                  disabled={isLoading}
+                  className={`${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''} ${
+                    errors.slug ? 'border-red-500' : ''
+                  }`}
+                />
+                {errors.slug && (
+                  <div className={`flex items-center gap-1 mt-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>
+                    <AlertCircle className="w-3 h-3" />
+                    {errors.slug}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  Vendor <span className="text-red-500">*</span>
+                </label>
+                <Input
+                  value={vendor}
+                  onChange={(e) => setVendor(e.target.value)}
+                  placeholder="e.g., Stripe, Inc."
+                  disabled={isLoading}
+                  className={`${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''} ${
+                    errors.vendor ? 'border-red-500' : ''
+                  }`}
+                />
+                {errors.vendor && (
+                  <div className={`flex items-center gap-1 mt-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>
+                    <AlertCircle className="w-3 h-3" />
+                    {errors.vendor}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  Category
+                </label>
+                <Input
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  placeholder="e.g., Payments, Analytics, Communications"
+                  disabled={isLoading}
+                  className={isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  Service URL
+                </label>
+                <Input
+                  value={serviceUrl}
+                  onChange={(e) => setServiceUrl(e.target.value)}
+                  placeholder="https://dashboard.stripe.com"
+                  disabled={isLoading}
+                  className={`${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''} ${
+                    errors.service_url ? 'border-red-500' : ''
+                  }`}
+                />
+                {errors.service_url && (
+                  <div className={`flex items-center gap-1 mt-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>
+                    <AlertCircle className="w-3 h-3" />
+                    {errors.service_url}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  Status
+                </label>
+                <select
+                  value={status}
+                  onChange={(e) => setStatus(e.target.value)}
+                  disabled={isLoading}
+                  className={selectClass}
+                >
+                  {STATUS_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                Description
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                disabled={isLoading}
+                placeholder="Brief description of this service and how it is used"
+                className={`w-full px-3 py-2 rounded-lg border resize-none ${
+                  isDarkMode
+                    ? 'bg-gray-700 border-gray-600 text-white placeholder:text-gray-400'
+                    : 'bg-white border-gray-300 text-gray-900 placeholder:text-gray-500'
+                }`}
+              />
+            </div>
+
+            <div>
+              <label className={`block text-sm mb-1.5 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                Icon
+              </label>
+              <IconUpload value={icon} onChange={setIcon} isDarkMode={isDarkMode} />
+            </div>
+          </div>
+        </div>
+
+        {/* Links */}
+        <div className={`p-6 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <h3 className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Links
+          </h3>
+          <p className={`mb-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+            Named links to documentation, API references, status pages, etc.
+          </p>
+          <KeyValueEditor
+            value={links}
+            onChange={setLinks}
+            isDarkMode={isDarkMode}
+            keyPlaceholder="Label (e.g., docs)"
+            valuePlaceholder="URL (e.g., https://docs.stripe.com)"
+            disabled={isLoading}
+          />
+        </div>
+
+        {/* Identifiers */}
+        <div className={`p-6 rounded-lg border ${
+          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+        }`}>
+          <h3 className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Identifiers
+          </h3>
+          <p className={`mb-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+            External IDs such as account ID, org ID, or API key names.
+          </p>
+          <KeyValueEditor
+            value={identifiers}
+            onChange={setIdentifiers}
+            isDarkMode={isDarkMode}
+            keyPlaceholder="Label (e.g., account_id)"
+            valuePlaceholder="Value (e.g., acct_123)"
+            disabled={isLoading}
+          />
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/ui/key-value-editor.tsx
+++ b/src/components/ui/key-value-editor.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+import { Plus, Trash2 } from 'lucide-react'
+import { Button } from './button'
+import { Input } from './input'
+
+interface KeyValueEditorProps {
+  value: Record<string, string | number>
+  onChange: (value: Record<string, string | number>) => void
+  isDarkMode: boolean
+  keyPlaceholder?: string
+  valuePlaceholder?: string
+  disabled?: boolean
+}
+
+export function KeyValueEditor({
+  value,
+  onChange,
+  isDarkMode,
+  keyPlaceholder = 'Key',
+  valuePlaceholder = 'Value',
+  disabled = false,
+}: KeyValueEditorProps) {
+  const [newKey, setNewKey] = useState('')
+  const [newValue, setNewValue] = useState('')
+
+  const entries = Object.entries(value)
+
+  const handleAdd = () => {
+    const trimmedKey = newKey.trim()
+    const trimmedValue = newValue.trim()
+    if (!trimmedKey || !trimmedValue) return
+    onChange({ ...value, [trimmedKey]: trimmedValue })
+    setNewKey('')
+    setNewValue('')
+  }
+
+  const handleRemove = (key: string) => {
+    const next = { ...value }
+    delete next[key]
+    onChange(next)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleAdd()
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      {entries.map(([k, v]) => (
+        <div key={k} className="flex items-center gap-2">
+          <Input
+            value={k}
+            disabled
+            className={`flex-1 ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''} opacity-70`}
+          />
+          <Input
+            value={String(v)}
+            disabled
+            className={`flex-1 ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''} opacity-70`}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleRemove(k)}
+            disabled={disabled}
+            className={isDarkMode ? 'text-red-400 hover:text-red-300 hover:bg-red-900/20' : 'text-red-600 hover:text-red-700 hover:bg-red-50'}
+          >
+            <Trash2 className="w-4 h-4" />
+          </Button>
+        </div>
+      ))}
+
+      <div className="flex items-center gap-2">
+        <Input
+          value={newKey}
+          onChange={(e) => setNewKey(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={keyPlaceholder}
+          disabled={disabled}
+          className={`flex-1 ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
+        />
+        <Input
+          value={newValue}
+          onChange={(e) => setNewValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={valuePlaceholder}
+          disabled={disabled}
+          className={`flex-1 ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleAdd}
+          disabled={disabled || !newKey.trim() || !newValue.trim()}
+          className={isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'}
+        >
+          <Plus className="w-4 h-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -435,6 +435,45 @@ export interface BlueprintCreate {
   version?: number
 }
 
+// Third-Party Service types
+export interface ThirdPartyService {
+  name: string
+  slug: string
+  description?: string | null
+  icon?: string | null
+  vendor: string
+  service_url?: string | null
+  category?: string | null
+  status: 'active' | 'deprecated' | 'evaluating' | 'inactive'
+  links: Record<string, string>
+  identifiers: Record<string, string | number>
+  organization: {
+    name: string
+    slug: string
+  }
+  team?: {
+    name: string
+    slug: string
+  } | null
+  [key: string]: unknown
+}
+
+export interface ThirdPartyServiceCreate {
+  name: string
+  slug: string
+  description?: string | null
+  icon?: string | null
+  vendor: string
+  service_url?: string | null
+  category?: string | null
+  status?: string
+  links?: Record<string, string>
+  identifiers?: Record<string, string | number>
+  organization_slug: string
+  team_slug?: string | null
+  [key: string]: unknown
+}
+
 export interface SchemaProperty {
   id: string
   name: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -482,11 +482,7 @@ export interface ServiceApplication {
   app_type: string
   application_url?: string | null
   client_id: string
-  client_secret: string
   scopes: string[]
-  webhook_secret?: string | null
-  private_key?: string | null
-  signing_secret?: string | null
   settings: Record<string, string | number | boolean>
   status: 'active' | 'inactive' | 'revoked'
 }
@@ -505,6 +501,32 @@ export interface ServiceApplicationCreate {
   signing_secret?: string | null
   settings?: Record<string, string | number | boolean>
   status?: 'active' | 'inactive' | 'revoked'
+}
+
+export interface ServiceApplicationUpdate {
+  slug: string
+  name: string
+  description?: string | null
+  app_type: string
+  application_url?: string | null
+  client_id: string
+  scopes?: string[]
+  settings?: Record<string, string | number | boolean>
+  status?: 'active' | 'inactive' | 'revoked'
+}
+
+export interface ServiceApplicationSecrets {
+  client_secret: string
+  webhook_secret?: string | null
+  private_key?: string | null
+  signing_secret?: string | null
+}
+
+export interface ServiceApplicationSecretsUpdate {
+  client_secret?: string | null
+  webhook_secret?: string | null
+  private_key?: string | null
+  signing_secret?: string | null
 }
 
 export interface SchemaProperty {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -474,6 +474,39 @@ export interface ThirdPartyServiceCreate {
   [key: string]: unknown
 }
 
+// Service Application types
+export interface ServiceApplication {
+  slug: string
+  name: string
+  description?: string | null
+  app_type: string
+  application_url?: string | null
+  client_id: string
+  client_secret: string
+  scopes: string[]
+  webhook_secret?: string | null
+  private_key?: string | null
+  signing_secret?: string | null
+  settings: Record<string, string | number | boolean>
+  status: 'active' | 'inactive' | 'revoked'
+}
+
+export interface ServiceApplicationCreate {
+  slug: string
+  name: string
+  description?: string | null
+  app_type: string
+  application_url?: string | null
+  client_id: string
+  client_secret: string
+  scopes?: string[]
+  webhook_secret?: string | null
+  private_key?: string | null
+  signing_secret?: string | null
+  settings?: Record<string, string | number | boolean>
+  status?: 'active' | 'inactive' | 'revoked'
+}
+
 export interface SchemaProperty {
   id: string
   name: string


### PR DESCRIPTION
## Summary
Add admin UI for managing Third-Party Services and their OAuth2 Service Applications in Imbi.

## Problem
There was no UI for administrators to manage third-party service integrations or their associated OAuth2 applications. These had to be managed directly through the API.

## Solution
- Add TypeScript types and API endpoint functions for Third-Party Services and Service Applications
- Add `ThirdPartyServiceManagement` admin page with CRUD operations for services
- Add `ThirdPartyServiceDetail` view with nested OAuth2 application management
- Add `ThirdPartyServiceForm` and `OAuth2ApplicationForm` dialog components
- Add reusable `KeyValueEditor` component for editing dict fields (e.g., extra_values)
- Add `install` dependency to the `dev` recipe in the justfile
- Wire up new admin section in the sidebar navigation

## Impact
Adds a new "Third-Party Services" section to the admin area. No changes to existing functionality.

### Testing
Manually tested with the dev server: created, edited, and deleted services and applications, verified form validation and error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI to manage third‑party services (list, create, edit, delete) with metadata and detail views.
  * Manage OAuth2 applications per service (create, edit, delete) and view application details.
  * View, reveal, copy, and update application secrets with controlled reveal and edit flows.
  * New form and key/value editor components for creating and editing services and applications.

* **Chores**
  * Development recipe renamed and now runs post-install steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->