### PR TITLE
Add relationship blueprint UI and refactor admin forms

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -272,7 +272,7 @@ export const deleteEnvironment = (orgSlug: string, slug: string) =>
   )
 
 export const getEnvironmentSchema = () =>
-  getDynamicSchema('EnvironmentWithBlueprints', ENVIRONMENT_BASE_FIELDS)
+  getDynamicSchema('EnvironmentRequest', ENVIRONMENT_BASE_FIELDS)
 
 // Admin - Project Types
 export const listProjectTypes = async (
@@ -311,7 +311,7 @@ export const deleteProjectType = (orgSlug: string, slug: string) =>
   )
 
 export const getProjectTypeSchema = () =>
-  getDynamicSchema('ProjectTypeWithBlueprints', PROJECT_TYPE_BASE_FIELDS)
+  getDynamicSchema('ProjectTypeRequest', PROJECT_TYPE_BASE_FIELDS)
 
 // Admin - User Management
 export const listAdminUsers = async (params?: {
@@ -561,7 +561,7 @@ export const getDynamicSchema = async (
 }
 
 export const getTeamSchema = () =>
-  getDynamicSchema('TeamWithBlueprints', TEAM_BASE_FIELDS)
+  getDynamicSchema('TeamRequest', TEAM_BASE_FIELDS)
 
 // Admin - Teams
 export const listTeams = async (orgSlug: string): Promise<Team[]> => {

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -81,7 +81,7 @@ export function Admin({ isDarkMode }: AdminProps) {
   const { section } = useParams<{ section?: string }>()
   const currentSection: AdminSection = isValidSection(section)
     ? section
-    : 'teams'
+    : 'blueprints'
   const [isCollapsed, setIsCollapsed] = useState(false)
   const { selectedOrganization } = useOrganization()
 

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -50,18 +50,18 @@ type AdminSection =
   | 'oauth'
 
 const VALID_SECTIONS: AdminSection[] = [
-  'teams',
-  'environments',
-  'project-types',
-  'third-party-services',
-  'webhooks',
-  'link-definitions',
   'blueprints',
-  'organizations',
-  'users',
-  'service-accounts',
-  'roles',
+  'environments',
+  'link-definitions',
   'oauth',
+  'organizations',
+  'project-types',
+  'roles',
+  'service-accounts',
+  'teams',
+  'third-party-services',
+  'users',
+  'webhooks',
 ]
 
 function isValidSection(value: string | undefined): value is AdminSection {
@@ -89,10 +89,10 @@ export function Admin({ isDarkMode }: AdminProps) {
 
   const orgAdminSections: SectionDef[] = [
     {
-      id: 'teams',
-      label: 'Teams',
-      icon: UsersRound,
-      description: 'Manage teams',
+      id: 'blueprints',
+      label: 'Blueprints',
+      icon: FileJson,
+      description: 'Configure metadata templates',
       scope: 'org',
     },
     {
@@ -103,10 +103,24 @@ export function Admin({ isDarkMode }: AdminProps) {
       scope: 'org',
     },
     {
+      id: 'link-definitions',
+      label: 'Link Definitions',
+      icon: Link2,
+      description: 'Manage link definitions for projects',
+      scope: 'org',
+    },
+    {
       id: 'project-types',
       label: 'Project Types',
       icon: FolderTree,
       description: 'Manage project types',
+      scope: 'org',
+    },
+    {
+      id: 'teams',
+      label: 'Teams',
+      icon: UsersRound,
+      description: 'Manage teams',
       scope: 'org',
     },
     {
@@ -123,42 +137,21 @@ export function Admin({ isDarkMode }: AdminProps) {
       description: 'Configure inbound webhook processing',
       scope: 'org',
     },
-    {
-      id: 'link-definitions',
-      label: 'Link Definitions',
-      icon: Link2,
-      description: 'Manage link definitions for projects',
-      scope: 'org',
-    },
-    {
-      id: 'blueprints',
-      label: 'Blueprints',
-      icon: FileJson,
-      description: 'Configure metadata templates',
-      scope: 'org',
-    },
   ]
 
   const systemAdminSections: SectionDef[] = [
+    {
+      id: 'oauth',
+      label: 'OAuth Providers',
+      icon: ExternalLink,
+      description: 'Configure SSO authentication providers',
+      scope: 'system',
+    },
     {
       id: 'organizations',
       label: 'Organizations',
       icon: Building2,
       description: 'Manage organizational units and access',
-      scope: 'system',
-    },
-    {
-      id: 'users',
-      label: 'User Management',
-      icon: Users,
-      description: 'Manage user accounts and administrators',
-      scope: 'system',
-    },
-    {
-      id: 'service-accounts',
-      label: 'Service Accounts',
-      icon: Bot,
-      description: 'Manage service accounts and API keys',
       scope: 'system',
     },
     {
@@ -169,10 +162,17 @@ export function Admin({ isDarkMode }: AdminProps) {
       scope: 'system',
     },
     {
-      id: 'oauth',
-      label: 'OAuth Providers',
-      icon: ExternalLink,
-      description: 'Configure SSO authentication providers',
+      id: 'service-accounts',
+      label: 'Service Accounts',
+      icon: Bot,
+      description: 'Manage service accounts and API keys',
+      scope: 'system',
+    },
+    {
+      id: 'users',
+      label: 'User Management',
+      icon: Users,
+      description: 'Manage user accounts and administrators',
       scope: 'system',
     },
   ]

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -20,7 +20,6 @@ import { BlueprintForm } from './blueprints/BlueprintForm'
 import { BlueprintDetail } from './blueprints/BlueprintDetail'
 import { ImportBlueprintDialog } from './blueprints/ImportBlueprintDialog'
 import { useAdminNav } from '@/hooks/useAdminNav'
-import { useOpenApiSpec, getSchemaEnum } from '@/api/openapi'
 import {
   listBlueprints,
   deleteBlueprint,
@@ -90,6 +89,19 @@ export function getTypeColor(type: string, allTypes: string[]): string {
   return TYPE_COLORS[(idx >= 0 ? idx : 0) % TYPE_COLORS.length]
 }
 
+/** Return the path type used in API URLs and compound keys. */
+export function blueprintPathType(bp: Blueprint): string {
+  return bp.kind === 'relationship' ? 'relationship' : bp.type || 'unknown'
+}
+
+/** Label shown in the type badge. */
+export function blueprintTypeLabel(bp: Blueprint): string {
+  if (bp.kind === 'relationship') {
+    return `${bp.source} → ${bp.target}`
+  }
+  return bp.type || 'unknown'
+}
+
 export function getTypeBadgeClasses(
   type: string,
   allTypes: string[],
@@ -157,11 +169,15 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
     queryFn: () => listBlueprints(),
   })
 
-  // Fetch blueprint types from OpenAPI spec
-  const { data: openApiSpec } = useOpenApiSpec()
-  const blueprintTypes = openApiSpec
-    ? getSchemaEnum(openApiSpec, 'Blueprint', 'type')
-    : []
+  // Known node types for blueprint targets
+  const blueprintTypes = [
+    'Environment',
+    'Organization',
+    'Project',
+    'ProjectType',
+    'Team',
+    'ThirdPartyService',
+  ]
 
   // Refresh frontend queries after mutations
   // The backend auto-refreshes its OpenAPI schema cache on blueprint CRUD
@@ -230,7 +246,9 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
       const matchesDesc = bp.description?.toLowerCase().includes(query) ?? false
       if (!matchesName && !matchesDesc) return false
     }
-    if (typeFilter && bp.type !== typeFilter) return false
+    if (typeFilter === 'relationship') {
+      if (bp.kind !== 'relationship') return false
+    } else if (typeFilter && bp.type !== typeFilter) return false
     if (enabledFilter === 'enabled' && !bp.enabled) return false
     if (enabledFilter === 'disabled' && bp.enabled) return false
     return true
@@ -376,6 +394,7 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
                 {t}
               </option>
             ))}
+            <option value="relationship">Relationship</option>
           </select>
           <select
             value={enabledFilter}
@@ -452,9 +471,12 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
               ) : (
                 filteredBlueprints.map((bp: Blueprint) => (
                   <tr
-                    key={`${bp.type}/${bp.slug}`}
+                    key={`${blueprintPathType(bp)}/${bp.slug}`}
                     onClick={() =>
-                      handleViewClick({ type: bp.type, slug: bp.slug })
+                      handleViewClick({
+                        type: blueprintPathType(bp),
+                        slug: bp.slug,
+                      })
                     }
                     className="cursor-pointer transition-colors hover:bg-secondary"
                   >
@@ -478,9 +500,9 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
                     </td>
                     <td className="whitespace-nowrap px-5 py-3.5">
                       <span
-                        className={`inline-flex items-center rounded-sm px-2 py-0.5 text-xs font-medium ${getTypeBadgeClasses(bp.type, blueprintTypes, isDarkMode)}`}
+                        className={`inline-flex items-center rounded-sm px-2 py-0.5 text-xs font-medium ${getTypeBadgeClasses(blueprintPathType(bp), blueprintTypes, isDarkMode)}`}
                       >
-                        {bp.type}
+                        {blueprintTypeLabel(bp)}
                       </span>
                     </td>
                     <td className="whitespace-nowrap px-5 py-3.5 text-center">
@@ -507,7 +529,7 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
                           onClick={(e) => {
                             e.stopPropagation()
                             handleEditClick({
-                              type: bp.type,
+                              type: blueprintPathType(bp),
                               slug: bp.slug,
                             })
                           }}
@@ -519,7 +541,10 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
                         <button
                           onClick={(e) => {
                             e.stopPropagation()
-                            handleDelete({ type: bp.type, slug: bp.slug })
+                            handleDelete({
+                              type: blueprintPathType(bp),
+                              slug: bp.slug,
+                            })
                           }}
                           disabled={deleteMutation.isPending}
                           className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-danger hover:text-danger"

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -97,7 +97,7 @@ export function blueprintPathType(bp: Blueprint): string {
 /** Label shown in the type badge. */
 export function blueprintTypeLabel(bp: Blueprint): string {
   if (bp.kind === 'relationship') {
-    return `${bp.source} → ${bp.target}`
+    return `${bp.source ?? '?'} → ${bp.target ?? '?'}`
   }
   return bp.type || 'unknown'
 }

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -85,6 +85,7 @@ const TYPE_COLOR_CLASSES: Record<string, { light: string; dark: string }> = {
 }
 
 export function getTypeColor(type: string, allTypes: string[]): string {
+  if (type === 'relationship') return 'amber'
   const idx = allTypes.indexOf(type)
   return TYPE_COLORS[(idx >= 0 ? idx : 0) % TYPE_COLORS.length]
 }

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -98,7 +98,7 @@ export function blueprintPathType(bp: Blueprint): string {
 /** Label shown in the type badge. */
 export function blueprintTypeLabel(bp: Blueprint): string {
   if (bp.kind === 'relationship') {
-    return `${bp.source ?? '?'} → ${bp.target ?? '?'}`
+    return `${bp.source ?? '?'} → ${bp.target ?? '?'} (${bp.edge ?? '?'})`
   }
   return bp.type || 'unknown'
 }

--- a/src/components/admin/EnvironmentManagement.tsx
+++ b/src/components/admin/EnvironmentManagement.tsx
@@ -220,7 +220,7 @@ export function EnvironmentManagement({
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Environment

--- a/src/components/admin/OrganizationManagement.tsx
+++ b/src/components/admin/OrganizationManagement.tsx
@@ -225,7 +225,7 @@ export function OrganizationManagement({
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Organization

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -215,7 +215,7 @@ export function ProjectTypeManagement({
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Project Type

--- a/src/components/admin/RoleManagement.tsx
+++ b/src/components/admin/RoleManagement.tsx
@@ -264,7 +264,7 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
         </div>
         <Button
           onClick={handleCreateClick}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Role

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -263,7 +263,7 @@ export function ServiceAccountManagement({
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Service Account
@@ -328,7 +328,7 @@ export function ServiceAccountManagement({
                   {!searchQuery && statusFilter === 'all' && (
                     <Button
                       onClick={goToCreate}
-                      className="mt-4 bg-[#2A4DD0] text-white hover:bg-blue-700"
+                      className="mt-4 bg-amber-border text-white hover:bg-amber-border-strong"
                     >
                       Create Your First Service Account
                     </Button>

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -209,7 +209,7 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Team

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -255,7 +255,7 @@ export function ThirdPartyServiceManagement({
             setSelectedSlug(null)
             setViewMode('create')
           }}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Service

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -367,7 +367,7 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
         </div>
         <Button
           onClick={handleCreateClick}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New User

--- a/src/components/admin/WebhookManagement.tsx
+++ b/src/components/admin/WebhookManagement.tsx
@@ -187,7 +187,7 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
         </div>
         <Button
           onClick={goToCreate}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Webhook

--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -175,9 +175,9 @@ export function BlueprintDetail({
       kind: blueprint.kind || 'node',
       ...(blueprint.kind === 'relationship'
         ? {
-            source: blueprint.source,
-            target: blueprint.target,
-            edge: blueprint.edge,
+            source: blueprint.source ?? '',
+            target: blueprint.target ?? '',
+            edge: blueprint.edge ?? '',
           }
         : { type: blueprint.type }),
       ...(blueprint.description ? { description: blueprint.description } : {}),

--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -172,7 +172,14 @@ export function BlueprintDetail({
     const exportObj: Record<string, unknown> = {
       name: blueprint.name,
       slug: blueprint.slug,
-      type: blueprint.type,
+      kind: blueprint.kind || 'node',
+      ...(blueprint.kind === 'relationship'
+        ? {
+            source: blueprint.source,
+            target: blueprint.target,
+            edge: blueprint.edge,
+          }
+        : { type: blueprint.type }),
       ...(blueprint.description ? { description: blueprint.description } : {}),
       enabled: blueprint.enabled,
       priority: blueprint.priority,
@@ -236,9 +243,11 @@ export function BlueprintDetail({
                   {blueprint.name}
                 </h2>
                 <span
-                  className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${getTypeBadgeClasses(blueprint.type, blueprintTypes, isDarkMode)}`}
+                  className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${getTypeBadgeClasses(blueprint.kind === 'relationship' ? 'relationship' : blueprint.type || '', blueprintTypes, isDarkMode)}`}
                 >
-                  {blueprint.type}
+                  {blueprint.kind === 'relationship'
+                    ? `${blueprint.source} → ${blueprint.target} (${blueprint.edge})`
+                    : blueprint.type}
                 </span>
               </div>
               <p
@@ -263,7 +272,7 @@ export function BlueprintDetail({
             </Button>
             <Button
               onClick={onEdit}
-              className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+              className="bg-amber-border text-white hover:bg-amber-border-strong"
             >
               <Edit2 className="mr-2 h-4 w-4" />
               Edit Blueprint

--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -246,7 +246,7 @@ export function BlueprintDetail({
                   className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${getTypeBadgeClasses(blueprint.kind === 'relationship' ? 'relationship' : blueprint.type || '', blueprintTypes, isDarkMode)}`}
                 >
                   {blueprint.kind === 'relationship'
-                    ? `${blueprint.source} → ${blueprint.target} (${blueprint.edge})`
+                    ? `${blueprint.source ?? '?'} → ${blueprint.target ?? '?'} (${blueprint.edge ?? '?'})`
                     : blueprint.type}
                 </span>
               </div>

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -40,6 +40,37 @@ interface BlueprintFormProps {
 
 type SchemaEditorMode = 'visual' | 'code'
 
+// Known relationships keyed by "Source:Target"
+const RELATIONSHIP_MAP: Record<string, string[]> = {
+  'Project:Environment': ['DEPLOYED_IN'],
+  'Project:ProjectType': ['TYPE'],
+  'Project:Team': ['OWNED_BY'],
+  'Project:Project': ['DEPENDS_ON'],
+  'Team:Organization': ['BELONGS_TO'],
+  'Environment:Organization': ['BELONGS_TO'],
+  'ProjectType:Organization': ['BELONGS_TO'],
+  'ThirdPartyService:Organization': ['BELONGS_TO'],
+}
+
+function getRelationshipTypes(source: string, target: string): string[] {
+  if (!source || !target) {
+    // Show all unique types when pair not yet selected
+    const all = new Set<string>()
+    for (const types of Object.values(RELATIONSHIP_MAP)) {
+      for (const t of types) all.add(t)
+    }
+    return Array.from(all).sort()
+  }
+  return RELATIONSHIP_MAP[`${source}:${target}`] || []
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
 const PROPERTY_TYPES: SchemaProperty['type'][] = [
   'string',
   'integer',
@@ -214,7 +245,11 @@ export function BlueprintForm({
   // Form state
   const [name, setName] = useState('')
   const [slug, setSlug] = useState('')
+  const [kind, setKind] = useState<'node' | 'relationship'>('node')
   const [type, setType] = useState('')
+  const [source, setSource] = useState('')
+  const [target, setTarget] = useState('')
+  const [edge, setEdge] = useState('')
   const [description, setDescription] = useState('')
   const [enabled, setEnabled] = useState(true)
   const [priority, setPriority] = useState(0)
@@ -255,7 +290,11 @@ export function BlueprintForm({
     if (existingBlueprint) {
       setName(existingBlueprint.name)
       setSlug(existingBlueprint.slug)
-      setType(existingBlueprint.type)
+      setKind(existingBlueprint.kind || 'node')
+      setType(existingBlueprint.type || '')
+      setSource(existingBlueprint.source || '')
+      setTarget(existingBlueprint.target || '')
+      setEdge(existingBlueprint.edge || '')
       setDescription(existingBlueprint.description || '')
       setEnabled(existingBlueprint.enabled)
       setPriority(existingBlueprint.priority)
@@ -470,7 +509,13 @@ export function BlueprintForm({
       errors.slug =
         'Slug must contain only lowercase letters, numbers, and hyphens'
     }
-    if (!type) errors.type = 'Type is required'
+    if (kind === 'node') {
+      if (!type) errors.type = 'Type is required'
+    } else {
+      if (!source.trim()) errors.source = 'Source is required'
+      if (!target.trim()) errors.target = 'Target is required'
+      if (!edge.trim()) errors.edge = 'Edge is required'
+    }
 
     // Validate schema
     try {
@@ -528,7 +573,15 @@ export function BlueprintForm({
     const data: BlueprintCreate = {
       name: name.trim(),
       slug: slug.trim() || undefined,
-      type,
+      kind,
+      ...(kind === 'node'
+        ? { type }
+        : {
+            type: null,
+            source: source.trim(),
+            target: target.trim(),
+            edge: edge.trim(),
+          }),
       description: description.trim() || null,
       enabled,
       priority,
@@ -604,7 +657,7 @@ export function BlueprintForm({
           <Button
             onClick={handleSave}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading
@@ -638,9 +691,19 @@ export function BlueprintForm({
               <div
                 className={`mt-1 text-sm ${isDarkMode ? 'text-red-300' : 'text-red-700'}`}
               >
-                {error?.response?.data?.detail ||
-                  error?.message ||
-                  'An error occurred'}
+                {(() => {
+                  const detail = error?.response?.data?.detail
+                  if (Array.isArray(detail)) {
+                    return detail
+                      .map((e: { msg?: string; loc?: string[] }) =>
+                        e.msg
+                          ? `${e.loc?.slice(-1)[0] || 'field'}: ${e.msg}`
+                          : JSON.stringify(e),
+                      )
+                      .join('; ')
+                  }
+                  return detail || error?.message || 'An error occurred'
+                })()}
               </div>
             </div>
           </div>
@@ -721,19 +784,18 @@ export function BlueprintForm({
             )}
           </div>
 
-          {/* Type */}
+          {/* Kind */}
           <div>
             <label
               className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
             >
-              Type <span className="text-red-500">*</span>
+              Kind <span className="text-red-500">*</span>
             </label>
             <select
-              value={type}
-              onChange={(e) => {
-                setType(e.target.value)
-                handleFieldChange('type')
-              }}
+              value={kind}
+              onChange={(e) =>
+                setKind(e.target.value as 'node' | 'relationship')
+              }
               disabled={isLoading || isEditing}
               className={`w-full rounded-md border px-3 py-2 text-sm ${
                 isDarkMode
@@ -741,26 +803,165 @@ export function BlueprintForm({
                   : 'border-gray-300 bg-white text-gray-900'
               } ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
             >
-              <option value="">Select a type...</option>
-              {blueprintTypes.map((t) => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
-              ))}
+              <option value="node">Object</option>
+              <option value="relationship">Relationship</option>
             </select>
             {isEditing && (
               <p
                 className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
               >
-                Type cannot be changed after creation
-              </p>
-            )}
-            {touched.type && validationErrors.type && (
-              <p className="mt-1 text-sm text-red-600">
-                {validationErrors.type}
+                Kind cannot be changed after creation
               </p>
             )}
           </div>
+
+          {/* Type (node) or Source/Target/Edge (relationship) */}
+          {kind === 'node' ? (
+            <div>
+              <label
+                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              >
+                Type <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={type}
+                onChange={(e) => {
+                  setType(e.target.value)
+                  handleFieldChange('type')
+                }}
+                disabled={isLoading || isEditing}
+                className={`w-full rounded-md border px-3 py-2 text-sm ${
+                  isDarkMode
+                    ? 'border-gray-600 bg-gray-700 text-white'
+                    : 'border-gray-300 bg-white text-gray-900'
+                } ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
+              >
+                <option value="">Select a type...</option>
+                {blueprintTypes.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+              {touched.type && validationErrors.type && (
+                <p className="mt-1 text-sm text-red-600">
+                  {validationErrors.type}
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="col-span-2 grid grid-cols-[1fr_auto_1fr_auto_1fr] items-end gap-2">
+              <div>
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Source <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={source}
+                  onChange={(e) => {
+                    setSource(e.target.value)
+                    const valid = getRelationshipTypes(e.target.value, target)
+                    if (edge && !valid.includes(edge)) setEdge('')
+                  }}
+                  disabled={isLoading || isEditing}
+                  className={`w-full rounded-md border px-3 py-2 text-sm ${
+                    isDarkMode
+                      ? 'border-gray-600 bg-gray-700 text-white'
+                      : 'border-gray-300 bg-white text-gray-900'
+                  } ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
+                >
+                  <option value="">Select source...</option>
+                  {blueprintTypes.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+                {touched.source && validationErrors.source && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {validationErrors.source}
+                  </p>
+                )}
+              </div>
+              <div
+                className={`pb-2 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+              >
+                →
+              </div>
+              <div>
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Relationship Type <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={edge}
+                  onChange={(e) => setEdge(e.target.value)}
+                  disabled={isLoading || isEditing || (!source && !target)}
+                  className={`w-full rounded-md border px-3 py-2 text-sm ${
+                    isDarkMode
+                      ? 'border-gray-600 bg-gray-700 text-white'
+                      : 'border-gray-300 bg-white text-gray-900'
+                  } ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
+                >
+                  <option value="">
+                    {source && target
+                      ? 'Select type...'
+                      : 'Pick source & target first'}
+                  </option>
+                  {getRelationshipTypes(source, target).map((rt) => (
+                    <option key={rt} value={rt}>
+                      {toTitleCase(rt)}
+                    </option>
+                  ))}
+                </select>
+                {touched.edge && validationErrors.edge && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {validationErrors.edge}
+                  </p>
+                )}
+              </div>
+              <div
+                className={`pb-2 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+              >
+                →
+              </div>
+              <div>
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Target <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={target}
+                  onChange={(e) => {
+                    setTarget(e.target.value)
+                    const valid = getRelationshipTypes(source, e.target.value)
+                    if (edge && !valid.includes(edge)) setEdge('')
+                  }}
+                  disabled={isLoading || isEditing}
+                  className={`w-full rounded-md border px-3 py-2 text-sm ${
+                    isDarkMode
+                      ? 'border-gray-600 bg-gray-700 text-white'
+                      : 'border-gray-300 bg-white text-gray-900'
+                  } ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
+                >
+                  <option value="">Select target...</option>
+                  {blueprintTypes.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+                {touched.target && validationErrors.target && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {validationErrors.target}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
 
           {/* Priority */}
           <div>

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -703,10 +703,17 @@ export function BlueprintForm({
                   const detail = error?.response?.data?.detail
                   if (Array.isArray(detail)) {
                     return detail
-                      .map((e: { msg?: string; loc?: string[] }) =>
-                        e.msg
-                          ? `${e.loc?.slice(-1)[0] || 'field'}: ${e.msg}`
-                          : JSON.stringify(e),
+                      .map(
+                        (e: { msg?: string; loc?: Array<string | number> }) => {
+                          const field =
+                            e.loc
+                              ?.filter((segment) => segment !== 'body')
+                              .map(String)
+                              .join('.') || 'field'
+                          return e.msg
+                            ? `${field}: ${e.msg}`
+                            : JSON.stringify(e)
+                        },
                       )
                       .join('; ')
                   }

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -545,7 +545,15 @@ export function BlueprintForm({
     }
 
     setValidationErrors(errors)
-    setTouched({ name: true, slug: true, type: true, schema: true })
+    setTouched({
+      name: true,
+      slug: true,
+      type: true,
+      schema: true,
+      source: true,
+      target: true,
+      edge: true,
+    })
     return Object.keys(errors).length === 0
   }
 
@@ -861,6 +869,7 @@ export function BlueprintForm({
                   value={source}
                   onChange={(e) => {
                     setSource(e.target.value)
+                    handleFieldChange('source')
                     const valid = getRelationshipTypes(e.target.value, target)
                     if (edge && !valid.includes(edge)) setEdge('')
                   }}
@@ -897,8 +906,11 @@ export function BlueprintForm({
                 </label>
                 <select
                   value={edge}
-                  onChange={(e) => setEdge(e.target.value)}
-                  disabled={isLoading || isEditing || (!source && !target)}
+                  onChange={(e) => {
+                    setEdge(e.target.value)
+                    handleFieldChange('edge')
+                  }}
+                  disabled={isLoading || isEditing || !source || !target}
                   className={`w-full rounded-md border px-3 py-2 text-sm ${
                     isDarkMode
                       ? 'border-gray-600 bg-gray-700 text-white'
@@ -921,6 +933,15 @@ export function BlueprintForm({
                     {validationErrors.edge}
                   </p>
                 )}
+                {source &&
+                  target &&
+                  getRelationshipTypes(source, target).length === 0 && (
+                    <p
+                      className={`mt-1 text-xs ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}
+                    >
+                      No relationship types defined for {source} &rarr; {target}
+                    </p>
+                  )}
               </div>
               <div
                 className={`pb-2 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
@@ -937,6 +958,7 @@ export function BlueprintForm({
                   value={target}
                   onChange={(e) => {
                     setTarget(e.target.value)
+                    handleFieldChange('target')
                     const valid = getRelationshipTypes(source, e.target.value)
                     if (edge && !valid.includes(edge)) setEdge('')
                   }}

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -911,44 +911,54 @@ export function BlueprintForm({
                 >
                   Relationship Type <span className="text-red-500">*</span>
                 </label>
-                <select
-                  value={edge}
-                  onChange={(e) => {
-                    setEdge(e.target.value)
-                    handleFieldChange('edge')
-                  }}
-                  disabled={isLoading || isEditing || !source || !target}
-                  className={`w-full rounded-md border px-3 py-2 text-sm ${
-                    isDarkMode
-                      ? 'border-gray-600 bg-gray-700 text-white'
-                      : 'border-gray-300 bg-white text-gray-900'
-                  } ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
-                >
-                  <option value="">
-                    {source && target
-                      ? 'Select type...'
-                      : 'Pick source & target first'}
-                  </option>
-                  {getRelationshipTypes(source, target).map((rt) => (
-                    <option key={rt} value={rt}>
-                      {toTitleCase(rt)}
+                {source &&
+                target &&
+                (getRelationshipTypes(source, target).length === 0 ||
+                  (edge &&
+                    !getRelationshipTypes(source, target).includes(edge))) ? (
+                  <Input
+                    value={edge}
+                    onChange={(e) => {
+                      setEdge(e.target.value)
+                      handleFieldChange('edge')
+                    }}
+                    disabled={isLoading || isEditing}
+                    placeholder="Enter relationship type..."
+                    className={`w-full ${
+                      isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+                    }`}
+                  />
+                ) : (
+                  <select
+                    value={edge}
+                    onChange={(e) => {
+                      setEdge(e.target.value)
+                      handleFieldChange('edge')
+                    }}
+                    disabled={isLoading || isEditing || !source || !target}
+                    className={`w-full rounded-md border px-3 py-2 text-sm ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700 text-white'
+                        : 'border-gray-300 bg-white text-gray-900'
+                    } ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
+                  >
+                    <option value="">
+                      {source && target
+                        ? 'Select type...'
+                        : 'Pick source & target first'}
                     </option>
-                  ))}
-                </select>
+                    {getRelationshipTypes(source, target).map((rt) => (
+                      <option key={rt} value={rt}>
+                        {toTitleCase(rt)}
+                      </option>
+                    ))}
+                  </select>
+                )}
                 {touched.edge && validationErrors.edge && (
                   <p className="mt-1 text-sm text-red-600">
                     {validationErrors.edge}
                   </p>
                 )}
-                {source &&
-                  target &&
-                  getRelationshipTypes(source, target).length === 0 && (
-                    <p
-                      className={`mt-1 text-xs ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}
-                    >
-                      No relationship types defined for {source} &rarr; {target}
-                    </p>
-                  )}
               </div>
               <div
                 className={`pb-2 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -717,7 +717,9 @@ export function BlueprintForm({
                       )
                       .join('; ')
                   }
-                  return detail || error?.message || 'An error occurred'
+                  return typeof detail === 'string'
+                    ? detail
+                    : error?.message || 'An error occurred'
                 })()}
               </div>
             </div>

--- a/src/components/admin/blueprints/ImportBlueprintDialog.tsx
+++ b/src/components/admin/blueprints/ImportBlueprintDialog.tsx
@@ -30,7 +30,7 @@ type DetectedFormat = 'json' | 'yaml' | 'unknown'
 
 const VALID_TYPES = new Set(['Team', 'Environment', 'ProjectType', 'Project'])
 
-const REQUIRED_FIELDS = ['name', 'type', 'json_schema'] as const
+const REQUIRED_FIELDS = ['name', 'json_schema'] as const
 
 function detectFormat(input: string): DetectedFormat {
   const trimmed = input.trim()
@@ -71,13 +71,25 @@ function validateBlueprintShape(
     return { valid: false, error: '"name" must be a non-empty string.' }
   }
 
-  // Validate type
-  const typesToCheck =
-    blueprintTypes.length > 0 ? blueprintTypes : Array.from(VALID_TYPES)
-  if (typeof obj.type !== 'string' || !typesToCheck.includes(obj.type)) {
-    return {
-      valid: false,
-      error: `"type" must be one of: ${typesToCheck.join(', ')}. Got "${String(obj.type)}".`,
+  // Validate kind + type/relationship fields
+  const bpKind = (obj.kind as string) || 'node'
+  if (bpKind === 'relationship') {
+    for (const f of ['source', 'target', 'edge'] as const) {
+      if (typeof obj[f] !== 'string' || !(obj[f] as string).trim()) {
+        return {
+          valid: false,
+          error: `"${f}" is required for relationship blueprints.`,
+        }
+      }
+    }
+  } else {
+    const typesToCheck =
+      blueprintTypes.length > 0 ? blueprintTypes : Array.from(VALID_TYPES)
+    if (typeof obj.type !== 'string' || !typesToCheck.includes(obj.type)) {
+      return {
+        valid: false,
+        error: `"type" must be one of: ${typesToCheck.join(', ')}. Got "${String(obj.type)}".`,
+      }
     }
   }
 
@@ -178,7 +190,15 @@ function validateBlueprintShape(
 
   const blueprint: BlueprintCreate = {
     name: (obj.name as string).trim(),
-    type: obj.type as string,
+    kind: bpKind as 'node' | 'relationship',
+    ...(bpKind === 'relationship'
+      ? {
+          type: null,
+          source: (obj.source as string).trim(),
+          target: (obj.target as string).trim(),
+          edge: (obj.edge as string).trim(),
+        }
+      : { type: obj.type as string }),
     json_schema: jsonSchema,
     ...(obj.slug ? { slug: obj.slug as string } : {}),
     ...(obj.description !== undefined
@@ -473,10 +493,14 @@ export function ImportBlueprintDialog({
                   <span
                     className={isDarkMode ? 'text-gray-400' : 'text-gray-500'}
                   >
-                    Type:{' '}
+                    {parsedPreview.kind === 'relationship'
+                      ? 'Edge:'
+                      : 'Type:'}{' '}
                   </span>
                   <span className={isDarkMode ? 'text-white' : 'text-gray-900'}>
-                    {parsedPreview.type}
+                    {parsedPreview.kind === 'relationship'
+                      ? `${parsedPreview.source} → ${parsedPreview.target} (${parsedPreview.edge})`
+                      : parsedPreview.type}
                   </span>
                 </div>
                 {parsedPreview.slug && (
@@ -566,7 +590,7 @@ export function ImportBlueprintDialog({
           <Button
             onClick={handleValidateAndImport}
             disabled={isLoading || !rawInput.trim()}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Upload className="mr-2 h-4 w-4" />
             {isLoading ? 'Importing...' : 'Import'}

--- a/src/components/admin/blueprints/ImportBlueprintDialog.tsx
+++ b/src/components/admin/blueprints/ImportBlueprintDialog.tsx
@@ -73,6 +73,12 @@ function validateBlueprintShape(
 
   // Validate kind + type/relationship fields
   const bpKind = (obj.kind as string) || 'node'
+  if (bpKind !== 'node' && bpKind !== 'relationship') {
+    return {
+      valid: false,
+      error: `"kind" must be one of: node, relationship. Got "${bpKind}".`,
+    }
+  }
   if (bpKind === 'relationship') {
     for (const f of ['source', 'target', 'edge'] as const) {
       if (typeof obj[f] !== 'string' || !(obj[f] as string).trim()) {
@@ -370,14 +376,33 @@ export function ImportBlueprintDialog({
             <code
               className={`rounded px-1 py-0.5 text-xs ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}
             >
-              type
+              json_schema
             </code>
-            ,{' '}
+            , and either{' '}
             <code
               className={`rounded px-1 py-0.5 text-xs ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}
             >
-              json_schema
+              type
+            </code>{' '}
+            (node) or{' '}
+            <code
+              className={`rounded px-1 py-0.5 text-xs ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}
+            >
+              source
             </code>
+            /
+            <code
+              className={`rounded px-1 py-0.5 text-xs ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}
+            >
+              target
+            </code>
+            /
+            <code
+              className={`rounded px-1 py-0.5 text-xs ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}
+            >
+              edge
+            </code>{' '}
+            (relationship)
           </DialogDescription>
         </DialogHeader>
 

--- a/src/components/admin/environments/EnvironmentDetail.tsx
+++ b/src/components/admin/environments/EnvironmentDetail.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
 import { getEnvironmentSchema } from '@/api/endpoints'
 import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
+import { getIcon } from '@/lib/icons'
 import { extractDynamicFields } from '@/lib/utils'
 import type { Environment } from '@/types'
 
@@ -50,13 +51,19 @@ export function EnvironmentDetail({
         >
           <div>
             <div className="flex items-center gap-3">
-              {environment.icon && (
-                <img
-                  src={environment.icon}
-                  alt=""
-                  className="h-8 w-8 rounded object-cover"
-                />
-              )}
+              {environment.icon &&
+                (environment.icon.startsWith('/uploads/') ? (
+                  <img
+                    src={environment.icon}
+                    alt=""
+                    className="h-8 w-8 rounded object-cover"
+                  />
+                ) : (
+                  (() => {
+                    const Icon = getIcon(environment.icon, null)
+                    return Icon ? <Icon className="h-8 w-8" /> : null
+                  })()
+                ))}
               <h2
                 className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
               >

--- a/src/components/admin/environments/EnvironmentDetail.tsx
+++ b/src/components/admin/environments/EnvironmentDetail.tsx
@@ -73,7 +73,7 @@ export function EnvironmentDetail({
           </div>
           <Button
             onClick={onEdit}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Environment

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -4,6 +4,7 @@ import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { IconUpload } from '@/components/ui/icon-upload'
+import { IconPicker } from '@/components/ui/icon-picker'
 import { ColorPicker } from '@/components/ui/color-picker'
 import {
   DynamicFormFields,
@@ -146,7 +147,7 @@ export function EnvironmentForm({
           <Button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading
@@ -345,11 +346,32 @@ export function EnvironmentForm({
               >
                 Icon
               </label>
-              <IconUpload
-                value={icon}
-                onChange={setIcon}
-                isDarkMode={isDarkMode}
-              />
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Pick from Simple Icons
+                  </p>
+                  <IconPicker
+                    value={icon.startsWith('si-') ? icon : ''}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Or upload a custom image
+                  </p>
+                  <IconUpload
+                    value={icon.startsWith('si-') ? '' : icon}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+              </div>
             </div>
 
             <ColorPicker

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -13,6 +13,7 @@ import {
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { getEnvironmentSchema } from '@/api/endpoints'
 import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
+import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { extractDynamicFields, slugify } from '@/lib/utils'
 import type { Environment, EnvironmentCreate } from '@/types'
 
@@ -43,6 +44,7 @@ export function EnvironmentForm({
   )
   const [description, setDescription] = useState(environment?.description || '')
   const [icon, setIcon] = useState(environment?.icon || '')
+  const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [labelColor, setLabelColor] = useState(environment?.label_color ?? '')
   const [orgSlug, setOrgSlug] = useState(
     environment?.organization.slug || selectedOrganization?.slug || '',
@@ -355,7 +357,7 @@ export function EnvironmentForm({
                   </p>
                   <IconPicker
                     value={icon.startsWith('si-') ? icon : ''}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>
@@ -367,7 +369,7 @@ export function EnvironmentForm({
                   </p>
                   <IconUpload
                     value={icon.startsWith('si-') ? '' : icon}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>

--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { slugify } from '@/lib/utils'
@@ -105,7 +106,7 @@ export function LinkDefinitionForm({
           <Button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading
@@ -291,11 +292,32 @@ export function LinkDefinitionForm({
               >
                 Icon
               </label>
-              <IconUpload
-                value={icon}
-                onChange={setIcon}
-                isDarkMode={isDarkMode}
-              />
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Pick from Simple Icons
+                  </p>
+                  <IconPicker
+                    value={icon.startsWith('si-') ? icon : ''}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Or upload a custom image
+                  </p>
+                  <IconUpload
+                    value={icon.startsWith('si-') ? '' : icon}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+              </div>
             </div>
 
             <div>

--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
 import type { LinkDefinition, LinkDefinitionCreate } from '@/types'
 
@@ -34,6 +35,7 @@ export function LinkDefinitionForm({
     linkDefinition?.description || '',
   )
   const [icon, setIcon] = useState(linkDefinition?.icon || '')
+  const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [urlTemplate, setUrlTemplate] = useState(
     linkDefinition?.url_template || '',
   )
@@ -301,7 +303,7 @@ export function LinkDefinitionForm({
                   </p>
                   <IconPicker
                     value={icon.startsWith('si-') ? icon : ''}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>
@@ -313,7 +315,7 @@ export function LinkDefinitionForm({
                   </p>
                   <IconUpload
                     value={icon.startsWith('si-') ? '' : icon}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>

--- a/src/components/admin/organizations/OrganizationDetail.tsx
+++ b/src/components/admin/organizations/OrganizationDetail.tsx
@@ -65,7 +65,7 @@ export function OrganizationDetail({
           </div>
           <Button
             onClick={onEdit}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Organization

--- a/src/components/admin/organizations/OrganizationForm.tsx
+++ b/src/components/admin/organizations/OrganizationForm.tsx
@@ -101,7 +101,7 @@ export function OrganizationForm({
           <Button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading

--- a/src/components/admin/project-types/ProjectTypeDetail.tsx
+++ b/src/components/admin/project-types/ProjectTypeDetail.tsx
@@ -73,7 +73,7 @@ export function ProjectTypeDetail({
           </div>
           <Button
             onClick={onEdit}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Project Type

--- a/src/components/admin/project-types/ProjectTypeDetail.tsx
+++ b/src/components/admin/project-types/ProjectTypeDetail.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
 import { getProjectTypeSchema } from '@/api/endpoints'
 import { PROJECT_TYPE_BASE_FIELDS_SET } from '@/lib/constants'
+import { getIcon } from '@/lib/icons'
 import { extractDynamicFields } from '@/lib/utils'
 import type { ProjectType } from '@/types'
 
@@ -50,13 +51,19 @@ export function ProjectTypeDetail({
         >
           <div>
             <div className="flex items-center gap-3">
-              {projectType.icon && (
-                <img
-                  src={projectType.icon}
-                  alt=""
-                  className="h-8 w-8 rounded object-cover"
-                />
-              )}
+              {projectType.icon &&
+                (projectType.icon.startsWith('/uploads/') ? (
+                  <img
+                    src={projectType.icon}
+                    alt=""
+                    className="h-8 w-8 rounded object-cover"
+                  />
+                ) : (
+                  (() => {
+                    const Icon = getIcon(projectType.icon, null)
+                    return Icon ? <Icon className="h-8 w-8" /> : null
+                  })()
+                ))}
               <h2
                 className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
               >

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -4,6 +4,7 @@ import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { IconUpload } from '@/components/ui/icon-upload'
+import { IconPicker } from '@/components/ui/icon-picker'
 import {
   DynamicFormFields,
   validateDynamicFields,
@@ -137,7 +138,7 @@ export function ProjectTypeForm({
           <Button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading
@@ -315,11 +316,32 @@ export function ProjectTypeForm({
               >
                 Icon
               </label>
-              <IconUpload
-                value={icon}
-                onChange={setIcon}
-                isDarkMode={isDarkMode}
-              />
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Pick from Simple Icons
+                  </p>
+                  <IconPicker
+                    value={icon.startsWith('si-') ? icon : ''}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Or upload a custom image
+                  </p>
+                  <IconUpload
+                    value={icon.startsWith('si-') ? '' : icon}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+              </div>
             </div>
 
             {/* Dynamic Blueprint Fields */}

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -12,6 +12,7 @@ import {
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { getProjectTypeSchema } from '@/api/endpoints'
 import { PROJECT_TYPE_BASE_FIELDS_SET } from '@/lib/constants'
+import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { extractDynamicFields, slugify } from '@/lib/utils'
 import type { ProjectType, ProjectTypeCreate } from '@/types'
 
@@ -39,6 +40,7 @@ export function ProjectTypeForm({
   const [slug, setSlug] = useState(projectType?.slug || '')
   const [description, setDescription] = useState(projectType?.description || '')
   const [icon, setIcon] = useState(projectType?.icon || '')
+  const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [orgSlug, setOrgSlug] = useState(
     projectType?.organization.slug || selectedOrganization?.slug || '',
   )
@@ -325,7 +327,7 @@ export function ProjectTypeForm({
                   </p>
                   <IconPicker
                     value={icon.startsWith('si-') ? icon : ''}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>
@@ -337,7 +339,7 @@ export function ProjectTypeForm({
                   </p>
                   <IconUpload
                     value={icon.startsWith('si-') ? '' : icon}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>

--- a/src/components/admin/roles/RoleDetail.tsx
+++ b/src/components/admin/roles/RoleDetail.tsx
@@ -251,7 +251,7 @@ export function RoleDetail({
           {!role.is_system && (
             <Button
               onClick={onEdit}
-              className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+              className="bg-amber-border text-white hover:bg-amber-border-strong"
             >
               <Edit2 className="mr-2 h-4 w-4" />
               Edit Role
@@ -404,7 +404,7 @@ export function RoleDetail({
                   <Button
                     onClick={handleGrantPermission}
                     disabled={!selectedPermission || grantMutation.isPending}
-                    className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+                    className="bg-amber-border text-white hover:bg-amber-border-strong"
                     size="sm"
                   >
                     <Plus className="mr-2 h-4 w-4" />

--- a/src/components/admin/roles/RoleForm.tsx
+++ b/src/components/admin/roles/RoleForm.tsx
@@ -301,7 +301,7 @@ export function RoleForm({
                 isLoading ||
                 (!isEditing && (adminSettingsLoading || !!adminSettingsError))
               }
-              className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+              className="bg-amber-border text-white hover:bg-amber-border-strong"
             >
               <Save className="mr-2 h-4 w-4" />
               {isLoading

--- a/src/components/admin/service-accounts/ServiceAccountDetail.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountDetail.tsx
@@ -427,7 +427,7 @@ export function ServiceAccountDetail({
           </div>
           <Button
             onClick={onEdit}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Account
@@ -568,7 +568,7 @@ export function ServiceAccountDetail({
                 disabled={
                   !newOrgSlug || !newRoleSlug || addOrgMutation.isPending
                 }
-                className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+                className="bg-amber-border text-white hover:bg-amber-border-strong"
                 size="sm"
               >
                 {addOrgMutation.isPending ? 'Adding...' : 'Add'}
@@ -797,7 +797,7 @@ export function ServiceAccountDetail({
                   disabled={
                     !credentialName.trim() || createCredentialMutation.isPending
                   }
-                  className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+                  className="bg-amber-border text-white hover:bg-amber-border-strong"
                 >
                   {createCredentialMutation.isPending
                     ? 'Creating...'
@@ -1105,7 +1105,7 @@ export function ServiceAccountDetail({
               <Button
                 onClick={handleCreateKey}
                 disabled={createKeyMutation.isPending}
-                className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+                className="bg-amber-border text-white hover:bg-amber-border-strong"
               >
                 {createKeyMutation.isPending ? 'Creating...' : 'Create'}
               </Button>

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -157,7 +157,7 @@ export function ServiceAccountForm({
           <Button
             onClick={handleSave}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading

--- a/src/components/admin/teams/TeamDetail.tsx
+++ b/src/components/admin/teams/TeamDetail.tsx
@@ -142,7 +142,7 @@ export function TeamDetail({
           </div>
           <Button
             onClick={onEdit}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Team
@@ -265,7 +265,7 @@ export function TeamDetail({
                   disabled={
                     !newMemberEmail.trim() || addMemberMutation.isPending
                   }
-                  className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+                  className="bg-amber-border text-white hover:bg-amber-border-strong"
                 >
                   {addMemberMutation.isPending ? 'Adding...' : 'Add'}
                 </Button>

--- a/src/components/admin/teams/TeamDetail.tsx
+++ b/src/components/admin/teams/TeamDetail.tsx
@@ -21,6 +21,7 @@ import {
   getTeamSchema,
 } from '@/api/endpoints'
 import { TEAM_BASE_FIELDS_SET } from '@/lib/constants'
+import { getIcon } from '@/lib/icons'
 import { extractDynamicFields } from '@/lib/utils'
 import type { Team } from '@/types'
 
@@ -119,13 +120,19 @@ export function TeamDetail({
         >
           <div>
             <div className="flex items-center gap-3">
-              {team.icon && (
-                <img
-                  src={team.icon}
-                  alt=""
-                  className="h-8 w-8 rounded object-cover"
-                />
-              )}
+              {team.icon &&
+                (team.icon.startsWith('/uploads/') ? (
+                  <img
+                    src={team.icon}
+                    alt=""
+                    className="h-8 w-8 rounded object-cover"
+                  />
+                ) : (
+                  (() => {
+                    const Icon = getIcon(team.icon, null)
+                    return Icon ? <Icon className="h-8 w-8" /> : null
+                  })()
+                ))}
               <h2
                 className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
               >

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -12,6 +12,7 @@ import {
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { getTeamSchema } from '@/api/endpoints'
 import { TEAM_BASE_FIELDS_SET } from '@/lib/constants'
+import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { extractDynamicFields, slugify } from '@/lib/utils'
 import type { Team, TeamCreate } from '@/types'
 
@@ -39,6 +40,7 @@ export function TeamForm({
   const [slug, setSlug] = useState(team?.slug || '')
   const [description, setDescription] = useState(team?.description || '')
   const [icon, setIcon] = useState(team?.icon || '')
+  const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [orgSlug, setOrgSlug] = useState(
     team?.organization.slug || selectedOrganization?.slug || '',
   )
@@ -319,7 +321,7 @@ export function TeamForm({
                   </p>
                   <IconPicker
                     value={icon.startsWith('si-') ? icon : ''}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>
@@ -331,7 +333,7 @@ export function TeamForm({
                   </p>
                   <IconUpload
                     value={icon.startsWith('si-') ? '' : icon}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -4,6 +4,7 @@ import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
 import { IconUpload } from '../../ui/icon-upload'
+import { IconPicker } from '@/components/ui/icon-picker'
 import {
   DynamicFormFields,
   validateDynamicFields,
@@ -131,7 +132,7 @@ export function TeamForm({
           <Button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading
@@ -309,11 +310,32 @@ export function TeamForm({
               >
                 Icon
               </label>
-              <IconUpload
-                value={icon}
-                onChange={setIcon}
-                isDarkMode={isDarkMode}
-              />
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Pick from Simple Icons
+                  </p>
+                  <IconPicker
+                    value={icon.startsWith('si-') ? icon : ''}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Or upload a custom image
+                  </p>
+                  <IconUpload
+                    value={icon.startsWith('si-') ? '' : icon}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+              </div>
             </div>
 
             {/* Dynamic Blueprint Fields */}

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -339,7 +339,7 @@ export function ApplicationSecretsPanel({
                 updateMutation.isPending ||
                 Object.values(editValues).every((v) => !v.trim())
               }
-              className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+              className="bg-amber-border text-white hover:bg-amber-border-strong"
             >
               <Save className="mr-1 h-4 w-4" />
               {updateMutation.isPending ? 'Saving...' : 'Save Secrets'}

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -165,7 +165,7 @@ export function OAuth2ApplicationForm({
         <Button
           onClick={handleSubmit}
           disabled={isLoading}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           {isLoading ? 'Saving...' : isEdit ? 'Update' : 'Create'}
         </Button>

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -225,7 +225,7 @@ export function OAuth2ApplicationList({
             setViewMode('create')
           }}
           size="sm"
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           Add Application

--- a/src/components/admin/third-party-services/ServiceWebhookList.tsx
+++ b/src/components/admin/third-party-services/ServiceWebhookList.tsx
@@ -239,7 +239,7 @@ export function ServiceWebhookList({
             setViewMode('create')
           }}
           size="sm"
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Plus className="mr-2 h-4 w-4" />
           New Webhook

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -122,7 +122,7 @@ export function ThirdPartyServiceDetail({
             </div>
             <Button
               onClick={onEdit}
-              className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+              className="bg-amber-border text-white hover:bg-amber-border-strong"
             >
               <Edit2 className="mr-2 h-4 w-4" />
               Edit Service

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button'
 import { OAuth2ApplicationList } from './OAuth2ApplicationList'
 import { ServiceWebhookList } from './ServiceWebhookList'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { getIcon } from '@/lib/icons'
 import type { ThirdPartyService } from '@/types'
 
 interface ThirdPartyServiceDetailProps {
@@ -89,13 +90,19 @@ export function ThirdPartyServiceDetail({
               </Button>
               <div>
                 <div className="flex items-center gap-3">
-                  {service.icon && (
-                    <img
-                      src={service.icon}
-                      alt=""
-                      className="h-8 w-8 rounded object-cover"
-                    />
-                  )}
+                  {service.icon &&
+                    (service.icon.startsWith('/uploads/') ? (
+                      <img
+                        src={service.icon}
+                        alt=""
+                        className="h-8 w-8 rounded object-cover"
+                      />
+                    ) : (
+                      (() => {
+                        const Icon = getIcon(service.icon, null)
+                        return Icon ? <Icon className="h-8 w-8" /> : null
+                      })()
+                    ))}
                   <h2
                     className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                   >

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -4,6 +4,7 @@ import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { IconUpload } from '@/components/ui/icon-upload'
+import { IconPicker } from '@/components/ui/icon-picker'
 import { KeyValueEditor } from '@/components/ui/key-value-editor'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { listTeams } from '@/api/endpoints'
@@ -143,7 +144,7 @@ export function ThirdPartyServiceForm({
           <Button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading
@@ -393,11 +394,32 @@ export function ThirdPartyServiceForm({
               >
                 Icon
               </label>
-              <IconUpload
-                value={icon}
-                onChange={setIcon}
-                isDarkMode={isDarkMode}
-              />
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Pick from Simple Icons
+                  </p>
+                  <IconPicker
+                    value={icon.startsWith('si-') ? icon : ''}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Or upload a custom image
+                  </p>
+                  <IconUpload
+                    value={icon.startsWith('si-') ? '' : icon}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -8,6 +8,7 @@ import { IconPicker } from '@/components/ui/icon-picker'
 import { KeyValueEditor } from '@/components/ui/key-value-editor'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { listTeams } from '@/api/endpoints'
+import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
 import type { Team, ThirdPartyService, ThirdPartyServiceCreate } from '@/types'
 
@@ -42,6 +43,7 @@ export function ThirdPartyServiceForm({
   const [slug, setSlug] = useState(service?.slug || '')
   const [description, setDescription] = useState(service?.description || '')
   const [icon, setIcon] = useState(service?.icon || '')
+  const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [vendor, setVendor] = useState(service?.vendor || '')
   const [serviceUrl, setServiceUrl] = useState(service?.service_url || '')
   const [category, setCategory] = useState(service?.category || '')
@@ -403,7 +405,7 @@ export function ThirdPartyServiceForm({
                   </p>
                   <IconPicker
                     value={icon.startsWith('si-') ? icon : ''}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>
@@ -415,7 +417,7 @@ export function ThirdPartyServiceForm({
                   </p>
                   <IconUpload
                     value={icon.startsWith('si-') ? '' : icon}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -159,7 +159,7 @@ export function UserDetail({
           </div>
           <Button
             onClick={onEdit}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Edit2 className="mr-2 h-4 w-4" />
             Edit User
@@ -369,7 +369,7 @@ export function UserDetail({
                 disabled={
                   !newOrgSlug || !newRoleSlug || addOrgMutation.isPending
                 }
-                className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+                className="bg-amber-border text-white hover:bg-amber-border-strong"
                 size="sm"
               >
                 {addOrgMutation.isPending ? 'Adding...' : 'Add'}

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -223,7 +223,7 @@ export function UserForm({
           <Button
             onClick={handleSave}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading

--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -64,7 +64,7 @@ export function WebhookDetail({
         </div>
         <Button
           onClick={onEdit}
-          className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+          className="bg-amber-border text-white hover:bg-amber-border-strong"
         >
           <Edit2 className="mr-2 h-4 w-4" />
           Edit Webhook

--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Edit2, Webhook } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { getIcon } from '@/lib/icons'
 import type { Webhook as WebhookType } from '@/types'
 
 interface WebhookDetailProps {
@@ -31,11 +32,26 @@ export function WebhookDetail({
           <div>
             <div className="flex items-center gap-3">
               {webhook.icon ? (
-                <img
-                  src={webhook.icon}
-                  alt=""
-                  className="h-8 w-8 rounded object-cover"
-                />
+                webhook.icon.startsWith('/uploads/') ? (
+                  <img
+                    src={webhook.icon}
+                    alt=""
+                    className="h-8 w-8 rounded object-cover"
+                  />
+                ) : (
+                  (() => {
+                    const Icon = getIcon(webhook.icon, null)
+                    return Icon ? (
+                      <Icon className="h-8 w-8" />
+                    ) : (
+                      <img
+                        src={webhook.icon}
+                        alt=""
+                        className="h-8 w-8 rounded object-cover"
+                      />
+                    )
+                  })()
+                )
               ) : (
                 <div
                   className={`flex h-8 w-8 items-center justify-center rounded-lg ${

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -15,6 +15,7 @@ import { IconUpload } from '@/components/ui/icon-upload'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { listThirdPartyServices } from '@/api/endpoints'
+import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
 import { ApiError } from '@/api/client'
 import type { Webhook, WebhookCreate, WebhookRule } from '@/types'
@@ -46,6 +47,7 @@ export function WebhookForm({
   const [slug, setSlug] = useState(webhook?.slug || '')
   const [description, setDescription] = useState(webhook?.description || '')
   const [icon, setIcon] = useState(webhook?.icon || '')
+  const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [notificationPath, setNotificationPath] = useState(
     webhook?.notification_path || '/',
   )
@@ -413,7 +415,7 @@ export function WebhookForm({
                   </p>
                   <IconPicker
                     value={icon.startsWith('si-') ? icon : ''}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>
@@ -425,7 +427,7 @@ export function WebhookForm({
                   </p>
                   <IconUpload
                     value={icon.startsWith('si-') ? '' : icon}
-                    onChange={(v) => setIcon(v)}
+                    onChange={handleIconChange}
                     isDarkMode={isDarkMode}
                   />
                 </div>

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { IconUpload } from '@/components/ui/icon-upload'
+import { IconPicker } from '@/components/ui/icon-picker'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { listThirdPartyServices } from '@/api/endpoints'
 import { slugify } from '@/lib/utils'
@@ -209,7 +210,7 @@ export function WebhookForm({
           <Button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="bg-[#2A4DD0] text-white hover:bg-blue-700"
+            className="bg-amber-border text-white hover:bg-amber-border-strong"
           >
             <Save className="mr-2 h-4 w-4" />
             {isLoading
@@ -403,11 +404,32 @@ export function WebhookForm({
               >
                 Icon
               </label>
-              <IconUpload
-                value={icon}
-                onChange={setIcon}
-                isDarkMode={isDarkMode}
-              />
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Pick from Simple Icons
+                  </p>
+                  <IconPicker
+                    value={icon.startsWith('si-') ? icon : ''}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+                <div>
+                  <p
+                    className={`mb-1.5 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Or upload a custom image
+                  </p>
+                  <IconUpload
+                    value={icon.startsWith('si-') ? '' : icon}
+                    onChange={(v) => setIcon(v)}
+                    isDarkMode={isDarkMode}
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/ui/icon-picker.tsx
+++ b/src/components/ui/icon-picker.tsx
@@ -1,0 +1,221 @@
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
+import { Search, X } from 'lucide-react'
+import * as simpleIcons from '@icons-pack/react-simple-icons'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { getIcon } from '@/lib/icons'
+import type { ComponentType, SVGProps } from 'react'
+
+type IconComponent = ComponentType<
+  SVGProps<SVGSVGElement> & { size?: number | string }
+>
+
+interface IconEntry {
+  /** Display name, e.g. "GitHub" */
+  label: string
+  /** Stored value, e.g. "si-github" */
+  value: string
+}
+
+// Build the index once at module level
+const siLookup = simpleIcons as Record<string, unknown>
+const SI_ICONS: IconEntry[] = Object.keys(siLookup)
+  .filter((k) => k.startsWith('Si') && !k.endsWith('Hex') && k !== 'default')
+  .map((k) => {
+    // SiGithub → github, SiGoogleCloud → google-cloud
+    const raw = k.slice(2)
+    const kebab = raw.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+    return { label: raw, value: `si-${kebab}` }
+  })
+  .sort((a, b) => a.label.localeCompare(b.label))
+
+const MAX_RESULTS = 60
+
+interface IconPickerProps {
+  value?: string
+  onChange: (value: string) => void
+  isDarkMode: boolean
+}
+
+export function IconPicker({ value, onChange, isDarkMode }: IconPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return SI_ICONS.slice(0, MAX_RESULTS)
+    const q = query.toLowerCase()
+    return SI_ICONS.filter(
+      (i) => i.label.toLowerCase().includes(q) || i.value.includes(q),
+    ).slice(0, MAX_RESULTS)
+  }, [query])
+
+  const handleSelect = useCallback(
+    (iconValue: string) => {
+      onChange(iconValue)
+      setOpen(false)
+      setQuery('')
+    },
+    [onChange],
+  )
+
+  const handleClear = useCallback(() => {
+    onChange('')
+  }, [onChange])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const SelectedIcon: IconComponent | null = value ? getIcon(value) : null
+
+  return (
+    <div ref={containerRef} className="relative">
+      {/* Current value display */}
+      {value ? (
+        <div
+          className={`flex items-center gap-3 rounded-lg border p-2.5 ${
+            isDarkMode
+              ? 'border-gray-600 bg-gray-700'
+              : 'border-gray-300 bg-white'
+          }`}
+        >
+          <button
+            type="button"
+            onClick={() => setOpen(!open)}
+            className={`flex flex-1 items-center gap-3 text-left text-sm ${
+              isDarkMode ? 'text-gray-200' : 'text-gray-900'
+            }`}
+          >
+            {SelectedIcon && <SelectedIcon className="h-5 w-5 flex-shrink-0" />}
+            <code
+              className={`rounded px-1.5 py-0.5 text-xs ${
+                isDarkMode ? 'bg-gray-600' : 'bg-gray-100'
+              }`}
+            >
+              {value}
+            </code>
+          </button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleClear}
+            aria-label="Remove icon"
+            className={`h-7 w-7 p-0 ${
+              isDarkMode
+                ? 'text-gray-400 hover:text-red-400'
+                : 'text-gray-500 hover:text-red-600'
+            }`}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          className={`flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+            isDarkMode
+              ? 'border-gray-600 bg-gray-700 text-gray-400 hover:border-gray-500'
+              : 'border-gray-300 bg-white text-gray-500 hover:border-gray-400'
+          }`}
+        >
+          <Search className="h-4 w-4" />
+          Pick an icon...
+        </button>
+      )}
+
+      {/* Dropdown */}
+      {open && (
+        <div
+          className={`absolute z-50 mt-1 w-full rounded-lg border shadow-lg ${
+            isDarkMode
+              ? 'border-gray-600 bg-gray-800'
+              : 'border-gray-200 bg-white'
+          }`}
+        >
+          <div className="p-2">
+            <div className="relative">
+              <Search
+                className={`absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}
+              />
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search icons..."
+                autoFocus
+                className={`pl-9 ${
+                  isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+                }`}
+              />
+            </div>
+          </div>
+          <div className="max-h-64 overflow-y-auto px-2 pb-2">
+            {filtered.length === 0 ? (
+              <div
+                className={`py-6 text-center text-sm ${
+                  isDarkMode ? 'text-gray-500' : 'text-gray-400'
+                }`}
+              >
+                No icons found
+              </div>
+            ) : (
+              <div className="grid grid-cols-6 gap-1">
+                {filtered.map((icon) => {
+                  const Icon = getIcon(icon.value)
+                  const isSelected = value === icon.value
+                  return (
+                    <button
+                      key={icon.value}
+                      type="button"
+                      title={icon.value}
+                      onClick={() => handleSelect(icon.value)}
+                      className={`flex h-10 w-full items-center justify-center rounded-md transition-colors ${
+                        isSelected
+                          ? isDarkMode
+                            ? 'bg-blue-600/30 ring-1 ring-blue-500'
+                            : 'bg-blue-50 ring-1 ring-blue-400'
+                          : isDarkMode
+                            ? 'hover:bg-gray-700'
+                            : 'hover:bg-gray-100'
+                      }`}
+                    >
+                      <Icon
+                        className={`h-5 w-5 ${
+                          isDarkMode ? 'text-gray-300' : 'text-gray-700'
+                        }`}
+                      />
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+            {filtered.length === MAX_RESULTS && (
+              <p
+                className={`mt-2 text-center text-xs ${
+                  isDarkMode ? 'text-gray-500' : 'text-gray-400'
+                }`}
+              >
+                Type to narrow results
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/icon-picker.tsx
+++ b/src/components/ui/icon-picker.tsx
@@ -45,8 +45,14 @@ export function IconPicker({ value, onChange, isDarkMode }: IconPickerProps) {
   const filtered = useMemo(() => {
     if (!query.trim()) return SI_ICONS.slice(0, MAX_RESULTS)
     const q = query.toLowerCase()
+    const qNoSpace = q.replace(/\s+/g, '')
+    const qHyphen = q.replace(/\s+/g, '-')
     return SI_ICONS.filter(
-      (i) => i.label.toLowerCase().includes(q) || i.value.includes(q),
+      (i) =>
+        i.label.toLowerCase().includes(q) ||
+        i.label.toLowerCase().includes(qNoSpace) ||
+        i.value.includes(q) ||
+        i.value.includes(qHyphen),
     ).slice(0, MAX_RESULTS)
   }, [query])
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -106,6 +106,7 @@ export function useAuth(): UseAuthReturn {
     mutationFn: loginWithPassword,
     onSuccess: async (data) => {
       setTokens(data.access_token, data.refresh_token)
+      queryClient.invalidateQueries({ queryKey: ['organizations'] })
 
       try {
         await refetch()

--- a/src/hooks/useIconWithCleanup.ts
+++ b/src/hooks/useIconWithCleanup.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { useMutation } from '@tanstack/react-query'
 import { deleteUpload } from '@/api/endpoints'
 
 /**
@@ -11,24 +12,34 @@ export function useIconWithCleanup(
   currentIcon: string,
   setIcon: (v: string) => void,
 ) {
+  const { mutate: mutateDeleteUpload } = useMutation({
+    mutationFn: deleteUpload,
+  })
+
   return useCallback(
     (newValue: string) => {
       // If the current icon is an uploaded file and we are replacing it
-      // with a different value, delete the old upload from the server.
+      // with a different non-empty value (e.g. switching to a Simple Icon),
+      // delete the old upload from the server. Skip cleanup when newValue
+      // is empty because that signals removal from IconUpload, which
+      // handles its own deletion in handleRemove().
       if (
         currentIcon &&
         currentIcon.startsWith('/uploads/') &&
-        newValue !== currentIcon
+        newValue !== currentIcon &&
+        newValue !== ''
       ) {
         const match = currentIcon.match(/\/uploads\/(.+)$/)
         if (match) {
-          deleteUpload(match[1]).catch(() => {
-            // Best-effort cleanup; ignore errors
+          mutateDeleteUpload(match[1], {
+            onError: () => {
+              // Best-effort cleanup; ignore errors
+            },
           })
         }
       }
       setIcon(newValue)
     },
-    [currentIcon, setIcon],
+    [currentIcon, setIcon, mutateDeleteUpload],
   )
 }

--- a/src/hooks/useIconWithCleanup.ts
+++ b/src/hooks/useIconWithCleanup.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react'
+import { deleteUpload } from '@/api/endpoints'
+
+/**
+ * Returns a setter that cleans up any previously uploaded file before
+ * applying the new icon value. Pass the current icon value and the
+ * real setter. The returned function should be handed to both
+ * IconPicker's and IconUpload's `onChange`.
+ */
+export function useIconWithCleanup(
+  currentIcon: string,
+  setIcon: (v: string) => void,
+) {
+  return useCallback(
+    (newValue: string) => {
+      // If the current icon is an uploaded file and we are replacing it
+      // with a different value, delete the old upload from the server.
+      if (
+        currentIcon &&
+        currentIcon.startsWith('/uploads/') &&
+        newValue !== currentIcon
+      ) {
+        const match = currentIcon.match(/\/uploads\/(.+)$/)
+        if (match) {
+          deleteUpload(match[1]).catch(() => {
+            // Best-effort cleanup; ignore errors
+          })
+        }
+      }
+      setIcon(newValue)
+    },
+    [currentIcon, setIcon],
+  )
+}

--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/authStore'
 import { useAuth } from '@/hooks/useAuth'
 
 export function OAuthCallbackPage() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { accessToken, setAccessToken } = useAuthStore()
   const { user, error } = useAuth()
 
@@ -26,9 +28,10 @@ export function OAuthCallbackPage() {
     }
 
     setAccessToken(token)
+    queryClient.invalidateQueries({ queryKey: ['organizations'] })
 
     window.history.replaceState({}, '', '/auth/callback')
-  }, [navigate, setAccessToken])
+  }, [navigate, setAccessToken, queryClient])
 
   useEffect(() => {
     if (user) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -539,7 +539,11 @@ export interface BlueprintFilter {
 export interface Blueprint {
   name: string
   slug: string
-  type: string
+  kind: 'node' | 'relationship'
+  type?: string | null
+  source?: string | null
+  target?: string | null
+  edge?: string | null
   description?: string | null
   enabled: boolean
   priority: number
@@ -551,7 +555,11 @@ export interface Blueprint {
 export interface BlueprintCreate {
   name: string
   slug?: string
-  type: string
+  kind?: 'node' | 'relationship'
+  type?: string | null
+  source?: string | null
+  target?: string | null
+  edge?: string | null
   description?: string | null
   enabled?: boolean
   priority?: number


### PR DESCRIPTION
## Summary
- Extend blueprint management to support relationship blueprints with kind, source, target, and edge fields (BlueprintForm, BlueprintDetail, ImportBlueprintDialog)
- Refactor admin forms (EnvironmentForm, TeamForm, ProjectTypeForm, ThirdPartyServiceForm, WebhookForm, LinkDefinitionForm) for consistent save-notification patterns
- Add new icon picker component (`src/components/ui/icon-picker.tsx`)
- Update Blueprint type definition with kind/source/target/edge fields
- Minor auth flow fixes in useAuth hook and OAuthCallbackPage
- Admin navigation and blueprint management updates for new blueprint types

## Test plan
- [ ] Verify creating a new node blueprint still works as before
- [ ] Verify creating a new relationship blueprint with source/target/edge fields
- [ ] Verify importing blueprints handles both node and relationship kinds
- [ ] Verify admin forms (environments, teams, project types, third-party services, webhooks, link definitions) save and show notifications correctly
- [ ] Verify icon picker component renders and allows selection
- [ ] Verify OAuth callback flow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)