### PR TITLE
Add project settings tab

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -108,6 +108,7 @@ export interface ProjectSchemaSectionProperty {
   minimum?: number | null
   maximum?: number | null
   'x-ui'?: {
+    editable?: boolean
     'color-map'?: Record<string, string>
     'icon-map'?: Record<string, string>
     'color-range'?: Record<string, string>

--- a/src/components/EditEnvironmentsCard.tsx
+++ b/src/components/EditEnvironmentsCard.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card } from '@/components/ui/card'
+import { EnvironmentBadge } from '@/components/ui/environment-badge'
+import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
+import type { Environment } from '@/types'
+
+interface EditEnvironmentsCardProps {
+  environments: Environment[]
+  isDarkMode: boolean
+  isSaving: boolean
+  onSave: (envData: Record<string, Record<string, string>>) => void
+}
+
+function toLabel(key: string): string {
+  return key
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+export function EditEnvironmentsCard({
+  environments,
+  isDarkMode,
+  isSaving,
+  onSave,
+}: EditEnvironmentsCardProps) {
+  // Discover dynamic edge fields across all environments
+  const dynamicFields = useMemo(() => {
+    const fieldSet = new Set<string>()
+    for (const env of environments) {
+      for (const key of Object.keys(env)) {
+        if (!ENVIRONMENT_BASE_FIELDS_SET.has(key)) {
+          fieldSet.add(key)
+        }
+      }
+    }
+    return [...fieldSet].sort()
+  }, [environments])
+
+  const [data, setData] = useState<Record<string, Record<string, string>>>({})
+
+  useEffect(() => {
+    const initial: Record<string, Record<string, string>> = {}
+    for (const env of environments) {
+      const fields: Record<string, string> = {}
+      for (const key of dynamicFields) {
+        const val = env[key]
+        fields[key] = val != null ? String(val) : ''
+      }
+      initial[env.slug] = fields
+    }
+    setData(initial)
+  }, [environments, dynamicFields])
+
+  const updateField = (envSlug: string, field: string, value: string) => {
+    setData((prev) => ({
+      ...prev,
+      [envSlug]: { ...prev[envSlug], [field]: value },
+    }))
+  }
+
+  const handleSave = () => {
+    const result: Record<string, Record<string, string>> = {}
+    for (const env of environments) {
+      result[env.slug] = data[env.slug] ?? {}
+    }
+    onSave(result)
+  }
+
+  const inputClass = isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+  const headerClass = `mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`
+  const labelClass = `text-xs font-medium ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`
+
+  if (dynamicFields.length === 0) return null
+
+  return (
+    <Card className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}>
+      <h3 className={headerClass}>Environment Specific Details</h3>
+
+      <div className="space-y-4">
+        {environments.map((env) => (
+          <div key={env.slug} className="flex gap-3">
+            <div className="w-[15%] flex-shrink-0 pt-1">
+              <EnvironmentBadge
+                name={env.name}
+                slug={env.slug}
+                label_color={env.label_color}
+              />
+            </div>
+            <div className="flex-1 space-y-2">
+              {dynamicFields.map((field) => (
+                <div key={field}>
+                  <label className={`mb-1 block ${labelClass}`}>
+                    {toLabel(field)}
+                  </label>
+                  <Input
+                    value={data[env.slug]?.[field] ?? ''}
+                    onChange={(e) =>
+                      updateField(env.slug, field, e.target.value)
+                    }
+                    disabled={isSaving}
+                    placeholder={toLabel(field)}
+                    className={`text-sm ${inputClass}`}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 flex justify-end">
+        <Button
+          size="sm"
+          className="border-amber-border bg-amber-bg text-amber-text hover:bg-amber-bg/80"
+          onClick={handleSave}
+          disabled={isSaving}
+        >
+          {isSaving ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/EditLinksCard.tsx
+++ b/src/components/EditLinksCard.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect, useMemo } from 'react'
+import { getIcon } from '@/lib/icons'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card } from '@/components/ui/card'
+import type { LinkDefinition } from '@/types'
+
+interface EditLinksCardProps {
+  linkDefs: LinkDefinition[]
+  links: Record<string, string>
+  isDarkMode: boolean
+  isSaving: boolean
+  onSave: (links: Record<string, string>) => void
+}
+
+export function EditLinksCard({
+  linkDefs,
+  links,
+  isDarkMode,
+  isSaving,
+  onSave,
+}: EditLinksCardProps) {
+  const [urls, setUrls] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    const initial: Record<string, string> = {}
+    for (const def of linkDefs) {
+      initial[def.slug] = links[def.slug] ?? ''
+    }
+    setUrls(initial)
+  }, [linkDefs, links])
+
+  const handleSave = () => {
+    const result: Record<string, string> = {}
+    for (const [slug, url] of Object.entries(urls)) {
+      const trimmed = url.trim()
+      if (trimmed) result[slug] = trimmed
+    }
+    onSave(result)
+  }
+
+  const inputClass = isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+  const headerClass = `mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`
+
+  const sorted = useMemo(
+    () => [...linkDefs].sort((a, b) => a.name.localeCompare(b.name)),
+    [linkDefs],
+  )
+
+  return (
+    <Card className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}>
+      <h3 className={headerClass}>Links</h3>
+
+      <div className="space-y-3">
+        {sorted.map((def) => {
+          const Icon = getIcon(def.icon)
+          return (
+            <div key={def.slug} className="flex items-center gap-3">
+              <div
+                className={`flex w-[15%] flex-shrink-0 items-center gap-2 ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
+              >
+                <Icon className="h-4 w-4 flex-shrink-0" />
+                <span className="truncate text-sm">{def.name}</span>
+              </div>
+              <Input
+                value={urls[def.slug] ?? ''}
+                onChange={(e) =>
+                  setUrls((prev) => ({ ...prev, [def.slug]: e.target.value }))
+                }
+                disabled={isSaving}
+                placeholder={def.url_template || 'https://...'}
+                type="url"
+                className={`flex-1 text-sm ${inputClass}`}
+              />
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="mt-4 flex justify-end">
+        <Button
+          size="sm"
+          className="border-amber-border bg-amber-bg text-amber-text hover:bg-amber-bg/80"
+          onClick={handleSave}
+          disabled={isSaving}
+        >
+          {isSaving ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/EditProjectForm.tsx
+++ b/src/components/EditProjectForm.tsx
@@ -1,0 +1,208 @@
+import { useState, useMemo, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { updateProject, getProjectSchema, listTeams } from '@/api/endpoints'
+import type { DynamicSchema, DynamicFieldSchema } from '@/api/endpoints'
+import type { Project } from '@/types'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Card } from '@/components/ui/card'
+import {
+  DynamicFormFields,
+  validateDynamicFields,
+} from '@/components/ui/dynamic-fields'
+import { PROJECT_BASE_FIELDS_SET } from '@/lib/constants'
+
+interface EditProjectFormProps {
+  project: Project
+  isDarkMode: boolean
+}
+
+export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug || ''
+  const queryClient = useQueryClient()
+
+  const [name, setName] = useState(project.name)
+  const [description, setDescription] = useState(project.description ?? '')
+  const [teamSlug, setTeamSlug] = useState(project.team.slug)
+  const [dynamicData, setDynamicData] = useState<Record<string, unknown>>({})
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const { data: teams = [], isLoading: teamsLoading } = useQuery({
+    queryKey: ['teams', orgSlug],
+    queryFn: () => listTeams(orgSlug),
+    enabled: !!orgSlug,
+  })
+
+  const { data: projectSchema } = useQuery({
+    queryKey: ['projectSchema', orgSlug, project.id],
+    queryFn: () => getProjectSchema(orgSlug, project.id),
+    enabled: !!orgSlug,
+  })
+
+  // Flatten schema sections into editable fields only, skipping base and non-editable fields
+  const editableSchema = useMemo<DynamicSchema>(() => {
+    if (!projectSchema) return { properties: {} }
+    const properties: Record<string, DynamicFieldSchema> = {}
+    const seen = new Set<string>()
+    for (const section of projectSchema.sections) {
+      for (const [key, def] of Object.entries(section.properties)) {
+        if (PROJECT_BASE_FIELDS_SET.has(key) || seen.has(key)) continue
+        seen.add(key)
+        if (def['x-ui']?.editable === false) continue
+        properties[key] = {
+          type: def.type ?? undefined,
+          format: def.format ?? undefined,
+          title: def.title ?? undefined,
+          description: def.description ?? undefined,
+          enum: def.enum ?? undefined,
+          default: def.default,
+          minimum: def.minimum ?? undefined,
+          maximum: def.maximum ?? undefined,
+        }
+      }
+    }
+    return { properties }
+  }, [projectSchema])
+
+  // Sync form state when project data changes (e.g. after a successful save)
+  useEffect(() => {
+    setName(project.name)
+    setDescription(project.description ?? '')
+    setTeamSlug(project.team.slug)
+    const initial: Record<string, unknown> = {}
+    for (const key of Object.keys(editableSchema.properties)) {
+      if (project[key] !== undefined) {
+        initial[key] = project[key]
+      }
+    }
+    setDynamicData(initial)
+  }, [editableSchema, project])
+
+  const projectTypeSlug = project.project_types?.[0]?.slug ?? ''
+
+  const mutation = useMutation({
+    mutationFn: (payload: Record<string, unknown>) =>
+      updateProject(orgSlug, projectTypeSlug, project.slug, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['project', orgSlug, project.id],
+      })
+    },
+  })
+
+  const handleSave = () => {
+    const newErrors: Record<string, string> = {}
+
+    if (!name.trim()) {
+      newErrors.name = 'Name is required'
+    }
+
+    const dynamicErrors = validateDynamicFields(editableSchema, dynamicData)
+    Object.assign(newErrors, dynamicErrors)
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors)
+      return
+    }
+
+    setErrors({})
+    mutation.mutate({
+      name: name.trim(),
+      description: description.trim() || null,
+      team_slug: teamSlug,
+      ...dynamicData,
+    })
+  }
+
+  const inputClass = isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+  const labelClass = `mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`
+
+  return (
+    <Card className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}>
+      <h3 className={`mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+        Project Details
+      </h3>
+
+      <div className="space-y-4">
+        <div>
+          <label className={labelClass}>
+            Name <span className="text-red-500">*</span>
+          </label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={mutation.isPending}
+            className={`${inputClass} ${errors.name ? 'border-red-500' : ''}`}
+          />
+          {errors.name && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+              {errors.name}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className={labelClass}>Description</label>
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={mutation.isPending}
+            rows={3}
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className={labelClass}>Team</label>
+          <select
+            value={teamSlug}
+            onChange={(e) => setTeamSlug(e.target.value)}
+            disabled={mutation.isPending || teamsLoading}
+            className={`w-full rounded-lg border px-3 py-2 text-sm ${
+              isDarkMode
+                ? 'border-gray-600 bg-gray-700 text-white'
+                : 'border-gray-300 bg-white text-gray-900'
+            }`}
+          >
+            {teams.map((t) => (
+              <option key={t.slug} value={t.slug}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <DynamicFormFields
+          schema={editableSchema}
+          data={dynamicData}
+          errors={errors}
+          onChange={(key, value) =>
+            setDynamicData((prev) => ({ ...prev, [key]: value }))
+          }
+          isDarkMode={isDarkMode}
+          isLoading={mutation.isPending}
+        />
+      </div>
+
+      {mutation.isError && (
+        <p className="mt-4 text-center text-sm text-red-600 dark:text-red-400">
+          Failed to save. Please try again.
+        </p>
+      )}
+
+      <div className="mt-4 flex justify-end">
+        <Button
+          size="sm"
+          className="border-amber-border bg-amber-bg text-amber-text hover:bg-amber-bg/80"
+          onClick={handleSave}
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/EditProjectForm.tsx
+++ b/src/components/EditProjectForm.tsx
@@ -30,13 +30,21 @@ export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
   const [dynamicData, setDynamicData] = useState<Record<string, unknown>>({})
   const [errors, setErrors] = useState<Record<string, string>>({})
 
-  const { data: teams = [], isLoading: teamsLoading } = useQuery({
+  const {
+    data: teams = [],
+    isLoading: teamsLoading,
+    isError: teamsError,
+  } = useQuery({
     queryKey: ['teams', orgSlug],
     queryFn: () => listTeams(orgSlug),
     enabled: !!orgSlug,
   })
 
-  const { data: projectSchema } = useQuery({
+  const {
+    data: projectSchema,
+    isLoading: schemaLoading,
+    isError: schemaError,
+  } = useQuery({
     queryKey: ['projectSchema', orgSlug, project.id],
     queryFn: () => getProjectSchema(orgSlug, project.id),
     enabled: !!orgSlug,
@@ -81,7 +89,8 @@ export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
     setDynamicData(initial)
   }, [editableSchema, project])
 
-  const projectTypeSlug = project.project_types?.[0]?.slug ?? ''
+  const projectTypeSlug =
+    project.project_type?.slug ?? project.project_types?.[0]?.slug ?? ''
 
   const mutation = useMutation({
     mutationFn: (payload: Record<string, unknown>) =>
@@ -93,8 +102,15 @@ export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
     },
   })
 
+  const isLoading = teamsLoading || schemaLoading
+  const isDataError = teamsError || schemaError
+
   const handleSave = () => {
     const newErrors: Record<string, string> = {}
+
+    if (!projectTypeSlug) {
+      newErrors.projectType = 'Project type is missing'
+    }
 
     if (!name.trim()) {
       newErrors.name = 'Name is required'
@@ -119,6 +135,38 @@ export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
 
   const inputClass = isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
   const labelClass = `mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`
+
+  if (isLoading) {
+    return (
+      <Card
+        className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
+      >
+        <h3 className={`mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+          Project Details
+        </h3>
+        <p
+          className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
+        >
+          Loading...
+        </p>
+      </Card>
+    )
+  }
+
+  if (isDataError) {
+    return (
+      <Card
+        className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
+      >
+        <h3 className={`mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+          Project Details
+        </h3>
+        <p className="text-sm text-red-600 dark:text-red-400">
+          Failed to load form data. Please try refreshing the page.
+        </p>
+      </Card>
+    )
+  }
 
   return (
     <Card className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}>
@@ -198,7 +246,7 @@ export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
           size="sm"
           className="border-amber-border bg-amber-bg text-amber-text hover:bg-amber-bg/80"
           onClick={handleSave}
-          disabled={mutation.isPending}
+          disabled={mutation.isPending || !projectTypeSlug}
         >
           {mutation.isPending ? 'Saving...' : 'Save'}
         </Button>

--- a/src/components/EditableKeyValueCard.tsx
+++ b/src/components/EditableKeyValueCard.tsx
@@ -109,6 +109,8 @@ export function EditableKeyValueCard({
               className={`flex-1 text-sm ${inputClass}`}
             />
             <button
+              type="button"
+              aria-label={`Remove ${title.toLowerCase()} row ${index + 1}`}
               onClick={() => removeRow(index)}
               disabled={isSaving}
               className={`rounded p-1.5 ${

--- a/src/components/EditableKeyValueCard.tsx
+++ b/src/components/EditableKeyValueCard.tsx
@@ -1,0 +1,156 @@
+import { useState, useEffect } from 'react'
+import { Trash2, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card } from '@/components/ui/card'
+
+interface EditableKeyValueCardProps {
+  title: string
+  entries: Record<string, string | number>
+  isDarkMode: boolean
+  isSaving: boolean
+  keyLabel?: string
+  valueLabel?: string
+  keyPlaceholder?: string
+  valuePlaceholder?: string
+  readOnlyKeys?: boolean
+  showHeader?: boolean
+  onSave: (entries: Record<string, string>) => void
+}
+
+export function EditableKeyValueCard({
+  title,
+  entries,
+  isDarkMode,
+  isSaving,
+  keyLabel = 'Key',
+  valueLabel = 'Value',
+  keyPlaceholder = 'key',
+  valuePlaceholder = 'value',
+  readOnlyKeys = false,
+  showHeader = true,
+  onSave,
+}: EditableKeyValueCardProps) {
+  const [rows, setRows] = useState<[string, string][]>([])
+
+  useEffect(() => {
+    setRows(
+      Object.entries(entries)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, String(v)]),
+    )
+  }, [entries])
+
+  const updateRow = (index: number, col: 0 | 1, value: string) => {
+    setRows((prev) => {
+      const next = [...prev]
+      next[index] = [...next[index]] as [string, string]
+      next[index][col] = value
+      return next
+    })
+  }
+
+  const removeRow = (index: number) => {
+    setRows((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const addRow = () => {
+    setRows((prev) => [...prev, ['', '']])
+  }
+
+  const handleSave = () => {
+    const result: Record<string, string> = {}
+    for (const [k, v] of rows) {
+      const key = k.trim()
+      if (key) result[key] = v
+    }
+    onSave(result)
+  }
+
+  const inputClass = isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+  const headerClass = `mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`
+  const labelClass = `text-xs font-medium ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`
+
+  return (
+    <Card className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}>
+      <h3 className={headerClass}>{title}</h3>
+
+      {showHeader && rows.length > 0 && (
+        <div className="mb-2 flex items-center gap-2 px-1">
+          <span className={`flex-1 ${labelClass}`}>{keyLabel}</span>
+          <span className={`flex-1 ${labelClass}`}>{valueLabel}</span>
+          <div className="w-8" />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {rows.map(([key, val], index) => (
+          <div key={`${index}-${key}`} className="flex items-center gap-2">
+            {readOnlyKeys ? (
+              <span
+                className={`w-[15%] flex-shrink-0 text-sm ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
+              >
+                {key}
+              </span>
+            ) : (
+              <Input
+                value={key}
+                onChange={(e) => updateRow(index, 0, e.target.value)}
+                disabled={isSaving}
+                placeholder={keyPlaceholder}
+                className={`flex-1 font-mono text-sm ${inputClass}`}
+              />
+            )}
+            <Input
+              value={val}
+              onChange={(e) => updateRow(index, 1, e.target.value)}
+              disabled={isSaving}
+              placeholder={valuePlaceholder}
+              className={`flex-1 text-sm ${inputClass}`}
+            />
+            <button
+              onClick={() => removeRow(index)}
+              disabled={isSaving}
+              className={`rounded p-1.5 ${
+                isDarkMode
+                  ? 'text-red-400 hover:bg-red-900/20'
+                  : 'text-red-600 hover:bg-red-50'
+              }`}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between">
+        {!readOnlyKeys ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={addRow}
+            disabled={isSaving}
+            className={
+              isDarkMode
+                ? 'border-gray-600 text-gray-300 hover:bg-gray-700'
+                : ''
+            }
+          >
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            Add
+          </Button>
+        ) : (
+          <div />
+        )}
+        <Button
+          size="sm"
+          className="border-amber-border bg-amber-bg text-amber-text hover:bg-amber-bg/80"
+          onClick={handleSave}
+          disabled={isSaving}
+        >
+          {isSaving ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -26,6 +26,8 @@ import { formatDistanceToNow } from 'date-fns'
 import { Link, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { ApiError } from '@/api/client'
+import { sortEnvironments } from '@/lib/utils'
 import {
   listLinkDefinitions,
   getProjectSchema,
@@ -273,11 +275,7 @@ export function ProjectDetail({
   ]
 
   const sortedEnvironments = useMemo(
-    () =>
-      [...(project.environments || [])].sort((a, b) => {
-        const orderDiff = (a.sort_order ?? 0) - (b.sort_order ?? 0)
-        return orderDiff !== 0 ? orderDiff : a.name.localeCompare(b.name)
-      }),
+    () => sortEnvironments(project.environments || []),
     [project.environments],
   )
 
@@ -1099,6 +1097,16 @@ function SettingsTab({
     })
   }
 
+  const mutationErrorHandler = (label: string) => {
+    return (error: ApiError<{ detail?: string }> | Error) => {
+      const detail =
+        error instanceof ApiError
+          ? error.response?.data?.detail || error.message
+          : error.message
+      alert(`Failed to ${label}: ${detail}`)
+    }
+  }
+
   const linksMutation = useMutation({
     mutationFn: (links: Record<string, string>) => {
       if (!orgSlug || !projectTypeSlug)
@@ -1106,6 +1114,7 @@ function SettingsTab({
       return updateProject(orgSlug, projectTypeSlug, project.slug, { links })
     },
     onSuccess: invalidateProject,
+    onError: mutationErrorHandler('save links'),
   })
 
   const identifiersMutation = useMutation({
@@ -1117,6 +1126,7 @@ function SettingsTab({
       })
     },
     onSuccess: invalidateProject,
+    onError: mutationErrorHandler('save identifiers'),
   })
 
   const envMutation = useMutation({
@@ -1128,6 +1138,7 @@ function SettingsTab({
       })
     },
     onSuccess: invalidateProject,
+    onError: mutationErrorHandler('save environments'),
   })
 
   const deleteMutation = useMutation({
@@ -1137,6 +1148,7 @@ function SettingsTab({
       return deleteProject(orgSlug, projectTypeSlug, project.slug)
     },
     onSuccess: () => navigate('/'),
+    onError: mutationErrorHandler('delete project'),
   })
 
   const {
@@ -1150,11 +1162,7 @@ function SettingsTab({
   })
 
   const sortedEnvironments = useMemo(
-    () =>
-      [...(project.environments || [])].sort((a, b) => {
-        const orderDiff = (a.sort_order ?? 0) - (b.sort_order ?? 0)
-        return orderDiff !== 0 ? orderDiff : a.name.localeCompare(b.name)
-      }),
+    () => sortEnvironments(project.environments || []),
     [project.environments],
   )
 

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -23,12 +23,14 @@ import {
 import { useEffect, useMemo, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { Link, useNavigate } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import {
   listLinkDefinitions,
   getProjectSchema,
   getProjectRelationships,
+  updateProject,
+  deleteProject,
 } from '@/api/endpoints'
 import { buildRelationshipEdges } from '@/lib/relationship-edges'
 import type { ProjectSchemaSection } from '@/api/endpoints'
@@ -37,6 +39,10 @@ import {
   type GraphProject,
 } from '@/components/ProjectsGraphCanvas'
 import { EditRelationshipsDialog } from '@/components/EditRelationshipsDialog'
+import { EditProjectForm } from '@/components/EditProjectForm'
+import { EditableKeyValueCard } from '@/components/EditableKeyValueCard'
+import { EditLinksCard } from '@/components/EditLinksCard'
+import { EditEnvironmentsCard } from '@/components/EditEnvironmentsCard'
 import type { Project, ProjectRelationship } from '@/types'
 
 interface ProjectDetailProps {
@@ -48,7 +54,7 @@ interface ProjectDetailProps {
 const VALID_TABS = [
   'overview',
   'configuration',
-  'components',
+  'dependencies',
   'relationships',
   'logs',
   'notes',
@@ -354,8 +360,11 @@ export function ProjectDetail({
 
   const tabs: { id: TabType; label: string }[] = [
     { id: 'overview', label: 'Overview' },
-    { id: 'components', label: 'Components' },
     { id: 'configuration', label: 'Configuration' },
+    { id: 'dependencies', label: 'Dependencies' },
+    { id: 'logs', label: 'Logs' },
+    { id: 'notes', label: 'Notes' },
+    { id: 'operations-log', label: 'Operations Log' },
     {
       id: 'relationships',
       label: (() => {
@@ -364,9 +373,6 @@ export function ProjectDetail({
         return `Relationships (${total})`
       })(),
     },
-    { id: 'logs', label: 'Logs' },
-    { id: 'notes', label: 'Notes' },
-    { id: 'operations-log', label: 'Operations Log' },
     { id: 'settings', label: '' },
   ]
 
@@ -491,13 +497,7 @@ export function ProjectDetail({
               <Card
                 className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
               >
-                <div className="mb-4 flex items-center justify-between">
-                  <h3 className={value}>Project Details</h3>
-                  <Button variant="ghost" size="sm">
-                    Edit
-                  </Button>
-                </div>
-
+                <h3 className={`mb-4 ${value}`}>Project Details</h3>
                 <div className="space-y-0">
                   <div
                     className={`flex items-center justify-between border-b py-1.5 ${divider}`}
@@ -512,9 +512,7 @@ export function ProjectDetail({
                     className={`flex items-center justify-between border-b py-1.5 ${divider}`}
                   >
                     <span className={`text-sm ${label}`}>Slug</span>
-                    <span
-                      className={`rounded px-2 py-0.5 font-mono text-sm ${isDarkMode ? 'bg-gray-700 text-white' : 'bg-slate-100 text-slate-900'}`}
-                    >
+                    <span className={`font-mono text-sm ${value}`}>
                       {project.slug}
                     </span>
                   </div>
@@ -546,7 +544,6 @@ export function ProjectDetail({
                     </div>
                   )}
 
-                  {/* Blueprint attributes */}
                   {attributeFields.map(
                     ({
                       key,
@@ -610,32 +607,73 @@ export function ProjectDetail({
                 </div>
               </Card>
 
-              {/* Identifiers */}
-              {project.identifiers &&
-                Object.keys(project.identifiers).length > 0 && (
-                  <Card
-                    className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-                  >
-                    <h3 className={`mb-4 ${value}`}>Identifiers</h3>
-                    <div className="space-y-0">
-                      {Object.entries(project.identifiers)
-                        .sort(([a], [b]) => a.localeCompare(b))
-                        .map(([owner, id]) => (
-                          <div
-                            key={owner}
-                            className={`flex items-center justify-between border-b py-2 ${divider} last:border-0`}
-                          >
-                            <span className={`text-sm ${label}`}>{owner}</span>
+              {/* Environments */}
+              {sortedEnvironments.length > 0 && (
+                <Card
+                  className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
+                >
+                  <h3 className={`mb-4 ${value}`}>Environments</h3>
+                  <div className="space-y-0">
+                    {sortedEnvironments.map((env) => {
+                      let url: string | null = null
+                      if (typeof env.url === 'string' && env.url !== '') {
+                        try {
+                          const parsed = new URL(env.url)
+                          if (
+                            parsed.protocol === 'http:' ||
+                            parsed.protocol === 'https:'
+                          ) {
+                            url = parsed.toString()
+                          }
+                        } catch {
+                          url = null
+                        }
+                      }
+                      const deployment = deploymentStatus[env.slug]
+                      return (
+                        <div
+                          key={env.slug}
+                          className={`flex items-center border-b py-2 ${divider} last:border-0`}
+                        >
+                          <div className="w-32 flex-shrink-0">
+                            <EnvironmentBadge
+                              name={env.name}
+                              slug={env.slug}
+                              label_color={env.label_color}
+                            />
+                          </div>
+                          <div className="flex-1 text-center">
                             <span
-                              className={`rounded px-2 py-0.5 font-mono text-sm ${isDarkMode ? 'bg-gray-700 text-white' : 'bg-slate-100 text-slate-900'}`}
+                              className={`font-mono text-sm ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
                             >
-                              {id}
+                              {deployment?.version ?? ''}
                             </span>
                           </div>
-                        ))}
-                    </div>
-                  </Card>
-                )}
+                          <div className="flex-1 text-right">
+                            {url ? (
+                              <a
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={`inline-flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-amber-400' : 'text-amber-text'} hover:underline`}
+                              >
+                                {url}
+                                <ExternalLink
+                                  className={`h-3 w-3 ${isDarkMode ? 'text-amber-400' : 'text-amber-text'}`}
+                                />
+                              </a>
+                            ) : (
+                              <span className={`text-sm ${muted}`}>
+                                &mdash;
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </Card>
+              )}
             </div>
 
             {/* Right column: Health & Compliance + Recent Activity */}
@@ -681,60 +719,6 @@ export function ProjectDetail({
                   Policy scoring and compliance checks will appear here.
                 </p>
               </Card>
-
-              {/* Environments */}
-              {sortedEnvironments.length > 0 && (
-                <Card
-                  className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-                >
-                  <h3 className={`mb-4 ${value}`}>Environments</h3>
-                  <div className="space-y-0">
-                    {sortedEnvironments.map((env) => {
-                      let url: string | null = null
-                      if (typeof env.url === 'string' && env.url !== '') {
-                        try {
-                          const parsed = new URL(env.url)
-                          if (
-                            parsed.protocol === 'http:' ||
-                            parsed.protocol === 'https:'
-                          ) {
-                            url = parsed.toString()
-                          }
-                        } catch {
-                          url = null
-                        }
-                      }
-                      return (
-                        <div
-                          key={env.slug}
-                          className={`flex items-center justify-between border-b py-2 ${divider} last:border-0`}
-                        >
-                          <EnvironmentBadge
-                            name={env.name}
-                            slug={env.slug}
-                            label_color={env.label_color}
-                          />
-                          {url ? (
-                            <a
-                              href={url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className={`flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-amber-400' : 'text-amber-text'} hover:underline`}
-                            >
-                              {url}
-                              <ExternalLink
-                                className={`h-3 w-3 ${isDarkMode ? 'text-amber-400' : 'text-amber-text'}`}
-                              />
-                            </a>
-                          ) : (
-                            <span className={`text-sm ${muted}`}>—</span>
-                          )}
-                        </div>
-                      )
-                    })}
-                  </div>
-                </Card>
-              )}
 
               {/* Recent Activity (mocked) */}
               <Card
@@ -791,8 +775,8 @@ export function ProjectDetail({
             isDarkMode={isDarkMode}
           />
         </TabsContent>
-        <TabsContent value="components">
-          <PlaceholderTab name="Components" isDarkMode={isDarkMode} />
+        <TabsContent value="dependencies">
+          <PlaceholderTab name="Dependencies" isDarkMode={isDarkMode} />
         </TabsContent>
         <TabsContent value="logs">
           <PlaceholderTab name="Logs" isDarkMode={isDarkMode} />
@@ -804,7 +788,7 @@ export function ProjectDetail({
           <PlaceholderTab name="Operations Log" isDarkMode={isDarkMode} />
         </TabsContent>
         <TabsContent value="settings">
-          <PlaceholderTab name="Settings" isDarkMode={isDarkMode} />
+          <SettingsTab project={project} isDarkMode={isDarkMode} />
         </TabsContent>
       </Tabs>
     </div>
@@ -1089,6 +1073,161 @@ function SidebarProjectRow({
         <span className={`flex-shrink-0 text-[10px] ${muted}`}>{typeSlug}</span>
       )}
     </li>
+  )
+}
+
+function SettingsTab({
+  project,
+  isDarkMode,
+}: {
+  project: Project
+  isDarkMode: boolean
+}) {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug || ''
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const projectTypeSlug = project.project_types?.[0]?.slug ?? ''
+
+  const invalidateProject = () => {
+    queryClient.invalidateQueries({
+      queryKey: ['project', orgSlug, project.id],
+    })
+  }
+
+  const linksMutation = useMutation({
+    mutationFn: (links: Record<string, string>) =>
+      updateProject(orgSlug, projectTypeSlug, project.slug, { links }),
+    onSuccess: invalidateProject,
+  })
+
+  const identifiersMutation = useMutation({
+    mutationFn: (identifiers: Record<string, string>) =>
+      updateProject(orgSlug, projectTypeSlug, project.slug, { identifiers }),
+    onSuccess: invalidateProject,
+  })
+
+  const envMutation = useMutation({
+    mutationFn: (environments: Record<string, Record<string, string>>) =>
+      updateProject(orgSlug, projectTypeSlug, project.slug, { environments }),
+    onSuccess: invalidateProject,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteProject(orgSlug, projectTypeSlug, project.slug),
+    onSuccess: () => navigate('/'),
+  })
+
+  const { data: linkDefs = [] } = useQuery({
+    queryKey: ['linkDefinitions', orgSlug],
+    queryFn: () => listLinkDefinitions(orgSlug),
+    enabled: !!orgSlug,
+  })
+
+  const sortedEnvironments = useMemo(
+    () =>
+      [...(project.environments || [])].sort((a, b) => {
+        const orderDiff = (a.sort_order ?? 0) - (b.sort_order ?? 0)
+        return orderDiff !== 0 ? orderDiff : a.name.localeCompare(b.name)
+      }),
+    [project.environments],
+  )
+
+  return (
+    <div className="space-y-6">
+      <EditProjectForm project={project} isDarkMode={isDarkMode} />
+
+      {linkDefs.length > 0 && (
+        <EditLinksCard
+          linkDefs={linkDefs}
+          links={project.links || {}}
+          isDarkMode={isDarkMode}
+          isSaving={linksMutation.isPending}
+          onSave={(entries) => linksMutation.mutate(entries)}
+        />
+      )}
+
+      {sortedEnvironments.length > 0 && (
+        <EditEnvironmentsCard
+          environments={sortedEnvironments}
+          isDarkMode={isDarkMode}
+          isSaving={envMutation.isPending}
+          onSave={(envData) => envMutation.mutate(envData)}
+        />
+      )}
+
+      <EditableKeyValueCard
+        title="Identifiers"
+        entries={project.identifiers || {}}
+        isDarkMode={isDarkMode}
+        isSaving={identifiersMutation.isPending}
+        readOnlyKeys
+        showHeader={false}
+        valuePlaceholder="identifier"
+        onSave={(entries) => identifiersMutation.mutate(entries)}
+      />
+
+      <Card
+        className={`border-amber-300 p-6 ${isDarkMode ? 'border-amber-700 bg-gray-800' : ''}`}
+      >
+        <h3
+          className={`mb-2 font-semibold ${isDarkMode ? 'text-amber-500' : 'text-amber-700'}`}
+        >
+          Archive Project
+        </h3>
+        <p
+          className={`mb-1 text-sm ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
+        >
+          Archiving the project will make it entirely read only.
+        </p>
+        <p
+          className={`mb-4 text-sm font-medium ${isDarkMode ? 'text-amber-400' : 'text-amber-700'}`}
+        >
+          It will be hidden from the dashboard, won&apos;t show up in searches,
+          and will be disabled as a dependency for any other projects that are
+          dependent upon it.
+        </p>
+        <Button variant="outline" size="sm" disabled>
+          Archive Project
+        </Button>
+      </Card>
+
+      <Card
+        className={`border-red-300 p-6 ${isDarkMode ? 'border-red-800 bg-gray-800' : ''}`}
+      >
+        <h3
+          className={`mb-2 font-semibold ${isDarkMode ? 'text-red-500' : 'text-red-700'}`}
+        >
+          Delete Project
+        </h3>
+        <p
+          className={`mb-1 text-sm ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
+        >
+          This action will <strong>permanently delete</strong>{' '}
+          <code
+            className={`rounded px-1.5 py-0.5 font-mono text-sm ${isDarkMode ? 'bg-gray-700 text-white' : 'bg-slate-100 text-slate-900'}`}
+          >
+            {project.slug}
+          </code>{' '}
+          immediately, removing the project and all associated data, including
+          facts, operation logs, and notes.
+        </p>
+        <p
+          className={`mb-4 text-sm font-medium ${isDarkMode ? 'text-red-400' : 'text-red-700'}`}
+        >
+          Are you ABSOLUTELY SURE you wish to delete this project?
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
+          onClick={() => deleteMutation.mutate()}
+          disabled={deleteMutation.isPending}
+        >
+          {deleteMutation.isPending ? 'Deleting...' : 'Delete Project'}
+        </Button>
+      </Card>
+    </div>
   )
 }
 

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -11,6 +11,7 @@ import { resolveColor, resolveIcon } from '@/lib/ui-maps'
 import type { XUiMaps } from '@/lib/ui-maps'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { EnvironmentBadge } from '@/components/ui/environment-badge'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -1087,7 +1088,10 @@ function SettingsTab({
   const orgSlug = selectedOrganization?.slug || ''
   const queryClient = useQueryClient()
   const navigate = useNavigate()
-  const projectTypeSlug = project.project_types?.[0]?.slug ?? ''
+  const projectTypeSlug =
+    project.project_type?.slug ?? project.project_types?.[0]?.slug ?? ''
+  const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
   const invalidateProject = () => {
     queryClient.invalidateQueries({
@@ -1096,29 +1100,50 @@ function SettingsTab({
   }
 
   const linksMutation = useMutation({
-    mutationFn: (links: Record<string, string>) =>
-      updateProject(orgSlug, projectTypeSlug, project.slug, { links }),
+    mutationFn: (links: Record<string, string>) => {
+      if (!orgSlug || !projectTypeSlug)
+        return Promise.reject(new Error('Missing project type'))
+      return updateProject(orgSlug, projectTypeSlug, project.slug, { links })
+    },
     onSuccess: invalidateProject,
   })
 
   const identifiersMutation = useMutation({
-    mutationFn: (identifiers: Record<string, string>) =>
-      updateProject(orgSlug, projectTypeSlug, project.slug, { identifiers }),
+    mutationFn: (identifiers: Record<string, string>) => {
+      if (!orgSlug || !projectTypeSlug)
+        return Promise.reject(new Error('Missing project type'))
+      return updateProject(orgSlug, projectTypeSlug, project.slug, {
+        identifiers,
+      })
+    },
     onSuccess: invalidateProject,
   })
 
   const envMutation = useMutation({
-    mutationFn: (environments: Record<string, Record<string, string>>) =>
-      updateProject(orgSlug, projectTypeSlug, project.slug, { environments }),
+    mutationFn: (environments: Record<string, Record<string, string>>) => {
+      if (!orgSlug || !projectTypeSlug)
+        return Promise.reject(new Error('Missing project type'))
+      return updateProject(orgSlug, projectTypeSlug, project.slug, {
+        environments,
+      })
+    },
     onSuccess: invalidateProject,
   })
 
   const deleteMutation = useMutation({
-    mutationFn: () => deleteProject(orgSlug, projectTypeSlug, project.slug),
+    mutationFn: () => {
+      if (!orgSlug || !projectTypeSlug)
+        return Promise.reject(new Error('Missing project type'))
+      return deleteProject(orgSlug, projectTypeSlug, project.slug)
+    },
     onSuccess: () => navigate('/'),
   })
 
-  const { data: linkDefs = [] } = useQuery({
+  const {
+    data: linkDefs = [],
+    isLoading: linkDefsLoading,
+    isError: linkDefsError,
+  } = useQuery({
     queryKey: ['linkDefinitions', orgSlug],
     queryFn: () => listLinkDefinitions(orgSlug),
     enabled: !!orgSlug,
@@ -1137,7 +1162,27 @@ function SettingsTab({
     <div className="space-y-6">
       <EditProjectForm project={project} isDarkMode={isDarkMode} />
 
-      {linkDefs.length > 0 && (
+      {linkDefsLoading && (
+        <Card
+          className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
+        >
+          <p
+            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
+          >
+            Loading link definitions...
+          </p>
+        </Card>
+      )}
+      {linkDefsError && (
+        <Card
+          className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
+        >
+          <p className="text-sm text-red-600 dark:text-red-400">
+            Failed to load link definitions.
+          </p>
+        </Card>
+      )}
+      {!linkDefsLoading && !linkDefsError && linkDefs.length > 0 && (
         <EditLinksCard
           linkDefs={linkDefs}
           links={project.links || {}}
@@ -1217,15 +1262,66 @@ function SettingsTab({
         >
           Are you ABSOLUTELY SURE you wish to delete this project?
         </p>
-        <Button
-          variant="outline"
-          size="sm"
-          className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
-          onClick={() => deleteMutation.mutate()}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? 'Deleting...' : 'Delete Project'}
-        </Button>
+        {!showDeleteConfirm ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
+            onClick={() => setShowDeleteConfirm(true)}
+            disabled={!projectTypeSlug}
+          >
+            Delete Project
+          </Button>
+        ) : (
+          <div className="space-y-3">
+            <p
+              className={`text-sm ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
+            >
+              Type{' '}
+              <code
+                className={`rounded px-1.5 py-0.5 font-mono text-sm ${isDarkMode ? 'bg-gray-700 text-white' : 'bg-slate-100 text-slate-900'}`}
+              >
+                {project.slug}
+              </code>{' '}
+              to confirm deletion:
+            </p>
+            <Input
+              value={deleteConfirmSlug}
+              onChange={(e) => setDeleteConfirmSlug(e.target.value)}
+              placeholder={project.slug}
+              disabled={deleteMutation.isPending}
+              className={
+                isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+              }
+            />
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
+                onClick={() => deleteMutation.mutate()}
+                disabled={
+                  deleteConfirmSlug !== project.slug ||
+                  deleteMutation.isPending ||
+                  !projectTypeSlug
+                }
+              >
+                {deleteMutation.isPending ? 'Deleting...' : 'Confirm Delete'}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setShowDeleteConfirm(false)
+                  setDeleteConfirmSlug('')
+                }}
+                disabled={deleteMutation.isPending}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
       </Card>
     </div>
   )

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -150,7 +150,8 @@ function buildJsonSchema(
       ['color-age', prop.colorAge],
       ['icon-age', prop.iconAge],
     ]
-    const xUiObj: Record<string, Record<string, string>> = {}
+    const xUiObj: Record<string, unknown> = {}
+    if (prop.editable === false) xUiObj['editable'] = false
     for (const [key, map] of uiEntries) {
       if (map && Object.keys(map).length > 0) xUiObj[key] = map
     }
@@ -192,6 +193,7 @@ function schemaToProperties(schema: Record<string, unknown>): SchemaProperty[] {
       maximum: propSchema.maximum as number | undefined,
       minLength: propSchema.minLength as number | undefined,
       maxLength: propSchema.maxLength as number | undefined,
+      editable: xUi?.['editable'] === false ? false : undefined,
       colorMap: xUi?.['color-map'] as Record<string, string> | undefined,
       iconMap: xUi?.['icon-map'] as Record<string, string> | undefined,
       colorRange: xUi?.['color-range'] as Record<string, string> | undefined,
@@ -1409,6 +1411,24 @@ export function BlueprintForm({
                           className={`cursor-pointer select-none text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
                         >
                           Required
+                        </label>
+                      </div>
+
+                      <div className="flex items-center gap-1.5">
+                        <Checkbox
+                          id={`editable-${prop.id}`}
+                          checked={prop.editable !== false}
+                          onCheckedChange={(checked) =>
+                            updateProperty(prop.id, {
+                              editable: checked === true ? undefined : false,
+                            })
+                          }
+                        />
+                        <label
+                          htmlFor={`editable-${prop.id}`}
+                          className={`cursor-pointer select-none text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                        >
+                          Editable
                         </label>
                       </div>
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,8 +21,22 @@ export const NODE_BASE_FIELDS_SET = new Set(NODE_BASE_FIELDS)
 export const TEAM_BASE_FIELDS = NODE_BASE_FIELDS
 export const TEAM_BASE_FIELDS_SET = NODE_BASE_FIELDS_SET
 
-export const ENVIRONMENT_BASE_FIELDS = [...NODE_BASE_FIELDS, 'sort_order']
+export const ENVIRONMENT_BASE_FIELDS = [...NODE_BASE_FIELDS, 'sort_order', 'id']
 export const ENVIRONMENT_BASE_FIELDS_SET = new Set(ENVIRONMENT_BASE_FIELDS)
 
 export const PROJECT_TYPE_BASE_FIELDS = NODE_BASE_FIELDS
 export const PROJECT_TYPE_BASE_FIELDS_SET = NODE_BASE_FIELDS_SET
+
+export const PROJECT_BASE_FIELDS = [
+  ...NODE_BASE_FIELDS,
+  'team',
+  'team_slug',
+  'id',
+  'project_type',
+  'project_types',
+  'environments',
+  'links',
+  'identifiers',
+  'url',
+]
+export const PROJECT_BASE_FIELDS_SET = new Set(PROJECT_BASE_FIELDS)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
-import type { BlueprintFilter } from '@/types'
+import type { BlueprintFilter, Environment } from '@/types'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -44,6 +44,17 @@ export function extractDynamicFields(
     }
   }
   return result
+}
+
+/**
+ * Return a new array of environments sorted by sort_order (ascending,
+ * nullish treated as 0) and falling back to name.localeCompare for ties.
+ */
+export function sortEnvironments(environments: Environment[]): Environment[] {
+  return [...environments].sort((a, b) => {
+    const orderDiff = (a.sort_order ?? 0) - (b.sort_order ?? 0)
+    return orderDiff !== 0 ? orderDiff : a.name.localeCompare(b.name)
+  })
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -723,6 +723,7 @@ export interface SchemaProperty {
   maximum?: number
   minLength?: number
   maxLength?: number
+  editable?: boolean
   colorMap?: Record<string, string>
   iconMap?: Record<string, string>
   colorRange?: Record<string, string>


### PR DESCRIPTION
## Summary
- Add a full **Settings tab** to the project detail page with editable cards for project details, links, environment-specific details, and identifiers
- Add **Archive Project** (placeholder) and **Delete Project** danger zone cards
- Add `x-ui.editable` support to blueprint schema editor and project edit form
- Reorganize overview tab: move Environments card to left column with version display, move Identifiers to settings
- Rename Components tab to Dependencies, alphabetize tabs (Overview pinned first, cog last)

## Test plan
- [ ] Navigate to a project detail page — verify Overview tab shows environments with version column
- [ ] Click Settings tab — verify Project Details, Links, Environment Specific Details, Identifiers, Archive, and Delete cards render
- [ ] Edit project name/description/team in Project Details card and save
- [ ] Edit a link URL and save — verify it persists on refresh
- [ ] Edit an environment URL and save
- [ ] Edit an identifier value and save
- [ ] Verify non-editable blueprint fields (x-ui.editable: false) are excluded from the edit form
- [ ] In admin blueprints, toggle the Editable checkbox on a property and verify it persists
- [ ] Click Delete Project — verify redirect to home after deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)