### PR TITLE
Add project count to link definitions and brand link colors

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -408,7 +408,7 @@ export function ProjectDetail({ project, isDarkMode }: ProjectDetailProps) {
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center gap-1.5 text-sm text-amber-text hover:underline"
+                    className={`flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-amber-400' : 'text-amber-text'} hover:underline`}
                   >
                     <Icon className="h-4 w-4" />
                     <span>{linkLabel}</span>
@@ -663,10 +663,12 @@ export function ProjectDetail({ project, isDarkMode }: ProjectDetailProps) {
                               href={url}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="flex items-center gap-1.5 text-sm text-amber-text hover:underline"
+                              className={`flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-amber-400' : 'text-amber-text'} hover:underline`}
                             >
                               {url}
-                              <ExternalLink className="h-3 w-3 text-amber-text" />
+                              <ExternalLink
+                                className={`h-3 w-3 ${isDarkMode ? 'text-amber-400' : 'text-amber-text'}`}
+                              />
                             </a>
                           ) : (
                             <span className={`text-sm ${muted}`}>—</span>

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -644,10 +644,20 @@ export function ProjectDetail({ project, isDarkMode }: ProjectDetailProps) {
                   <h3 className={`mb-4 ${value}`}>Environments</h3>
                   <div className="space-y-0">
                     {sortedEnvironments.map((env) => {
-                      const url =
-                        typeof env.url === 'string' && env.url !== ''
-                          ? env.url
-                          : null
+                      let url: string | null = null
+                      if (typeof env.url === 'string' && env.url !== '') {
+                        try {
+                          const parsed = new URL(env.url)
+                          if (
+                            parsed.protocol === 'http:' ||
+                            parsed.protocol === 'https:'
+                          ) {
+                            url = parsed.toString()
+                          }
+                        } catch {
+                          url = null
+                        }
+                      }
                       return (
                         <div
                           key={env.slug}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -439,7 +439,7 @@ export function ProjectDetail({ project, isDarkMode }: ProjectDetailProps) {
         </TabsList>
 
         <TabsContent value="overview">
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
             {/* Left column: Details */}
             <div className="space-y-6">
               <Card

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -408,11 +408,10 @@ export function ProjectDetail({ project, isDarkMode }: ProjectDetailProps) {
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center gap-1.5 text-sm text-blue-600 hover:underline"
+                    className="flex items-center gap-1.5 text-sm text-amber-text hover:underline"
                   >
                     <Icon className="h-4 w-4" />
                     <span>{linkLabel}</span>
-                    <ExternalLink className="h-3 w-3" />
                   </a>
                 </span>
               ),

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -223,7 +223,7 @@ export function LinkDefinitionManagement({
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-amber-border text-white hover:bg-amber-border-strong"
+          className="bg-amber-border-strong text-white hover:bg-amber-900"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Link Definition
@@ -358,11 +358,15 @@ export function LinkDefinitionManagement({
                   >
                     {ld.icon
                       ? (() => {
-                          const Icon = getIcon(ld.icon)
-                          return (
+                          const Icon = getIcon(ld.icon, null)
+                          return Icon ? (
                             <Icon
                               className={`mx-auto h-5 w-5 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
                             />
+                          ) : (
+                            <span className="text-xs text-red-400">
+                              {ld.icon}
+                            </span>
                           )
                         })()
                       : '--'}

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
 import { Plus, Search, Trash2, Link2, AlertCircle } from 'lucide-react'
+import { getIcon } from '@/lib/icons'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -222,7 +223,7 @@ export function LinkDefinitionManagement({
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Link Definition
@@ -268,6 +269,13 @@ export function LinkDefinitionManagement({
                   }`}
                 >
                   URL Template
+                </th>
+                <th
+                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                  }`}
+                >
+                  Projects
                 </th>
                 <th
                   className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
@@ -348,7 +356,16 @@ export function LinkDefinitionManagement({
                       isDarkMode ? 'text-gray-300' : 'text-gray-600'
                     }`}
                   >
-                    {ld.icon || '--'}
+                    {ld.icon
+                      ? (() => {
+                          const Icon = getIcon(ld.icon)
+                          return (
+                            <Icon
+                              className={`mx-auto h-5 w-5 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                            />
+                          )
+                        })()
+                      : '--'}
                   </td>
                   <td
                     className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
@@ -372,6 +389,11 @@ export function LinkDefinitionManagement({
                         --
                       </span>
                     )}
+                  </td>
+                  <td
+                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                  >
+                    {ld.relationships?.projects?.count ?? 0}
                   </td>
                   <td
                     className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -223,7 +223,7 @@ export function LinkDefinitionManagement({
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-amber-border-strong text-white hover:bg-amber-900"
+          className="bg-amber-border-strong text-white hover:brightness-125"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Link Definition
@@ -364,7 +364,9 @@ export function LinkDefinitionManagement({
                               className={`mx-auto h-5 w-5 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
                             />
                           ) : (
-                            <span className="text-xs text-red-400">
+                            <span
+                              className={`text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                            >
                               {ld.icon}
                             </span>
                           )

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -395,7 +395,15 @@ export function LinkDefinitionManagement({
                     )}
                   </td>
                   <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${
+                      (ld.relationships?.projects?.count ?? 0) === 0
+                        ? isDarkMode
+                          ? 'text-gray-600'
+                          : 'text-gray-400'
+                        : isDarkMode
+                          ? 'text-gray-300'
+                          : 'text-gray-600'
+                    }`}
                   >
                     {ld.relationships?.projects?.count ?? 0}
                   </td>

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -94,8 +94,17 @@ const siLookup = simpleIcons as Record<string, unknown>
  */
 export function getIcon(
   iconName: string | null | undefined,
-  fallback: IconComponent = ExternalLink as IconComponent,
-): IconComponent {
+  fallback: null,
+): IconComponent | null
+export function getIcon(
+  iconName: string | null | undefined,
+  fallback?: IconComponent,
+): IconComponent
+export function getIcon(
+  iconName: string | null | undefined,
+  fallback?: IconComponent | null,
+): IconComponent | null {
+  if (fallback === undefined) fallback = ExternalLink as IconComponent
   if (!iconName) return fallback
 
   // Simple Icons: si-github → SiGithub

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,6 +99,9 @@ export interface LinkDefinition {
     name: string
     slug: string
   }
+  relationships?: {
+    projects?: RelationshipLink
+  }
 }
 
 export interface LinkDefinitionCreate {


### PR DESCRIPTION
## Summary
- Display project usage count column in the link definitions admin table, sourced from the API's new `relationships.projects.count` field
- Change project detail external links from blue to amber brand color (`text-amber-text`)
- Remove redundant external-link icons from the project detail link bar

## Test plan
- [ ] Verify link definitions admin table shows "Projects" column with counts
- [ ] Verify project detail external links render in amber brand color
- [ ] Verify no external-link icons appear next to link labels in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)