### PR TITLE
Disable delete action when associated items exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dist-ssr
 .env.*.local
 
 figma/
+.worktrees/

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -277,9 +277,9 @@ export function Admin({ isDarkMode }: AdminProps) {
             <div className="px-8 py-6">
               <div className="flex items-center gap-3">
                 {currentSectionData && (
-                  <currentSectionData.icon className="h-6 w-6 text-amber-text" />
+                  <currentSectionData.icon className="h-5 w-5 text-amber-text" />
                 )}
-                <h1 className="text-2xl font-semibold text-primary">
+                <h1 className="text-xl font-semibold text-primary">
                   {currentSectionData?.label}
                 </h1>
               </div>

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -10,7 +10,13 @@ import { getIcon } from '@/lib/icons'
 import { resolveColor, resolveIcon } from '@/lib/ui-maps'
 import type { XUiMaps } from '@/lib/ui-maps'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { EnvironmentBadge } from '@/components/ui/environment-badge'
@@ -493,184 +499,192 @@ export function ProjectDetail({
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
             {/* Left column: Details */}
             <div className="space-y-6">
-              <Card
-                className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-              >
-                <h3 className={`mb-4 ${value}`}>Project Details</h3>
-                <div className="space-y-0">
-                  <div
-                    className={`flex items-center justify-between border-b py-1.5 ${divider}`}
-                  >
-                    <span className={`text-sm ${label}`}>Team</span>
-                    <span className={`text-sm ${value}`}>
-                      {project.team.name}
-                    </span>
-                  </div>
-
-                  <div
-                    className={`flex items-center justify-between border-b py-1.5 ${divider}`}
-                  >
-                    <span className={`text-sm ${label}`}>Slug</span>
-                    <span className={`font-mono text-sm ${value}`}>
-                      {project.slug}
-                    </span>
-                  </div>
-
-                  {project.created_at && (
+              <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+                <CardHeader>
+                  <CardTitle>Project details</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-0">
                     <div
                       className={`flex items-center justify-between border-b py-1.5 ${divider}`}
                     >
-                      <span className={`text-sm ${label}`}>Created</span>
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span
-                              className={`text-sm ${value} cursor-help underline decoration-dotted`}
-                            >
-                              {formatDistanceToNow(
-                                new Date(project.created_at),
-                                { addSuffix: true },
-                              )}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>
-                              {new Date(project.created_at).toLocaleString()}
-                            </p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
+                      <span className={`text-sm ${label}`}>Team</span>
+                      <span className={`text-sm ${value}`}>
+                        {project.team.name}
+                      </span>
                     </div>
-                  )}
 
-                  {attributeFields.map(
-                    ({
-                      key,
-                      label: fieldLabel,
-                      value: fieldValue,
-                      rawValue,
-                      title: fieldTitle,
-                      uiMaps,
-                    }) => {
-                      const mappedColor = resolveColor(uiMaps, rawValue)
-                      const mappedIcon = resolveIcon(uiMaps, rawValue)
-                      const FieldIcon = mappedIcon ? getIcon(mappedIcon) : null
-                      const textColorClass = mappedColor
-                        ? (COLOR_TEXT[mappedColor] ?? value)
-                        : value
-                      return (
-                        <div
-                          key={key}
-                          className={`flex items-center justify-between border-b py-1.5 ${divider} last:border-0`}
-                        >
-                          <span className={`text-sm ${label}`}>
-                            {fieldLabel}
-                          </span>
-                          {fieldValue !== null ? (
-                            <span className="flex items-center gap-1.5">
-                              {FieldIcon && (
-                                <FieldIcon
-                                  className={`h-3.5 w-3.5 flex-shrink-0 ${textColorClass}`}
-                                />
-                              )}
-                              {fieldTitle ? (
-                                <TooltipProvider delayDuration={200}>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <span
-                                        className={`text-sm ${textColorClass} cursor-help underline decoration-dotted`}
-                                      >
-                                        {fieldValue}
-                                      </span>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>{fieldTitle}</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
-                              ) : (
-                                <span className={`text-sm ${textColorClass}`}>
-                                  {fieldValue}
-                                </span>
-                              )}
+                    <div
+                      className={`flex items-center justify-between border-b py-1.5 ${divider}`}
+                    >
+                      <span className={`text-sm ${label}`}>Slug</span>
+                      <span className={`font-mono text-sm ${value}`}>
+                        {project.slug}
+                      </span>
+                    </div>
+
+                    {project.created_at && (
+                      <div
+                        className={`flex items-center justify-between border-b py-1.5 ${divider}`}
+                      >
+                        <span className={`text-sm ${label}`}>Created</span>
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span
+                                className={`text-sm ${value} cursor-help underline decoration-dotted`}
+                              >
+                                {formatDistanceToNow(
+                                  new Date(project.created_at),
+                                  { addSuffix: true },
+                                )}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>
+                                {new Date(project.created_at).toLocaleString()}
+                              </p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    )}
+
+                    {attributeFields.map(
+                      ({
+                        key,
+                        label: fieldLabel,
+                        value: fieldValue,
+                        rawValue,
+                        title: fieldTitle,
+                        uiMaps,
+                      }) => {
+                        const mappedColor = resolveColor(uiMaps, rawValue)
+                        const mappedIcon = resolveIcon(uiMaps, rawValue)
+                        const FieldIcon = mappedIcon
+                          ? getIcon(mappedIcon)
+                          : null
+                        const textColorClass = mappedColor
+                          ? (COLOR_TEXT[mappedColor] ?? value)
+                          : value
+                        return (
+                          <div
+                            key={key}
+                            className={`flex items-center justify-between border-b py-1.5 ${divider} last:border-0`}
+                          >
+                            <span className={`text-sm ${label}`}>
+                              {fieldLabel}
                             </span>
-                          ) : (
-                            <span className={`text-sm italic ${muted}`}>
-                              Not set
-                            </span>
-                          )}
-                        </div>
-                      )
-                    },
-                  )}
-                </div>
+                            {fieldValue !== null ? (
+                              <span className="flex items-center gap-1.5">
+                                {FieldIcon && (
+                                  <FieldIcon
+                                    className={`h-3.5 w-3.5 flex-shrink-0 ${textColorClass}`}
+                                  />
+                                )}
+                                {fieldTitle ? (
+                                  <TooltipProvider delayDuration={200}>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <span
+                                          className={`text-sm ${textColorClass} cursor-help underline decoration-dotted`}
+                                        >
+                                          {fieldValue}
+                                        </span>
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        <p>{fieldTitle}</p>
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </TooltipProvider>
+                                ) : (
+                                  <span className={`text-sm ${textColorClass}`}>
+                                    {fieldValue}
+                                  </span>
+                                )}
+                              </span>
+                            ) : (
+                              <span className={`text-sm italic ${muted}`}>
+                                Not set
+                              </span>
+                            )}
+                          </div>
+                        )
+                      },
+                    )}
+                  </div>
+                </CardContent>
               </Card>
 
               {/* Environments */}
               {sortedEnvironments.length > 0 && (
                 <Card
-                  className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
+                  className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}
                 >
-                  <h3 className={`mb-4 ${value}`}>Environments</h3>
-                  <div className="space-y-0">
-                    {sortedEnvironments.map((env) => {
-                      let url: string | null = null
-                      if (typeof env.url === 'string' && env.url !== '') {
-                        try {
-                          const parsed = new URL(env.url)
-                          if (
-                            parsed.protocol === 'http:' ||
-                            parsed.protocol === 'https:'
-                          ) {
-                            url = parsed.toString()
+                  <CardHeader>
+                    <CardTitle>Environments</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-0">
+                      {sortedEnvironments.map((env) => {
+                        let url: string | null = null
+                        if (typeof env.url === 'string' && env.url !== '') {
+                          try {
+                            const parsed = new URL(env.url)
+                            if (
+                              parsed.protocol === 'http:' ||
+                              parsed.protocol === 'https:'
+                            ) {
+                              url = parsed.toString()
+                            }
+                          } catch {
+                            url = null
                           }
-                        } catch {
-                          url = null
                         }
-                      }
-                      const deployment = deploymentStatus[env.slug]
-                      return (
-                        <div
-                          key={env.slug}
-                          className={`flex items-center border-b py-2 ${divider} last:border-0`}
-                        >
-                          <div className="w-32 flex-shrink-0">
-                            <EnvironmentBadge
-                              name={env.name}
-                              slug={env.slug}
-                              label_color={env.label_color}
-                            />
-                          </div>
-                          <div className="flex-1 text-center">
-                            <span
-                              className={`font-mono text-sm ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
-                            >
-                              {deployment?.version ?? ''}
-                            </span>
-                          </div>
-                          <div className="flex-1 text-right">
-                            {url ? (
-                              <a
-                                href={url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className={`inline-flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-amber-400' : 'text-amber-text'} hover:underline`}
+                        const deployment = deploymentStatus[env.slug]
+                        return (
+                          <div
+                            key={env.slug}
+                            className={`flex items-center border-b py-2 ${divider} last:border-0`}
+                          >
+                            <div className="w-32 flex-shrink-0">
+                              <EnvironmentBadge
+                                name={env.name}
+                                slug={env.slug}
+                                label_color={env.label_color}
+                              />
+                            </div>
+                            <div className="flex-1 text-center">
+                              <span
+                                className={`font-mono text-sm ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
                               >
-                                {url}
-                                <ExternalLink
-                                  className={`h-3 w-3 ${isDarkMode ? 'text-amber-400' : 'text-amber-text'}`}
-                                />
-                              </a>
-                            ) : (
-                              <span className={`text-sm ${muted}`}>
-                                &mdash;
+                                {deployment?.version ?? ''}
                               </span>
-                            )}
+                            </div>
+                            <div className="flex-1 text-right">
+                              {url ? (
+                                <a
+                                  href={url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className={`inline-flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-amber-400' : 'text-amber-text'} hover:underline`}
+                                >
+                                  {url}
+                                  <ExternalLink
+                                    className={`h-3 w-3 ${isDarkMode ? 'text-amber-400' : 'text-amber-text'}`}
+                                  />
+                                </a>
+                              ) : (
+                                <span className={`text-sm ${muted}`}>
+                                  &mdash;
+                                </span>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      )
-                    })}
-                  </div>
+                        )
+                      })}
+                    </div>
+                  </CardContent>
                 </Card>
               )}
             </div>
@@ -678,86 +692,88 @@ export function ProjectDetail({
             {/* Right column: Health & Compliance + Recent Activity */}
             <div className="space-y-6">
               {/* Health & Compliance */}
-              <Card
-                className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-              >
-                <h3 className={`mb-4 ${value}`}>Health &amp; Compliance</h3>
-
-                <div className="mb-4 flex items-center gap-3">
-                  <div
-                    className={`flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg text-2xl font-medium ${
-                      healthScore >= 90
-                        ? 'bg-green-50 text-green-700'
-                        : healthScore >= 80
-                          ? 'bg-emerald-50 text-emerald-700'
-                          : healthScore >= 70
-                            ? 'bg-amber-50 text-amber-700'
-                            : 'bg-red-50 text-red-700'
-                    }`}
-                  >
-                    {healthScore}
-                  </div>
-                  <div>
-                    <div className="flex items-center gap-1.5">
-                      {healthTrend === 'down' ? (
-                        <TrendingDown className="h-4 w-4 text-red-600" />
-                      ) : (
-                        <TrendingUp className="h-4 w-4 text-green-600" />
-                      )}
-                      <span
-                        className={`text-sm ${healthTrend === 'down' ? 'text-red-600' : 'text-green-600'}`}
-                      >
-                        {healthTrend === 'down' ? 'Declining' : 'Improving'}
-                      </span>
+              <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+                <CardHeader>
+                  <CardTitle>Health &amp; compliance</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="mb-4 flex items-center gap-3">
+                    <div
+                      className={`flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg text-2xl font-medium ${
+                        healthScore >= 90
+                          ? 'bg-green-50 text-green-700'
+                          : healthScore >= 80
+                            ? 'bg-emerald-50 text-emerald-700'
+                            : healthScore >= 70
+                              ? 'bg-amber-50 text-amber-700'
+                              : 'bg-red-50 text-red-700'
+                      }`}
+                    >
+                      {healthScore}
                     </div>
-                    <p className={`text-xs ${muted}`}>Health score</p>
+                    <div>
+                      <div className="flex items-center gap-1.5">
+                        {healthTrend === 'down' ? (
+                          <TrendingDown className="h-4 w-4 text-red-600" />
+                        ) : (
+                          <TrendingUp className="h-4 w-4 text-green-600" />
+                        )}
+                        <span
+                          className={`text-sm ${healthTrend === 'down' ? 'text-red-600' : 'text-green-600'}`}
+                        >
+                          {healthTrend === 'down' ? 'Declining' : 'Improving'}
+                        </span>
+                      </div>
+                      <p className={`text-xs ${muted}`}>Health score</p>
+                    </div>
                   </div>
-                </div>
 
-                <p className={`text-sm ${muted}`}>
-                  Policy scoring and compliance checks will appear here.
-                </p>
+                  <p className={`text-sm ${muted}`}>
+                    Policy scoring and compliance checks will appear here.
+                  </p>
+                </CardContent>
               </Card>
 
               {/* Recent Activity (mocked) */}
-              <Card
-                className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-              >
-                <h3 className={`mb-4 ${value}`}>Recent Activity</h3>
-
-                <div className="space-y-4">
-                  {feed.map((item, index) => (
-                    <div key={index} className="flex items-start gap-2.5">
-                      <div className="min-w-0 flex-1">
-                        <p className={`text-sm leading-snug ${value}`}>
-                          <span className="font-medium">{item.user}</span>{' '}
-                          <span className={label}>{item.action}</span>{' '}
-                          <span
-                            style={{
-                              color:
-                                project.environments?.find(
-                                  (e) => e.name === item.environment,
-                                )?.label_color || undefined,
-                            }}
-                          >
-                            {item.environment}
-                          </span>
-                        </p>
-                        <div className="mt-0.5 flex items-center gap-1.5">
-                          <span className={`text-xs ${muted}`}>
-                            {item.time}
-                          </span>
-                          <span className={`text-xs ${muted}`}>&bull;</span>
-                          <span
-                            className={`font-mono text-xs ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
-                          >
-                            {item.version}
-                          </span>
+              <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+                <CardHeader>
+                  <CardTitle>Recent activity</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    {feed.map((item, index) => (
+                      <div key={index} className="flex items-start gap-2.5">
+                        <div className="min-w-0 flex-1">
+                          <p className={`text-sm leading-snug ${value}`}>
+                            <span className="font-medium">{item.user}</span>{' '}
+                            <span className={label}>{item.action}</span>{' '}
+                            <span
+                              style={{
+                                color:
+                                  project.environments?.find(
+                                    (e) => e.name === item.environment,
+                                  )?.label_color || undefined,
+                              }}
+                            >
+                              {item.environment}
+                            </span>
+                          </p>
+                          <div className="mt-0.5 flex items-center gap-1.5">
+                            <span className={`text-xs ${muted}`}>
+                              {item.time}
+                            </span>
+                            <span className={`text-xs ${muted}`}>&bull;</span>
+                            <span
+                              className={`font-mono text-xs ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
+                            >
+                              {item.version}
+                            </span>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  ))}
-                </div>
+                    ))}
+                  </div>
+                </CardContent>
               </Card>
             </div>
           </div>
@@ -814,20 +830,23 @@ function RelationshipsTab({
   const [filter, setFilter] = useState<RelFilter>('all')
   const [editDialogOpen, setEditDialogOpen] = useState(false)
 
-  const cardClass = `p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`
   const sub = isDarkMode ? 'text-gray-400' : 'text-slate-500'
 
   if (isLoading) {
     return (
-      <Card className={cardClass}>
-        <p className={sub}>Loading relationships…</p>
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent>
+          <p className={sub}>Loading relationships…</p>
+        </CardContent>
       </Card>
     )
   }
   if (isError && !data) {
     return (
-      <Card className={cardClass}>
-        <p className={sub}>Failed to load relationships.</p>
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent>
+          <p className={sub}>Failed to load relationships.</p>
+        </CardContent>
       </Card>
     )
   }
@@ -890,15 +909,17 @@ function RelationshipsTab({
   return (
     <>
       {rels.length === 0 ? (
-        <Card className={`${cardClass} flex items-center justify-between`}>
-          <p className={sub}>This project has no relationships.</p>
-          <Button
-            size="sm"
-            className="gap-1 border-amber-border bg-amber-bg text-amber-text hover:bg-amber-bg/80"
-            onClick={() => setEditDialogOpen(true)}
-          >
-            Edit
-          </Button>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="flex items-center justify-between">
+            <p className={sub}>This project has no relationships.</p>
+            <Button
+              size="sm"
+              className="gap-1 border-amber-border bg-amber-bg text-amber-text hover:bg-amber-bg/80"
+              onClick={() => setEditDialogOpen(true)}
+            >
+              Edit
+            </Button>
+          </CardContent>
         </Card>
       ) : (
         <div
@@ -973,77 +994,80 @@ function RelationshipsSidebar({
 
   return (
     <Card
-      className={`h-full min-h-0 w-full flex-shrink-0 overflow-y-auto p-4 ${
+      className={`h-full min-h-0 w-full flex-shrink-0 overflow-y-auto ${
         isDarkMode ? 'border-gray-700 bg-gray-800' : ''
       }`}
     >
-      {/* Filter chips + Add button */}
-      <div className="mb-4 flex items-center justify-between">
-        <div className="flex flex-wrap gap-1.5">
-          {(['all', 'uses', 'used-by'] as const).map((f) => (
-            <button
-              key={f}
-              type="button"
-              aria-pressed={filter === f}
-              onClick={() => onFilterChange(f)}
-              className={`${chipBase} ${filter === f ? chipSelected : chipUnselected}`}
+      <CardHeader className="p-4 pb-2">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-wrap gap-1.5">
+            {(['all', 'uses', 'used-by'] as const).map((f) => (
+              <button
+                key={f}
+                type="button"
+                aria-pressed={filter === f}
+                onClick={() => onFilterChange(f)}
+                className={`${chipBase} ${filter === f ? chipSelected : chipUnselected}`}
+              >
+                {f === 'all' ? 'All' : f === 'uses' ? 'Uses' : 'Used by'}
+              </button>
+            ))}
+          </div>
+          <Button variant="ghost" size="sm" onClick={onAdd}>
+            Edit
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-4 pt-2">
+        {/* Outbound (USES) section */}
+        {outboundVisible && (
+          <div className="mb-4">
+            <h4
+              className={`mb-2 text-[10px] font-medium uppercase tracking-[0.12em] ${sectionLabel}`}
             >
-              {f === 'all' ? 'All' : f === 'uses' ? 'Uses' : 'Used by'}
-            </button>
-          ))}
-        </div>
-        <Button variant="ghost" size="sm" onClick={onAdd}>
-          Edit
-        </Button>
-      </div>
+              Uses
+            </h4>
+            {outbound.length === 0 ? (
+              <p className={`text-xs ${sub}`}>None</p>
+            ) : (
+              <ul className="space-y-1">
+                {outbound.map((r, i) => (
+                  <SidebarProjectRow
+                    key={`out:${r.project.id}:${i}`}
+                    rel={r}
+                    isDarkMode={isDarkMode}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
 
-      {/* Outbound (USES) section */}
-      {outboundVisible && (
-        <div className="mb-4">
-          <h4
-            className={`mb-2 text-[10px] font-medium uppercase tracking-[0.12em] ${sectionLabel}`}
-          >
-            Uses
-          </h4>
-          {outbound.length === 0 ? (
-            <p className={`text-xs ${sub}`}>None</p>
-          ) : (
-            <ul className="space-y-1">
-              {outbound.map((r, i) => (
-                <SidebarProjectRow
-                  key={`out:${r.project.id}:${i}`}
-                  rel={r}
-                  isDarkMode={isDarkMode}
-                />
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
-
-      {/* Inbound (USED BY) section */}
-      {inboundVisible && (
-        <div>
-          <h4
-            className={`mb-2 text-[10px] font-medium uppercase tracking-[0.12em] ${sectionLabel}`}
-          >
-            Used by
-          </h4>
-          {inbound.length === 0 ? (
-            <p className={`text-xs ${sub}`}>None</p>
-          ) : (
-            <ul className="space-y-1">
-              {inbound.map((r, i) => (
-                <SidebarProjectRow
-                  key={`in:${r.project.id}:${i}`}
-                  rel={r}
-                  isDarkMode={isDarkMode}
-                />
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
+        {/* Inbound (USED BY) section */}
+        {inboundVisible && (
+          <div>
+            <h4
+              className={`mb-2 text-[10px] font-medium uppercase tracking-[0.12em] ${sectionLabel}`}
+            >
+              Used by
+            </h4>
+            {inbound.length === 0 ? (
+              <p className={`text-xs ${sub}`}>None</p>
+            ) : (
+              <ul className="space-y-1">
+                {inbound.map((r, i) => (
+                  <SidebarProjectRow
+                    key={`in:${r.project.id}:${i}`}
+                    rel={r}
+                    isDarkMode={isDarkMode}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </CardContent>
     </Card>
   )
 }
@@ -1171,23 +1195,23 @@ function SettingsTab({
       <EditProjectForm project={project} isDarkMode={isDarkMode} />
 
       {linkDefsLoading && (
-        <Card
-          className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-        >
-          <p
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
-          >
-            Loading link definitions...
-          </p>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent>
+            <p
+              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-slate-500'}`}
+            >
+              Loading link definitions...
+            </p>
+          </CardContent>
         </Card>
       )}
       {linkDefsError && (
-        <Card
-          className={`p-6 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-        >
-          <p className="text-sm text-red-600 dark:text-red-400">
-            Failed to load link definitions.
-          </p>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent>
+            <p className="text-sm text-red-600 dark:text-red-400">
+              Failed to load link definitions.
+            </p>
+          </CardContent>
         </Card>
       )}
       {!linkDefsLoading && !linkDefsError && linkDefs.length > 0 && (
@@ -1221,115 +1245,106 @@ function SettingsTab({
       />
 
       <Card
-        className={`border-amber-300 p-6 ${isDarkMode ? 'border-amber-700 bg-gray-800' : ''}`}
+        className={`border-amber-300 ${isDarkMode ? 'border-amber-700 bg-gray-800' : ''}`}
       >
-        <h3
-          className={`mb-2 font-semibold ${isDarkMode ? 'text-amber-500' : 'text-amber-700'}`}
-        >
-          Archive Project
-        </h3>
-        <p
-          className={`mb-1 text-sm ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
-        >
-          Archiving the project will make it entirely read only.
-        </p>
-        <p
-          className={`mb-4 text-sm font-medium ${isDarkMode ? 'text-amber-400' : 'text-amber-700'}`}
-        >
-          It will be hidden from the dashboard, won&apos;t show up in searches,
-          and will be disabled as a dependency for any other projects that are
-          dependent upon it.
-        </p>
-        <Button variant="outline" size="sm" disabled>
-          Archive Project
-        </Button>
+        <CardHeader>
+          <CardTitle>Archive project</CardTitle>
+          <CardDescription
+            className={isDarkMode ? 'text-gray-300' : 'text-slate-700'}
+          >
+            Archiving the project will make it entirely read only. It will be
+            hidden from the dashboard, won&apos;t show up in searches, and will
+            be disabled as a dependency for any other projects that are
+            dependent upon it.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button variant="outline" size="sm" disabled>
+            Archive project
+          </Button>
+        </CardContent>
       </Card>
 
       <Card
-        className={`border-red-300 p-6 ${isDarkMode ? 'border-red-800 bg-gray-800' : ''}`}
+        className={`border-red-300 ${isDarkMode ? 'border-red-800 bg-gray-800' : ''}`}
       >
-        <h3
-          className={`mb-2 font-semibold ${isDarkMode ? 'text-red-500' : 'text-red-700'}`}
-        >
-          Delete Project
-        </h3>
-        <p
-          className={`mb-1 text-sm ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
-        >
-          This action will <strong>permanently delete</strong>{' '}
-          <code
-            className={`rounded px-1.5 py-0.5 font-mono text-sm ${isDarkMode ? 'bg-gray-700 text-white' : 'bg-slate-100 text-slate-900'}`}
+        <CardHeader>
+          <CardTitle>Delete project</CardTitle>
+          <CardDescription
+            className={isDarkMode ? 'text-gray-300' : 'text-slate-700'}
           >
-            {project.slug}
-          </code>{' '}
-          immediately, removing the project and all associated data, including
-          facts, operation logs, and notes.
-        </p>
-        <p
-          className={`mb-4 text-sm font-medium ${isDarkMode ? 'text-red-400' : 'text-red-700'}`}
-        >
-          Are you ABSOLUTELY SURE you wish to delete this project?
-        </p>
-        {!showDeleteConfirm ? (
-          <Button
-            variant="outline"
-            size="sm"
-            className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
-            onClick={() => setShowDeleteConfirm(true)}
-            disabled={!projectTypeSlug}
-          >
-            Delete Project
-          </Button>
-        ) : (
-          <div className="space-y-3">
-            <p
-              className={`text-sm ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
+            This action will <strong>permanently delete</strong>{' '}
+            <code
+              className={`rounded px-1.5 py-0.5 font-mono text-sm ${isDarkMode ? 'bg-gray-700 text-white' : 'bg-slate-100 text-slate-900'}`}
             >
-              Type{' '}
-              <code
-                className={`rounded px-1.5 py-0.5 font-mono text-sm ${isDarkMode ? 'bg-gray-700 text-white' : 'bg-slate-100 text-slate-900'}`}
+              {project.slug}
+            </code>{' '}
+            immediately, removing the project and all associated data, including
+            facts, operation logs, and notes. Are you absolutely sure?
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!showDeleteConfirm ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
+              onClick={() => setShowDeleteConfirm(true)}
+              disabled={!projectTypeSlug}
+            >
+              Delete Project
+            </Button>
+          ) : (
+            <div className="space-y-3">
+              <p
+                className={`text-sm ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}
               >
-                {project.slug}
-              </code>{' '}
-              to confirm deletion:
-            </p>
-            <Input
-              value={deleteConfirmSlug}
-              onChange={(e) => setDeleteConfirmSlug(e.target.value)}
-              placeholder={project.slug}
-              disabled={deleteMutation.isPending}
-              className={
-                isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
-              }
-            />
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
-                onClick={() => deleteMutation.mutate()}
-                disabled={
-                  deleteConfirmSlug !== project.slug ||
-                  deleteMutation.isPending ||
-                  !projectTypeSlug
-                }
-              >
-                {deleteMutation.isPending ? 'Deleting...' : 'Confirm Delete'}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setShowDeleteConfirm(false)
-                  setDeleteConfirmSlug('')
-                }}
+                Type{' '}
+                <code
+                  className={`rounded px-1.5 py-0.5 font-mono text-sm ${isDarkMode ? 'bg-gray-700 text-white' : 'bg-slate-100 text-slate-900'}`}
+                >
+                  {project.slug}
+                </code>{' '}
+                to confirm deletion:
+              </p>
+              <Input
+                value={deleteConfirmSlug}
+                onChange={(e) => setDeleteConfirmSlug(e.target.value)}
+                placeholder={project.slug}
                 disabled={deleteMutation.isPending}
-              >
-                Cancel
-              </Button>
+                className={
+                  isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+                }
+              />
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
+                  onClick={() => deleteMutation.mutate()}
+                  disabled={
+                    deleteConfirmSlug !== project.slug ||
+                    deleteMutation.isPending ||
+                    !projectTypeSlug
+                  }
+                >
+                  {deleteMutation.isPending ? 'Deleting...' : 'Confirm Delete'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setShowDeleteConfirm(false)
+                    setDeleteConfirmSlug('')
+                  }}
+                  disabled={deleteMutation.isPending}
+                >
+                  Cancel
+                </Button>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </CardContent>
       </Card>
     </div>
   )
@@ -1343,17 +1358,15 @@ function PlaceholderTab({
   isDarkMode: boolean
 }) {
   return (
-    <Card className={`p-12 ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}>
-      <div className="text-center">
-        <h3
-          className={`mb-2 text-lg ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
+    <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+      <CardContent className="py-12 text-center">
+        <CardTitle>{name}</CardTitle>
+        <CardDescription
+          className={isDarkMode ? 'text-gray-400' : 'text-slate-500'}
         >
-          {name}
-        </h3>
-        <p className={isDarkMode ? 'text-gray-400' : 'text-slate-500'}>
           This tab will be implemented in a future update.
-        </p>
-      </div>
+        </CardDescription>
+      </CardContent>
     </Card>
   )
 }

--- a/src/components/ProjectsGraphCanvas.tsx
+++ b/src/components/ProjectsGraphCanvas.tsx
@@ -18,7 +18,7 @@ import {
 } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
+import { Card, CardHeader, CardContent } from '@/components/ui/card'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -258,8 +258,8 @@ export function ProjectsGraphCanvas({
         } ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
       >
         {/* Toolbar */}
-        <div
-          className={`flex flex-shrink-0 items-center gap-2 border-b px-4 py-3 ${
+        <CardHeader
+          className={`flex-shrink-0 flex-row items-center gap-2 space-y-0 border-b px-4 py-3 ${
             isDarkMode ? 'border-gray-700' : 'border-gray-200'
           }`}
         >
@@ -384,11 +384,11 @@ export function ProjectsGraphCanvas({
               Double-click to open
             </span>
           </div>
-        </div>
+        </CardHeader>
 
         {/* Canvas */}
-        <div
-          className={`relative ${isFullscreen ? 'flex-1' : 'min-h-[400px] flex-1'}`}
+        <CardContent
+          className={`relative p-0 ${isFullscreen ? 'flex-1' : 'min-h-[400px] flex-1'}`}
         >
           {isRendering && nodes.length > 0 && (
             <div
@@ -431,7 +431,7 @@ export function ProjectsGraphCanvas({
               onNodeDoubleClick={handleNodeDoubleClick}
             />
           )}
-        </div>
+        </CardContent>
       </Card>
     </div>
   )

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -5,7 +5,6 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   Plus,
   Search,
-  Edit2,
   FileJson,
   AlertCircle,
   CheckCircle,
@@ -532,29 +531,6 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
           deleteMutation.mutate({ type: blueprintPathType(bp), slug: bp.slug })
         }
         isDeleting={deleteMutation.isPending}
-        actions={(bp) => (
-          <TooltipProvider delayDuration={200}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    handleEditClick({
-                      type: blueprintPathType(bp),
-                      slug: bp.slug,
-                    })
-                  }}
-                  className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-secondary hover:text-primary"
-                >
-                  <Edit2 className="h-4 w-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Edit</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
         emptyMessage={
           searchQuery || typeFilter || enabledFilter
             ? 'No blueprints match your filters'

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -15,6 +15,7 @@ import {
   Filter,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import { BlueprintForm } from './blueprints/BlueprintForm'
 import { BlueprintDetail } from './blueprints/BlueprintDetail'
@@ -141,13 +142,15 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
     slug: selectedSlug,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
   const [typeFilter, setTypeFilter] = useState<string>('')
   const [enabledFilter, setEnabledFilter] = useState<string>('')
   const [importDialogOpen, setImportDialogOpen] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<
+    (BlueprintKey & { name: string }) | null
+  >(null)
 
   // Parse compound key from URL slug (format: "type:slug")
   const selectedKey = useMemo<BlueprintKey | null>(() => {
@@ -255,13 +258,17 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
     return true
   })
 
-  const handleDelete = (key: BlueprintKey) => {
-    if (
-      confirm(
-        'Are you sure you want to delete this blueprint? This action cannot be undone.',
-      )
-    ) {
-      deleteMutation.mutate(key)
+  const handleDelete = (key: BlueprintKey, name: string) => {
+    setDeleteTarget({ ...key, name })
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate({
+        type: deleteTarget.type,
+        slug: deleteTarget.slug,
+      })
+      setDeleteTarget(null)
     }
   }
 
@@ -274,7 +281,7 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
   }
 
   const handleViewClick = (key: BlueprintKey) => {
-    goToDetail(`${key.type}:${key.slug}`)
+    goToEdit(`${key.type}:${key.slug}`)
   }
 
   const handleSave = (data: BlueprintCreate) => {
@@ -372,6 +379,12 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
   // View mode: List (default)
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex flex-1 items-center gap-3">
@@ -542,10 +555,13 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
                         <button
                           onClick={(e) => {
                             e.stopPropagation()
-                            handleDelete({
-                              type: blueprintPathType(bp),
-                              slug: bp.slug,
-                            })
+                            handleDelete(
+                              {
+                                type: blueprintPathType(bp),
+                                slug: bp.slug,
+                              },
+                              bp.name,
+                            )
                           }}
                           disabled={deleteMutation.isPending}
                           className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-danger hover:text-danger"

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -17,6 +17,12 @@ import {
 import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { BlueprintForm } from './blueprints/BlueprintForm'
 import { BlueprintDetail } from './blueprints/BlueprintDetail'
 import { ImportBlueprintDialog } from './blueprints/ImportBlueprintDialog'
@@ -120,18 +126,27 @@ function renderFilterCell(
 ): React.ReactNode {
   const f = parseFilterFromBlueprint(filter)
   if (!f) return null
-  const title = [
+  const tooltipLines = [
     f.project_type?.length ? `Project Types: ${f.project_type.join(', ')}` : '',
     f.environment?.length ? `Environments: ${f.environment.join(', ')}` : '',
-  ]
-    .filter(Boolean)
-    .join('\n')
+  ].filter(Boolean)
   return (
-    <span title={title}>
-      <Filter
-        className={`mx-auto h-4 w-4 ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}
-      />
-    </span>
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span>
+            <Filter
+              className={`mx-auto h-4 w-4 ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          {tooltipLines.map((line) => (
+            <p key={line}>{line}</p>
+          ))}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 
@@ -539,36 +554,52 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
                     </td>
                     <td className="whitespace-nowrap px-5 py-3.5">
                       <div className="flex items-center justify-end gap-1">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleEditClick({
-                              type: blueprintPathType(bp),
-                              slug: bp.slug,
-                            })
-                          }}
-                          className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-secondary hover:text-primary"
-                          title="Edit"
-                        >
-                          <Edit2 className="h-4 w-4" />
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleDelete(
-                              {
-                                type: blueprintPathType(bp),
-                                slug: bp.slug,
-                              },
-                              bp.name,
-                            )
-                          }}
-                          disabled={deleteMutation.isPending}
-                          className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-danger hover:text-danger"
-                          title="Delete"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  handleEditClick({
+                                    type: blueprintPathType(bp),
+                                    slug: bp.slug,
+                                  })
+                                }}
+                                className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-secondary hover:text-primary"
+                              >
+                                <Edit2 className="h-4 w-4" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Edit</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  handleDelete(
+                                    {
+                                      type: blueprintPathType(bp),
+                                      slug: bp.slug,
+                                    },
+                                    bp.name,
+                                  )
+                                }}
+                                disabled={deleteMutation.isPending}
+                                className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-danger hover:text-danger"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Delete</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       </div>
                     </td>
                   </tr>

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -6,7 +6,6 @@ import {
   Plus,
   Search,
   Edit2,
-  Trash2,
   FileJson,
   AlertCircle,
   CheckCircle,
@@ -15,8 +14,8 @@ import {
   Filter,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
+import { AdminTable } from '@/components/ui/admin-table'
 import {
   Tooltip,
   TooltipContent,
@@ -163,9 +162,6 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
   const [typeFilter, setTypeFilter] = useState<string>('')
   const [enabledFilter, setEnabledFilter] = useState<string>('')
   const [importDialogOpen, setImportDialogOpen] = useState(false)
-  const [deleteTarget, setDeleteTarget] = useState<
-    (BlueprintKey & { name: string }) | null
-  >(null)
 
   // Parse compound key from URL slug (format: "type:slug")
   const selectedKey = useMemo<BlueprintKey | null>(() => {
@@ -272,20 +268,6 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
     if (enabledFilter === 'disabled' && bp.enabled) return false
     return true
   })
-
-  const handleDelete = (key: BlueprintKey, name: string) => {
-    setDeleteTarget({ ...key, name })
-  }
-
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate({
-        type: deleteTarget.type,
-        slug: deleteTarget.slug,
-      })
-      setDeleteTarget(null)
-    }
-  }
 
   const handleCreateClick = () => {
     goToCreate()
@@ -394,12 +376,6 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
   // View mode: List (default)
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex flex-1 items-center gap-3">
@@ -454,161 +430,137 @@ export function BlueprintManagement({ isDarkMode }: BlueprintManagementProps) {
         </div>
       </div>
 
-      {/* Blueprints Table */}
-      <div className="overflow-hidden rounded-md border border-tertiary bg-primary">
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th className="px-5 py-3 text-left text-xs font-medium uppercase tracking-wider text-secondary">
-                  Name
-                </th>
-                <th className="px-5 py-3 text-left text-xs font-medium uppercase tracking-wider text-secondary">
-                  Slug
-                </th>
-                <th className="px-5 py-3 text-left text-xs font-medium uppercase tracking-wider text-secondary">
-                  Type
-                </th>
-                <th className="px-5 py-3 text-center text-xs font-medium uppercase tracking-wider text-secondary">
-                  Enabled
-                </th>
-                <th className="px-5 py-3 text-center text-xs font-medium uppercase tracking-wider text-secondary">
-                  Filter
-                </th>
-                <th className="px-5 py-3 text-center text-xs font-medium uppercase tracking-wider text-secondary">
-                  Priority
-                </th>
-                <th className="px-5 py-3 text-center text-xs font-medium uppercase tracking-wider text-secondary">
-                  Version
-                </th>
-                <th className="px-5 py-3 text-right text-xs font-medium uppercase tracking-wider text-secondary">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-[var(--color-border-tertiary)]">
-              {filteredBlueprints.length === 0 ? (
-                <tr>
-                  <td colSpan={8} className="px-5 py-12 text-center">
-                    <div className="text-sm text-tertiary">
-                      {searchQuery || typeFilter || enabledFilter
-                        ? 'No blueprints match your filters'
-                        : 'No blueprints created yet'}
+      <AdminTable<Blueprint>
+        columns={[
+          {
+            key: 'name',
+            header: 'Name',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (bp) => (
+              <div className="flex items-center gap-2.5">
+                <FileJson className="h-4 w-4 flex-shrink-0 text-amber-text-mid" />
+                <div>
+                  <span className="text-sm font-medium text-primary">
+                    {bp.name}
+                  </span>
+                  {bp.description && (
+                    <div className="mt-0.5 text-xs text-tertiary">
+                      {bp.description}
                     </div>
-                  </td>
-                </tr>
+                  )}
+                </div>
+              </div>
+            ),
+          },
+          {
+            key: 'slug',
+            header: 'Slug',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (bp) => (
+              <span className="whitespace-nowrap font-mono text-sm text-secondary">
+                {bp.slug}
+              </span>
+            ),
+          },
+          {
+            key: 'type',
+            header: 'Type',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (bp) => (
+              <span
+                className={`inline-flex items-center whitespace-nowrap rounded-sm px-2 py-0.5 text-xs font-medium ${getTypeBadgeClasses(blueprintPathType(bp), blueprintTypes, isDarkMode)}`}
+              >
+                {blueprintTypeLabel(bp)}
+              </span>
+            ),
+          },
+          {
+            key: 'enabled',
+            header: 'Enabled',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (bp) =>
+              bp.enabled ? (
+                <CheckCircle className="mx-auto h-4 w-4 text-success" />
               ) : (
-                filteredBlueprints.map((bp: Blueprint) => (
-                  <tr
-                    key={`${blueprintPathType(bp)}/${bp.slug}`}
-                    onClick={() =>
-                      handleViewClick({
-                        type: blueprintPathType(bp),
-                        slug: bp.slug,
-                      })
-                    }
-                    className="cursor-pointer transition-colors hover:bg-secondary"
-                  >
-                    <td className="px-5 py-3.5">
-                      <div className="flex items-center gap-2.5">
-                        <FileJson className="h-4 w-4 flex-shrink-0 text-amber-text-mid" />
-                        <div>
-                          <span className="text-sm font-medium text-primary">
-                            {bp.name}
-                          </span>
-                          {bp.description && (
-                            <div className="mt-0.5 text-xs text-tertiary">
-                              {bp.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5 font-mono text-sm text-secondary">
-                      {bp.slug}
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5">
-                      <span
-                        className={`inline-flex items-center rounded-sm px-2 py-0.5 text-xs font-medium ${getTypeBadgeClasses(blueprintPathType(bp), blueprintTypes, isDarkMode)}`}
-                      >
-                        {blueprintTypeLabel(bp)}
-                      </span>
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5 text-center">
-                      {bp.enabled ? (
-                        <CheckCircle className="mx-auto h-4 w-4 text-success" />
-                      ) : (
-                        <XCircle className="mx-auto h-4 w-4 text-tertiary" />
-                      )}
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5 text-center">
-                      {renderFilterCell(bp.filter, isDarkMode) || (
-                        <span className="text-xs text-tertiary">&mdash;</span>
-                      )}
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5 text-center text-sm text-primary">
-                      {bp.priority}
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5 text-center font-mono text-sm text-secondary">
-                      v{bp.version}
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5">
-                      <div className="flex items-center justify-end gap-1">
-                        <TooltipProvider delayDuration={200}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleEditClick({
-                                    type: blueprintPathType(bp),
-                                    slug: bp.slug,
-                                  })
-                                }}
-                                className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-secondary hover:text-primary"
-                              >
-                                <Edit2 className="h-4 w-4" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>Edit</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                        <TooltipProvider delayDuration={200}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleDelete(
-                                    {
-                                      type: blueprintPathType(bp),
-                                      slug: bp.slug,
-                                    },
-                                    bp.name,
-                                  )
-                                }}
-                                disabled={deleteMutation.isPending}
-                                className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-danger hover:text-danger"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>Delete</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      </div>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
+                <XCircle className="mx-auto h-4 w-4 text-tertiary" />
+              ),
+          },
+          {
+            key: 'filter',
+            header: 'Filter',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (bp) =>
+              renderFilterCell(bp.filter, isDarkMode) || (
+                <span className="text-xs text-tertiary">&mdash;</span>
+              ),
+          },
+          {
+            key: 'priority',
+            header: 'Priority',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (bp) => (
+              <span className="whitespace-nowrap text-sm text-primary">
+                {bp.priority}
+              </span>
+            ),
+          },
+          {
+            key: 'version',
+            header: 'Version',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (bp) => (
+              <span className="whitespace-nowrap font-mono text-sm text-secondary">
+                v{bp.version}
+              </span>
+            ),
+          },
+        ]}
+        rows={filteredBlueprints}
+        getRowKey={(bp) => `${blueprintPathType(bp)}/${bp.slug}`}
+        getDeleteLabel={(bp) => bp.name}
+        onRowClick={(bp) =>
+          handleViewClick({ type: blueprintPathType(bp), slug: bp.slug })
+        }
+        onDelete={(bp) =>
+          deleteMutation.mutate({ type: blueprintPathType(bp), slug: bp.slug })
+        }
+        isDeleting={deleteMutation.isPending}
+        actions={(bp) => (
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleEditClick({
+                      type: blueprintPathType(bp),
+                      slug: bp.slug,
+                    })
+                  }}
+                  className="rounded-sm p-1.5 text-tertiary transition-colors hover:bg-secondary hover:text-primary"
+                >
+                  <Edit2 className="h-4 w-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Edit</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+        emptyMessage={
+          searchQuery || typeFilter || enabledFilter
+            ? 'No blueprints match your filters'
+            : 'No blueprints created yet'
+        }
+      />
 
       {/* Import Dialog */}
       <ImportBlueprintDialog

--- a/src/components/admin/EnvironmentManagement.tsx
+++ b/src/components/admin/EnvironmentManagement.tsx
@@ -6,8 +6,10 @@ import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
+import { Card, CardContent } from '@/components/ui/card'
 import { EnvironmentForm } from './environments/EnvironmentForm'
 import { EnvironmentDetail } from './environments/EnvironmentDetail'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import {
@@ -33,10 +35,14 @@ export function EnvironmentManagement({
     slug: selectedEnvSlug,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+    orgSlug: string
+  } | null>(null)
 
   const {
     data: environments = [],
@@ -109,12 +115,22 @@ export function EnvironmentManagement({
   )
 
   const handleDelete = (slug: string) => {
-    const env = environments.find((e) => e.slug === slug)
-    if (
-      env &&
-      confirm(`Delete environment "${env.name}"? This action cannot be undone.`)
-    ) {
-      deleteMutation.mutate({ orgSlug: env.organization.slug, slug })
+    const item = environments.find((x) => x.slug === slug)
+    if (item)
+      setDeleteTarget({
+        slug,
+        name: item.name,
+        orgSlug: item.organization.slug,
+      })
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate({
+        orgSlug: deleteTarget.orgSlug,
+        slug: deleteTarget.slug,
+      })
+      setDeleteTarget(null)
     }
   }
 
@@ -202,6 +218,12 @@ export function EnvironmentManagement({
 
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -229,202 +251,198 @@ export function EnvironmentManagement({
       </div>
 
       {/* Environments Table */}
-      <div
-        className={`rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Environment
-                </th>
-                <th
-                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Slug
-                </th>
-                <th
-                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Order
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Projects
-                </th>
-                <th
-                  className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Last Updated
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-            >
-              {filteredEnvironments.map((env) => (
-                <tr
-                  key={env.slug}
-                  onClick={() => goToDetail(env.slug)}
-                  onKeyDown={(e) => {
-                    if (e.currentTarget !== e.target) return
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      goToDetail(env.slug)
-                    }
-                  }}
-                  tabIndex={0}
-                  aria-label={`View environment ${env.name}`}
-                  className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                >
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                      <div
-                        className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                          isDarkMode ? 'bg-green-900/30' : 'bg-green-50'
-                        }`}
-                      >
-                        {env.icon ? (
-                          <EntityIcon
-                            icon={env.icon}
-                            className="h-5 w-5 rounded object-cover"
-                          />
-                        ) : (
-                          <Globe
-                            className={`h-4 w-4 ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
-                          />
-                        )}
-                      </div>
-                      <div>
-                        <div
-                          className={
-                            isDarkMode ? 'text-white' : 'text-gray-900'
-                          }
-                        >
-                          {env.name}
-                        </div>
-                        {env.description && (
-                          <div
-                            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                          >
-                            {env.description}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-center text-sm">
-                    {env.label_color ? (
-                      <span
-                        className="rounded px-2 py-1 text-xs font-medium"
-                        style={{
-                          backgroundColor: env.label_color + '20',
-                          color: env.label_color,
-                          border: `1px solid ${env.label_color}40`,
-                        }}
-                      >
-                        {env.slug}
-                      </span>
-                    ) : (
-                      <code
-                        className={`rounded px-2 py-1 ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
-                        }`}
-                      >
-                        {env.slug}
-                      </code>
-                    )}
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                  >
-                    {env.sort_order ?? 0}
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                      (env.relationships?.projects?.count ?? 0) === 0
-                        ? isDarkMode
-                          ? 'text-gray-600'
-                          : 'text-gray-400'
-                        : isDarkMode
-                          ? 'text-gray-300'
-                          : 'text-gray-600'
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="border-b border-tertiary bg-secondary">
+                <tr>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
                     }`}
                   >
-                    {env.relationships?.projects?.count ?? 0}
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    Environment
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
                   >
-                    {formatRelativeDate(env.updated_at ?? env.created_at)}
-                  </td>
-                  <td
-                    className="whitespace-nowrap px-6 py-4 text-right"
-                    onClick={(e) => e.stopPropagation()}
-                    onKeyDown={(e) => e.stopPropagation()}
+                    Slug
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
                   >
-                    <div className="flex items-center justify-end gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        aria-label={`Delete environment ${env.name}`}
-                        onClick={() => handleDelete(env.slug)}
-                        disabled={deleteMutation.isPending}
-                        className={
-                          isDarkMode
-                            ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                            : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                        }
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </td>
+                    Order
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Projects
+                  </th>
+                  <th
+                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Last Updated
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Actions
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody
+                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+              >
+                {filteredEnvironments.map((env) => (
+                  <tr
+                    key={env.slug}
+                    onClick={() => goToEdit(env.slug)}
+                    onKeyDown={(e) => {
+                      if (e.currentTarget !== e.target) return
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        goToEdit(env.slug)
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-label={`Edit environment ${env.name}`}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                  >
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                            isDarkMode ? 'bg-green-900/30' : 'bg-green-50'
+                          }`}
+                        >
+                          {env.icon ? (
+                            <EntityIcon
+                              icon={env.icon}
+                              className="h-5 w-5 rounded object-cover"
+                            />
+                          ) : (
+                            <Globe
+                              className={`h-4 w-4 ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
+                            />
+                          )}
+                        </div>
+                        <div>
+                          <div
+                            className={
+                              isDarkMode ? 'text-white' : 'text-gray-900'
+                            }
+                          >
+                            {env.name}
+                          </div>
+                          {env.description && (
+                            <div
+                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                            >
+                              {env.description}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-center text-sm">
+                      {env.label_color ? (
+                        <span
+                          className="rounded px-2 py-1 text-xs font-medium"
+                          style={{
+                            backgroundColor: env.label_color + '20',
+                            color: env.label_color,
+                            border: `1px solid ${env.label_color}40`,
+                          }}
+                        >
+                          {env.slug}
+                        </span>
+                      ) : (
+                        <code
+                          className={`rounded px-2 py-1 ${
+                            isDarkMode
+                              ? 'bg-gray-700 text-gray-300'
+                              : 'bg-gray-100 text-gray-700'
+                          }`}
+                        >
+                          {env.slug}
+                        </code>
+                      )}
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      {env.sort_order ?? 0}
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
+                        (env.relationships?.projects?.count ?? 0) === 0
+                          ? isDarkMode
+                            ? 'text-gray-600'
+                            : 'text-gray-400'
+                          : isDarkMode
+                            ? 'text-gray-300'
+                            : 'text-gray-600'
+                      }`}
+                    >
+                      {env.relationships?.projects?.count ?? 0}
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      {formatRelativeDate(env.updated_at ?? env.created_at)}
+                    </td>
+                    <td
+                      className="whitespace-nowrap px-6 py-4 text-right"
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex items-center justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Delete environment ${env.name}`}
+                          onClick={() => handleDelete(env.slug)}
+                          disabled={deleteMutation.isPending}
+                          className={
+                            isDarkMode
+                              ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
+                              : 'text-red-600 hover:bg-red-50 hover:text-red-700'
+                          }
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
 
-          {filteredEnvironments.length === 0 && (
-            <div
-              className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-            >
-              {searchQuery
-                ? 'No environments found matching your search.'
-                : selectedOrganization
-                  ? `No environments in ${selectedOrganization.name} yet.`
-                  : 'No environments created yet.'}
-            </div>
-          )}
-        </div>
-      </div>
+            {filteredEnvironments.length === 0 && (
+              <div
+                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                {searchQuery
+                  ? 'No environments found matching your search.'
+                  : selectedOrganization
+                    ? `No environments in ${selectedOrganization.name} yet.`
+                    : 'No environments created yet.'}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/EnvironmentManagement.tsx
+++ b/src/components/admin/EnvironmentManagement.tsx
@@ -1,15 +1,15 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import { Plus, Search, Trash2, Globe, AlertCircle } from 'lucide-react'
+import { Plus, Search, Globe, AlertCircle } from 'lucide-react'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
-import { Card, CardContent } from '@/components/ui/card'
+import { AdminTable } from '@/components/ui/admin-table'
+import type { CanDeleteResult } from '@/components/ui/admin-table'
 import { EnvironmentForm } from './environments/EnvironmentForm'
 import { EnvironmentDetail } from './environments/EnvironmentDetail'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import {
@@ -38,11 +38,6 @@ export function EnvironmentManagement({
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-    orgSlug: string
-  } | null>(null)
 
   const {
     data: environments = [],
@@ -114,24 +109,16 @@ export function EnvironmentManagement({
     [environments, selectedEnvSlug],
   )
 
-  const handleDelete = (slug: string) => {
-    const item = environments.find((x) => x.slug === slug)
-    if (item)
-      setDeleteTarget({
-        slug,
-        name: item.name,
-        orgSlug: item.organization.slug,
-      })
+  type Environment = (typeof environments)[number]
+
+  const handleDelete = (env: Environment) => {
+    deleteMutation.mutate({ orgSlug: env.organization.slug, slug: env.slug })
   }
 
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate({
-        orgSlug: deleteTarget.orgSlug,
-        slug: deleteTarget.slug,
-      })
-      setDeleteTarget(null)
-    }
+  const canDeleteEnvironment = (env: Environment): CanDeleteResult => {
+    const projects = env.relationships?.projects?.count ?? 0
+    if (projects === 0) return { allowed: true }
+    return { allowed: false, reason: `Has ${projects} project(s)` }
   }
 
   const handleSave = (formOrgSlug: string, envData: EnvironmentCreate) => {
@@ -218,12 +205,6 @@ export function EnvironmentManagement({
 
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -250,199 +231,125 @@ export function EnvironmentManagement({
         </Button>
       </div>
 
-      {/* Environments Table */}
-      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="border-b border-tertiary bg-secondary">
-                <tr>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Environment
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Slug
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Order
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Projects
-                  </th>
-                  <th
-                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Last Updated
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-              >
-                {filteredEnvironments.map((env) => (
-                  <tr
-                    key={env.slug}
-                    onClick={() => goToEdit(env.slug)}
-                    onKeyDown={(e) => {
-                      if (e.currentTarget !== e.target) return
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        goToEdit(env.slug)
-                      }
-                    }}
-                    tabIndex={0}
-                    aria-label={`Edit environment ${env.name}`}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                  >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                            isDarkMode ? 'bg-green-900/30' : 'bg-green-50'
-                          }`}
-                        >
-                          {env.icon ? (
-                            <EntityIcon
-                              icon={env.icon}
-                              className="h-5 w-5 rounded object-cover"
-                            />
-                          ) : (
-                            <Globe
-                              className={`h-4 w-4 ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
-                            />
-                          )}
-                        </div>
-                        <div>
-                          <div
-                            className={
-                              isDarkMode ? 'text-white' : 'text-gray-900'
-                            }
-                          >
-                            {env.name}
-                          </div>
-                          {env.description && (
-                            <div
-                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                            >
-                              {env.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td className="whitespace-nowrap px-6 py-4 text-center text-sm">
-                      {env.label_color ? (
-                        <span
-                          className="rounded px-2 py-1 text-xs font-medium"
-                          style={{
-                            backgroundColor: env.label_color + '20',
-                            color: env.label_color,
-                            border: `1px solid ${env.label_color}40`,
-                          }}
-                        >
-                          {env.slug}
-                        </span>
-                      ) : (
-                        <code
-                          className={`rounded px-2 py-1 ${
-                            isDarkMode
-                              ? 'bg-gray-700 text-gray-300'
-                              : 'bg-gray-100 text-gray-700'
-                          }`}
-                        >
-                          {env.slug}
-                        </code>
-                      )}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+      <AdminTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Environment',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (env) => (
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex size-8 flex-shrink-0 items-center justify-center rounded-lg ${isDarkMode ? 'bg-green-900/30' : 'bg-green-50'}`}
+                >
+                  {env.icon ? (
+                    <EntityIcon
+                      icon={env.icon}
+                      className="size-5 rounded object-cover"
+                    />
+                  ) : (
+                    <Globe
+                      className={`h-4 w-4 ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
+                    />
+                  )}
+                </div>
+                <div>
+                  <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                    {env.name}
+                  </div>
+                  {env.description && (
+                    <div
+                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      {env.sort_order ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                        (env.relationships?.projects?.count ?? 0) === 0
-                          ? isDarkMode
-                            ? 'text-gray-600'
-                            : 'text-gray-400'
-                          : isDarkMode
-                            ? 'text-gray-300'
-                            : 'text-gray-600'
-                      }`}
-                    >
-                      {env.relationships?.projects?.count ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {formatRelativeDate(env.updated_at ?? env.created_at)}
-                    </td>
-                    <td
-                      className="whitespace-nowrap px-6 py-4 text-right"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          aria-label={`Delete environment ${env.name}`}
-                          onClick={() => handleDelete(env.slug)}
-                          disabled={deleteMutation.isPending}
-                          className={
-                            isDarkMode
-                              ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                              : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                          }
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-
-            {filteredEnvironments.length === 0 && (
-              <div
-                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-              >
-                {searchQuery
-                  ? 'No environments found matching your search.'
-                  : selectedOrganization
-                    ? `No environments in ${selectedOrganization.name} yet.`
-                    : 'No environments created yet.'}
+                      {env.description}
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+            ),
+          },
+          {
+            key: 'slug',
+            header: 'Slug',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (env) =>
+              env.label_color ? (
+                <span
+                  className="rounded px-2 py-1 text-xs font-medium"
+                  style={{
+                    backgroundColor: env.label_color + '20',
+                    color: env.label_color,
+                    border: `1px solid ${env.label_color}40`,
+                  }}
+                >
+                  {env.slug}
+                </span>
+              ) : (
+                <code
+                  className={`rounded px-2 py-1 ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`}
+                >
+                  {env.slug}
+                </code>
+              ),
+          },
+          {
+            key: 'order',
+            header: 'Order',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (env) => (
+              <span className={isDarkMode ? 'text-gray-300' : 'text-gray-600'}>
+                {env.sort_order ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'projects',
+            header: 'Projects',
+            headerAlign: 'right',
+            cellAlign: 'right',
+            render: (env) => (
+              <span
+                className={
+                  (env.relationships?.projects?.count ?? 0) === 0
+                    ? isDarkMode
+                      ? 'text-gray-600'
+                      : 'text-gray-400'
+                    : isDarkMode
+                      ? 'text-gray-300'
+                      : 'text-gray-600'
+                }
+              >
+                {env.relationships?.projects?.count ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'updated',
+            header: 'Last Updated',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (env) =>
+              formatRelativeDate(env.updated_at ?? env.created_at),
+          },
+        ]}
+        rows={filteredEnvironments}
+        getRowKey={(env) => env.slug}
+        getDeleteLabel={(env) => env.name}
+        onRowClick={(env) => goToEdit(env.slug)}
+        onDelete={handleDelete}
+        canDelete={canDeleteEnvironment}
+        isDeleting={deleteMutation.isPending}
+        emptyMessage={
+          searchQuery
+            ? 'No environments found matching your search.'
+            : selectedOrganization
+              ? `No environments in ${selectedOrganization.name} yet.`
+              : 'No environments created yet.'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -6,7 +6,9 @@ import { getIcon } from '@/lib/icons'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Card, CardContent } from '@/components/ui/card'
 import { LinkDefinitionForm } from './link-definitions/LinkDefinitionForm'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import {
@@ -35,6 +37,11 @@ export function LinkDefinitionManagement({
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+    orgSlug: string
+  } | null>(null)
 
   const {
     data: linkDefinitions = [],
@@ -107,14 +114,22 @@ export function LinkDefinitionManagement({
   )
 
   const handleDelete = (slug: string) => {
-    const ld = linkDefinitions.find((l) => l.slug === slug)
-    if (
-      ld &&
-      confirm(
-        `Delete link definition "${ld.name}"? This action cannot be undone.`,
-      )
-    ) {
-      deleteMutation.mutate({ orgSlug: ld.organization.slug, slug })
+    const item = linkDefinitions.find((x) => x.slug === slug)
+    if (item)
+      setDeleteTarget({
+        slug,
+        name: item.name,
+        orgSlug: item.organization.slug,
+      })
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate({
+        orgSlug: deleteTarget.orgSlug,
+        slug: deleteTarget.slug,
+      })
+      setDeleteTarget(null)
     }
   }
 
@@ -204,6 +219,12 @@ export function LinkDefinitionManagement({
 
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -231,229 +252,225 @@ export function LinkDefinitionManagement({
       </div>
 
       {/* Link Definitions Table */}
-      <div
-        className={`rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Name
-                </th>
-                <th
-                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Slug
-                </th>
-                <th
-                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Icon
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  URL Template
-                </th>
-                <th
-                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Projects
-                </th>
-                <th
-                  className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Last Updated
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-            >
-              {filteredLinkDefinitions.map((ld) => (
-                <tr
-                  key={ld.slug}
-                  onClick={() => goToEdit(ld.slug)}
-                  onKeyDown={(e) => {
-                    if (e.currentTarget !== e.target) return
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      goToEdit(ld.slug)
-                    }
-                  }}
-                  tabIndex={0}
-                  aria-label={`Edit link definition ${ld.name}`}
-                  className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                >
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                      <div
-                        className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                          isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
-                        }`}
-                      >
-                        <Link2
-                          className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-                        />
-                      </div>
-                      <div>
-                        <div
-                          className={
-                            isDarkMode ? 'text-white' : 'text-gray-900'
-                          }
-                        >
-                          {ld.name}
-                        </div>
-                        {ld.description && (
-                          <div
-                            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                          >
-                            {ld.description}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-center text-sm">
-                    <code
-                      className={`rounded px-2 py-1 ${
-                        isDarkMode
-                          ? 'bg-gray-700 text-gray-300'
-                          : 'bg-gray-100 text-gray-700'
-                      }`}
-                    >
-                      {ld.slug}
-                    </code>
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${
-                      isDarkMode ? 'text-gray-300' : 'text-gray-600'
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="border-b border-tertiary bg-secondary">
+                <tr>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
                     }`}
                   >
-                    {ld.icon
-                      ? (() => {
-                          const Icon = getIcon(ld.icon, null)
-                          return Icon ? (
-                            <Icon
-                              className={`mx-auto h-5 w-5 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                            />
-                          ) : (
-                            <span
-                              className={`text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
-                            >
-                              {ld.icon}
-                            </span>
-                          )
-                        })()
-                      : '--'}
-                  </td>
-                  <td
-                    className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    Name
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
                   >
-                    {ld.url_template ? (
+                    Slug
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Icon
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    URL Template
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Projects
+                  </th>
+                  <th
+                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Last Updated
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+              >
+                {filteredLinkDefinitions.map((ld) => (
+                  <tr
+                    key={ld.slug}
+                    onClick={() => goToEdit(ld.slug)}
+                    onKeyDown={(e) => {
+                      if (e.currentTarget !== e.target) return
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        goToEdit(ld.slug)
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-label={`Edit link definition ${ld.name}`}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                  >
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                            isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
+                          }`}
+                        >
+                          <Link2
+                            className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+                          />
+                        </div>
+                        <div>
+                          <div
+                            className={
+                              isDarkMode ? 'text-white' : 'text-gray-900'
+                            }
+                          >
+                            {ld.name}
+                          </div>
+                          {ld.description && (
+                            <div
+                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                            >
+                              {ld.description}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-center text-sm">
                       <code
-                        className={`rounded px-2 py-1 text-xs ${
+                        className={`rounded px-2 py-1 ${
                           isDarkMode
                             ? 'bg-gray-700 text-gray-300'
                             : 'bg-gray-100 text-gray-700'
                         }`}
                       >
-                        {ld.url_template}
+                        {ld.slug}
                       </code>
-                    ) : (
-                      <span
-                        className={
-                          isDarkMode ? 'text-gray-600' : 'text-gray-400'
-                        }
-                      >
-                        --
-                      </span>
-                    )}
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${
-                      (ld.relationships?.projects?.count ?? 0) === 0
-                        ? isDarkMode
-                          ? 'text-gray-600'
-                          : 'text-gray-400'
-                        : isDarkMode
-                          ? 'text-gray-300'
-                          : 'text-gray-600'
-                    }`}
-                  >
-                    {ld.relationships?.projects?.count ?? 0}
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                  >
-                    {formatRelativeDate(ld.updated_at ?? ld.created_at)}
-                  </td>
-                  <td
-                    className="whitespace-nowrap px-6 py-4 text-right"
-                    onClick={(e) => e.stopPropagation()}
-                    onKeyDown={(e) => e.stopPropagation()}
-                  >
-                    <div className="flex items-center justify-end gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        aria-label={`Delete link definition ${ld.name}`}
-                        onClick={() => handleDelete(ld.slug)}
-                        disabled={deleteMutation.isPending}
-                        className={
-                          isDarkMode
-                            ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                            : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                        }
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${
+                        isDarkMode ? 'text-gray-300' : 'text-gray-600'
+                      }`}
+                    >
+                      {ld.icon
+                        ? (() => {
+                            const Icon = getIcon(ld.icon, null)
+                            return Icon ? (
+                              <Icon
+                                className={`mx-auto h-5 w-5 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                              />
+                            ) : (
+                              <span
+                                className={`text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                              >
+                                {ld.icon}
+                              </span>
+                            )
+                          })()
+                        : '--'}
+                    </td>
+                    <td
+                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      {ld.url_template ? (
+                        <code
+                          className={`rounded px-2 py-1 text-xs ${
+                            isDarkMode
+                              ? 'bg-gray-700 text-gray-300'
+                              : 'bg-gray-100 text-gray-700'
+                          }`}
+                        >
+                          {ld.url_template}
+                        </code>
+                      ) : (
+                        <span
+                          className={
+                            isDarkMode ? 'text-gray-600' : 'text-gray-400'
+                          }
+                        >
+                          --
+                        </span>
+                      )}
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${
+                        (ld.relationships?.projects?.count ?? 0) === 0
+                          ? isDarkMode
+                            ? 'text-gray-600'
+                            : 'text-gray-400'
+                          : isDarkMode
+                            ? 'text-gray-300'
+                            : 'text-gray-600'
+                      }`}
+                    >
+                      {ld.relationships?.projects?.count ?? 0}
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      {formatRelativeDate(ld.updated_at ?? ld.created_at)}
+                    </td>
+                    <td
+                      className="whitespace-nowrap px-6 py-4 text-right"
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex items-center justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Delete link definition ${ld.name}`}
+                          onClick={() => handleDelete(ld.slug)}
+                          disabled={deleteMutation.isPending}
+                          className={
+                            isDarkMode
+                              ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
+                              : 'text-red-600 hover:bg-red-50 hover:text-red-700'
+                          }
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
 
-          {filteredLinkDefinitions.length === 0 && (
-            <div
-              className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-            >
-              {searchQuery
-                ? 'No link definitions found matching your search.'
-                : selectedOrganization
-                  ? `No link definitions in ${selectedOrganization.name} yet.`
-                  : 'No link definitions created yet.'}
-            </div>
-          )}
-        </div>
-      </div>
+            {filteredLinkDefinitions.length === 0 && (
+              <div
+                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                {searchQuery
+                  ? 'No link definitions found matching your search.'
+                  : selectedOrganization
+                    ? `No link definitions in ${selectedOrganization.name} yet.`
+                    : 'No link definitions created yet.'}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -1,14 +1,13 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import { Plus, Search, Trash2, Link2, AlertCircle } from 'lucide-react'
+import { Plus, Search, Link2, AlertCircle } from 'lucide-react'
 import { getIcon } from '@/lib/icons'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Card, CardContent } from '@/components/ui/card'
+import { AdminTable, type CanDeleteResult } from '@/components/ui/admin-table'
 import { LinkDefinitionForm } from './link-definitions/LinkDefinitionForm'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import {
@@ -37,11 +36,6 @@ export function LinkDefinitionManagement({
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-    orgSlug: string
-  } | null>(null)
 
   const {
     data: linkDefinitions = [],
@@ -113,24 +107,16 @@ export function LinkDefinitionManagement({
     [linkDefinitions, selectedSlug],
   )
 
-  const handleDelete = (slug: string) => {
-    const item = linkDefinitions.find((x) => x.slug === slug)
-    if (item)
-      setDeleteTarget({
-        slug,
-        name: item.name,
-        orgSlug: item.organization.slug,
-      })
+  const handleDelete = (ld: (typeof linkDefinitions)[number]) => {
+    deleteMutation.mutate({ orgSlug: ld.organization.slug, slug: ld.slug })
   }
 
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate({
-        orgSlug: deleteTarget.orgSlug,
-        slug: deleteTarget.slug,
-      })
-      setDeleteTarget(null)
-    }
+  const canDeleteLinkDefinition = (
+    ld: (typeof linkDefinitions)[number],
+  ): CanDeleteResult => {
+    const projects = ld.relationships?.projects?.count ?? 0
+    if (projects === 0) return { allowed: true }
+    return { allowed: false, reason: `Has ${projects} project(s)` }
   }
 
   const handleSave = (formOrgSlug: string, data: LinkDefinitionCreate) => {
@@ -219,12 +205,6 @@ export function LinkDefinitionManagement({
 
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -251,226 +231,142 @@ export function LinkDefinitionManagement({
         </Button>
       </div>
 
-      {/* Link Definitions Table */}
-      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="border-b border-tertiary bg-secondary">
-                <tr>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Name
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Slug
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Icon
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    URL Template
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Projects
-                  </th>
-                  <th
-                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Last Updated
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-              >
-                {filteredLinkDefinitions.map((ld) => (
-                  <tr
-                    key={ld.slug}
-                    onClick={() => goToEdit(ld.slug)}
-                    onKeyDown={(e) => {
-                      if (e.currentTarget !== e.target) return
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        goToEdit(ld.slug)
-                      }
-                    }}
-                    tabIndex={0}
-                    aria-label={`Edit link definition ${ld.name}`}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                  >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                            isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
-                          }`}
-                        >
-                          <Link2
-                            className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-                          />
-                        </div>
-                        <div>
-                          <div
-                            className={
-                              isDarkMode ? 'text-white' : 'text-gray-900'
-                            }
-                          >
-                            {ld.name}
-                          </div>
-                          {ld.description && (
-                            <div
-                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                            >
-                              {ld.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td className="whitespace-nowrap px-6 py-4 text-center text-sm">
-                      <code
-                        className={`rounded px-2 py-1 ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
-                        }`}
-                      >
-                        {ld.slug}
-                      </code>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${
-                        isDarkMode ? 'text-gray-300' : 'text-gray-600'
-                      }`}
+      <AdminTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Name',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (ld) => (
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex size-8 flex-shrink-0 items-center justify-center rounded-lg ${isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'}`}
+                >
+                  <Link2
+                    className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+                  />
+                </div>
+                <div>
+                  <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                    {ld.name}
+                  </div>
+                  {ld.description && (
+                    <div
+                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      {ld.icon
-                        ? (() => {
-                            const Icon = getIcon(ld.icon, null)
-                            return Icon ? (
-                              <Icon
-                                className={`mx-auto h-5 w-5 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                              />
-                            ) : (
-                              <span
-                                className={`text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
-                              >
-                                {ld.icon}
-                              </span>
-                            )
-                          })()
-                        : '--'}
-                    </td>
-                    <td
-                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {ld.url_template ? (
-                        <code
-                          className={`rounded px-2 py-1 text-xs ${
-                            isDarkMode
-                              ? 'bg-gray-700 text-gray-300'
-                              : 'bg-gray-100 text-gray-700'
-                          }`}
-                        >
-                          {ld.url_template}
-                        </code>
-                      ) : (
-                        <span
-                          className={
-                            isDarkMode ? 'text-gray-600' : 'text-gray-400'
-                          }
-                        >
-                          --
-                        </span>
-                      )}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${
-                        (ld.relationships?.projects?.count ?? 0) === 0
-                          ? isDarkMode
-                            ? 'text-gray-600'
-                            : 'text-gray-400'
-                          : isDarkMode
-                            ? 'text-gray-300'
-                            : 'text-gray-600'
-                      }`}
-                    >
-                      {ld.relationships?.projects?.count ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {formatRelativeDate(ld.updated_at ?? ld.created_at)}
-                    </td>
-                    <td
-                      className="whitespace-nowrap px-6 py-4 text-right"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          aria-label={`Delete link definition ${ld.name}`}
-                          onClick={() => handleDelete(ld.slug)}
-                          disabled={deleteMutation.isPending}
-                          className={
-                            isDarkMode
-                              ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                              : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                          }
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-
-            {filteredLinkDefinitions.length === 0 && (
-              <div
-                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-              >
-                {searchQuery
-                  ? 'No link definitions found matching your search.'
-                  : selectedOrganization
-                    ? `No link definitions in ${selectedOrganization.name} yet.`
-                    : 'No link definitions created yet.'}
+                      {ld.description}
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+            ),
+          },
+          {
+            key: 'slug',
+            header: 'Slug',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (ld) => (
+              <code
+                className={`rounded px-2 py-1 ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`}
+              >
+                {ld.slug}
+              </code>
+            ),
+          },
+          {
+            key: 'icon',
+            header: 'Icon',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (ld) => {
+              if (!ld.icon)
+                return (
+                  <span
+                    className={isDarkMode ? 'text-gray-600' : 'text-gray-400'}
+                  >
+                    --
+                  </span>
+                )
+              const Icon = getIcon(ld.icon, null)
+              return Icon ? (
+                <Icon
+                  className={`mx-auto h-5 w-5 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                />
+              ) : (
+                <span
+                  className={`text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                >
+                  {ld.icon}
+                </span>
+              )
+            },
+          },
+          {
+            key: 'url_template',
+            header: 'URL Template',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (ld) =>
+              ld.url_template ? (
+                <code
+                  className={`rounded px-2 py-1 text-xs ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`}
+                >
+                  {ld.url_template}
+                </code>
+              ) : (
+                <span
+                  className={isDarkMode ? 'text-gray-600' : 'text-gray-400'}
+                >
+                  --
+                </span>
+              ),
+          },
+          {
+            key: 'projects',
+            header: 'Projects',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (ld) => (
+              <span
+                className={
+                  (ld.relationships?.projects?.count ?? 0) === 0
+                    ? isDarkMode
+                      ? 'text-gray-600'
+                      : 'text-gray-400'
+                    : isDarkMode
+                      ? 'text-gray-300'
+                      : 'text-gray-600'
+                }
+              >
+                {ld.relationships?.projects?.count ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'updated',
+            header: 'Last Updated',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (ld) => formatRelativeDate(ld.updated_at ?? ld.created_at),
+          },
+        ]}
+        rows={filteredLinkDefinitions}
+        getRowKey={(ld) => ld.slug}
+        getDeleteLabel={(ld) => ld.name}
+        onRowClick={(ld) => goToEdit(ld.slug)}
+        onDelete={handleDelete}
+        canDelete={canDeleteLinkDefinition}
+        isDeleting={deleteMutation.isPending}
+        emptyMessage={
+          searchQuery
+            ? 'No link definitions found matching your search.'
+            : selectedOrganization
+              ? `No link definitions in ${selectedOrganization.name} yet.`
+              : 'No link definitions created yet.'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/OAuthManagement.tsx
+++ b/src/components/admin/OAuthManagement.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Search, Power, AlertCircle, CheckCircle } from 'lucide-react'
 import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { getAuthProviders } from '@/api/endpoints'
 import type { AuthProvider } from '@/types'
 
@@ -111,28 +112,18 @@ export function OAuthManagement({ isDarkMode }: OAuthManagementProps) {
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filteredProviders.map((provider: AuthProvider) => (
-            <div
+            <Card
               key={provider.id}
-              className={`rounded-lg border p-4 ${
-                isDarkMode
-                  ? 'border-gray-700 bg-gray-800'
-                  : 'border-gray-200 bg-white'
-              }`}
+              className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}
             >
-              <div className="mb-3 flex items-start justify-between">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <div className="flex items-center gap-2">
                   <span className="text-xl">
                     {provider.type === 'oauth'
                       ? '\uD83D\uDD12'
                       : '\uD83D\uDD11'}
                   </span>
-                  <h3
-                    className={`font-medium ${
-                      isDarkMode ? 'text-white' : 'text-gray-900'
-                    }`}
-                  >
-                    {provider.name}
-                  </h3>
+                  <CardTitle>{provider.name}</CardTitle>
                 </div>
                 {provider.enabled ? (
                   <CheckCircle className="h-5 w-5 flex-shrink-0 text-green-500" />
@@ -143,30 +134,32 @@ export function OAuthManagement({ isDarkMode }: OAuthManagementProps) {
                     }`}
                   />
                 )}
-              </div>
-              <div className="flex items-center gap-2">
-                <span
-                  className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
-                    isDarkMode
-                      ? 'bg-gray-700 text-gray-300'
-                      : 'bg-gray-100 text-gray-600'
-                  }`}
-                >
-                  {provider.type}
-                </span>
-                <span
-                  className={`text-xs ${
-                    provider.enabled
-                      ? 'text-green-500'
-                      : isDarkMode
-                        ? 'text-gray-500'
-                        : 'text-gray-400'
-                  }`}
-                >
-                  {provider.enabled ? 'Enabled' : 'Disabled'}
-                </span>
-              </div>
-            </div>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
+                      isDarkMode
+                        ? 'bg-gray-700 text-gray-300'
+                        : 'bg-gray-100 text-gray-600'
+                    }`}
+                  >
+                    {provider.type}
+                  </span>
+                  <span
+                    className={`text-xs ${
+                      provider.enabled
+                        ? 'text-green-500'
+                        : isDarkMode
+                          ? 'text-gray-500'
+                          : 'text-gray-400'
+                    }`}
+                  >
+                    {provider.enabled ? 'Enabled' : 'Disabled'}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
           ))}
         </div>
       )}

--- a/src/components/admin/OrganizationManagement.tsx
+++ b/src/components/admin/OrganizationManagement.tsx
@@ -1,19 +1,13 @@
 import { useState, useMemo } from 'react'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { AdminTable } from '@/components/ui/admin-table'
+import type { CanDeleteResult } from '@/components/ui/admin-table'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import { Plus, Search, Trash2, Building2, AlertCircle } from 'lucide-react'
+import { Plus, Search, Building2, AlertCircle } from 'lucide-react'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
-import { Card, CardContent } from '@/components/ui/card'
 import { OrganizationForm } from './organizations/OrganizationForm'
 import { OrganizationDetail } from './organizations/OrganizationDetail'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -41,10 +35,6 @@ export function OrganizationManagement({
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-  } | null>(null)
 
   const {
     data: organizations = [],
@@ -55,19 +45,15 @@ export function OrganizationManagement({
     queryFn: listOrganizations,
   })
 
-  const canDeleteOrg = (
-    slug: string,
-  ): { allowed: boolean; reason?: string } => {
+  type Organization = (typeof organizations)[number]
+
+  const canDeleteOrganization = (org: Organization): CanDeleteResult => {
     if (organizations.length <= 1) {
       return { allowed: false, reason: 'Cannot delete the only organization' }
     }
-    const org = organizations.find((o) => o.slug === slug)
-    const teamCount = org?.relationships?.teams?.count ?? 0
+    const teamCount = org.relationships?.teams?.count ?? 0
     if (teamCount > 0) {
-      return {
-        allowed: false,
-        reason: `Has ${teamCount} team(s)`,
-      }
+      return { allowed: false, reason: `Has ${teamCount} team(s)` }
     }
     return { allowed: true }
   }
@@ -118,21 +104,8 @@ export function OrganizationManagement({
     [organizations, selectedOrgSlug],
   )
 
-  const handleDelete = (slug: string) => {
-    const check = canDeleteOrg(slug)
-    if (!check.allowed) return
-
-    const org = organizations.find((o) => o.slug === slug)
-    if (org) {
-      setDeleteTarget({ slug, name: org.name })
-    }
-  }
-
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate(deleteTarget.slug)
-      setDeleteTarget(null)
-    }
+  const handleDelete = (org: Organization) => {
+    deleteMutation.mutate(org.slug)
   }
 
   const handleSave = (orgData: OrganizationCreate) => {
@@ -220,12 +193,6 @@ export function OrganizationManagement({
 
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -252,222 +219,142 @@ export function OrganizationManagement({
         </Button>
       </div>
 
-      {/* Organizations Table */}
-      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="border-b border-tertiary bg-secondary">
-                <tr>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Organization
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Slug
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Teams
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Members
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Projects
-                  </th>
-                  <th
-                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Last Updated
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-              >
-                {filteredOrgs.map((org) => {
-                  const deleteCheck = canDeleteOrg(org.slug)
-                  return (
-                    <tr
-                      key={org.slug}
-                      onClick={() => goToEdit(org.slug)}
-                      className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+      <AdminTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Organization',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (org) => (
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex size-8 flex-shrink-0 items-center justify-center rounded-lg ${isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'}`}
+                >
+                  {org.icon ? (
+                    <EntityIcon
+                      icon={org.icon}
+                      className="size-5 rounded object-cover"
+                    />
+                  ) : (
+                    <Building2
+                      className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+                    />
+                  )}
+                </div>
+                <div>
+                  <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                    {org.name}
+                  </div>
+                  {org.description && (
+                    <div
+                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      <td className="px-6 py-4">
-                        <div className="flex items-center gap-3">
-                          <div
-                            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                              isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
-                            }`}
-                          >
-                            {org.icon ? (
-                              <EntityIcon
-                                icon={org.icon}
-                                className="h-5 w-5 rounded object-cover"
-                              />
-                            ) : (
-                              <Building2
-                                className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-                              />
-                            )}
-                          </div>
-                          <div>
-                            <div
-                              className={
-                                isDarkMode ? 'text-white' : 'text-gray-900'
-                              }
-                            >
-                              {org.name}
-                            </div>
-                            {org.description && (
-                              <div
-                                className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                              >
-                                {org.description}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </td>
-                      <td
-                        className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                      >
-                        <code
-                          className={`rounded px-2 py-1 ${
-                            isDarkMode
-                              ? 'bg-gray-700 text-gray-300'
-                              : 'bg-gray-100 text-gray-700'
-                          }`}
-                        >
-                          {org.slug}
-                        </code>
-                      </td>
-                      <td
-                        className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                          (org.relationships?.teams?.count ?? 0) === 0
-                            ? isDarkMode
-                              ? 'text-gray-600'
-                              : 'text-gray-400'
-                            : isDarkMode
-                              ? 'text-gray-300'
-                              : 'text-gray-600'
-                        }`}
-                      >
-                        {org.relationships?.teams?.count ?? 0}
-                      </td>
-                      <td
-                        className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                          (org.relationships?.members?.count ?? 0) === 0
-                            ? isDarkMode
-                              ? 'text-gray-600'
-                              : 'text-gray-400'
-                            : isDarkMode
-                              ? 'text-gray-300'
-                              : 'text-gray-600'
-                        }`}
-                      >
-                        {org.relationships?.members?.count ?? 0}
-                      </td>
-                      <td
-                        className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                          (org.relationships?.projects?.count ?? 0) === 0
-                            ? isDarkMode
-                              ? 'text-gray-600'
-                              : 'text-gray-400'
-                            : isDarkMode
-                              ? 'text-gray-300'
-                              : 'text-gray-600'
-                        }`}
-                      >
-                        {org.relationships?.projects?.count ?? 0}
-                      </td>
-                      <td
-                        className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                      >
-                        {formatRelativeDate(org.updated_at ?? org.created_at)}
-                      </td>
-                      <td
-                        className="whitespace-nowrap px-6 py-4 text-right"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <div className="flex items-center justify-end gap-2">
-                          <TooltipProvider delayDuration={200}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="inline-flex">
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => handleDelete(org.slug)}
-                                    disabled={
-                                      !deleteCheck.allowed ||
-                                      deleteMutation.isPending
-                                    }
-                                    className={
-                                      isDarkMode
-                                        ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none'
-                                        : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none'
-                                    }
-                                  >
-                                    <Trash2 className="h-4 w-4" />
-                                  </Button>
-                                </span>
-                              </TooltipTrigger>
-                              {deleteCheck.reason && (
-                                <TooltipContent>
-                                  <p>{deleteCheck.reason}</p>
-                                </TooltipContent>
-                              )}
-                            </Tooltip>
-                          </TooltipProvider>
-                        </div>
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-
-            {filteredOrgs.length === 0 && (
-              <div
-                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-              >
-                {searchQuery
-                  ? 'No organizations match your search.'
-                  : 'No organizations created yet.'}
+                      {org.description}
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+            ),
+          },
+          {
+            key: 'slug',
+            header: 'Slug',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (org) => (
+              <code
+                className={`rounded px-2 py-1 ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`}
+              >
+                {org.slug}
+              </code>
+            ),
+          },
+          {
+            key: 'teams',
+            header: 'Teams',
+            headerAlign: 'right',
+            cellAlign: 'right',
+            render: (org) => (
+              <span
+                className={
+                  (org.relationships?.teams?.count ?? 0) === 0
+                    ? isDarkMode
+                      ? 'text-gray-600'
+                      : 'text-gray-400'
+                    : isDarkMode
+                      ? 'text-gray-300'
+                      : 'text-gray-600'
+                }
+              >
+                {org.relationships?.teams?.count ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'members',
+            header: 'Members',
+            headerAlign: 'right',
+            cellAlign: 'right',
+            render: (org) => (
+              <span
+                className={
+                  (org.relationships?.members?.count ?? 0) === 0
+                    ? isDarkMode
+                      ? 'text-gray-600'
+                      : 'text-gray-400'
+                    : isDarkMode
+                      ? 'text-gray-300'
+                      : 'text-gray-600'
+                }
+              >
+                {org.relationships?.members?.count ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'projects',
+            header: 'Projects',
+            headerAlign: 'right',
+            cellAlign: 'right',
+            render: (org) => (
+              <span
+                className={
+                  (org.relationships?.projects?.count ?? 0) === 0
+                    ? isDarkMode
+                      ? 'text-gray-600'
+                      : 'text-gray-400'
+                    : isDarkMode
+                      ? 'text-gray-300'
+                      : 'text-gray-600'
+                }
+              >
+                {org.relationships?.projects?.count ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'updated',
+            header: 'Last Updated',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (org) =>
+              formatRelativeDate(org.updated_at ?? org.created_at),
+          },
+        ]}
+        rows={filteredOrgs}
+        getRowKey={(org) => org.slug}
+        getDeleteLabel={(org) => org.name}
+        onRowClick={(org) => goToEdit(org.slug)}
+        onDelete={handleDelete}
+        canDelete={canDeleteOrganization}
+        isDeleting={deleteMutation.isPending}
+        emptyMessage={
+          searchQuery
+            ? 'No organizations match your search.'
+            : 'No organizations created yet.'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/OrganizationManagement.tsx
+++ b/src/components/admin/OrganizationManagement.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
 import { Plus, Search, Trash2, Building2, AlertCircle } from 'lucide-react'
@@ -6,6 +7,7 @@ import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
+import { Card, CardContent } from '@/components/ui/card'
 import { OrganizationForm } from './organizations/OrganizationForm'
 import { OrganizationDetail } from './organizations/OrganizationDetail'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -30,10 +32,13 @@ export function OrganizationManagement({
     slug: selectedOrgSlug,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+  } | null>(null)
 
   const {
     data: organizations = [],
@@ -112,13 +117,15 @@ export function OrganizationManagement({
     if (!check.allowed) return
 
     const org = organizations.find((o) => o.slug === slug)
-    if (
-      org &&
-      confirm(
-        `Delete organization "${org.name}"? This action cannot be undone.`,
-      )
-    ) {
-      deleteMutation.mutate(slug)
+    if (org) {
+      setDeleteTarget({ slug, name: org.name })
+    }
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate(deleteTarget.slug)
+      setDeleteTarget(null)
     }
   }
 
@@ -207,6 +214,12 @@ export function OrganizationManagement({
 
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -234,212 +247,208 @@ export function OrganizationManagement({
       </div>
 
       {/* Organizations Table */}
-      <div
-        className={`rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Organization
-                </th>
-                <th
-                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Slug
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Teams
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Members
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Projects
-                </th>
-                <th
-                  className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Last Updated
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-            >
-              {filteredOrgs.map((org) => {
-                const deleteCheck = canDeleteOrg(org.slug)
-                return (
-                  <tr
-                    key={org.slug}
-                    onClick={() => goToDetail(org.slug)}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="border-b border-tertiary bg-secondary">
+                <tr>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
                   >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                            isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
+                    Organization
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Slug
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Teams
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Members
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Projects
+                  </th>
+                  <th
+                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Last Updated
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+              >
+                {filteredOrgs.map((org) => {
+                  const deleteCheck = canDeleteOrg(org.slug)
+                  return (
+                    <tr
+                      key={org.slug}
+                      onClick={() => goToEdit(org.slug)}
+                      className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                    >
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-3">
+                          <div
+                            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                              isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
+                            }`}
+                          >
+                            {org.icon ? (
+                              <EntityIcon
+                                icon={org.icon}
+                                className="h-5 w-5 rounded object-cover"
+                              />
+                            ) : (
+                              <Building2
+                                className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+                              />
+                            )}
+                          </div>
+                          <div>
+                            <div
+                              className={
+                                isDarkMode ? 'text-white' : 'text-gray-900'
+                              }
+                            >
+                              {org.name}
+                            </div>
+                            {org.description && (
+                              <div
+                                className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                              >
+                                {org.description}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td
+                        className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                      >
+                        <code
+                          className={`rounded px-2 py-1 ${
+                            isDarkMode
+                              ? 'bg-gray-700 text-gray-300'
+                              : 'bg-gray-100 text-gray-700'
                           }`}
                         >
-                          {org.icon ? (
-                            <EntityIcon
-                              icon={org.icon}
-                              className="h-5 w-5 rounded object-cover"
-                            />
-                          ) : (
-                            <Building2
-                              className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-                            />
-                          )}
-                        </div>
-                        <div>
-                          <div
-                            className={
-                              isDarkMode ? 'text-white' : 'text-gray-900'
-                            }
-                          >
-                            {org.name}
-                          </div>
-                          {org.description && (
-                            <div
-                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                            >
-                              {org.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      <code
-                        className={`rounded px-2 py-1 ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
+                          {org.slug}
+                        </code>
+                      </td>
+                      <td
+                        className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
+                          (org.relationships?.teams?.count ?? 0) === 0
+                            ? isDarkMode
+                              ? 'text-gray-600'
+                              : 'text-gray-400'
+                            : isDarkMode
+                              ? 'text-gray-300'
+                              : 'text-gray-600'
                         }`}
                       >
-                        {org.slug}
-                      </code>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                        (org.relationships?.teams?.count ?? 0) === 0
-                          ? isDarkMode
-                            ? 'text-gray-600'
-                            : 'text-gray-400'
-                          : isDarkMode
-                            ? 'text-gray-300'
-                            : 'text-gray-600'
-                      }`}
-                    >
-                      {org.relationships?.teams?.count ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                        (org.relationships?.members?.count ?? 0) === 0
-                          ? isDarkMode
-                            ? 'text-gray-600'
-                            : 'text-gray-400'
-                          : isDarkMode
-                            ? 'text-gray-300'
-                            : 'text-gray-600'
-                      }`}
-                    >
-                      {org.relationships?.members?.count ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                        (org.relationships?.projects?.count ?? 0) === 0
-                          ? isDarkMode
-                            ? 'text-gray-600'
-                            : 'text-gray-400'
-                          : isDarkMode
-                            ? 'text-gray-300'
-                            : 'text-gray-600'
-                      }`}
-                    >
-                      {org.relationships?.projects?.count ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {formatRelativeDate(org.updated_at ?? org.created_at)}
-                    </td>
-                    <td
-                      className="whitespace-nowrap px-6 py-4 text-right"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleDelete(org.slug)}
-                          disabled={
-                            !deleteCheck.allowed || deleteMutation.isPending
-                          }
-                          title={deleteCheck.reason}
-                          className={
-                            isDarkMode
-                              ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                              : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                          }
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+                        {org.relationships?.teams?.count ?? 0}
+                      </td>
+                      <td
+                        className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
+                          (org.relationships?.members?.count ?? 0) === 0
+                            ? isDarkMode
+                              ? 'text-gray-600'
+                              : 'text-gray-400'
+                            : isDarkMode
+                              ? 'text-gray-300'
+                              : 'text-gray-600'
+                        }`}
+                      >
+                        {org.relationships?.members?.count ?? 0}
+                      </td>
+                      <td
+                        className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
+                          (org.relationships?.projects?.count ?? 0) === 0
+                            ? isDarkMode
+                              ? 'text-gray-600'
+                              : 'text-gray-400'
+                            : isDarkMode
+                              ? 'text-gray-300'
+                              : 'text-gray-600'
+                        }`}
+                      >
+                        {org.relationships?.projects?.count ?? 0}
+                      </td>
+                      <td
+                        className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                      >
+                        {formatRelativeDate(org.updated_at ?? org.created_at)}
+                      </td>
+                      <td
+                        className="whitespace-nowrap px-6 py-4 text-right"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <div className="flex items-center justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleDelete(org.slug)}
+                            disabled={
+                              !deleteCheck.allowed || deleteMutation.isPending
+                            }
+                            title={deleteCheck.reason}
+                            className={
+                              isDarkMode
+                                ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
+                                : 'text-red-600 hover:bg-red-50 hover:text-red-700'
+                            }
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
 
-          {filteredOrgs.length === 0 && (
-            <div
-              className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-            >
-              {searchQuery
-                ? 'No organizations match your search.'
-                : 'No organizations created yet.'}
-            </div>
-          )}
-        </div>
-      </div>
+            {filteredOrgs.length === 0 && (
+              <div
+                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                {searchQuery
+                  ? 'No organizations match your search.'
+                  : 'No organizations created yet.'}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/OrganizationManagement.tsx
+++ b/src/components/admin/OrganizationManagement.tsx
@@ -1,4 +1,10 @@
 import { useState, useMemo } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
@@ -413,22 +419,35 @@ export function OrganizationManagement({
                         onClick={(e) => e.stopPropagation()}
                       >
                         <div className="flex items-center justify-end gap-2">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleDelete(org.slug)}
-                            disabled={
-                              !deleteCheck.allowed || deleteMutation.isPending
-                            }
-                            title={deleteCheck.reason}
-                            className={
-                              isDarkMode
-                                ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                                : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                            }
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
+                          <TooltipProvider delayDuration={200}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="inline-flex">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => handleDelete(org.slug)}
+                                    disabled={
+                                      !deleteCheck.allowed ||
+                                      deleteMutation.isPending
+                                    }
+                                    className={
+                                      isDarkMode
+                                        ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none'
+                                        : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none'
+                                    }
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </Button>
+                                </span>
+                              </TooltipTrigger>
+                              {deleteCheck.reason && (
+                                <TooltipContent>
+                                  <p>{deleteCheck.reason}</p>
+                                </TooltipContent>
+                              )}
+                            </Tooltip>
+                          </TooltipProvider>
                         </div>
                       </td>
                     </tr>

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -1,19 +1,13 @@
 import { useState, useMemo } from 'react'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { AdminTable } from '@/components/ui/admin-table'
+import type { CanDeleteResult } from '@/components/ui/admin-table'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import { Plus, Search, Trash2, Layers, AlertCircle } from 'lucide-react'
+import { Plus, Search, Layers, AlertCircle } from 'lucide-react'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
-import { Card, CardContent } from '@/components/ui/card'
 import { ProjectTypeForm } from './project-types/ProjectTypeForm'
 import { ProjectTypeDetail } from './project-types/ProjectTypeDetail'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -44,11 +38,6 @@ export function ProjectTypeManagement({
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-    orgSlug: string
-  } | null>(null)
 
   const {
     data: projectTypes = [],
@@ -115,21 +104,16 @@ export function ProjectTypeManagement({
     [projectTypes, selectedPtSlug],
   )
 
-  const handleDelete = (slug: string) => {
-    const pt = projectTypes.find((p) => p.slug === slug)
-    if (pt) {
-      setDeleteTarget({ slug, name: pt.name, orgSlug: pt.organization.slug })
-    }
+  const handleDelete = (pt: (typeof projectTypes)[number]) => {
+    deleteMutation.mutate({ orgSlug: pt.organization.slug, slug: pt.slug })
   }
 
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate({
-        orgSlug: deleteTarget.orgSlug,
-        slug: deleteTarget.slug,
-      })
-      setDeleteTarget(null)
-    }
+  const canDeleteProjectType = (
+    pt: (typeof projectTypes)[number],
+  ): CanDeleteResult => {
+    const projects = pt.relationships?.projects?.count ?? 0
+    if (projects === 0) return { allowed: true }
+    return { allowed: false, reason: `Has ${projects} project(s)` }
   }
 
   const handleSave = (formOrgSlug: string, ptData: ProjectTypeCreate) => {
@@ -216,12 +200,6 @@ export function ProjectTypeManagement({
 
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -248,201 +226,101 @@ export function ProjectTypeManagement({
         </Button>
       </div>
 
-      {/* Project Types Table */}
-      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="border-b border-tertiary bg-secondary">
-                <tr>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Project Type
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Slug
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Projects
-                  </th>
-                  <th
-                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Last Updated
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-              >
-                {filteredProjectTypes.map((pt) => (
-                  <tr
-                    key={pt.slug}
-                    onClick={() => goToEdit(pt.slug)}
-                    onKeyDown={(e) => {
-                      if (e.currentTarget !== e.target) return
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        goToEdit(pt.slug)
-                      }
-                    }}
-                    tabIndex={0}
-                    aria-label={`Edit project type ${pt.name}`}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                  >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                            isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'
-                          }`}
-                        >
-                          {pt.icon ? (
-                            <EntityIcon
-                              icon={pt.icon}
-                              className="h-5 w-5 rounded object-cover"
-                            />
-                          ) : (
-                            <Layers
-                              className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
-                            />
-                          )}
-                        </div>
-                        <div>
-                          <div
-                            className={
-                              isDarkMode ? 'text-white' : 'text-gray-900'
-                            }
-                          >
-                            {pt.name}
-                          </div>
-                          {pt.description && (
-                            <div
-                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                            >
-                              {pt.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+      <AdminTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Project Type',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (pt) => (
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex size-8 flex-shrink-0 items-center justify-center rounded-lg ${isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'}`}
+                >
+                  {pt.icon ? (
+                    <EntityIcon
+                      icon={pt.icon}
+                      className="size-5 rounded object-cover"
+                    />
+                  ) : (
+                    <Layers
+                      className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+                    />
+                  )}
+                </div>
+                <div>
+                  <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                    {pt.name}
+                  </div>
+                  {pt.description && (
+                    <div
+                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      <code
-                        className={`rounded px-2 py-1 ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
-                        }`}
-                      >
-                        {pt.slug}
-                      </code>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                        (pt.relationships?.projects?.count ?? 0) === 0
-                          ? isDarkMode
-                            ? 'text-gray-600'
-                            : 'text-gray-400'
-                          : isDarkMode
-                            ? 'text-gray-300'
-                            : 'text-gray-600'
-                      }`}
-                    >
-                      {pt.relationships?.projects?.count ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {formatRelativeDate(pt.updated_at ?? pt.created_at)}
-                    </td>
-                    <td
-                      className="whitespace-nowrap px-6 py-4 text-right"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center justify-end gap-2">
-                        {(() => {
-                          const projectCount =
-                            pt.relationships?.projects?.count ?? 0
-                          const canDelete = projectCount === 0
-                          const tooltipText = !canDelete
-                            ? `Cannot delete: has ${projectCount} project(s)`
-                            : undefined
-                          return (
-                            <TooltipProvider delayDuration={200}>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span className="inline-flex">
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      aria-label={`Delete project type ${pt.name}`}
-                                      onClick={() => handleDelete(pt.slug)}
-                                      disabled={
-                                        deleteMutation.isPending || !canDelete
-                                      }
-                                      className={
-                                        isDarkMode
-                                          ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none disabled:opacity-30'
-                                          : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none disabled:opacity-30'
-                                      }
-                                    >
-                                      <Trash2 className="h-4 w-4" />
-                                    </Button>
-                                  </span>
-                                </TooltipTrigger>
-                                {tooltipText && (
-                                  <TooltipContent>
-                                    <p>{tooltipText}</p>
-                                  </TooltipContent>
-                                )}
-                              </Tooltip>
-                            </TooltipProvider>
-                          )
-                        })()}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-
-            {filteredProjectTypes.length === 0 && (
-              <div
-                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-              >
-                {searchQuery
-                  ? 'No project types found matching your search.'
-                  : selectedOrganization
-                    ? `No project types in ${selectedOrganization.name} yet.`
-                    : 'No project types created yet.'}
+                      {pt.description}
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+            ),
+          },
+          {
+            key: 'slug',
+            header: 'Slug',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (pt) => (
+              <code
+                className={`rounded px-2 py-1 ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`}
+              >
+                {pt.slug}
+              </code>
+            ),
+          },
+          {
+            key: 'projects',
+            header: 'Projects',
+            headerAlign: 'right',
+            cellAlign: 'right',
+            render: (pt) => (
+              <span
+                className={
+                  (pt.relationships?.projects?.count ?? 0) === 0
+                    ? isDarkMode
+                      ? 'text-gray-600'
+                      : 'text-gray-400'
+                    : isDarkMode
+                      ? 'text-gray-300'
+                      : 'text-gray-600'
+                }
+              >
+                {pt.relationships?.projects?.count ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'updated',
+            header: 'Last Updated',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (pt) => formatRelativeDate(pt.updated_at ?? pt.created_at),
+          },
+        ]}
+        rows={filteredProjectTypes}
+        getRowKey={(pt) => pt.slug}
+        getDeleteLabel={(pt) => pt.name}
+        onRowClick={(pt) => goToEdit(pt.slug)}
+        onDelete={handleDelete}
+        canDelete={canDeleteProjectType}
+        isDeleting={deleteMutation.isPending}
+        emptyMessage={
+          searchQuery
+            ? 'No project types found matching your search.'
+            : selectedOrganization
+              ? `No project types in ${selectedOrganization.name} yet.`
+              : 'No project types created yet.'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -6,6 +6,7 @@ import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
+import { Card, CardContent } from '@/components/ui/card'
 import { ProjectTypeForm } from './project-types/ProjectTypeForm'
 import { ProjectTypeDetail } from './project-types/ProjectTypeDetail'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -33,7 +34,6 @@ export function ProjectTypeManagement({
     slug: selectedPtSlug,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
@@ -224,179 +224,187 @@ export function ProjectTypeManagement({
       </div>
 
       {/* Project Types Table */}
-      <div
-        className={`rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Project Type
-                </th>
-                <th
-                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Slug
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Projects
-                </th>
-                <th
-                  className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Last Updated
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-            >
-              {filteredProjectTypes.map((pt) => (
-                <tr
-                  key={pt.slug}
-                  onClick={() => goToDetail(pt.slug)}
-                  onKeyDown={(e) => {
-                    if (e.currentTarget !== e.target) return
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      goToDetail(pt.slug)
-                    }
-                  }}
-                  tabIndex={0}
-                  aria-label={`View project type ${pt.name}`}
-                  className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                >
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                      <div
-                        className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                          isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'
-                        }`}
-                      >
-                        {pt.icon ? (
-                          <EntityIcon
-                            icon={pt.icon}
-                            className="h-5 w-5 rounded object-cover"
-                          />
-                        ) : (
-                          <Layers
-                            className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
-                          />
-                        )}
-                      </div>
-                      <div>
-                        <div
-                          className={
-                            isDarkMode ? 'text-white' : 'text-gray-900'
-                          }
-                        >
-                          {pt.name}
-                        </div>
-                        {pt.description && (
-                          <div
-                            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                          >
-                            {pt.description}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                  >
-                    <code
-                      className={`rounded px-2 py-1 ${
-                        isDarkMode
-                          ? 'bg-gray-700 text-gray-300'
-                          : 'bg-gray-100 text-gray-700'
-                      }`}
-                    >
-                      {pt.slug}
-                    </code>
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                      (pt.relationships?.projects?.count ?? 0) === 0
-                        ? isDarkMode
-                          ? 'text-gray-600'
-                          : 'text-gray-400'
-                        : isDarkMode
-                          ? 'text-gray-300'
-                          : 'text-gray-600'
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="border-b border-tertiary bg-secondary">
+                <tr>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
                     }`}
                   >
-                    {pt.relationships?.projects?.count ?? 0}
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    Project Type
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
                   >
-                    {formatRelativeDate(pt.updated_at ?? pt.created_at)}
-                  </td>
-                  <td
-                    className="whitespace-nowrap px-6 py-4 text-right"
-                    onClick={(e) => e.stopPropagation()}
-                    onKeyDown={(e) => e.stopPropagation()}
+                    Slug
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
                   >
-                    <div className="flex items-center justify-end gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        aria-label={`Delete project type ${pt.name}`}
-                        onClick={() => handleDelete(pt.slug)}
-                        disabled={deleteMutation.isPending}
-                        className={
-                          isDarkMode
-                            ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                            : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                        }
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </td>
+                    Projects
+                  </th>
+                  <th
+                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Last Updated
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Actions
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody
+                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+              >
+                {filteredProjectTypes.map((pt) => (
+                  <tr
+                    key={pt.slug}
+                    onClick={() => goToEdit(pt.slug)}
+                    onKeyDown={(e) => {
+                      if (e.currentTarget !== e.target) return
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        goToEdit(pt.slug)
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-label={`Edit project type ${pt.name}`}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                  >
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                            isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'
+                          }`}
+                        >
+                          {pt.icon ? (
+                            <EntityIcon
+                              icon={pt.icon}
+                              className="h-5 w-5 rounded object-cover"
+                            />
+                          ) : (
+                            <Layers
+                              className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+                            />
+                          )}
+                        </div>
+                        <div>
+                          <div
+                            className={
+                              isDarkMode ? 'text-white' : 'text-gray-900'
+                            }
+                          >
+                            {pt.name}
+                          </div>
+                          {pt.description && (
+                            <div
+                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                            >
+                              {pt.description}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      <code
+                        className={`rounded px-2 py-1 ${
+                          isDarkMode
+                            ? 'bg-gray-700 text-gray-300'
+                            : 'bg-gray-100 text-gray-700'
+                        }`}
+                      >
+                        {pt.slug}
+                      </code>
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
+                        (pt.relationships?.projects?.count ?? 0) === 0
+                          ? isDarkMode
+                            ? 'text-gray-600'
+                            : 'text-gray-400'
+                          : isDarkMode
+                            ? 'text-gray-300'
+                            : 'text-gray-600'
+                      }`}
+                    >
+                      {pt.relationships?.projects?.count ?? 0}
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      {formatRelativeDate(pt.updated_at ?? pt.created_at)}
+                    </td>
+                    <td
+                      className="whitespace-nowrap px-6 py-4 text-right"
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex items-center justify-end gap-2">
+                        {(() => {
+                          const projectCount =
+                            pt.relationships?.projects?.count ?? 0
+                          const canDelete = projectCount === 0
+                          return (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              aria-label={`Delete project type ${pt.name}`}
+                              onClick={() => handleDelete(pt.slug)}
+                              disabled={deleteMutation.isPending || !canDelete}
+                              title={
+                                !canDelete
+                                  ? `Cannot delete: has ${projectCount} project(s)`
+                                  : undefined
+                              }
+                              className={
+                                isDarkMode
+                                  ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:opacity-30'
+                                  : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:opacity-30'
+                              }
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          )
+                        })()}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
 
-          {filteredProjectTypes.length === 0 && (
-            <div
-              className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-            >
-              {searchQuery
-                ? 'No project types found matching your search.'
-                : selectedOrganization
-                  ? `No project types in ${selectedOrganization.name} yet.`
-                  : 'No project types created yet.'}
-            </div>
-          )}
-        </div>
-      </div>
+            {filteredProjectTypes.length === 0 && (
+              <div
+                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                {searchQuery
+                  ? 'No project types found matching your search.'
+                  : selectedOrganization
+                    ? `No project types in ${selectedOrganization.name} yet.`
+                    : 'No project types created yet.'}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -1,4 +1,10 @@
 import { useState, useMemo } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
@@ -385,24 +391,35 @@ export function ProjectTypeManagement({
                             ? `Cannot delete: has ${projectCount} project(s)`
                             : undefined
                           return (
-                            <span className="inline-flex" title={tooltipText}>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                aria-label={`Delete project type ${pt.name}`}
-                                onClick={() => handleDelete(pt.slug)}
-                                disabled={
-                                  deleteMutation.isPending || !canDelete
-                                }
-                                className={
-                                  isDarkMode
-                                    ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none disabled:opacity-30'
-                                    : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none disabled:opacity-30'
-                                }
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </span>
+                            <TooltipProvider delayDuration={200}>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="inline-flex">
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      aria-label={`Delete project type ${pt.name}`}
+                                      onClick={() => handleDelete(pt.slug)}
+                                      disabled={
+                                        deleteMutation.isPending || !canDelete
+                                      }
+                                      className={
+                                        isDarkMode
+                                          ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none disabled:opacity-30'
+                                          : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none disabled:opacity-30'
+                                      }
+                                    >
+                                      <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                  </span>
+                                </TooltipTrigger>
+                                {tooltipText && (
+                                  <TooltipContent>
+                                    <p>{tooltipText}</p>
+                                  </TooltipContent>
+                                )}
+                              </Tooltip>
+                            </TooltipProvider>
                           )
                         })()}
                       </div>

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
 import { Plus, Search, Trash2, Layers, AlertCircle } from 'lucide-react'
@@ -37,6 +38,11 @@ export function ProjectTypeManagement({
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+    orgSlug: string
+  } | null>(null)
 
   const {
     data: projectTypes = [],
@@ -105,11 +111,18 @@ export function ProjectTypeManagement({
 
   const handleDelete = (slug: string) => {
     const pt = projectTypes.find((p) => p.slug === slug)
-    if (
-      pt &&
-      confirm(`Delete project type "${pt.name}"? This action cannot be undone.`)
-    ) {
-      deleteMutation.mutate({ orgSlug: pt.organization.slug, slug })
+    if (pt) {
+      setDeleteTarget({ slug, name: pt.name, orgSlug: pt.organization.slug })
+    }
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate({
+        orgSlug: deleteTarget.orgSlug,
+        slug: deleteTarget.slug,
+      })
+      setDeleteTarget(null)
     }
   }
 
@@ -197,6 +210,12 @@ export function ProjectTypeManagement({
 
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -362,26 +381,28 @@ export function ProjectTypeManagement({
                           const projectCount =
                             pt.relationships?.projects?.count ?? 0
                           const canDelete = projectCount === 0
+                          const tooltipText = !canDelete
+                            ? `Cannot delete: has ${projectCount} project(s)`
+                            : undefined
                           return (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              aria-label={`Delete project type ${pt.name}`}
-                              onClick={() => handleDelete(pt.slug)}
-                              disabled={deleteMutation.isPending || !canDelete}
-                              title={
-                                !canDelete
-                                  ? `Cannot delete: has ${projectCount} project(s)`
-                                  : undefined
-                              }
-                              className={
-                                isDarkMode
-                                  ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:opacity-30'
-                                  : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:opacity-30'
-                              }
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
+                            <span className="inline-flex" title={tooltipText}>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                aria-label={`Delete project type ${pt.name}`}
+                                onClick={() => handleDelete(pt.slug)}
+                                disabled={
+                                  deleteMutation.isPending || !canDelete
+                                }
+                                className={
+                                  isDarkMode
+                                    ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none disabled:opacity-30'
+                                    : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none disabled:opacity-30'
+                                }
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </span>
                           )
                         })()}
                       </div>

--- a/src/components/admin/RoleManagement.tsx
+++ b/src/components/admin/RoleManagement.tsx
@@ -14,6 +14,12 @@ import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { RoleForm } from './roles/RoleForm'
 import { RoleDetail } from './roles/RoleDetail'
@@ -411,48 +417,70 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
                       </td>
                       <td className="whitespace-nowrap px-4 py-3">
                         <div className="flex items-center justify-end gap-2">
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              handleEditClick(role.slug)
-                            }}
-                            disabled={isSystem}
-                            className={`rounded p-1.5 ${
-                              isSystem
-                                ? 'cursor-not-allowed opacity-40'
-                                : isDarkMode
-                                  ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
-                                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-                            }`}
-                            title={
-                              isSystem
-                                ? 'System roles cannot be edited'
-                                : 'Edit'
-                            }
-                          >
-                            <Edit2 className="h-4 w-4" />
-                          </button>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              handleDelete(role.slug)
-                            }}
-                            disabled={deleteMutation.isPending || isSystem}
-                            className={`rounded p-1.5 ${
-                              isSystem
-                                ? 'cursor-not-allowed opacity-40'
-                                : isDarkMode
-                                  ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                                  : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                            }`}
-                            title={
-                              isSystem
-                                ? 'System roles cannot be deleted'
-                                : 'Delete'
-                            }
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </button>
+                          <TooltipProvider delayDuration={200}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="inline-flex">
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      handleEditClick(role.slug)
+                                    }}
+                                    disabled={isSystem}
+                                    className={`rounded p-1.5 ${
+                                      isSystem
+                                        ? 'cursor-not-allowed opacity-40'
+                                        : isDarkMode
+                                          ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                                          : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                                    }`}
+                                  >
+                                    <Edit2 className="h-4 w-4" />
+                                  </button>
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>
+                                  {isSystem
+                                    ? 'System roles cannot be edited'
+                                    : 'Edit'}
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                          <TooltipProvider delayDuration={200}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="inline-flex">
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      handleDelete(role.slug)
+                                    }}
+                                    disabled={
+                                      deleteMutation.isPending || isSystem
+                                    }
+                                    className={`rounded p-1.5 ${
+                                      isSystem
+                                        ? 'cursor-not-allowed opacity-40'
+                                        : isDarkMode
+                                          ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                                          : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                                    }`}
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </button>
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>
+                                  {isSystem
+                                    ? 'System roles cannot be deleted'
+                                    : 'Delete'}
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
                         </div>
                       </td>
                     </tr>

--- a/src/components/admin/RoleManagement.tsx
+++ b/src/components/admin/RoleManagement.tsx
@@ -13,6 +13,8 @@ import {
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Card, CardContent } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { RoleForm } from './roles/RoleForm'
 import { RoleDetail } from './roles/RoleDetail'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -38,10 +40,13 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
     slug: selectedRoleSlug,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+  } | null>(null)
 
   // Fetch roles from API
   const {
@@ -142,12 +147,16 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
   })
 
   const handleDelete = (slug: string) => {
-    if (
-      confirm(
-        'Are you sure you want to delete this role? This action cannot be undone.',
-      )
-    ) {
-      deleteMutation.mutate(slug)
+    const role = roles.find((r) => r.slug === slug)
+    if (role) {
+      setDeleteTarget({ slug: role.slug, name: role.name })
+    }
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate(deleteTarget.slug)
+      setDeleteTarget(null)
     }
   }
 
@@ -160,7 +169,7 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
   }
 
   const handleViewClick = (slug: string) => {
-    goToDetail(slug)
+    goToEdit(slug)
   }
 
   const handleSave = (roleData: RoleCreate, permissions: string[]) => {
@@ -245,6 +254,13 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
   // View mode: List (default)
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        confirmLabel="Delete"
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -272,181 +288,181 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
       </div>
 
       {/* Roles Table */}
-      <div
-        className={`overflow-hidden rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
+      <Card
+        className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
       >
-        <table className="w-full">
-          <thead className="border-b border-tertiary bg-secondary">
-            <tr>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Role
-              </th>
-              <th
-                className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Slug
-              </th>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Description
-              </th>
-              <th
-                className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Type
-              </th>
-              <th
-                className={`whitespace-nowrap px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Last Updated
-              </th>
-              <th
-                className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className={
-              isDarkMode
-                ? 'divide-y divide-gray-700'
-                : 'divide-y divide-gray-200'
-            }
-          >
-            {filteredRoles.length === 0 ? (
+        <CardContent className="p-0">
+          <table className="w-full">
+            <thead className="border-b border-tertiary bg-secondary">
               <tr>
-                <td colSpan={6} className="px-4 py-12 text-center">
-                  <div
-                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                  >
-                    {searchQuery
-                      ? 'No roles match your search'
-                      : 'No roles created yet'}
-                  </div>
-                </td>
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Role
+                </th>
+                <th
+                  className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Slug
+                </th>
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Description
+                </th>
+                <th
+                  className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Type
+                </th>
+                <th
+                  className={`whitespace-nowrap px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Last Updated
+                </th>
+                <th
+                  className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Actions
+                </th>
               </tr>
-            ) : (
-              filteredRoles.map((role) => {
-                const isSystem =
-                  'is_system' in role && (role as RoleDetailType).is_system
-                return (
-                  <tr
-                    key={role.slug}
-                    onClick={() => handleViewClick(role.slug)}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'}`}
-                  >
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <Shield
-                          className={`h-4 w-4 flex-shrink-0 ${
-                            isDarkMode ? 'text-blue-400' : 'text-blue-600'
-                          }`}
-                        />
-                        <span
-                          className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                        >
-                          {role.name}
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-4 py-3 text-center font-mono text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            </thead>
+            <tbody
+              className={
+                isDarkMode
+                  ? 'divide-y divide-gray-700'
+                  : 'divide-y divide-gray-200'
+              }
+            >
+              {filteredRoles.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-12 text-center">
+                    <div
+                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      {role.slug}
-                    </td>
-                    <td
-                      className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                      {searchQuery
+                        ? 'No roles match your search'
+                        : 'No roles created yet'}
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                filteredRoles.map((role) => {
+                  const isSystem =
+                    'is_system' in role && (role as RoleDetailType).is_system
+                  return (
+                    <tr
+                      key={role.slug}
+                      onClick={() => handleViewClick(role.slug)}
+                      className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'}`}
                     >
-                      {role.description || '-'}
-                    </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-center">
-                      {isSystem ? (
-                        <span
-                          className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-amber-900/30 text-amber-400'
-                              : 'bg-amber-100 text-amber-700'
-                          }`}
-                        >
-                          <Lock className="h-3 w-3" />
-                          System
-                        </span>
-                      ) : (
-                        <span
-                          className={`rounded px-2 py-1 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-blue-900/30 text-blue-400'
-                              : 'bg-blue-100 text-blue-700'
-                          }`}
-                        >
-                          Custom
-                        </span>
-                      )}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-4 py-3 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {formatRelativeDate(role.updated_at)}
-                    </td>
-                    <td className="whitespace-nowrap px-4 py-3">
-                      <div className="flex items-center justify-end gap-2">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleEditClick(role.slug)
-                          }}
-                          disabled={isSystem}
-                          className={`rounded p-1.5 ${
-                            isSystem
-                              ? 'cursor-not-allowed opacity-40'
-                              : isDarkMode
-                                ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
-                                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-                          }`}
-                          title={
-                            isSystem ? 'System roles cannot be edited' : 'Edit'
-                          }
-                        >
-                          <Edit2 className="h-4 w-4" />
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleDelete(role.slug)
-                          }}
-                          disabled={deleteMutation.isPending || isSystem}
-                          className={`rounded p-1.5 ${
-                            isSystem
-                              ? 'cursor-not-allowed opacity-40'
-                              : isDarkMode
-                                ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                                : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                          }`}
-                          title={
-                            isSystem
-                              ? 'System roles cannot be deleted'
-                              : 'Delete'
-                          }
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                )
-              })
-            )}
-          </tbody>
-        </table>
-      </div>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <Shield
+                            className={`h-4 w-4 flex-shrink-0 ${
+                              isDarkMode ? 'text-blue-400' : 'text-blue-600'
+                            }`}
+                          />
+                          <span
+                            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                          >
+                            {role.name}
+                          </span>
+                        </div>
+                      </td>
+                      <td
+                        className={`whitespace-nowrap px-4 py-3 text-center font-mono text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                      >
+                        {role.slug}
+                      </td>
+                      <td
+                        className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                      >
+                        {role.description || '-'}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-center">
+                        {isSystem ? (
+                          <span
+                            className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-amber-900/30 text-amber-400'
+                                : 'bg-amber-100 text-amber-700'
+                            }`}
+                          >
+                            <Lock className="h-3 w-3" />
+                            System
+                          </span>
+                        ) : (
+                          <span
+                            className={`rounded px-2 py-1 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-blue-900/30 text-blue-400'
+                                : 'bg-blue-100 text-blue-700'
+                            }`}
+                          >
+                            Custom
+                          </span>
+                        )}
+                      </td>
+                      <td
+                        className={`whitespace-nowrap px-4 py-3 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                      >
+                        {formatRelativeDate(role.updated_at)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3">
+                        <div className="flex items-center justify-end gap-2">
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleEditClick(role.slug)
+                            }}
+                            disabled={isSystem}
+                            className={`rounded p-1.5 ${
+                              isSystem
+                                ? 'cursor-not-allowed opacity-40'
+                                : isDarkMode
+                                  ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                            }`}
+                            title={
+                              isSystem
+                                ? 'System roles cannot be edited'
+                                : 'Edit'
+                            }
+                          >
+                            <Edit2 className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleDelete(role.slug)
+                            }}
+                            disabled={deleteMutation.isPending || isSystem}
+                            className={`rounded p-1.5 ${
+                              isSystem
+                                ? 'cursor-not-allowed opacity-40'
+                                : isDarkMode
+                                  ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                                  : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                            }`}
+                            title={
+                              isSystem
+                                ? 'System roles cannot be deleted'
+                                : 'Delete'
+                            }
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/RoleManagement.tsx
+++ b/src/components/admin/RoleManagement.tsx
@@ -161,6 +161,12 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
           <TooltipTrigger asChild>
             <span className="inline-flex">
               <button
+                type="button"
+                aria-label={
+                  isSystem
+                    ? `System role ${role.name} cannot be edited`
+                    : `Edit role ${role.name}`
+                }
                 onClick={(e) => {
                   e.stopPropagation()
                   handleEditClick(role.slug)
@@ -387,11 +393,10 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
         rows={filteredRoles}
         getRowKey={(role) => role.slug}
         getDeleteLabel={(role) => role.name}
-        onRowClick={(role) => {
-          const isSystem =
-            'is_system' in role && (role as RoleDetailType).is_system
-          if (!isSystem) handleViewClick(role.slug)
-        }}
+        onRowClick={(role) => handleViewClick(role.slug)}
+        isRowClickable={(role) =>
+          !('is_system' in role && (role as RoleDetailType).is_system)
+        }
         onDelete={handleDelete}
         canDelete={canDeleteRole}
         isDeleting={deleteMutation.isPending}

--- a/src/components/admin/RoleManagement.tsx
+++ b/src/components/admin/RoleManagement.tsx
@@ -1,26 +1,18 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import {
-  Plus,
-  Search,
-  Edit2,
-  Trash2,
-  Shield,
-  AlertCircle,
-  Lock,
-} from 'lucide-react'
+import { Plus, Search, Edit2, Shield, AlertCircle, Lock } from 'lucide-react'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Card, CardContent } from '@/components/ui/card'
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { AdminTable } from '@/components/ui/admin-table'
+import type { CanDeleteResult } from '@/components/ui/admin-table'
 import { RoleForm } from './roles/RoleForm'
 import { RoleDetail } from './roles/RoleDetail'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -34,6 +26,8 @@ import {
   revokePermission,
 } from '@/api/endpoints'
 import type { RoleDetail as RoleDetailType, RoleCreate } from '@/types'
+
+type Role = Awaited<ReturnType<typeof getRoles>>[number]
 
 interface RoleManagementProps {
   isDarkMode: boolean
@@ -49,10 +43,6 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-  } | null>(null)
 
   // Fetch roles from API
   const {
@@ -152,18 +142,48 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
     return true
   })
 
-  const handleDelete = (slug: string) => {
-    const role = roles.find((r) => r.slug === slug)
-    if (role) {
-      setDeleteTarget({ slug: role.slug, name: role.name })
-    }
+  const handleDelete = (role: Role) => {
+    deleteMutation.mutate(role.slug)
   }
 
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate(deleteTarget.slug)
-      setDeleteTarget(null)
-    }
+  const canDeleteRole = (role: Role): CanDeleteResult => {
+    const isSystem = 'is_system' in role && (role as RoleDetailType).is_system
+    if (isSystem)
+      return { allowed: false, reason: 'System roles cannot be deleted' }
+    return { allowed: true }
+  }
+
+  const roleActions = (role: Role) => {
+    const isSystem = 'is_system' in role && (role as RoleDetailType).is_system
+    return (
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleEditClick(role.slug)
+                }}
+                disabled={isSystem}
+                className={`rounded p-1.5 ${
+                  isSystem
+                    ? 'cursor-not-allowed opacity-40'
+                    : isDarkMode
+                      ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                }`}
+              >
+                <Edit2 className="h-4 w-4" />
+              </button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{isSystem ? 'System roles cannot be edited' : 'Edit'}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
   }
 
   const handleCreateClick = () => {
@@ -260,13 +280,6 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
   // View mode: List (default)
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        confirmLabel="Delete"
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -293,204 +306,96 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
         </Button>
       </div>
 
-      {/* Roles Table */}
-      <Card
-        className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-      >
-        <CardContent className="p-0">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+      <AdminTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Role',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (role) => (
+              <div className="flex items-center gap-2">
+                <Shield
+                  className={`h-4 w-4 flex-shrink-0 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+                />
+                <span
+                  className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                 >
-                  Role
-                </th>
-                <th
-                  className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                  {role.name}
+                </span>
+              </div>
+            ),
+          },
+          {
+            key: 'slug',
+            header: 'Slug',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (role) => (
+              <span
+                className={`font-mono text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                {role.slug}
+              </span>
+            ),
+          },
+          {
+            key: 'description',
+            header: 'Description',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (role) => (
+              <span
+                className={`text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              >
+                {role.description || '-'}
+              </span>
+            ),
+          },
+          {
+            key: 'type',
+            header: 'Type',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (role) => {
+              const isSystem =
+                'is_system' in role && (role as RoleDetailType).is_system
+              return isSystem ? (
+                <span
+                  className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${isDarkMode ? 'bg-amber-900/30 text-amber-400' : 'bg-amber-100 text-amber-700'}`}
                 >
-                  Slug
-                </th>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Description
-                </th>
-                <th
-                  className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Type
-                </th>
-                <th
-                  className={`whitespace-nowrap px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Last Updated
-                </th>
-                <th
-                  className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={
-                isDarkMode
-                  ? 'divide-y divide-gray-700'
-                  : 'divide-y divide-gray-200'
-              }
-            >
-              {filteredRoles.length === 0 ? (
-                <tr>
-                  <td colSpan={6} className="px-4 py-12 text-center">
-                    <div
-                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                    >
-                      {searchQuery
-                        ? 'No roles match your search'
-                        : 'No roles created yet'}
-                    </div>
-                  </td>
-                </tr>
+                  <Lock className="h-3 w-3" />
+                  System
+                </span>
               ) : (
-                filteredRoles.map((role) => {
-                  const isSystem =
-                    'is_system' in role && (role as RoleDetailType).is_system
-                  return (
-                    <tr
-                      key={role.slug}
-                      onClick={() => handleViewClick(role.slug)}
-                      className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'}`}
-                    >
-                      <td className="px-4 py-3">
-                        <div className="flex items-center gap-2">
-                          <Shield
-                            className={`h-4 w-4 flex-shrink-0 ${
-                              isDarkMode ? 'text-blue-400' : 'text-blue-600'
-                            }`}
-                          />
-                          <span
-                            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                          >
-                            {role.name}
-                          </span>
-                        </div>
-                      </td>
-                      <td
-                        className={`whitespace-nowrap px-4 py-3 text-center font-mono text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                      >
-                        {role.slug}
-                      </td>
-                      <td
-                        className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                      >
-                        {role.description || '-'}
-                      </td>
-                      <td className="whitespace-nowrap px-4 py-3 text-center">
-                        {isSystem ? (
-                          <span
-                            className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${
-                              isDarkMode
-                                ? 'bg-amber-900/30 text-amber-400'
-                                : 'bg-amber-100 text-amber-700'
-                            }`}
-                          >
-                            <Lock className="h-3 w-3" />
-                            System
-                          </span>
-                        ) : (
-                          <span
-                            className={`rounded px-2 py-1 text-xs font-medium ${
-                              isDarkMode
-                                ? 'bg-blue-900/30 text-blue-400'
-                                : 'bg-blue-100 text-blue-700'
-                            }`}
-                          >
-                            Custom
-                          </span>
-                        )}
-                      </td>
-                      <td
-                        className={`whitespace-nowrap px-4 py-3 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                      >
-                        {formatRelativeDate(role.updated_at)}
-                      </td>
-                      <td className="whitespace-nowrap px-4 py-3">
-                        <div className="flex items-center justify-end gap-2">
-                          <TooltipProvider delayDuration={200}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="inline-flex">
-                                  <button
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      handleEditClick(role.slug)
-                                    }}
-                                    disabled={isSystem}
-                                    className={`rounded p-1.5 ${
-                                      isSystem
-                                        ? 'cursor-not-allowed opacity-40'
-                                        : isDarkMode
-                                          ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
-                                          : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-                                    }`}
-                                  >
-                                    <Edit2 className="h-4 w-4" />
-                                  </button>
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                <p>
-                                  {isSystem
-                                    ? 'System roles cannot be edited'
-                                    : 'Edit'}
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                          <TooltipProvider delayDuration={200}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="inline-flex">
-                                  <button
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      handleDelete(role.slug)
-                                    }}
-                                    disabled={
-                                      deleteMutation.isPending || isSystem
-                                    }
-                                    className={`rounded p-1.5 ${
-                                      isSystem
-                                        ? 'cursor-not-allowed opacity-40'
-                                        : isDarkMode
-                                          ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                                          : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                                    }`}
-                                  >
-                                    <Trash2 className="h-4 w-4" />
-                                  </button>
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                <p>
-                                  {isSystem
-                                    ? 'System roles cannot be deleted'
-                                    : 'Delete'}
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        </div>
-                      </td>
-                    </tr>
-                  )
-                })
-              )}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
+                <span
+                  className={`rounded px-2 py-1 text-xs font-medium ${isDarkMode ? 'bg-blue-900/30 text-blue-400' : 'bg-blue-100 text-blue-700'}`}
+                >
+                  Custom
+                </span>
+              )
+            },
+          },
+          {
+            key: 'updated',
+            header: 'Last Updated',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (role) => formatRelativeDate(role.updated_at),
+          },
+        ]}
+        rows={filteredRoles}
+        getRowKey={(role) => role.slug}
+        getDeleteLabel={(role) => role.name}
+        onRowClick={(role) => handleViewClick(role.slug)}
+        onDelete={handleDelete}
+        canDelete={canDeleteRole}
+        isDeleting={deleteMutation.isPending}
+        actions={roleActions}
+        emptyMessage={
+          searchQuery ? 'No roles match your search' : 'No roles created yet'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/RoleManagement.tsx
+++ b/src/components/admin/RoleManagement.tsx
@@ -387,7 +387,11 @@ export function RoleManagement({ isDarkMode }: RoleManagementProps) {
         rows={filteredRoles}
         getRowKey={(role) => role.slug}
         getDeleteLabel={(role) => role.name}
-        onRowClick={(role) => handleViewClick(role.slug)}
+        onRowClick={(role) => {
+          const isSystem =
+            'is_system' in role && (role as RoleDetailType).is_system
+          if (!isSystem) handleViewClick(role.slug)
+        }}
         onDelete={handleDelete}
         canDelete={canDeleteRole}
         isDeleting={deleteMutation.isPending}

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -5,6 +5,12 @@ import { Plus, Search, Trash2, Power, Bot, AlertCircle } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Card, CardContent } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { ServiceAccountForm } from './service-accounts/ServiceAccountForm'
 import { ServiceAccountDetail } from './service-accounts/ServiceAccountDetail'
@@ -420,21 +426,29 @@ export function ServiceAccountManagement({
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-2">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleDelete(account.slug)
-                          }}
-                          disabled={deleteMutation.isPending}
-                          className={`rounded p-1.5 ${
-                            isDarkMode
-                              ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                              : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                          }`}
-                          title="Delete"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  handleDelete(account.slug)
+                                }}
+                                disabled={deleteMutation.isPending}
+                                className={`rounded p-1.5 ${
+                                  isDarkMode
+                                    ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                                    : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                                }`}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Delete</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       </div>
                     </td>
                   </tr>

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -1,17 +1,10 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import { Plus, Search, Trash2, Power, Bot, AlertCircle } from 'lucide-react'
+import { Plus, Search, Power, Bot, AlertCircle } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
-import { Card, CardContent } from '@/components/ui/card'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { AdminTable } from '@/components/ui/admin-table'
 import { ServiceAccountForm } from './service-accounts/ServiceAccountForm'
 import { ServiceAccountDetail } from './service-accounts/ServiceAccountDetail'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -47,10 +40,6 @@ export function ServiceAccountManagement({
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-  } | null>(null)
 
   // Fetch service accounts from dedicated endpoint
   const {
@@ -135,18 +124,8 @@ export function ServiceAccountManagement({
       !!selectedAccountSlug && (viewMode === 'detail' || viewMode === 'edit'),
   })
 
-  const handleDelete = (slug: string) => {
-    const account = serviceAccounts.find((a: ServiceAccount) => a.slug === slug)
-    if (account) {
-      setDeleteTarget({ slug: account.slug, name: account.display_name })
-    }
-  }
-
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate(deleteTarget.slug)
-      setDeleteTarget(null)
-    }
+  const handleDelete = (account: ServiceAccount) => {
+    deleteMutation.mutate(account.slug)
   }
 
   const handleViewClick = (account: ServiceAccount) => {
@@ -245,14 +224,6 @@ export function ServiceAccountManagement({
   // View mode: List (default)
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        description="This will revoke all API access and cannot be undone."
-        confirmLabel="Delete"
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex flex-1 items-center gap-3">
@@ -293,171 +264,100 @@ export function ServiceAccountManagement({
       </div>
 
       {/* Service Accounts Table */}
-      <Card
-        className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-      >
-        <CardContent className="p-0">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+      <AdminTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Service Account',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (account) => (
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex size-8 items-center justify-center rounded-full ${isDarkMode ? 'bg-purple-900/30' : 'bg-purple-100'}`}
                 >
-                  Service Account
-                </th>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Slug
-                </th>
-                <th
-                  className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Status
-                </th>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Last Authenticated
-                </th>
-                <th
-                  className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={
-                isDarkMode
-                  ? 'divide-y divide-gray-700'
-                  : 'divide-y divide-gray-200'
-              }
-            >
-              {filteredAccounts.length === 0 ? (
-                <tr>
-                  <td colSpan={5} className="px-4 py-12 text-center">
-                    <div
-                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                    >
-                      {searchQuery || statusFilter !== 'all'
-                        ? 'No service accounts match your filters'
-                        : 'No service accounts created yet'}
-                    </div>
-                    {!searchQuery && statusFilter === 'all' && (
-                      <Button
-                        onClick={goToCreate}
-                        className="mt-4 bg-amber-border text-white hover:bg-amber-border-strong"
-                      >
-                        Create Your First Service Account
-                      </Button>
-                    )}
-                  </td>
-                </tr>
-              ) : (
-                filteredAccounts.map((account: ServiceAccount) => (
-                  <tr
-                    key={account.slug}
-                    onClick={() => handleViewClick(account)}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'} ${
-                      !account.is_active ? 'opacity-60' : ''
-                    }`}
+                  <Bot
+                    className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+                  />
+                </div>
+                <div>
+                  <div
+                    className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                   >
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-8 w-8 items-center justify-center rounded-full ${
-                            isDarkMode ? 'bg-purple-900/30' : 'bg-purple-100'
-                          }`}
-                        >
-                          <Bot
-                            className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
-                          />
-                        </div>
-                        <div>
-                          <div
-                            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                          >
-                            {account.display_name}
-                          </div>
-                          {account.description && (
-                            <div
-                              className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-                            >
-                              {account.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td
-                      className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                    {account.display_name}
+                  </div>
+                  {account.description && (
+                    <div
+                      className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
                     >
-                      <code
-                        className={`rounded px-2 py-0.5 text-xs ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-600'
-                        }`}
-                      >
-                        {account.slug}
-                      </code>
-                    </td>
-                    <td className="px-4 py-3 text-center">
-                      <span
-                        className={`inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium ${
-                          account.is_active
-                            ? isDarkMode
-                              ? 'bg-green-900/30 text-green-400'
-                              : 'bg-green-100 text-green-700'
-                            : isDarkMode
-                              ? 'bg-gray-700 text-gray-400'
-                              : 'bg-gray-100 text-gray-600'
-                        }`}
-                      >
-                        <Power className="h-3 w-3" />
-                        {account.is_active ? 'Active' : 'Inactive'}
-                      </span>
-                    </td>
-                    <td
-                      className={`px-4 py-3 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                    >
-                      {formatDate(account.last_authenticated)}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center justify-end gap-2">
-                        <TooltipProvider delayDuration={200}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleDelete(account.slug)
-                                }}
-                                disabled={deleteMutation.isPending}
-                                className={`rounded p-1.5 ${
-                                  isDarkMode
-                                    ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                                    : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                                }`}
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>Delete</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      </div>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
+                      {account.description}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ),
+          },
+          {
+            key: 'slug',
+            header: 'Slug',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (account) => (
+              <code
+                className={`rounded px-2 py-0.5 text-xs ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-600'}`}
+              >
+                {account.slug}
+              </code>
+            ),
+          },
+          {
+            key: 'status',
+            header: 'Status',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (account) => (
+              <span
+                className={`inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium ${
+                  account.is_active
+                    ? isDarkMode
+                      ? 'bg-green-900/30 text-green-400'
+                      : 'bg-green-100 text-green-700'
+                    : isDarkMode
+                      ? 'bg-gray-700 text-gray-400'
+                      : 'bg-gray-100 text-gray-600'
+                }`}
+              >
+                <Power className="h-3 w-3" />
+                {account.is_active ? 'Active' : 'Inactive'}
+              </span>
+            ),
+          },
+          {
+            key: 'last_auth',
+            header: 'Last Authenticated',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (account) => (
+              <span
+                className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                {formatDate(account.last_authenticated)}
+              </span>
+            ),
+          },
+        ]}
+        rows={filteredAccounts}
+        getRowKey={(account) => account.slug}
+        getDeleteLabel={(account) => account.display_name}
+        onRowClick={(account) => handleViewClick(account)}
+        onDelete={handleDelete}
+        isDeleting={deleteMutation.isPending}
+        emptyMessage={
+          searchQuery || statusFilter !== 'all'
+            ? 'No service accounts match your filters'
+            : 'No service accounts created yet'
+        }
+      />
 
       {/* Summary */}
       {filteredAccounts.length > 0 && (

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -4,6 +4,8 @@ import type { ApiError } from '@/api/client'
 import { Plus, Search, Trash2, Power, Bot, AlertCircle } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
+import { Card, CardContent } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { ServiceAccountForm } from './service-accounts/ServiceAccountForm'
 import { ServiceAccountDetail } from './service-accounts/ServiceAccountDetail'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -35,11 +37,14 @@ export function ServiceAccountManagement({
     slug: selectedAccountSlug,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+  } | null>(null)
 
   // Fetch service accounts from dedicated endpoint
   const {
@@ -126,17 +131,20 @@ export function ServiceAccountManagement({
 
   const handleDelete = (slug: string) => {
     const account = serviceAccounts.find((a: ServiceAccount) => a.slug === slug)
-    if (
-      confirm(
-        `Are you sure you want to delete "${account?.display_name}"? This will revoke all API access and cannot be undone.`,
-      )
-    ) {
-      deleteMutation.mutate(slug)
+    if (account) {
+      setDeleteTarget({ slug: account.slug, name: account.display_name })
+    }
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate(deleteTarget.slug)
+      setDeleteTarget(null)
     }
   }
 
   const handleViewClick = (account: ServiceAccount) => {
-    goToDetail(account.slug)
+    goToEdit(account.slug)
   }
 
   const handleEditClick = (account: ServiceAccount) => {
@@ -231,6 +239,14 @@ export function ServiceAccountManagement({
   // View mode: List (default)
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        description="This will revoke all API access and cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex flex-1 items-center gap-3">
@@ -271,165 +287,163 @@ export function ServiceAccountManagement({
       </div>
 
       {/* Service Accounts Table */}
-      <div
-        className={`overflow-hidden rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
+      <Card
+        className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
       >
-        <table className="w-full">
-          <thead className="border-b border-tertiary bg-secondary">
-            <tr>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Service Account
-              </th>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Slug
-              </th>
-              <th
-                className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Status
-              </th>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Last Authenticated
-              </th>
-              <th
-                className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className={
-              isDarkMode
-                ? 'divide-y divide-gray-700'
-                : 'divide-y divide-gray-200'
-            }
-          >
-            {filteredAccounts.length === 0 ? (
+        <CardContent className="p-0">
+          <table className="w-full">
+            <thead className="border-b border-tertiary bg-secondary">
               <tr>
-                <td colSpan={5} className="px-4 py-12 text-center">
-                  <div
-                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                  >
-                    {searchQuery || statusFilter !== 'all'
-                      ? 'No service accounts match your filters'
-                      : 'No service accounts created yet'}
-                  </div>
-                  {!searchQuery && statusFilter === 'all' && (
-                    <Button
-                      onClick={goToCreate}
-                      className="mt-4 bg-amber-border text-white hover:bg-amber-border-strong"
-                    >
-                      Create Your First Service Account
-                    </Button>
-                  )}
-                </td>
-              </tr>
-            ) : (
-              filteredAccounts.map((account: ServiceAccount) => (
-                <tr
-                  key={account.slug}
-                  onClick={() => handleViewClick(account)}
-                  className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'} ${
-                    !account.is_active ? 'opacity-60' : ''
-                  }`}
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                 >
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-3">
-                      <div
-                        className={`flex h-8 w-8 items-center justify-center rounded-full ${
-                          isDarkMode ? 'bg-purple-900/30' : 'bg-purple-100'
-                        }`}
-                      >
-                        <Bot
-                          className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
-                        />
-                      </div>
-                      <div>
-                        <div
-                          className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                        >
-                          {account.display_name}
-                        </div>
-                        {account.description && (
-                          <div
-                            className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-                          >
-                            {account.description}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                  >
-                    <code
-                      className={`rounded px-2 py-0.5 text-xs ${
-                        isDarkMode
-                          ? 'bg-gray-700 text-gray-300'
-                          : 'bg-gray-100 text-gray-600'
-                      }`}
+                  Service Account
+                </th>
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Slug
+                </th>
+                <th
+                  className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Status
+                </th>
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Last Authenticated
+                </th>
+                <th
+                  className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              className={
+                isDarkMode
+                  ? 'divide-y divide-gray-700'
+                  : 'divide-y divide-gray-200'
+              }
+            >
+              {filteredAccounts.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-12 text-center">
+                    <div
+                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      {account.slug}
-                    </code>
-                  </td>
-                  <td className="px-4 py-3 text-center">
-                    <span
-                      className={`inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium ${
-                        account.is_active
-                          ? isDarkMode
-                            ? 'bg-green-900/30 text-green-400'
-                            : 'bg-green-100 text-green-700'
-                          : isDarkMode
-                            ? 'bg-gray-700 text-gray-400'
-                            : 'bg-gray-100 text-gray-600'
-                      }`}
-                    >
-                      <Power className="h-3 w-3" />
-                      {account.is_active ? 'Active' : 'Inactive'}
-                    </span>
-                  </td>
-                  <td
-                    className={`px-4 py-3 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                  >
-                    {formatDate(account.last_authenticated)}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center justify-end gap-2">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleDelete(account.slug)
-                        }}
-                        disabled={deleteMutation.isPending}
-                        className={`rounded p-1.5 ${
-                          isDarkMode
-                            ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                            : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                        }`}
-                        title="Delete"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
+                      {searchQuery || statusFilter !== 'all'
+                        ? 'No service accounts match your filters'
+                        : 'No service accounts created yet'}
                     </div>
+                    {!searchQuery && statusFilter === 'all' && (
+                      <Button
+                        onClick={goToCreate}
+                        className="mt-4 bg-amber-border text-white hover:bg-amber-border-strong"
+                      >
+                        Create Your First Service Account
+                      </Button>
+                    )}
                   </td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+              ) : (
+                filteredAccounts.map((account: ServiceAccount) => (
+                  <tr
+                    key={account.slug}
+                    onClick={() => handleViewClick(account)}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'} ${
+                      !account.is_active ? 'opacity-60' : ''
+                    }`}
+                  >
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className={`flex h-8 w-8 items-center justify-center rounded-full ${
+                            isDarkMode ? 'bg-purple-900/30' : 'bg-purple-100'
+                          }`}
+                        >
+                          <Bot
+                            className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+                          />
+                        </div>
+                        <div>
+                          <div
+                            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                          >
+                            {account.display_name}
+                          </div>
+                          {account.description && (
+                            <div
+                              className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                            >
+                              {account.description}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                    >
+                      <code
+                        className={`rounded px-2 py-0.5 text-xs ${
+                          isDarkMode
+                            ? 'bg-gray-700 text-gray-300'
+                            : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        {account.slug}
+                      </code>
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <span
+                        className={`inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium ${
+                          account.is_active
+                            ? isDarkMode
+                              ? 'bg-green-900/30 text-green-400'
+                              : 'bg-green-100 text-green-700'
+                            : isDarkMode
+                              ? 'bg-gray-700 text-gray-400'
+                              : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        <Power className="h-3 w-3" />
+                        {account.is_active ? 'Active' : 'Inactive'}
+                      </span>
+                    </td>
+                    <td
+                      className={`px-4 py-3 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                    >
+                      {formatDate(account.last_authenticated)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-2">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleDelete(account.slug)
+                          }}
+                          disabled={deleteMutation.isPending}
+                          className={`rounded p-1.5 ${
+                            isDarkMode
+                              ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                              : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                          }`}
+                          title="Delete"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
 
       {/* Summary */}
       {filteredAccounts.length > 0 && (

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -1,25 +1,20 @@
 import { useState, useMemo } from 'react'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import { Plus, Search, Trash2, Users, AlertCircle } from 'lucide-react'
+import { Plus, Search, Users, AlertCircle } from 'lucide-react'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
 import { Card, CardContent, CardDescription } from '@/components/ui/card'
+import { AdminTable } from '@/components/ui/admin-table'
+import type { CanDeleteResult } from '@/components/ui/admin-table'
 import { TeamForm } from './teams/TeamForm'
 import { TeamDetail } from './teams/TeamDetail'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import { listTeams, deleteTeam, createTeam, updateTeam } from '@/api/endpoints'
-import type { TeamCreate } from '@/types'
+import type { Team, TeamCreate } from '@/types'
 
 interface TeamManagementProps {
   isDarkMode: boolean
@@ -36,11 +31,6 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-    orgSlug: string
-  } | null>(null)
 
   const orgSlug = selectedOrganization?.slug
 
@@ -109,25 +99,19 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
     [teams, selectedTeamSlug],
   )
 
-  const handleDelete = (slug: string) => {
-    const team = teams.find((t) => t.slug === slug)
-    if (team) {
-      setDeleteTarget({
-        slug,
-        name: team.name,
-        orgSlug: team.organization.slug,
-      })
-    }
+  const handleDelete = (team: Team) => {
+    deleteMutation.mutate({ orgSlug: team.organization.slug, slug: team.slug })
   }
 
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate({
-        orgSlug: deleteTarget.orgSlug,
-        slug: deleteTarget.slug,
-      })
-      setDeleteTarget(null)
-    }
+  const canDeleteTeam = (team: Team): CanDeleteResult => {
+    const projects = team.relationships?.projects?.count ?? 0
+    const members = team.relationships?.members?.count ?? 0
+    if (projects === 0 && members === 0) return { allowed: true }
+    const parts = [
+      projects > 0 ? `${projects} project(s)` : '',
+      members > 0 ? `${members} member(s)` : '',
+    ].filter(Boolean)
+    return { allowed: false, reason: `Has ${parts.join(' and ')}` }
   }
 
   const handleSave = (formOrgSlug: string, teamData: TeamCreate) => {
@@ -214,12 +198,6 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
 
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -298,228 +276,129 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
         </Card>
       </div>
 
-      {/* Teams Table */}
-      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="border-b border-tertiary bg-secondary">
-                <tr>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Team
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Slug
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Projects
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Members
-                  </th>
-                  <th
-                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Last Updated
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-              >
-                {filteredTeams.map((team) => (
-                  <tr
-                    key={team.slug}
-                    onClick={() => goToEdit(team.slug)}
-                    onKeyDown={(e) => {
-                      if (e.currentTarget !== e.target) return
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        goToEdit(team.slug)
-                      }
-                    }}
-                    tabIndex={0}
-                    aria-label={`Edit team ${team.name}`}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                  >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                            isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
-                          }`}
-                        >
-                          {team.icon ? (
-                            <EntityIcon
-                              icon={team.icon}
-                              className="h-5 w-5 rounded object-cover"
-                            />
-                          ) : (
-                            <Users
-                              className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-                            />
-                          )}
-                        </div>
-                        <div>
-                          <div
-                            className={
-                              isDarkMode ? 'text-white' : 'text-gray-900'
-                            }
-                          >
-                            {team.name}
-                          </div>
-                          {team.description && (
-                            <div
-                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                            >
-                              {team.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+      <AdminTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Team',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (team) => (
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex size-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                    isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
+                  }`}
+                >
+                  {team.icon ? (
+                    <EntityIcon
+                      icon={team.icon}
+                      className="size-5 rounded object-cover"
+                    />
+                  ) : (
+                    <Users
+                      className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+                    />
+                  )}
+                </div>
+                <div>
+                  <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                    {team.name}
+                  </div>
+                  {team.description && (
+                    <div
+                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      <code
-                        className={`rounded px-2 py-1 ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
-                        }`}
-                      >
-                        {team.slug}
-                      </code>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                        (team.relationships?.projects?.count ?? 0) === 0
-                          ? isDarkMode
-                            ? 'text-gray-600'
-                            : 'text-gray-400'
-                          : isDarkMode
-                            ? 'text-gray-300'
-                            : 'text-gray-600'
-                      }`}
-                    >
-                      {team.relationships?.projects?.count ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                        (team.relationships?.members?.count ?? 0) === 0
-                          ? isDarkMode
-                            ? 'text-gray-600'
-                            : 'text-gray-400'
-                          : isDarkMode
-                            ? 'text-gray-300'
-                            : 'text-gray-600'
-                      }`}
-                    >
-                      {team.relationships?.members?.count ?? 0}
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {formatRelativeDate(team.updated_at ?? team.created_at)}
-                    </td>
-                    <td
-                      className="whitespace-nowrap px-6 py-4 text-right"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center justify-end gap-2">
-                        {(() => {
-                          const projectCount =
-                            team.relationships?.projects?.count ?? 0
-                          const memberCount =
-                            team.relationships?.members?.count ?? 0
-                          const canDelete =
-                            projectCount === 0 && memberCount === 0
-                          const disabledParts = [
-                            projectCount > 0
-                              ? `${projectCount} project(s)`
-                              : '',
-                            memberCount > 0 ? `${memberCount} member(s)` : '',
-                          ].filter(Boolean)
-                          const tooltipText = !canDelete
-                            ? `Cannot delete: has ${disabledParts.join(' and ')}`
-                            : undefined
-                          return (
-                            <TooltipProvider delayDuration={200}>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span className="inline-flex">
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      onClick={() => handleDelete(team.slug)}
-                                      disabled={
-                                        deleteMutation.isPending || !canDelete
-                                      }
-                                      className={
-                                        isDarkMode
-                                          ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none disabled:opacity-30'
-                                          : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none disabled:opacity-30'
-                                      }
-                                    >
-                                      <Trash2 className="h-4 w-4" />
-                                    </Button>
-                                  </span>
-                                </TooltipTrigger>
-                                {tooltipText && (
-                                  <TooltipContent>
-                                    <p>{tooltipText}</p>
-                                  </TooltipContent>
-                                )}
-                              </Tooltip>
-                            </TooltipProvider>
-                          )
-                        })()}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-
-            {filteredTeams.length === 0 && (
-              <div
-                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-              >
-                {searchQuery
-                  ? 'No teams found matching your search.'
-                  : selectedOrganization
-                    ? `No teams in ${selectedOrganization.name} yet.`
-                    : 'No teams created yet.'}
+                      {team.description}
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+            ),
+          },
+          {
+            key: 'slug',
+            header: 'Slug',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (team) => (
+              <code
+                className={`rounded px-2 py-1 ${
+                  isDarkMode
+                    ? 'bg-gray-700 text-gray-300'
+                    : 'bg-gray-100 text-gray-700'
+                }`}
+              >
+                {team.slug}
+              </code>
+            ),
+          },
+          {
+            key: 'projects',
+            header: 'Projects',
+            headerAlign: 'right',
+            cellAlign: 'right',
+            render: (team) => (
+              <span
+                className={
+                  (team.relationships?.projects?.count ?? 0) === 0
+                    ? isDarkMode
+                      ? 'text-gray-600'
+                      : 'text-gray-400'
+                    : isDarkMode
+                      ? 'text-gray-300'
+                      : 'text-gray-600'
+                }
+              >
+                {team.relationships?.projects?.count ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'members',
+            header: 'Members',
+            headerAlign: 'right',
+            cellAlign: 'right',
+            render: (team) => (
+              <span
+                className={
+                  (team.relationships?.members?.count ?? 0) === 0
+                    ? isDarkMode
+                      ? 'text-gray-600'
+                      : 'text-gray-400'
+                    : isDarkMode
+                      ? 'text-gray-300'
+                      : 'text-gray-600'
+                }
+              >
+                {team.relationships?.members?.count ?? 0}
+              </span>
+            ),
+          },
+          {
+            key: 'updated',
+            header: 'Last Updated',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (team) =>
+              formatRelativeDate(team.updated_at ?? team.created_at),
+          },
+        ]}
+        rows={filteredTeams}
+        getRowKey={(team) => team.slug}
+        getDeleteLabel={(team) => team.name}
+        onRowClick={(team) => goToEdit(team.slug)}
+        onDelete={handleDelete}
+        canDelete={canDeleteTeam}
+        isDeleting={deleteMutation.isPending}
+        emptyMessage={
+          searchQuery
+            ? 'No teams found matching your search.'
+            : selectedOrganization
+              ? `No teams in ${selectedOrganization.name} yet.`
+              : 'No teams created yet.'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -6,6 +6,7 @@ import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
+import { Card, CardContent, CardDescription } from '@/components/ui/card'
 import { TeamForm } from './teams/TeamForm'
 import { TeamDetail } from './teams/TeamDetail'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -25,7 +26,6 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
     slug: selectedTeamSlug,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
@@ -219,260 +219,265 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
 
       {/* Stats */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Total Teams
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            {filteredTeams.length}
-          </div>
-        </div>
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Total Projects
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            {filteredTeams.reduce(
-              (sum, t) => sum + (t.relationships?.projects?.count ?? 0),
-              0,
-            )}
-          </div>
-        </div>
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Total Members
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            {filteredTeams.reduce(
-              (sum, t) => sum + (t.relationships?.members?.count ?? 0),
-              0,
-            )}
-          </div>
-        </div>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Total Teams
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              {filteredTeams.length}
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Total Projects
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              {filteredTeams.reduce(
+                (sum, t) => sum + (t.relationships?.projects?.count ?? 0),
+                0,
+              )}
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Total Members
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              {filteredTeams.reduce(
+                (sum, t) => sum + (t.relationships?.members?.count ?? 0),
+                0,
+              )}
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       {/* Teams Table */}
-      <div
-        className={`rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Team
-                </th>
-                <th
-                  className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Slug
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Projects
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Members
-                </th>
-                <th
-                  className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Last Updated
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-            >
-              {filteredTeams.map((team) => (
-                <tr
-                  key={team.slug}
-                  onClick={() => goToDetail(team.slug)}
-                  onKeyDown={(e) => {
-                    if (e.currentTarget !== e.target) return
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      goToDetail(team.slug)
-                    }
-                  }}
-                  tabIndex={0}
-                  aria-label={`View team ${team.name}`}
-                  className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                >
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                      <div
-                        className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                          isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="border-b border-tertiary bg-secondary">
+                <tr>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Team
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Slug
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Projects
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Members
+                  </th>
+                  <th
+                    className={`whitespace-nowrap px-6 py-3 text-center text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Last Updated
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+              >
+                {filteredTeams.map((team) => (
+                  <tr
+                    key={team.slug}
+                    onClick={() => goToEdit(team.slug)}
+                    onKeyDown={(e) => {
+                      if (e.currentTarget !== e.target) return
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        goToEdit(team.slug)
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-label={`Edit team ${team.name}`}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                  >
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                            isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'
+                          }`}
+                        >
+                          {team.icon ? (
+                            <EntityIcon
+                              icon={team.icon}
+                              className="h-5 w-5 rounded object-cover"
+                            />
+                          ) : (
+                            <Users
+                              className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+                            />
+                          )}
+                        </div>
+                        <div>
+                          <div
+                            className={
+                              isDarkMode ? 'text-white' : 'text-gray-900'
+                            }
+                          >
+                            {team.name}
+                          </div>
+                          {team.description && (
+                            <div
+                              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                            >
+                              {team.description}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      <code
+                        className={`rounded px-2 py-1 ${
+                          isDarkMode
+                            ? 'bg-gray-700 text-gray-300'
+                            : 'bg-gray-100 text-gray-700'
                         }`}
                       >
-                        {team.icon ? (
-                          <EntityIcon
-                            icon={team.icon}
-                            className="h-5 w-5 rounded object-cover"
-                          />
-                        ) : (
-                          <Users
-                            className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-                          />
-                        )}
-                      </div>
-                      <div>
-                        <div
-                          className={
-                            isDarkMode ? 'text-white' : 'text-gray-900'
-                          }
-                        >
-                          {team.name}
-                        </div>
-                        {team.description && (
-                          <div
-                            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                          >
-                            {team.description}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                  >
-                    <code
-                      className={`rounded px-2 py-1 ${
-                        isDarkMode
-                          ? 'bg-gray-700 text-gray-300'
-                          : 'bg-gray-100 text-gray-700'
+                        {team.slug}
+                      </code>
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
+                        (team.relationships?.projects?.count ?? 0) === 0
+                          ? isDarkMode
+                            ? 'text-gray-600'
+                            : 'text-gray-400'
+                          : isDarkMode
+                            ? 'text-gray-300'
+                            : 'text-gray-600'
                       }`}
                     >
-                      {team.slug}
-                    </code>
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                      (team.relationships?.projects?.count ?? 0) === 0
-                        ? isDarkMode
-                          ? 'text-gray-600'
-                          : 'text-gray-400'
-                        : isDarkMode
-                          ? 'text-gray-300'
-                          : 'text-gray-600'
-                    }`}
-                  >
-                    {team.relationships?.projects?.count ?? 0}
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
-                      (team.relationships?.members?.count ?? 0) === 0
-                        ? isDarkMode
-                          ? 'text-gray-600'
-                          : 'text-gray-400'
-                        : isDarkMode
-                          ? 'text-gray-300'
-                          : 'text-gray-600'
-                    }`}
-                  >
-                    {team.relationships?.members?.count ?? 0}
-                  </td>
-                  <td
-                    className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                  >
-                    {formatRelativeDate(team.updated_at ?? team.created_at)}
-                  </td>
-                  <td
-                    className="whitespace-nowrap px-6 py-4 text-right"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <div className="flex items-center justify-end gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleDelete(team.slug)}
-                        disabled={deleteMutation.isPending}
-                        className={
-                          isDarkMode
-                            ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                            : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                        }
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                      {team.relationships?.projects?.count ?? 0}
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-right text-sm ${
+                        (team.relationships?.members?.count ?? 0) === 0
+                          ? isDarkMode
+                            ? 'text-gray-600'
+                            : 'text-gray-400'
+                          : isDarkMode
+                            ? 'text-gray-300'
+                            : 'text-gray-600'
+                      }`}
+                    >
+                      {team.relationships?.members?.count ?? 0}
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-6 py-4 text-center text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      {formatRelativeDate(team.updated_at ?? team.created_at)}
+                    </td>
+                    <td
+                      className="whitespace-nowrap px-6 py-4 text-right"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex items-center justify-end gap-2">
+                        {(() => {
+                          const projectCount =
+                            team.relationships?.projects?.count ?? 0
+                          const memberCount =
+                            team.relationships?.members?.count ?? 0
+                          const canDelete =
+                            projectCount === 0 && memberCount === 0
+                          const disabledParts = [
+                            projectCount > 0
+                              ? `${projectCount} project(s)`
+                              : '',
+                            memberCount > 0 ? `${memberCount} member(s)` : '',
+                          ].filter(Boolean)
+                          return (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleDelete(team.slug)}
+                              disabled={deleteMutation.isPending || !canDelete}
+                              title={
+                                !canDelete
+                                  ? `Cannot delete: has ${disabledParts.join(' and ')}`
+                                  : undefined
+                              }
+                              className={
+                                isDarkMode
+                                  ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:opacity-30'
+                                  : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:opacity-30'
+                              }
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          )
+                        })()}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
 
-          {filteredTeams.length === 0 && (
-            <div
-              className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-            >
-              {searchQuery
-                ? 'No teams found matching your search.'
-                : selectedOrganization
-                  ? `No teams in ${selectedOrganization.name} yet.`
-                  : 'No teams created yet.'}
-            </div>
-          )}
-        </div>
-      </div>
+            {filteredTeams.length === 0 && (
+              <div
+                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                {searchQuery
+                  ? 'No teams found matching your search.'
+                  : selectedOrganization
+                    ? `No teams in ${selectedOrganization.name} yet.`
+                    : 'No teams created yet.'}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -1,4 +1,10 @@
 import { useState, useMemo } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
@@ -463,23 +469,34 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
                             ? `Cannot delete: has ${disabledParts.join(' and ')}`
                             : undefined
                           return (
-                            <span className="inline-flex" title={tooltipText}>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleDelete(team.slug)}
-                                disabled={
-                                  deleteMutation.isPending || !canDelete
-                                }
-                                className={
-                                  isDarkMode
-                                    ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none disabled:opacity-30'
-                                    : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none disabled:opacity-30'
-                                }
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </span>
+                            <TooltipProvider delayDuration={200}>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="inline-flex">
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() => handleDelete(team.slug)}
+                                      disabled={
+                                        deleteMutation.isPending || !canDelete
+                                      }
+                                      className={
+                                        isDarkMode
+                                          ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none disabled:opacity-30'
+                                          : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none disabled:opacity-30'
+                                      }
+                                    >
+                                      <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                  </span>
+                                </TooltipTrigger>
+                                {tooltipText && (
+                                  <TooltipContent>
+                                    <p>{tooltipText}</p>
+                                  </TooltipContent>
+                                )}
+                              </Tooltip>
+                            </TooltipProvider>
                           )
                         })()}
                       </div>

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
 import { Plus, Search, Trash2, Users, AlertCircle } from 'lucide-react'
@@ -29,6 +30,11 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+    orgSlug: string
+  } | null>(null)
 
   const orgSlug = selectedOrganization?.slug
 
@@ -99,11 +105,22 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
 
   const handleDelete = (slug: string) => {
     const team = teams.find((t) => t.slug === slug)
-    if (
-      team &&
-      confirm(`Delete team "${team.name}"? This action cannot be undone.`)
-    ) {
-      deleteMutation.mutate({ orgSlug: team.organization.slug, slug })
+    if (team) {
+      setDeleteTarget({
+        slug,
+        name: team.name,
+        orgSlug: team.organization.slug,
+      })
+    }
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate({
+        orgSlug: deleteTarget.orgSlug,
+        slug: deleteTarget.slug,
+      })
+      setDeleteTarget(null)
     }
   }
 
@@ -191,6 +208,12 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
 
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -436,25 +459,27 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
                               : '',
                             memberCount > 0 ? `${memberCount} member(s)` : '',
                           ].filter(Boolean)
+                          const tooltipText = !canDelete
+                            ? `Cannot delete: has ${disabledParts.join(' and ')}`
+                            : undefined
                           return (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleDelete(team.slug)}
-                              disabled={deleteMutation.isPending || !canDelete}
-                              title={
-                                !canDelete
-                                  ? `Cannot delete: has ${disabledParts.join(' and ')}`
-                                  : undefined
-                              }
-                              className={
-                                isDarkMode
-                                  ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:opacity-30'
-                                  : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:opacity-30'
-                              }
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
+                            <span className="inline-flex" title={tooltipText}>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleDelete(team.slug)}
+                                disabled={
+                                  deleteMutation.isPending || !canDelete
+                                }
+                                className={
+                                  isDarkMode
+                                    ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300 disabled:pointer-events-none disabled:opacity-30'
+                                    : 'text-red-600 hover:bg-red-50 hover:text-red-700 disabled:pointer-events-none disabled:opacity-30'
+                                }
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </span>
                           )
                         })()}
                       </div>

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -1,10 +1,12 @@
 import { useState, useMemo } from 'react'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
 import { Plus, Search, Trash2, Cloud, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
+import { Card, CardContent, CardDescription } from '@/components/ui/card'
 import { ThirdPartyServiceForm } from './third-party-services/ThirdPartyServiceForm'
 import { ThirdPartyServiceDetail } from './third-party-services/ThirdPartyServiceDetail'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -60,6 +62,10 @@ export function ThirdPartyServiceManagement({
   const [viewMode, setViewMode] = useState<ViewMode>('list')
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+  } | null>(null)
 
   const orgSlug = selectedOrganization?.slug
 
@@ -150,13 +156,15 @@ export function ThirdPartyServiceManagement({
 
   const handleDelete = (slug: string) => {
     const svc = services.find((s) => s.slug === slug)
-    if (
-      svc &&
-      confirm(
-        `Delete third-party service "${svc.name}"? This action cannot be undone.`,
-      )
-    ) {
-      deleteMutation.mutate(slug)
+    if (svc) {
+      setDeleteTarget({ slug, name: svc.name })
+    }
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate(deleteTarget.slug)
+      setDeleteTarget(null)
     }
   }
 
@@ -234,6 +242,12 @@ export function ThirdPartyServiceManagement({
 
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -265,280 +279,260 @@ export function ThirdPartyServiceManagement({
 
       {/* Stats */}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Total Services
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            {filteredServices.length}
-          </div>
-        </div>
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Active
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
-          >
-            {statusCounts.active}
-          </div>
-        </div>
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Evaluating
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-          >
-            {statusCounts.evaluating}
-          </div>
-        </div>
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Deprecated
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-yellow-400' : 'text-yellow-600'}`}
-          >
-            {statusCounts.deprecated}
-          </div>
-        </div>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Total Services
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              {filteredServices.length}
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Active
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
+            >
+              {statusCounts.active}
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Evaluating
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+            >
+              {statusCounts.evaluating}
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Deprecated
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-yellow-400' : 'text-yellow-600'}`}
+            >
+              {statusCounts.deprecated}
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       {/* Services Table */}
-      <div
-        className={`rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Service
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Vendor
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Category
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Status
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Team
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-            >
-              {filteredServices.map((svc) => {
-                const statusColor =
-                  STATUS_COLORS[svc.status] || STATUS_COLORS.inactive
-                return (
-                  <tr
-                    key={svc.slug}
-                    onClick={() => {
-                      setSelectedSlug(svc.slug)
-                      setViewMode('detail')
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.currentTarget !== e.target) return
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="border-b border-tertiary bg-secondary">
+                <tr>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Service
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Vendor
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Category
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Status
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Team
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+              >
+                {filteredServices.map((svc) => {
+                  const statusColor =
+                    STATUS_COLORS[svc.status] || STATUS_COLORS.inactive
+                  return (
+                    <tr
+                      key={svc.slug}
+                      onClick={() => {
                         setSelectedSlug(svc.slug)
                         setViewMode('detail')
-                      }
-                    }}
-                    tabIndex={0}
-                    aria-label={`View service ${svc.name}`}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                  >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                            isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'
-                          }`}
-                        >
-                          {svc.icon ? (
-                            <EntityIcon
-                              icon={svc.icon}
-                              className="h-5 w-5 rounded object-cover"
-                            />
-                          ) : (
-                            <Cloud
-                              className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
-                            />
-                          )}
-                        </div>
-                        <div>
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.currentTarget !== e.target) return
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          setSelectedSlug(svc.slug)
+                          setViewMode('detail')
+                        }
+                      }}
+                      tabIndex={0}
+                      aria-label={`View service ${svc.name}`}
+                      className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                    >
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-3">
                           <div
+                            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                              isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'
+                            }`}
+                          >
+                            {svc.icon ? (
+                              <EntityIcon
+                                icon={svc.icon}
+                                className="h-5 w-5 rounded object-cover"
+                              />
+                            ) : (
+                              <Cloud
+                                className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+                              />
+                            )}
+                          </div>
+                          <div>
+                            <div
+                              className={
+                                isDarkMode ? 'text-white' : 'text-gray-900'
+                              }
+                            >
+                              {svc.name}
+                            </div>
+                            {svc.description && (
+                              <div
+                                className={`max-w-xs truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                              >
+                                {svc.description}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td
+                        className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                      >
+                        {svc.vendor}
+                      </td>
+                      <td
+                        className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                      >
+                        {svc.category || (
+                          <span
                             className={
-                              isDarkMode ? 'text-white' : 'text-gray-900'
+                              isDarkMode ? 'text-gray-500' : 'text-gray-400'
                             }
                           >
-                            {svc.name}
-                          </div>
-                          {svc.description && (
-                            <div
-                              className={`max-w-xs truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                            >
-                              {svc.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td
-                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {svc.vendor}
-                    </td>
-                    <td
-                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {svc.category || (
+                            --
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-6 py-4">
                         <span
-                          className={
-                            isDarkMode ? 'text-gray-500' : 'text-gray-400'
-                          }
-                        >
-                          --
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-6 py-4">
-                      <span
-                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                          isDarkMode
-                            ? `${statusColor.darkBg} ${statusColor.darkText}`
-                            : `${statusColor.bg} ${statusColor.text}`
-                        }`}
-                      >
-                        {svc.status}
-                      </span>
-                    </td>
-                    <td
-                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {svc.team?.name || (
-                        <span
-                          className={
-                            isDarkMode ? 'text-gray-500' : 'text-gray-400'
-                          }
-                        >
-                          --
-                        </span>
-                      )}
-                    </td>
-                    <td
-                      className="px-6 py-4 text-right"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          aria-label={`Delete service ${svc.name}`}
-                          onClick={() => handleDelete(svc.slug)}
-                          disabled={deleteMutation.isPending}
-                          className={
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
                             isDarkMode
-                              ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                              : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                          }
+                              ? `${statusColor.darkBg} ${statusColor.darkText}`
+                              : `${statusColor.bg} ${statusColor.text}`
+                          }`}
                         >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+                          {svc.status}
+                        </span>
+                      </td>
+                      <td
+                        className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                      >
+                        {svc.team?.name || (
+                          <span
+                            className={
+                              isDarkMode ? 'text-gray-500' : 'text-gray-400'
+                            }
+                          >
+                            --
+                          </span>
+                        )}
+                      </td>
+                      <td
+                        className="px-6 py-4 text-right"
+                        onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => e.stopPropagation()}
+                      >
+                        <div className="flex items-center justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label={`Delete service ${svc.name}`}
+                            onClick={() => handleDelete(svc.slug)}
+                            disabled={deleteMutation.isPending}
+                            className={
+                              isDarkMode
+                                ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
+                                : 'text-red-600 hover:bg-red-50 hover:text-red-700'
+                            }
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
 
-          {filteredServices.length === 0 && (
-            <div
-              className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-            >
-              {searchQuery
-                ? 'No services found matching your search.'
-                : selectedOrganization
-                  ? `No third-party services in ${selectedOrganization.name} yet.`
-                  : 'No third-party services created yet.'}
-            </div>
-          )}
-        </div>
-      </div>
+            {filteredServices.length === 0 && (
+              <div
+                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                {searchQuery
+                  ? 'No services found matching your search.'
+                  : selectedOrganization
+                    ? `No third-party services in ${selectedOrganization.name} yet.`
+                    : 'No third-party services created yet.'}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -1,12 +1,12 @@
 import { useState, useMemo } from 'react'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import { Plus, Search, Trash2, Cloud, AlertCircle } from 'lucide-react'
+import { Plus, Search, Cloud, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { EntityIcon } from '@/components/ui/entity-icon'
 import { Card, CardContent, CardDescription } from '@/components/ui/card'
+import { AdminTable, type AdminTableColumn } from '@/components/ui/admin-table'
 import { ThirdPartyServiceForm } from './third-party-services/ThirdPartyServiceForm'
 import { ThirdPartyServiceDetail } from './third-party-services/ThirdPartyServiceDetail'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -16,7 +16,7 @@ import {
   createThirdPartyService,
   updateThirdPartyService,
 } from '@/api/endpoints'
-import type { ThirdPartyServiceCreate } from '@/types'
+import type { ThirdPartyService, ThirdPartyServiceCreate } from '@/types'
 
 interface ThirdPartyServiceManagementProps {
   isDarkMode: boolean
@@ -62,10 +62,6 @@ export function ThirdPartyServiceManagement({
   const [viewMode, setViewMode] = useState<ViewMode>('list')
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-  } | null>(null)
 
   const orgSlug = selectedOrganization?.slug
 
@@ -154,20 +150,6 @@ export function ThirdPartyServiceManagement({
     return counts
   }, [filteredServices])
 
-  const handleDelete = (slug: string) => {
-    const svc = services.find((s) => s.slug === slug)
-    if (svc) {
-      setDeleteTarget({ slug, name: svc.name })
-    }
-  }
-
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate(deleteTarget.slug)
-      setDeleteTarget(null)
-    }
-  }
-
   const handleSave = (svcData: ThirdPartyServiceCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate(svcData)
@@ -240,14 +222,94 @@ export function ThirdPartyServiceManagement({
     )
   }
 
+  const columns: AdminTableColumn<ThirdPartyService>[] = [
+    {
+      key: 'service',
+      header: 'Service',
+      headerAlign: 'left',
+      cellAlign: 'left',
+      render: (svc) => (
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+              isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'
+            }`}
+          >
+            {svc.icon ? (
+              <EntityIcon
+                icon={svc.icon}
+                className="h-5 w-5 rounded object-cover"
+              />
+            ) : (
+              <Cloud
+                className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+              />
+            )}
+          </div>
+          <div>
+            <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+              {svc.name}
+            </div>
+            {svc.description && (
+              <div
+                className={`max-w-xs truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                {svc.description}
+              </div>
+            )}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'vendor',
+      header: 'Vendor',
+      headerAlign: 'left',
+      cellAlign: 'left',
+      render: (svc) => (
+        <span className="text-sm text-muted-foreground">{svc.vendor}</span>
+      ),
+    },
+    {
+      key: 'category',
+      header: 'Category',
+      headerAlign: 'left',
+      cellAlign: 'left',
+      render: (svc) =>
+        svc.category ?? <span className="text-muted-foreground">--</span>,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      headerAlign: 'center',
+      cellAlign: 'center',
+      render: (svc) => {
+        const statusColor = STATUS_COLORS[svc.status] || STATUS_COLORS.inactive
+        return (
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              isDarkMode
+                ? `${statusColor.darkBg} ${statusColor.darkText}`
+                : `${statusColor.bg} ${statusColor.text}`
+            }`}
+          >
+            {svc.status}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'team',
+      header: 'Team',
+      headerAlign: 'left',
+      cellAlign: 'left',
+      render: (svc) =>
+        svc.team?.name ?? <span className="text-muted-foreground">--</span>,
+    },
+  ]
+
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -338,201 +400,25 @@ export function ThirdPartyServiceManagement({
       </div>
 
       {/* Services Table */}
-      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="border-b border-tertiary bg-secondary">
-                <tr>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Service
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Vendor
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Category
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Status
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Team
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-              >
-                {filteredServices.map((svc) => {
-                  const statusColor =
-                    STATUS_COLORS[svc.status] || STATUS_COLORS.inactive
-                  return (
-                    <tr
-                      key={svc.slug}
-                      onClick={() => {
-                        setSelectedSlug(svc.slug)
-                        setViewMode('detail')
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.currentTarget !== e.target) return
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault()
-                          setSelectedSlug(svc.slug)
-                          setViewMode('detail')
-                        }
-                      }}
-                      tabIndex={0}
-                      aria-label={`View service ${svc.name}`}
-                      className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                    >
-                      <td className="px-6 py-4">
-                        <div className="flex items-center gap-3">
-                          <div
-                            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                              isDarkMode ? 'bg-purple-900/30' : 'bg-purple-50'
-                            }`}
-                          >
-                            {svc.icon ? (
-                              <EntityIcon
-                                icon={svc.icon}
-                                className="h-5 w-5 rounded object-cover"
-                              />
-                            ) : (
-                              <Cloud
-                                className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
-                              />
-                            )}
-                          </div>
-                          <div>
-                            <div
-                              className={
-                                isDarkMode ? 'text-white' : 'text-gray-900'
-                              }
-                            >
-                              {svc.name}
-                            </div>
-                            {svc.description && (
-                              <div
-                                className={`max-w-xs truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                              >
-                                {svc.description}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </td>
-                      <td
-                        className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                      >
-                        {svc.vendor}
-                      </td>
-                      <td
-                        className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                      >
-                        {svc.category || (
-                          <span
-                            className={
-                              isDarkMode ? 'text-gray-500' : 'text-gray-400'
-                            }
-                          >
-                            --
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-6 py-4">
-                        <span
-                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                            isDarkMode
-                              ? `${statusColor.darkBg} ${statusColor.darkText}`
-                              : `${statusColor.bg} ${statusColor.text}`
-                          }`}
-                        >
-                          {svc.status}
-                        </span>
-                      </td>
-                      <td
-                        className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                      >
-                        {svc.team?.name || (
-                          <span
-                            className={
-                              isDarkMode ? 'text-gray-500' : 'text-gray-400'
-                            }
-                          >
-                            --
-                          </span>
-                        )}
-                      </td>
-                      <td
-                        className="px-6 py-4 text-right"
-                        onClick={(e) => e.stopPropagation()}
-                        onKeyDown={(e) => e.stopPropagation()}
-                      >
-                        <div className="flex items-center justify-end gap-2">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            aria-label={`Delete service ${svc.name}`}
-                            onClick={() => handleDelete(svc.slug)}
-                            disabled={deleteMutation.isPending}
-                            className={
-                              isDarkMode
-                                ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                                : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                            }
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-
-            {filteredServices.length === 0 && (
-              <div
-                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-              >
-                {searchQuery
-                  ? 'No services found matching your search.'
-                  : selectedOrganization
-                    ? `No third-party services in ${selectedOrganization.name} yet.`
-                    : 'No third-party services created yet.'}
-              </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+      <AdminTable<ThirdPartyService>
+        columns={columns}
+        rows={filteredServices}
+        getRowKey={(svc) => svc.slug}
+        getDeleteLabel={(svc) => svc.name}
+        onRowClick={(svc) => {
+          setSelectedSlug(svc.slug)
+          setViewMode('detail')
+        }}
+        onDelete={(svc) => deleteMutation.mutate(svc.slug)}
+        isDeleting={deleteMutation.isPending}
+        emptyMessage={
+          searchQuery
+            ? 'No services found matching your search.'
+            : selectedOrganization
+              ? `No third-party services in ${selectedOrganization.name} yet.`
+              : 'No third-party services created yet.'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -13,6 +13,8 @@ import {
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Gravatar } from '../ui/gravatar'
+import { Card, CardContent } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { UserForm } from './users/UserForm'
 import { UserDetail } from './users/UserDetail'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -39,13 +41,16 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
     slug: selectedUserEmail,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
   const [userFilter, setUserFilter] = useState<UserFilter>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [selectedEmails, setSelectedEmails] = useState<Set<string>>(new Set())
+  const [deleteTarget, setDeleteTarget] = useState<{
+    email: string
+    name: string
+  } | null>(null)
 
   // Fetch users from API
   const {
@@ -150,12 +155,16 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
   }
 
   const handleDelete = (email: string) => {
-    if (
-      confirm(
-        'Are you sure you want to delete this user? This action cannot be undone.',
-      )
-    ) {
-      deleteMutation.mutate(email)
+    const user = users.find((u) => u.email === email)
+    if (user) {
+      setDeleteTarget({ email: user.email, name: user.display_name })
+    }
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate(deleteTarget.email)
+      setDeleteTarget(null)
     }
   }
 
@@ -227,7 +236,7 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
   }
 
   const handleViewClick = (user: AdminUser) => {
-    goToDetail(user.email)
+    goToEdit(user.email)
   }
 
   const handleSave = (userData: AdminUserCreate) => {
@@ -322,6 +331,13 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
   // View mode: List (default)
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        confirmLabel="Delete"
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex flex-1 items-center gap-3">
@@ -430,218 +446,216 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
       )}
 
       {/* Users Table */}
-      <div
-        className={`overflow-hidden rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
+      <Card
+        className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
       >
-        <table className="w-full">
-          <thead className="border-b border-tertiary bg-secondary">
-            <tr>
-              <th className="w-12 px-4 py-3">
-                <input
-                  type="checkbox"
-                  checked={
-                    selectedEmails.size === filteredUsers.length &&
-                    filteredUsers.length > 0
-                  }
-                  onChange={toggleSelectAll}
-                  className="rounded"
-                />
-              </th>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                User
-              </th>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Email
-              </th>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Type
-              </th>
-              <th
-                className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Status
-              </th>
-              <th
-                className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Last Login
-              </th>
-              <th
-                className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className={
-              isDarkMode
-                ? 'divide-y divide-gray-700'
-                : 'divide-y divide-gray-200'
-            }
-          >
-            {filteredUsers.length === 0 ? (
+        <CardContent className="p-0">
+          <table className="w-full">
+            <thead className="border-b border-tertiary bg-secondary">
               <tr>
-                <td colSpan={7} className="px-4 py-12 text-center">
-                  <div
-                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                  >
-                    {searchQuery ||
-                    userFilter !== 'all' ||
-                    statusFilter !== 'all'
-                      ? 'No users match your filters'
-                      : 'No users created yet'}
-                  </div>
-                </td>
-              </tr>
-            ) : (
-              filteredUsers.map((user) => (
-                <tr
-                  key={user.email}
-                  onClick={() => handleViewClick(user)}
-                  className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'} ${
-                    !user.is_active ? 'opacity-60' : ''
-                  }`}
+                <th className="w-12 px-4 py-3">
+                  <input
+                    type="checkbox"
+                    checked={
+                      selectedEmails.size === filteredUsers.length &&
+                      filteredUsers.length > 0
+                    }
+                    onChange={toggleSelectAll}
+                    className="rounded"
+                  />
+                </th>
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                 >
-                  <td
-                    className="px-4 py-3"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={selectedEmails.has(user.email)}
-                      onChange={() => toggleSelection(user.email)}
-                      className="rounded"
-                    />
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-3">
-                      <Gravatar
-                        email={user.email}
-                        size={32}
-                        alt={user.display_name}
-                        className="h-8 w-8 rounded-full"
-                      />
-                      <div>
-                        <div
-                          className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                        >
-                          {user.display_name}
-                        </div>
-                        <div
-                          className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                        >
-                          {getGroupNames(user)}
-                        </div>
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                  >
-                    {user.email}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      {user.is_admin ? (
-                        <span
-                          className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-red-900/30 text-red-400'
-                              : 'bg-red-100 text-red-700'
-                          }`}
-                        >
-                          <Crown className="h-3 w-3" />
-                          Admin
-                        </span>
-                      ) : (
-                        <span
-                          className={`rounded px-2 py-1 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-blue-900/30 text-blue-400'
-                              : 'bg-blue-100 text-blue-700'
-                          }`}
-                        >
-                          User
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-center">
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        handleToggleActive(user)
-                      }}
-                      disabled={toggleActiveMutation.isPending}
-                      className={`inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium ${
-                        user.is_active
-                          ? isDarkMode
-                            ? 'bg-green-900/30 text-green-400'
-                            : 'bg-green-100 text-green-700'
-                          : isDarkMode
-                            ? 'bg-gray-700 text-gray-400'
-                            : 'bg-gray-100 text-gray-600'
-                      }`}
+                  User
+                </th>
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Email
+                </th>
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Type
+                </th>
+                <th
+                  className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Status
+                </th>
+                <th
+                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Last Login
+                </th>
+                <th
+                  className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              className={
+                isDarkMode
+                  ? 'divide-y divide-gray-700'
+                  : 'divide-y divide-gray-200'
+              }
+            >
+              {filteredUsers.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-12 text-center">
+                    <div
+                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      <Power className="h-3 w-3" />
-                      {user.is_active ? 'Active' : 'Inactive'}
-                    </button>
-                  </td>
-                  <td
-                    className={`px-4 py-3 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                  >
-                    {formatDate(user.last_login)}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center justify-end gap-2">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleEditClick(user)
-                        }}
-                        className={`rounded p-1.5 ${
-                          isDarkMode
-                            ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
-                            : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-                        }`}
-                        title="Edit"
-                      >
-                        <Edit2 className="h-4 w-4" />
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleDelete(user.email)
-                        }}
-                        disabled={deleteMutation.isPending}
-                        className={`rounded p-1.5 ${
-                          isDarkMode
-                            ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                            : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                        }`}
-                        title="Delete"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
+                      {searchQuery ||
+                      userFilter !== 'all' ||
+                      statusFilter !== 'all'
+                        ? 'No users match your filters'
+                        : 'No users created yet'}
                     </div>
                   </td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+              ) : (
+                filteredUsers.map((user) => (
+                  <tr
+                    key={user.email}
+                    onClick={() => handleViewClick(user)}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'} ${
+                      !user.is_active ? 'opacity-60' : ''
+                    }`}
+                  >
+                    <td
+                      className="px-4 py-3"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedEmails.has(user.email)}
+                        onChange={() => toggleSelection(user.email)}
+                        className="rounded"
+                      />
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <Gravatar
+                          email={user.email}
+                          size={32}
+                          alt={user.display_name}
+                          className="h-8 w-8 rounded-full"
+                        />
+                        <div>
+                          <div
+                            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                          >
+                            {user.display_name}
+                          </div>
+                          <div
+                            className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                          >
+                            {getGroupNames(user)}
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                    >
+                      {user.email}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        {user.is_admin ? (
+                          <span
+                            className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-red-900/30 text-red-400'
+                                : 'bg-red-100 text-red-700'
+                            }`}
+                          >
+                            <Crown className="h-3 w-3" />
+                            Admin
+                          </span>
+                        ) : (
+                          <span
+                            className={`rounded px-2 py-1 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-blue-900/30 text-blue-400'
+                                : 'bg-blue-100 text-blue-700'
+                            }`}
+                          >
+                            User
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleToggleActive(user)
+                        }}
+                        disabled={toggleActiveMutation.isPending}
+                        className={`inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium ${
+                          user.is_active
+                            ? isDarkMode
+                              ? 'bg-green-900/30 text-green-400'
+                              : 'bg-green-100 text-green-700'
+                            : isDarkMode
+                              ? 'bg-gray-700 text-gray-400'
+                              : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        <Power className="h-3 w-3" />
+                        {user.is_active ? 'Active' : 'Inactive'}
+                      </button>
+                    </td>
+                    <td
+                      className={`px-4 py-3 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                    >
+                      {formatDate(user.last_login)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-2">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleEditClick(user)
+                          }}
+                          className={`rounded p-1.5 ${
+                            isDarkMode
+                              ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                              : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                          }`}
+                          title="Edit"
+                        >
+                          <Edit2 className="h-4 w-4" />
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleDelete(user.email)
+                          }}
+                          disabled={deleteMutation.isPending}
+                          className={`rounded p-1.5 ${
+                            isDarkMode
+                              ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                              : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                          }`}
+                          title="Delete"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
 
       {/* Summary */}
       {filteredUsers.length > 0 && (

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -14,6 +14,12 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Gravatar } from '../ui/gravatar'
 import { Card, CardContent } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { UserForm } from './users/UserForm'
 import { UserDetail } from './users/UserDetail'
@@ -618,35 +624,51 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-2">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleEditClick(user)
-                          }}
-                          className={`rounded p-1.5 ${
-                            isDarkMode
-                              ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
-                              : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-                          }`}
-                          title="Edit"
-                        >
-                          <Edit2 className="h-4 w-4" />
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleDelete(user.email)
-                          }}
-                          disabled={deleteMutation.isPending}
-                          className={`rounded p-1.5 ${
-                            isDarkMode
-                              ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                              : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                          }`}
-                          title="Delete"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  handleEditClick(user)
+                                }}
+                                className={`rounded p-1.5 ${
+                                  isDarkMode
+                                    ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                                    : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                                }`}
+                              >
+                                <Edit2 className="h-4 w-4" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Edit</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  handleDelete(user.email)
+                                }}
+                                disabled={deleteMutation.isPending}
+                                className={`rounded p-1.5 ${
+                                  isDarkMode
+                                    ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                                    : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                                }`}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Delete</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       </div>
                     </td>
                   </tr>

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -1,26 +1,17 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
-import {
-  Plus,
-  Search,
-  Edit2,
-  Trash2,
-  Power,
-  Crown,
-  AlertCircle,
-} from 'lucide-react'
+import { Plus, Search, Edit2, Power, Crown, AlertCircle } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Gravatar } from '../ui/gravatar'
-import { Card, CardContent } from '@/components/ui/card'
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { AdminTable } from '@/components/ui/admin-table'
 import { UserForm } from './users/UserForm'
 import { UserDetail } from './users/UserDetail'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -52,11 +43,6 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [userFilter, setUserFilter] = useState<UserFilter>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
-  const [selectedEmails, setSelectedEmails] = useState<Set<string>>(new Set())
-  const [deleteTarget, setDeleteTarget] = useState<{
-    email: string
-    name: string
-  } | null>(null)
 
   // Fetch users from API
   const {
@@ -160,52 +146,8 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
     })
   }
 
-  const handleDelete = (email: string) => {
-    const user = users.find((u) => u.email === email)
-    if (user) {
-      setDeleteTarget({ email: user.email, name: user.display_name })
-    }
-  }
-
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate(deleteTarget.email)
-      setDeleteTarget(null)
-    }
-  }
-
-  const handleBulkActivate = (activate: boolean) => {
-    // TODO: Implement when bulk API endpoints are available
-    alert(
-      `Bulk ${activate ? 'activation' : 'deactivation'} will be available once the API endpoints are implemented`,
-    )
-    setSelectedEmails(new Set())
-  }
-
-  const handleBulkDelete = () => {
-    // TODO: Implement when bulk API endpoints are available
-    alert(
-      'Bulk operations will be available once the API endpoints are implemented',
-    )
-    setSelectedEmails(new Set())
-  }
-
-  const toggleSelection = (email: string) => {
-    const newSelection = new Set(selectedEmails)
-    if (newSelection.has(email)) {
-      newSelection.delete(email)
-    } else {
-      newSelection.add(email)
-    }
-    setSelectedEmails(newSelection)
-  }
-
-  const toggleSelectAll = () => {
-    if (selectedEmails.size === filteredUsers.length) {
-      setSelectedEmails(new Set())
-    } else {
-      setSelectedEmails(new Set(filteredUsers.map((u) => u.email)))
-    }
+  const handleDelete = (user: AdminUser) => {
+    deleteMutation.mutate(user.email)
   }
 
   const formatDate = (dateString?: string | null) => {
@@ -258,6 +200,31 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
   const handleCancel = () => {
     goToList()
   }
+
+  const userActions = (user: AdminUser) => (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              handleEditClick(user)
+            }}
+            className={`rounded p-1.5 ${
+              isDarkMode
+                ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+            }`}
+          >
+            <Edit2 className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Edit</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
 
   // Loading state
   if (isLoading) {
@@ -337,13 +304,6 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
   // View mode: List (default)
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        confirmLabel="Delete"
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex flex-1 items-center gap-3">
@@ -396,298 +356,124 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
         </Button>
       </div>
 
-      {/* Bulk Actions */}
-      {selectedEmails.size > 0 && (
-        <div
-          className={`flex items-center justify-between rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-blue-700 bg-blue-900/20'
-              : 'border-blue-200 bg-blue-50'
-          }`}
-        >
-          <span
-            className={`text-sm ${isDarkMode ? 'text-blue-300' : 'text-blue-900'}`}
-          >
-            {selectedEmails.size} user(s) selected
-          </span>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handleBulkActivate(true)}
-              className={
-                isDarkMode
-                  ? 'border-gray-600 text-gray-300 hover:bg-gray-700'
-                  : ''
-              }
-            >
-              Activate Selected
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handleBulkActivate(false)}
-              className={
-                isDarkMode
-                  ? 'border-gray-600 text-gray-300 hover:bg-gray-700'
-                  : ''
-              }
-            >
-              Deactivate Selected
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleBulkDelete}
-              className={
-                isDarkMode
-                  ? 'border-red-700 text-red-400 hover:bg-red-900/20'
-                  : 'border-red-300 text-red-700 hover:bg-red-50'
-              }
-            >
-              Delete Selected
-            </Button>
-          </div>
-        </div>
-      )}
-
-      {/* Users Table */}
-      <Card
-        className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
-      >
-        <CardContent className="p-0">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th className="w-12 px-4 py-3">
-                  <input
-                    type="checkbox"
-                    checked={
-                      selectedEmails.size === filteredUsers.length &&
-                      filteredUsers.length > 0
-                    }
-                    onChange={toggleSelectAll}
-                    className="rounded"
-                  />
-                </th>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+      <AdminTable
+        columns={[
+          {
+            key: 'user',
+            header: 'User',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (user) => (
+              <div className="flex items-center gap-3">
+                <Gravatar
+                  email={user.email}
+                  size={32}
+                  alt={user.display_name}
+                  className="size-8 rounded-full"
+                />
+                <div>
+                  <div
+                    className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    {user.display_name}
+                  </div>
+                  <div
+                    className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    {getGroupNames(user)}
+                  </div>
+                </div>
+              </div>
+            ),
+          },
+          {
+            key: 'email',
+            header: 'Email',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (user) => (
+              <span
+                className={`text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              >
+                {user.email}
+              </span>
+            ),
+          },
+          {
+            key: 'type',
+            header: 'Type',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (user) =>
+              user.is_admin ? (
+                <span
+                  className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${isDarkMode ? 'bg-red-900/30 text-red-400' : 'bg-red-100 text-red-700'}`}
+                >
+                  <Crown className="h-3 w-3" />
+                  Admin
+                </span>
+              ) : (
+                <span
+                  className={`rounded px-2 py-1 text-xs font-medium ${isDarkMode ? 'bg-blue-900/30 text-blue-400' : 'bg-blue-100 text-blue-700'}`}
                 >
                   User
-                </th>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Email
-                </th>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Type
-                </th>
-                <th
-                  className={`px-4 py-3 text-center text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Status
-                </th>
-                <th
-                  className={`px-4 py-3 text-left text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Last Login
-                </th>
-                <th
-                  className={`px-4 py-3 text-right text-xs font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={
-                isDarkMode
-                  ? 'divide-y divide-gray-700'
-                  : 'divide-y divide-gray-200'
-              }
-            >
-              {filteredUsers.length === 0 ? (
-                <tr>
-                  <td colSpan={7} className="px-4 py-12 text-center">
-                    <div
-                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                    >
-                      {searchQuery ||
-                      userFilter !== 'all' ||
-                      statusFilter !== 'all'
-                        ? 'No users match your filters'
-                        : 'No users created yet'}
-                    </div>
-                  </td>
-                </tr>
-              ) : (
-                filteredUsers.map((user) => (
-                  <tr
-                    key={user.email}
-                    onClick={() => handleViewClick(user)}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'} ${
-                      !user.is_active ? 'opacity-60' : ''
-                    }`}
-                  >
-                    <td
-                      className="px-4 py-3"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedEmails.has(user.email)}
-                        onChange={() => toggleSelection(user.email)}
-                        className="rounded"
-                      />
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        <Gravatar
-                          email={user.email}
-                          size={32}
-                          alt={user.display_name}
-                          className="h-8 w-8 rounded-full"
-                        />
-                        <div>
-                          <div
-                            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                          >
-                            {user.display_name}
-                          </div>
-                          <div
-                            className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                          >
-                            {getGroupNames(user)}
-                          </div>
-                        </div>
-                      </div>
-                    </td>
-                    <td
-                      className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                    >
-                      {user.email}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        {user.is_admin ? (
-                          <span
-                            className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${
-                              isDarkMode
-                                ? 'bg-red-900/30 text-red-400'
-                                : 'bg-red-100 text-red-700'
-                            }`}
-                          >
-                            <Crown className="h-3 w-3" />
-                            Admin
-                          </span>
-                        ) : (
-                          <span
-                            className={`rounded px-2 py-1 text-xs font-medium ${
-                              isDarkMode
-                                ? 'bg-blue-900/30 text-blue-400'
-                                : 'bg-blue-100 text-blue-700'
-                            }`}
-                          >
-                            User
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-center">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleToggleActive(user)
-                        }}
-                        disabled={toggleActiveMutation.isPending}
-                        className={`inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium ${
-                          user.is_active
-                            ? isDarkMode
-                              ? 'bg-green-900/30 text-green-400'
-                              : 'bg-green-100 text-green-700'
-                            : isDarkMode
-                              ? 'bg-gray-700 text-gray-400'
-                              : 'bg-gray-100 text-gray-600'
-                        }`}
-                      >
-                        <Power className="h-3 w-3" />
-                        {user.is_active ? 'Active' : 'Inactive'}
-                      </button>
-                    </td>
-                    <td
-                      className={`px-4 py-3 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                    >
-                      {formatDate(user.last_login)}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center justify-end gap-2">
-                        <TooltipProvider delayDuration={200}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleEditClick(user)
-                                }}
-                                className={`rounded p-1.5 ${
-                                  isDarkMode
-                                    ? 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
-                                    : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-                                }`}
-                              >
-                                <Edit2 className="h-4 w-4" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>Edit</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                        <TooltipProvider delayDuration={200}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleDelete(user.email)
-                                }}
-                                disabled={deleteMutation.isPending}
-                                className={`rounded p-1.5 ${
-                                  isDarkMode
-                                    ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                                    : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                                }`}
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>Delete</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      </div>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
-
-      {/* Summary */}
-      {filteredUsers.length > 0 && (
-        <div
-          className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-        >
-          Showing {filteredUsers.length} of{' '}
-          {users.filter((u) => !u.is_service_account).length} user(s)
-        </div>
-      )}
+                </span>
+              ),
+          },
+          {
+            key: 'status',
+            header: 'Status',
+            headerAlign: 'center',
+            cellAlign: 'center',
+            render: (user) => (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleToggleActive(user)
+                }}
+                disabled={toggleActiveMutation.isPending}
+                className={`inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium ${
+                  user.is_active
+                    ? isDarkMode
+                      ? 'bg-green-900/30 text-green-400'
+                      : 'bg-green-100 text-green-700'
+                    : isDarkMode
+                      ? 'bg-gray-700 text-gray-400'
+                      : 'bg-gray-100 text-gray-600'
+                }`}
+              >
+                <Power className="h-3 w-3" />
+                {user.is_active ? 'Active' : 'Inactive'}
+              </button>
+            ),
+          },
+          {
+            key: 'last_login',
+            header: 'Last Login',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (user) => (
+              <span
+                className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                {formatDate(user.last_login)}
+              </span>
+            ),
+          },
+        ]}
+        rows={filteredUsers}
+        getRowKey={(user) => user.email}
+        getDeleteLabel={(user) => user.display_name}
+        onRowClick={(user) => handleViewClick(user)}
+        onDelete={handleDelete}
+        isDeleting={deleteMutation.isPending}
+        actions={userActions}
+        emptyMessage={
+          searchQuery || userFilter !== 'all' || statusFilter !== 'all'
+            ? 'No users match your filters'
+            : 'No users created yet'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/WebhookManagement.tsx
+++ b/src/components/admin/WebhookManagement.tsx
@@ -1,13 +1,13 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ApiError } from '@/api/client'
-import { Plus, Search, Trash2, Webhook, AlertCircle } from 'lucide-react'
+import { Plus, Search, Webhook, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardDescription } from '@/components/ui/card'
+import { AdminTable } from '@/components/ui/admin-table'
 import { WebhookForm } from './webhooks/WebhookForm'
 import { WebhookDetail } from './webhooks/WebhookDetail'
-import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import {
@@ -33,10 +33,6 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
-  const [deleteTarget, setDeleteTarget] = useState<{
-    slug: string
-    name: string
-  } | null>(null)
 
   const orgSlug = selectedOrganization?.slug
 
@@ -97,16 +93,8 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
     [webhooks, selectedSlug],
   )
 
-  const handleDelete = (slug: string) => {
-    const item = webhooks.find((x) => x.slug === slug)
-    if (item) setDeleteTarget({ slug, name: item.name })
-  }
-
-  const onDeleteConfirm = () => {
-    if (deleteTarget) {
-      deleteMutation.mutate(deleteTarget.slug)
-      setDeleteTarget(null)
-    }
+  const handleDelete = (wh: (typeof webhooks)[number]) => {
+    deleteMutation.mutate(wh.slug)
   }
 
   const handleSave = (data: WebhookCreate) => {
@@ -175,12 +163,6 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
 
   return (
     <div className="space-y-6">
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={onDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -254,168 +236,90 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
       </div>
 
       {/* Webhooks Table */}
-      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead
-                className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-              >
-                <tr>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Webhook
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Path
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Service
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Rules
-                  </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-              >
-                {filteredWebhooks.map((wh) => (
-                  <tr
-                    key={wh.slug}
-                    onClick={() => goToEdit(wh.slug)}
-                    onKeyDown={(e) => {
-                      if (e.currentTarget !== e.target) return
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        goToEdit(wh.slug)
-                      }
-                    }}
-                    tabIndex={0}
-                    aria-label={`Edit webhook ${wh.name}`}
-                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                  >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                            isDarkMode ? 'bg-indigo-900/30' : 'bg-indigo-50'
-                          }`}
-                        >
-                          <Webhook
-                            className={`h-4 w-4 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
-                          />
-                        </div>
-                        <div>
-                          <div
-                            className={
-                              isDarkMode ? 'text-white' : 'text-gray-900'
-                            }
-                          >
-                            {wh.name}
-                          </div>
-                          {wh.description && (
-                            <div
-                              className={`max-w-xs truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                            >
-                              {wh.description}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    <td className={`px-6 py-4`}>
-                      <code
-                        className={`rounded px-2 py-1 text-xs ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
-                        }`}
-                      >
-                        {wh.notification_path}
-                      </code>
-                    </td>
-                    <td
-                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+      <AdminTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Webhook',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (wh) => (
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex size-8 flex-shrink-0 items-center justify-center rounded-lg ${isDarkMode ? 'bg-indigo-900/30' : 'bg-indigo-50'}`}
+                >
+                  <Webhook
+                    className={`h-4 w-4 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
+                  />
+                </div>
+                <div>
+                  <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                    {wh.name}
+                  </div>
+                  {wh.description && (
+                    <div
+                      className={`max-w-xs truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                     >
-                      {wh.third_party_service?.name || (
-                        <span
-                          className={
-                            isDarkMode ? 'text-gray-500' : 'text-gray-400'
-                          }
-                        >
-                          --
-                        </span>
-                      )}
-                    </td>
-                    <td
-                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                    >
-                      {wh.rules.length}
-                    </td>
-                    <td
-                      className="px-6 py-4 text-right"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          aria-label={`Delete webhook ${wh.name}`}
-                          onClick={() => handleDelete(wh.slug)}
-                          disabled={deleteMutation.isPending}
-                          className={
-                            isDarkMode
-                              ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                              : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                          }
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-
-            {filteredWebhooks.length === 0 && (
-              <div
-                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-              >
-                {searchQuery
-                  ? 'No webhooks found matching your search.'
-                  : selectedOrganization
-                    ? `No webhooks in ${selectedOrganization.name} yet.`
-                    : 'No webhooks created yet.'}
+                      {wh.description}
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+            ),
+          },
+          {
+            key: 'path',
+            header: 'Path',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (wh) => (
+              <code
+                className={`rounded px-2 py-1 text-xs ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`}
+              >
+                {wh.notification_path}
+              </code>
+            ),
+          },
+          {
+            key: 'service',
+            header: 'Service',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (wh) =>
+              wh.third_party_service?.name || (
+                <span
+                  className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}
+                >
+                  --
+                </span>
+              ),
+          },
+          {
+            key: 'rules',
+            header: 'Rules',
+            headerAlign: 'left',
+            cellAlign: 'left',
+            render: (wh) => (
+              <span className={isDarkMode ? 'text-gray-300' : 'text-gray-600'}>
+                {wh.rules.length}
+              </span>
+            ),
+          },
+        ]}
+        rows={filteredWebhooks}
+        getRowKey={(wh) => wh.slug}
+        getDeleteLabel={(wh) => wh.name}
+        onRowClick={(wh) => goToEdit(wh.slug)}
+        onDelete={handleDelete}
+        isDeleting={deleteMutation.isPending}
+        emptyMessage={
+          searchQuery
+            ? 'No webhooks found matching your search.'
+            : selectedOrganization
+              ? `No webhooks in ${selectedOrganization.name} yet.`
+              : 'No webhooks created yet.'
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/WebhookManagement.tsx
+++ b/src/components/admin/WebhookManagement.tsx
@@ -4,8 +4,10 @@ import { ApiError } from '@/api/client'
 import { Plus, Search, Trash2, Webhook, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardDescription } from '@/components/ui/card'
 import { WebhookForm } from './webhooks/WebhookForm'
 import { WebhookDetail } from './webhooks/WebhookDetail'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import {
@@ -28,10 +30,13 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
     slug: selectedSlug,
     goToList,
     goToCreate,
-    goToDetail,
     goToEdit,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{
+    slug: string
+    name: string
+  } | null>(null)
 
   const orgSlug = selectedOrganization?.slug
 
@@ -93,12 +98,14 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
   )
 
   const handleDelete = (slug: string) => {
-    const wh = webhooks.find((w) => w.slug === slug)
-    if (
-      wh &&
-      confirm(`Delete webhook "${wh.name}"? This action cannot be undone.`)
-    ) {
-      deleteMutation.mutate(slug)
+    const item = webhooks.find((x) => x.slug === slug)
+    if (item) setDeleteTarget({ slug, name: item.name })
+  }
+
+  const onDeleteConfirm = () => {
+    if (deleteTarget) {
+      deleteMutation.mutate(deleteTarget.slug)
+      setDeleteTarget(null)
     }
   }
 
@@ -168,6 +175,12 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
 
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Delete "${deleteTarget?.name}"?`}
+        onConfirm={onDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex-1">
@@ -196,229 +209,213 @@ export function WebhookManagement({ isDarkMode }: WebhookManagementProps) {
 
       {/* Stats */}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Total Webhooks
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            {filteredWebhooks.length}
-          </div>
-        </div>
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            With Service
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-          >
-            {filteredWebhooks.filter((w) => w.third_party_service).length}
-          </div>
-        </div>
-        <div
-          className={`rounded-lg border p-4 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div
-            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Total Rules
-          </div>
-          <div
-            className={`mt-1 text-2xl ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
-          >
-            {filteredWebhooks.reduce((sum, w) => sum + w.rules.length, 0)}
-          </div>
-        </div>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Total Webhooks
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              {filteredWebhooks.length}
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              With Service
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+            >
+              {filteredWebhooks.filter((w) => w.third_party_service).length}
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="p-4">
+            <CardDescription
+              className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}
+            >
+              Total Rules
+            </CardDescription>
+            <div
+              className={`mt-1 text-2xl ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+            >
+              {filteredWebhooks.reduce((sum, w) => sum + w.rules.length, 0)}
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       {/* Webhooks Table */}
-      <div
-        className={`rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead
-              className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-            >
-              <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Webhook
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Path
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Service
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Rules
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-            >
-              {filteredWebhooks.map((wh) => (
-                <tr
-                  key={wh.slug}
-                  onClick={() => goToDetail(wh.slug)}
-                  onKeyDown={(e) => {
-                    if (e.currentTarget !== e.target) return
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      goToDetail(wh.slug)
-                    }
-                  }}
-                  tabIndex={0}
-                  aria-label={`View webhook ${wh.name}`}
-                  className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
-                >
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                      <div
-                        className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-                          isDarkMode ? 'bg-indigo-900/30' : 'bg-indigo-50'
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead
+                className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
+              >
+                <tr>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Webhook
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Path
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Service
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Rules
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+              >
+                {filteredWebhooks.map((wh) => (
+                  <tr
+                    key={wh.slug}
+                    onClick={() => goToEdit(wh.slug)}
+                    onKeyDown={(e) => {
+                      if (e.currentTarget !== e.target) return
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        goToEdit(wh.slug)
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-label={`Edit webhook ${wh.name}`}
+                    className={`cursor-pointer ${isDarkMode ? 'hover:bg-gray-700/50' : 'hover:bg-gray-50'}`}
+                  >
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                            isDarkMode ? 'bg-indigo-900/30' : 'bg-indigo-50'
+                          }`}
+                        >
+                          <Webhook
+                            className={`h-4 w-4 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
+                          />
+                        </div>
+                        <div>
+                          <div
+                            className={
+                              isDarkMode ? 'text-white' : 'text-gray-900'
+                            }
+                          >
+                            {wh.name}
+                          </div>
+                          {wh.description && (
+                            <div
+                              className={`max-w-xs truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                            >
+                              {wh.description}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className={`px-6 py-4`}>
+                      <code
+                        className={`rounded px-2 py-1 text-xs ${
+                          isDarkMode
+                            ? 'bg-gray-700 text-gray-300'
+                            : 'bg-gray-100 text-gray-700'
                         }`}
                       >
-                        <Webhook
-                          className={`h-4 w-4 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
-                        />
-                      </div>
-                      <div>
-                        <div
+                        {wh.notification_path}
+                      </code>
+                    </td>
+                    <td
+                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                    >
+                      {wh.third_party_service?.name || (
+                        <span
                           className={
-                            isDarkMode ? 'text-white' : 'text-gray-900'
+                            isDarkMode ? 'text-gray-500' : 'text-gray-400'
                           }
                         >
-                          {wh.name}
-                        </div>
-                        {wh.description && (
-                          <div
-                            className={`max-w-xs truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                          >
-                            {wh.description}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </td>
-                  <td className={`px-6 py-4`}>
-                    <code
-                      className={`rounded px-2 py-1 text-xs ${
-                        isDarkMode
-                          ? 'bg-gray-700 text-gray-300'
-                          : 'bg-gray-100 text-gray-700'
-                      }`}
+                          --
+                        </span>
+                      )}
+                    </td>
+                    <td
+                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
                     >
-                      {wh.notification_path}
-                    </code>
-                  </td>
-                  <td
-                    className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                  >
-                    {wh.third_party_service?.name || (
-                      <span
-                        className={
-                          isDarkMode ? 'text-gray-500' : 'text-gray-400'
-                        }
-                      >
-                        --
-                      </span>
-                    )}
-                  </td>
-                  <td
-                    className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                  >
-                    {wh.rules.length}
-                  </td>
-                  <td
-                    className="px-6 py-4 text-right"
-                    onClick={(e) => e.stopPropagation()}
-                    onKeyDown={(e) => e.stopPropagation()}
-                  >
-                    <div className="flex items-center justify-end gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        aria-label={`Delete webhook ${wh.name}`}
-                        onClick={() => handleDelete(wh.slug)}
-                        disabled={deleteMutation.isPending}
-                        className={
-                          isDarkMode
-                            ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
-                            : 'text-red-600 hover:bg-red-50 hover:text-red-700'
-                        }
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                      {wh.rules.length}
+                    </td>
+                    <td
+                      className="px-6 py-4 text-right"
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex items-center justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Delete webhook ${wh.name}`}
+                          onClick={() => handleDelete(wh.slug)}
+                          disabled={deleteMutation.isPending}
+                          className={
+                            isDarkMode
+                              ? 'text-red-400 hover:bg-red-900/20 hover:text-red-300'
+                              : 'text-red-600 hover:bg-red-50 hover:text-red-700'
+                          }
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
 
-          {filteredWebhooks.length === 0 && (
-            <div
-              className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-            >
-              {searchQuery
-                ? 'No webhooks found matching your search.'
-                : selectedOrganization
-                  ? `No webhooks in ${selectedOrganization.name} yet.`
-                  : 'No webhooks created yet.'}
-            </div>
-          )}
-        </div>
-      </div>
+            {filteredWebhooks.length === 0 && (
+              <div
+                className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                {searchQuery
+                  ? 'No webhooks found matching your search.'
+                  : selectedOrganization
+                    ? `No webhooks in ${selectedOrganization.name} yet.`
+                    : 'No webhooks created yet.'}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -19,6 +19,7 @@ import {
   Braces,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { CardTitle } from '@/components/ui/card'
 import { getBlueprint } from '@/api/endpoints'
 import { getTypeBadgeClasses } from '../BlueprintManagement'
 import { parseFilterFromBlueprint } from '@/lib/utils'
@@ -237,11 +238,7 @@ export function BlueprintDetail({
             </div>
             <div>
               <div className="flex items-center gap-2">
-                <h2
-                  className={`text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                >
-                  {blueprint.name}
-                </h2>
+                <CardTitle>{blueprint.name}</CardTitle>
                 <span
                   className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${getTypeBadgeClasses(blueprint.kind === 'relationship' ? 'relationship' : blueprint.type || '', blueprintTypes, isDarkMode)}`}
                 >
@@ -420,7 +417,7 @@ export function BlueprintDetail({
                 className={`h-4 w-4 ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}
               />
               <h3
-                className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
               >
                 Conditional Filter
               </h3>
@@ -494,7 +491,7 @@ export function BlueprintDetail({
           className={`border-b px-6 py-4 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
         >
           <h3
-            className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             Schema Properties
           </h3>
@@ -762,7 +759,7 @@ export function BlueprintDetail({
             />
           )}
           <h3
-            className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             Raw JSON Schema
           </h3>

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -14,8 +14,15 @@ import {
 } from 'lucide-react'
 import Ajv from 'ajv'
 import { Button } from '@/components/ui/button'
+import { CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import {
   getBlueprint,
   listEnvironments,
@@ -641,11 +648,9 @@ export function BlueprintForm({
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2
-            className={`text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
+          <CardTitle>
             {isEditing ? 'Edit Blueprint' : 'Create Blueprint'}
-          </h2>
+          </CardTitle>
           <p
             className={`mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
           >
@@ -738,7 +743,7 @@ export function BlueprintForm({
         }`}
       >
         <h3
-          className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          className={`mb-4 text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
         >
           Basic Information
         </h3>
@@ -776,32 +781,34 @@ export function BlueprintForm({
           </div>
 
           {/* Slug */}
-          <div>
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Slug
-            </label>
-            <Input
-              value={slug}
-              onChange={(e) => handleSlugChange(e.target.value)}
-              disabled={isLoading}
-              placeholder="auto-generated"
-              className={`font-mono ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''}`}
-            />
-            {!isEditing && !slugManuallyEdited && name && (
-              <p
-                className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+          {!isEditing && (
+            <div>
+              <label
+                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
               >
-                Auto-generated from name
-              </p>
-            )}
-            {touched.slug && validationErrors.slug && (
-              <p className="mt-1 text-sm text-red-600">
-                {validationErrors.slug}
-              </p>
-            )}
-          </div>
+                Slug
+              </label>
+              <Input
+                value={slug}
+                onChange={(e) => handleSlugChange(e.target.value)}
+                disabled={isLoading}
+                placeholder="auto-generated"
+                className={`font-mono ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''}`}
+              />
+              {!slugManuallyEdited && name && (
+                <p
+                  className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                >
+                  Auto-generated from name
+                </p>
+              )}
+              {touched.slug && validationErrors.slug && (
+                <p className="mt-1 text-sm text-red-600">
+                  {validationErrors.slug}
+                </p>
+              )}
+            </div>
+          )}
 
           {/* Kind */}
           <div>
@@ -1096,7 +1103,7 @@ export function BlueprintForm({
               className={`h-4 w-4 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
             />
             <h3
-              className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
             >
               Conditional Filter
             </h3>
@@ -1250,7 +1257,7 @@ export function BlueprintForm({
       >
         <div className="mb-4 flex items-center justify-between">
           <h3
-            className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             JSON Schema
           </h3>
@@ -1335,34 +1342,56 @@ export function BlueprintForm({
                     {/* Property Row */}
                     <div className="flex items-center gap-3 p-3">
                       <div className="flex flex-col gap-0.5">
-                        <button
-                          onClick={() => moveProperty(index, 'up')}
-                          disabled={index === 0}
-                          className={`rounded p-0.5 ${
-                            index === 0
-                              ? 'cursor-not-allowed opacity-30'
-                              : isDarkMode
-                                ? 'text-gray-400 hover:bg-gray-700'
-                                : 'text-gray-600 hover:bg-gray-200'
-                          }`}
-                          title="Move up"
-                        >
-                          <ChevronUp className="h-3 w-3" />
-                        </button>
-                        <button
-                          onClick={() => moveProperty(index, 'down')}
-                          disabled={index === schemaProperties.length - 1}
-                          className={`rounded p-0.5 ${
-                            index === schemaProperties.length - 1
-                              ? 'cursor-not-allowed opacity-30'
-                              : isDarkMode
-                                ? 'text-gray-400 hover:bg-gray-700'
-                                : 'text-gray-600 hover:bg-gray-200'
-                          }`}
-                          title="Move down"
-                        >
-                          <ChevronDown className="h-3 w-3" />
-                        </button>
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="inline-flex">
+                                <button
+                                  onClick={() => moveProperty(index, 'up')}
+                                  disabled={index === 0}
+                                  className={`rounded p-0.5 ${
+                                    index === 0
+                                      ? 'cursor-not-allowed opacity-30'
+                                      : isDarkMode
+                                        ? 'text-gray-400 hover:bg-gray-700'
+                                        : 'text-gray-600 hover:bg-gray-200'
+                                  }`}
+                                >
+                                  <ChevronUp className="h-3 w-3" />
+                                </button>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Move up</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="inline-flex">
+                                <button
+                                  onClick={() => moveProperty(index, 'down')}
+                                  disabled={
+                                    index === schemaProperties.length - 1
+                                  }
+                                  className={`rounded p-0.5 ${
+                                    index === schemaProperties.length - 1
+                                      ? 'cursor-not-allowed opacity-30'
+                                      : isDarkMode
+                                        ? 'text-gray-400 hover:bg-gray-700'
+                                        : 'text-gray-600 hover:bg-gray-200'
+                                  }`}
+                                >
+                                  <ChevronDown className="h-3 w-3" />
+                                </button>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Move down</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       </div>
 
                       <Input
@@ -1432,33 +1461,49 @@ export function BlueprintForm({
                         </label>
                       </div>
 
-                      <button
-                        onClick={() => toggleExpandProp(prop.id)}
-                        className={`rounded p-1.5 text-xs ${
-                          isDarkMode
-                            ? 'text-gray-400 hover:bg-gray-700'
-                            : 'text-gray-600 hover:bg-gray-200'
-                        }`}
-                        title="Advanced options"
-                      >
-                        {isExpanded ? (
-                          <ChevronUp className="h-3.5 w-3.5" />
-                        ) : (
-                          <ChevronDown className="h-3.5 w-3.5" />
-                        )}
-                      </button>
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() => toggleExpandProp(prop.id)}
+                              className={`rounded p-1.5 text-xs ${
+                                isDarkMode
+                                  ? 'text-gray-400 hover:bg-gray-700'
+                                  : 'text-gray-600 hover:bg-gray-200'
+                              }`}
+                            >
+                              {isExpanded ? (
+                                <ChevronUp className="h-3.5 w-3.5" />
+                              ) : (
+                                <ChevronDown className="h-3.5 w-3.5" />
+                              )}
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Advanced options</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
 
-                      <button
-                        onClick={() => removeProperty(prop.id)}
-                        className={`rounded p-1.5 ${
-                          isDarkMode
-                            ? 'text-red-400 hover:bg-red-900/20'
-                            : 'text-red-600 hover:bg-red-50'
-                        }`}
-                        title="Remove property"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() => removeProperty(prop.id)}
+                              className={`rounded p-1.5 ${
+                                isDarkMode
+                                  ? 'text-red-400 hover:bg-red-900/20'
+                                  : 'text-red-600 hover:bg-red-50'
+                              }`}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Remove property</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                     </div>
 
                     {/* Advanced Options */}

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -1347,6 +1347,8 @@ export function BlueprintForm({
                             <TooltipTrigger asChild>
                               <span className="inline-flex">
                                 <button
+                                  type="button"
+                                  aria-label="Move property up"
                                   onClick={() => moveProperty(index, 'up')}
                                   disabled={index === 0}
                                   className={`rounded p-0.5 ${
@@ -1371,6 +1373,8 @@ export function BlueprintForm({
                             <TooltipTrigger asChild>
                               <span className="inline-flex">
                                 <button
+                                  type="button"
+                                  aria-label="Move property down"
                                   onClick={() => moveProperty(index, 'down')}
                                   disabled={
                                     index === schemaProperties.length - 1
@@ -1465,6 +1469,12 @@ export function BlueprintForm({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button
+                              type="button"
+                              aria-label={
+                                isExpanded
+                                  ? 'Collapse advanced options'
+                                  : 'Expand advanced options'
+                              }
                               onClick={() => toggleExpandProp(prop.id)}
                               className={`rounded p-1.5 text-xs ${
                                 isDarkMode
@@ -1489,6 +1499,8 @@ export function BlueprintForm({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button
+                              type="button"
+                              aria-label="Remove property"
                               onClick={() => removeProperty(prop.id)}
                               className={`rounded p-1.5 ${
                                 isDarkMode

--- a/src/components/admin/environments/EnvironmentDetail.tsx
+++ b/src/components/admin/environments/EnvironmentDetail.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { ArrowLeft, Edit2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
 import { getEnvironmentSchema } from '@/api/endpoints'
 import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
@@ -42,13 +43,8 @@ export function EnvironmentDetail({
       </div>
 
       {/* Environment info card */}
-      <div
-        className={`rounded-lg border ${isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
-      >
-        {/* Title row */}
-        <div
-          className={`flex items-start justify-between border-b px-6 py-5 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-        >
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
           <div>
             <div className="flex items-center gap-3">
               {environment.icon && (
@@ -57,11 +53,7 @@ export function EnvironmentDetail({
                   className="h-8 w-8 rounded object-cover"
                 />
               )}
-              <h2
-                className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                {environment.name}
-              </h2>
+              <CardTitle>{environment.name}</CardTitle>
             </div>
             {environment.description && (
               <p
@@ -78,10 +70,9 @@ export function EnvironmentDetail({
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Environment
           </Button>
-        </div>
+        </CardHeader>
 
-        {/* Info section */}
-        <div className="p-6">
+        <CardContent className="p-6">
           <div className="grid grid-cols-2 gap-6">
             <div>
               <div
@@ -166,8 +157,8 @@ export function EnvironmentDetail({
               />
             )}
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Card, CardContent } from '@/components/ui/card'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { ColorPicker } from '@/components/ui/color-picker'
@@ -124,7 +125,7 @@ export function EnvironmentForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit Environment' : 'Create New Environment'}
           </h2>
@@ -194,20 +195,8 @@ export function EnvironmentForm({
 
       {/* Form */}
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Environment Information
-          </h3>
-
-          <div className="space-y-4">
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="space-y-4 pt-6">
             <div>
               <label
                 className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -245,7 +234,9 @@ export function EnvironmentForm({
               )}
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div
+              className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
+            >
               <div>
                 <label
                   className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -273,32 +264,34 @@ export function EnvironmentForm({
                 )}
               </div>
 
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Slug <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  value={slug}
-                  onChange={(e) => setSlug(e.target.value)}
-                  placeholder="e.g., production"
-                  disabled={isLoading}
-                  className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                    errors.slug ? 'border-red-500' : ''
-                  }`}
-                />
-                {errors.slug && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs ${
-                      isDarkMode ? 'text-red-400' : 'text-red-600'
-                    }`}
+              {!isEditing && (
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.slug}
-                  </div>
-                )}
-              </div>
+                    Slug <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="e.g., production"
+                    disabled={isLoading}
+                    className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                      errors.slug ? 'border-red-500' : ''
+                    }`}
+                  />
+                  {errors.slug && (
+                    <div
+                      className={`mt-1 flex items-center gap-1 text-xs ${
+                        isDarkMode ? 'text-red-400' : 'text-red-600'
+                      }`}
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      {errors.slug}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <div>
@@ -405,8 +398,8 @@ export function EnvironmentForm({
                 isLoading={isLoading}
               />
             )}
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       </form>
     </div>
   )

--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react'
-import { Save, X, AlertCircle } from 'lucide-react'
+import { Save, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -21,7 +28,6 @@ interface LinkDefinitionFormProps {
 export function LinkDefinitionForm({
   linkDefinition,
   onSave,
-  onCancel,
   isDarkMode,
   isLoading = false,
   error,
@@ -79,47 +85,6 @@ export function LinkDefinitionForm({
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2
-            className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            {isEditing ? 'Edit Link Definition' : 'Create New Link Definition'}
-          </h2>
-          <p
-            className={`mt-1 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            {isEditing
-              ? 'Update link definition information'
-              : 'Create a new link definition'}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            onClick={onCancel}
-            disabled={isLoading}
-            className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
-          >
-            <X className="mr-2 h-4 w-4" />
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={isLoading}
-            className="bg-amber-border text-white hover:bg-amber-border-strong"
-          >
-            <Save className="mr-2 h-4 w-4" />
-            {isLoading
-              ? 'Saving...'
-              : isEditing
-                ? 'Save Changes'
-                : 'Create Link Definition'}
-          </Button>
-        </div>
-      </div>
-
       {/* API Error */}
       {error && (
         <div
@@ -153,20 +118,31 @@ export function LinkDefinitionForm({
 
       {/* Form */}
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Link Definition Information
-          </h3>
-
-          <div className="space-y-4">
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b pb-4">
+            <div>
+              <CardTitle>
+                {isEditing ? 'Edit Link Definition' : 'Create Link Definition'}
+              </CardTitle>
+              <CardDescription className="mt-1">
+                Defines a type of project link displayed on the project details
+                page.
+              </CardDescription>
+            </div>
+            <Button
+              onClick={handleSubmit}
+              disabled={isLoading}
+              className="bg-amber-border text-white hover:bg-amber-border-strong"
+            >
+              <Save className="mr-2 h-4 w-4" />
+              {isLoading
+                ? 'Saving...'
+                : isEditing
+                  ? 'Save Changes'
+                  : 'Create Link Definition'}
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-4">
             <div>
               <label
                 htmlFor="link-def-org"
@@ -206,7 +182,9 @@ export function LinkDefinitionForm({
               )}
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div
+              className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
+            >
               <div>
                 <label
                   htmlFor="link-def-name"
@@ -236,34 +214,36 @@ export function LinkDefinitionForm({
                 )}
               </div>
 
-              <div>
-                <label
-                  htmlFor="link-def-slug"
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Slug <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  id="link-def-slug"
-                  value={slug}
-                  onChange={(e) => setSlug(e.target.value)}
-                  placeholder="e.g., github-repository"
-                  disabled={isLoading}
-                  className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                    errors.slug ? 'border-red-500' : ''
-                  }`}
-                />
-                {errors.slug && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs ${
-                      isDarkMode ? 'text-red-400' : 'text-red-600'
-                    }`}
+              {!isEditing && (
+                <div>
+                  <label
+                    htmlFor="link-def-slug"
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.slug}
-                  </div>
-                )}
-              </div>
+                    Slug <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    id="link-def-slug"
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="e.g., github-repository"
+                    disabled={isLoading}
+                    className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                      errors.slug ? 'border-red-500' : ''
+                    }`}
+                  />
+                  {errors.slug && (
+                    <div
+                      className={`mt-1 flex items-center gap-1 text-xs ${
+                        isDarkMode ? 'text-red-400' : 'text-red-600'
+                      }`}
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      {errors.slug}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <div>
@@ -357,8 +337,8 @@ export function LinkDefinitionForm({
                 URL template with placeholders in curly braces
               </p>
             </div>
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       </form>
     </div>
   )

--- a/src/components/admin/organizations/OrganizationDetail.tsx
+++ b/src/components/admin/organizations/OrganizationDetail.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Edit2, Building2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EntityIcon } from '@/components/ui/entity-icon'
 import { formatDate } from '@/lib/formatDate'
 import type { Organization } from '@/types'
@@ -32,13 +33,8 @@ export function OrganizationDetail({
       </div>
 
       {/* Organization info card */}
-      <div
-        className={`rounded-lg border ${isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
-      >
-        {/* Title row */}
-        <div
-          className={`flex items-start justify-between border-b px-6 py-5 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-        >
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
           <div className="flex items-center gap-3">
             {organization.icon ? (
               <EntityIcon
@@ -51,11 +47,7 @@ export function OrganizationDetail({
               />
             )}
             <div>
-              <h2
-                className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                {organization.name}
-              </h2>
+              <CardTitle>{organization.name}</CardTitle>
               <p
                 className={`mt-1 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
               >
@@ -70,10 +62,9 @@ export function OrganizationDetail({
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Organization
           </Button>
-        </div>
+        </CardHeader>
 
-        {/* Info section */}
-        <div className="p-6">
+        <CardContent className="p-6">
           <div className="grid grid-cols-2 gap-6 md:grid-cols-4">
             <div>
               <div
@@ -116,8 +107,8 @@ export function OrganizationDetail({
               </div>
             )}
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/organizations/OrganizationForm.tsx
+++ b/src/components/admin/organizations/OrganizationForm.tsx
@@ -3,6 +3,7 @@ import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
 import { IconUpload } from '../../ui/icon-upload'
+import { Card, CardContent } from '../../ui/card'
 import type { Organization, OrganizationCreate } from '@/types'
 
 interface OrganizationFormProps {
@@ -76,7 +77,7 @@ export function OrganizationForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit Organization' : 'Create New Organization'}
           </h2>
@@ -146,21 +147,11 @@ export function OrganizationForm({
 
       {/* Form */}
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Organization Information
-          </h3>
-
-          <div className="space-y-4">
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="space-y-4 pt-6">
+            <div
+              className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
+            >
               <div>
                 <label
                   className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -188,32 +179,34 @@ export function OrganizationForm({
                 )}
               </div>
 
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Slug <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  value={slug}
-                  onChange={(e) => setSlug(e.target.value)}
-                  placeholder="e.g., engineering"
-                  disabled={isLoading}
-                  className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                    errors.slug ? 'border-red-500' : ''
-                  }`}
-                />
-                {errors.slug && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs ${
-                      isDarkMode ? 'text-red-400' : 'text-red-600'
-                    }`}
+              {!isEditing && (
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.slug}
-                  </div>
-                )}
-              </div>
+                    Slug <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="e.g., engineering"
+                    disabled={isLoading}
+                    className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                      errors.slug ? 'border-red-500' : ''
+                    }`}
+                  />
+                  {errors.slug && (
+                    <div
+                      className={`mt-1 flex items-center gap-1 text-xs ${
+                        isDarkMode ? 'text-red-400' : 'text-red-600'
+                      }`}
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      {errors.slug}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <div>
@@ -248,8 +241,8 @@ export function OrganizationForm({
                 isDarkMode={isDarkMode}
               />
             </div>
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       </form>
     </div>
   )

--- a/src/components/admin/project-types/ProjectTypeDetail.tsx
+++ b/src/components/admin/project-types/ProjectTypeDetail.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { ArrowLeft, Edit2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
 import { getProjectTypeSchema } from '@/api/endpoints'
 import { PROJECT_TYPE_BASE_FIELDS_SET } from '@/lib/constants'
@@ -42,13 +43,8 @@ export function ProjectTypeDetail({
       </div>
 
       {/* Project Type info card */}
-      <div
-        className={`rounded-lg border ${isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
-      >
-        {/* Title row */}
-        <div
-          className={`flex items-start justify-between border-b px-6 py-5 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-        >
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
           <div>
             <div className="flex items-center gap-3">
               {projectType.icon &&
@@ -64,11 +60,7 @@ export function ProjectTypeDetail({
                     return Icon ? <Icon className="h-8 w-8" /> : null
                   })()
                 ))}
-              <h2
-                className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                {projectType.name}
-              </h2>
+              <CardTitle>{projectType.name}</CardTitle>
             </div>
             {projectType.description && (
               <p
@@ -85,10 +77,9 @@ export function ProjectTypeDetail({
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Project Type
           </Button>
-        </div>
+        </CardHeader>
 
-        {/* Info section */}
-        <div className="p-6">
+        <CardContent className="p-6">
           <div className="grid grid-cols-2 gap-6">
             <div>
               <div
@@ -133,8 +124,8 @@ export function ProjectTypeDetail({
               />
             )}
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -4,6 +4,7 @@ import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { IconUpload } from '@/components/ui/icon-upload'
+import { Card, CardContent } from '@/components/ui/card'
 import { IconPicker } from '@/components/ui/icon-picker'
 import {
   DynamicFormFields,
@@ -115,7 +116,7 @@ export function ProjectTypeForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit Project Type' : 'Create New Project Type'}
           </h2>
@@ -185,20 +186,8 @@ export function ProjectTypeForm({
 
       {/* Form */}
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Project Type Information
-          </h3>
-
-          <div className="space-y-4">
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="space-y-4 pt-6">
             <div>
               <label
                 className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -236,7 +225,9 @@ export function ProjectTypeForm({
               )}
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div
+              className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
+            >
               <div>
                 <label
                   className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -264,32 +255,34 @@ export function ProjectTypeForm({
                 )}
               </div>
 
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Slug <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  value={slug}
-                  onChange={(e) => setSlug(e.target.value)}
-                  placeholder="e.g., rest-api"
-                  disabled={isLoading}
-                  className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                    errors.slug ? 'border-red-500' : ''
-                  }`}
-                />
-                {errors.slug && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs ${
-                      isDarkMode ? 'text-red-400' : 'text-red-600'
-                    }`}
+              {!isEditing && (
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.slug}
-                  </div>
-                )}
-              </div>
+                    Slug <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="e.g., rest-api"
+                    disabled={isLoading}
+                    className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                      errors.slug ? 'border-red-500' : ''
+                    }`}
+                  />
+                  {errors.slug && (
+                    <div
+                      className={`mt-1 flex items-center gap-1 text-xs ${
+                        isDarkMode ? 'text-red-400' : 'text-red-600'
+                      }`}
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      {errors.slug}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <div>
@@ -369,8 +362,8 @@ export function ProjectTypeForm({
                 isLoading={isLoading}
               />
             )}
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       </form>
     </div>
   )

--- a/src/components/admin/roles/RoleDetail.tsx
+++ b/src/components/admin/roles/RoleDetail.tsx
@@ -15,6 +15,7 @@ import {
   Bot,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
   getRole,
@@ -26,6 +27,12 @@ import {
   revokePermission,
 } from '@/api/endpoints'
 import type { Permission, RoleUser, ServiceAccount } from '@/types'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 interface RoleDetailProps {
   slug: string
@@ -206,13 +213,8 @@ export function RoleDetail({
       </div>
 
       {/* Role info card */}
-      <div
-        className={`rounded-lg border ${isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
-      >
-        {/* Title row */}
-        <div
-          className={`flex items-start justify-between border-b px-6 py-5 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-        >
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
           <div className="flex items-center gap-3">
             <div
               className={`rounded-lg p-2 ${isDarkMode ? 'bg-blue-900/30' : 'bg-blue-100'}`}
@@ -223,11 +225,7 @@ export function RoleDetail({
             </div>
             <div>
               <div className="flex items-center gap-2">
-                <h2
-                  className={`text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                >
-                  {role.name}
-                </h2>
+                <CardTitle>{role.name}</CardTitle>
                 {role.is_system && (
                   <span
                     className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium ${
@@ -257,7 +255,7 @@ export function RoleDetail({
               Edit Role
             </Button>
           )}
-        </div>
+        </CardHeader>
 
         {/* Stats Bar */}
         <div
@@ -355,7 +353,7 @@ export function RoleDetail({
             })}
           </div>
         </div>
-      </div>
+      </Card>
 
       {/* Permissions Tab */}
       {activeTab === 'permissions' && (
@@ -443,96 +441,106 @@ export function RoleDetail({
               )}
             </div>
           ) : (
-            <div
-              className={`overflow-hidden rounded-lg border ${
-                isDarkMode
-                  ? 'border-gray-700 bg-gray-800'
-                  : 'border-gray-200 bg-white'
-              }`}
+            <Card
+              className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
             >
-              <table className="w-full">
-                <thead className="border-b border-tertiary bg-secondary">
-                  <tr>
-                    <th
-                      className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                        isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                      }`}
-                    >
-                      Permission
-                    </th>
-                    <th
-                      className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
-                        isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                      }`}
-                    >
-                      Description
-                    </th>
-                    {!role.is_system && (
+              <CardContent className="p-0">
+                <table className="w-full">
+                  <thead className="border-b border-tertiary bg-secondary">
+                    <tr>
                       <th
-                        className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                        className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
                           isDarkMode ? 'text-gray-400' : 'text-gray-500'
                         }`}
                       >
-                        Actions
+                        Permission
                       </th>
-                    )}
-                  </tr>
-                </thead>
-                <tbody
-                  className={
-                    isDarkMode
-                      ? 'divide-y divide-gray-700'
-                      : 'divide-y divide-gray-200'
-                  }
-                >
-                  {(role.permissions || [])
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((perm) => (
-                      <tr
-                        key={perm.name}
-                        className={
-                          isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'
-                        }
+                      <th
+                        className={`px-6 py-3 text-left text-xs uppercase tracking-wider ${
+                          isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                        }`}
                       >
-                        <td
-                          className={`px-6 py-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                        Description
+                      </th>
+                      {!role.is_system && (
+                        <th
+                          className={`px-6 py-3 text-right text-xs uppercase tracking-wider ${
+                            isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                          }`}
                         >
-                          <code
-                            className={`rounded px-2 py-1 text-sm ${
-                              isDarkMode
-                                ? 'bg-gray-700 text-blue-400'
-                                : 'bg-gray-100 text-[#2A4DD0]'
-                            }`}
+                          Actions
+                        </th>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody
+                    className={
+                      isDarkMode
+                        ? 'divide-y divide-gray-700'
+                        : 'divide-y divide-gray-200'
+                    }
+                  >
+                    {(role.permissions || [])
+                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .map((perm) => (
+                        <tr
+                          key={perm.name}
+                          className={
+                            isDarkMode
+                              ? 'hover:bg-gray-700'
+                              : 'hover:bg-gray-50'
+                          }
+                        >
+                          <td
+                            className={`px-6 py-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                           >
-                            {perm.name}
-                          </code>
-                        </td>
-                        <td
-                          className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                        >
-                          {perm.description || perm.action}
-                        </td>
-                        {!role.is_system && (
-                          <td className="px-6 py-4 text-right">
-                            <button
-                              onClick={() => handleRevokePermission(perm.name)}
-                              disabled={revokeMutation.isPending}
-                              className={`rounded p-1.5 ${
+                            <code
+                              className={`rounded px-2 py-1 text-sm ${
                                 isDarkMode
-                                  ? 'text-red-400 hover:bg-red-900/20'
-                                  : 'text-red-600 hover:bg-red-50'
+                                  ? 'bg-gray-700 text-blue-400'
+                                  : 'bg-gray-100 text-[#2A4DD0]'
                               }`}
-                              title="Remove permission"
                             >
-                              <Trash2 className="h-4 w-4" />
-                            </button>
+                              {perm.name}
+                            </code>
                           </td>
-                        )}
-                      </tr>
-                    ))}
-                </tbody>
-              </table>
-            </div>
+                          <td
+                            className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                          >
+                            {perm.description || perm.action}
+                          </td>
+                          {!role.is_system && (
+                            <td className="px-6 py-4 text-right">
+                              <TooltipProvider delayDuration={200}>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <button
+                                      onClick={() =>
+                                        handleRevokePermission(perm.name)
+                                      }
+                                      disabled={revokeMutation.isPending}
+                                      className={`rounded p-1.5 ${
+                                        isDarkMode
+                                          ? 'text-red-400 hover:bg-red-900/20'
+                                          : 'text-red-600 hover:bg-red-50'
+                                      }`}
+                                    >
+                                      <Trash2 className="h-4 w-4" />
+                                    </button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    <p>Remove permission</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            </td>
+                          )}
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
           )}
         </div>
       )}
@@ -599,96 +607,94 @@ export function RoleDetail({
               </div>
             </div>
           ) : (
-            <div
-              className={`overflow-hidden rounded-lg border ${
-                isDarkMode
-                  ? 'border-gray-700 bg-gray-800'
-                  : 'border-gray-200 bg-white'
-              }`}
+            <Card
+              className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
             >
-              <div
-                className={`grid grid-cols-[1fr_auto_auto] gap-4 border-b px-4 py-2.5 text-xs font-medium uppercase tracking-wider ${
-                  isDarkMode
-                    ? 'border-gray-700 bg-gray-800 text-gray-400'
-                    : 'border-gray-200 bg-gray-50 text-gray-500'
-                }`}
-              >
-                <div>User</div>
-                <div>Status</div>
-                <div>Last Login</div>
-              </div>
-              <div
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-100'}`}
-              >
-                {roleUsers.map((user: RoleUser) => (
-                  <div
-                    key={user.email}
-                    className="grid grid-cols-[1fr_auto_auto] items-center gap-4 px-4 py-3"
-                  >
-                    <div className="flex min-w-0 items-center gap-3">
-                      <Gravatar
-                        email={user.email}
-                        size={32}
-                        className="flex-shrink-0 rounded-full"
-                      />
-                      <div className="min-w-0">
-                        <div
-                          className={`truncate text-sm font-medium ${isDarkMode ? 'text-gray-200' : 'text-gray-900'}`}
-                        >
-                          {user.display_name}
-                        </div>
-                        <div
-                          className={`truncate text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                        >
-                          {user.email}
+              <CardContent className="p-0">
+                <div
+                  className={`grid grid-cols-[1fr_auto_auto] gap-4 border-b px-4 py-2.5 text-xs font-medium uppercase tracking-wider ${
+                    isDarkMode
+                      ? 'border-gray-700 bg-gray-800 text-gray-400'
+                      : 'border-gray-200 bg-gray-50 text-gray-500'
+                  }`}
+                >
+                  <div>User</div>
+                  <div>Status</div>
+                  <div>Last Login</div>
+                </div>
+                <div
+                  className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-100'}`}
+                >
+                  {roleUsers.map((user: RoleUser) => (
+                    <div
+                      key={user.email}
+                      className="grid grid-cols-[1fr_auto_auto] items-center gap-4 px-4 py-3"
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <Gravatar
+                          email={user.email}
+                          size={32}
+                          className="flex-shrink-0 rounded-full"
+                        />
+                        <div className="min-w-0">
+                          <div
+                            className={`truncate text-sm font-medium ${isDarkMode ? 'text-gray-200' : 'text-gray-900'}`}
+                          >
+                            {user.display_name}
+                          </div>
+                          <div
+                            className={`truncate text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                          >
+                            {user.email}
+                          </div>
                         </div>
                       </div>
+                      <div className="flex items-center gap-2">
+                        {user.is_active ? (
+                          <span
+                            className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-green-900/30 text-green-400'
+                                : 'bg-green-100 text-green-700'
+                            }`}
+                          >
+                            Active
+                          </span>
+                        ) : (
+                          <span
+                            className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-gray-700 text-gray-400'
+                                : 'bg-gray-100 text-gray-500'
+                            }`}
+                          >
+                            Inactive
+                          </span>
+                        )}
+                        {user.is_service_account && (
+                          <span
+                            className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-purple-900/30 text-purple-400'
+                                : 'bg-purple-100 text-purple-700'
+                            }`}
+                          >
+                            Service
+                          </span>
+                        )}
+                      </div>
+                      <div
+                        className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                      >
+                        {user.last_login
+                          ? new Date(user.last_login).toLocaleDateString()
+                          : 'Never'}
+                      </div>
                     </div>
-                    <div className="flex items-center gap-2">
-                      {user.is_active ? (
-                        <span
-                          className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-green-900/30 text-green-400'
-                              : 'bg-green-100 text-green-700'
-                          }`}
-                        >
-                          Active
-                        </span>
-                      ) : (
-                        <span
-                          className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-gray-700 text-gray-400'
-                              : 'bg-gray-100 text-gray-500'
-                          }`}
-                        >
-                          Inactive
-                        </span>
-                      )}
-                      {user.is_service_account && (
-                        <span
-                          className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-purple-900/30 text-purple-400'
-                              : 'bg-purple-100 text-purple-700'
-                          }`}
-                        >
-                          Service
-                        </span>
-                      )}
-                    </div>
-                    <div
-                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                    >
-                      {user.last_login
-                        ? new Date(user.last_login).toLocaleDateString()
-                        : 'Never'}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
           )}
         </div>
       )}
@@ -759,87 +765,85 @@ export function RoleDetail({
               </div>
             </div>
           ) : (
-            <div
-              className={`overflow-hidden rounded-lg border ${
-                isDarkMode
-                  ? 'border-gray-700 bg-gray-800'
-                  : 'border-gray-200 bg-white'
-              }`}
+            <Card
+              className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
             >
-              <div
-                className={`grid grid-cols-[1fr_auto_auto] gap-4 border-b px-4 py-2.5 text-xs font-medium uppercase tracking-wider ${
-                  isDarkMode
-                    ? 'border-gray-700 bg-gray-800 text-gray-400'
-                    : 'border-gray-200 bg-gray-50 text-gray-500'
-                }`}
-              >
-                <div>Service Account</div>
-                <div>Status</div>
-                <div>Last Authenticated</div>
-              </div>
-              <div
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-100'}`}
-              >
-                {roleServiceAccounts.map((sa: ServiceAccount) => (
-                  <div
-                    key={sa.slug}
-                    className="grid grid-cols-[1fr_auto_auto] items-center gap-4 px-4 py-3"
-                  >
-                    <div className="flex min-w-0 items-center gap-3">
-                      <div
-                        className={`rounded-full p-1.5 ${isDarkMode ? 'bg-purple-900/30' : 'bg-purple-100'}`}
-                      >
-                        <Bot
-                          className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
-                        />
-                      </div>
-                      <div className="min-w-0">
-                        <div
-                          className={`truncate text-sm font-medium ${isDarkMode ? 'text-gray-200' : 'text-gray-900'}`}
-                        >
-                          {sa.display_name}
-                        </div>
-                        <div
-                          className={`truncate font-mono text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                        >
-                          {sa.slug}
-                        </div>
-                      </div>
-                    </div>
-                    <div>
-                      {sa.is_active ? (
-                        <span
-                          className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-green-900/30 text-green-400'
-                              : 'bg-green-100 text-green-700'
-                          }`}
-                        >
-                          Active
-                        </span>
-                      ) : (
-                        <span
-                          className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
-                            isDarkMode
-                              ? 'bg-gray-700 text-gray-400'
-                              : 'bg-gray-100 text-gray-500'
-                          }`}
-                        >
-                          Inactive
-                        </span>
-                      )}
-                    </div>
+              <CardContent className="p-0">
+                <div
+                  className={`grid grid-cols-[1fr_auto_auto] gap-4 border-b px-4 py-2.5 text-xs font-medium uppercase tracking-wider ${
+                    isDarkMode
+                      ? 'border-gray-700 bg-gray-800 text-gray-400'
+                      : 'border-gray-200 bg-gray-50 text-gray-500'
+                  }`}
+                >
+                  <div>Service Account</div>
+                  <div>Status</div>
+                  <div>Last Authenticated</div>
+                </div>
+                <div
+                  className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-100'}`}
+                >
+                  {roleServiceAccounts.map((sa: ServiceAccount) => (
                     <div
-                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                      key={sa.slug}
+                      className="grid grid-cols-[1fr_auto_auto] items-center gap-4 px-4 py-3"
                     >
-                      {sa.last_authenticated
-                        ? new Date(sa.last_authenticated).toLocaleDateString()
-                        : 'Never'}
+                      <div className="flex min-w-0 items-center gap-3">
+                        <div
+                          className={`rounded-full p-1.5 ${isDarkMode ? 'bg-purple-900/30' : 'bg-purple-100'}`}
+                        >
+                          <Bot
+                            className={`h-4 w-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+                          />
+                        </div>
+                        <div className="min-w-0">
+                          <div
+                            className={`truncate text-sm font-medium ${isDarkMode ? 'text-gray-200' : 'text-gray-900'}`}
+                          >
+                            {sa.display_name}
+                          </div>
+                          <div
+                            className={`truncate font-mono text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                          >
+                            {sa.slug}
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        {sa.is_active ? (
+                          <span
+                            className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-green-900/30 text-green-400'
+                                : 'bg-green-100 text-green-700'
+                            }`}
+                          >
+                            Active
+                          </span>
+                        ) : (
+                          <span
+                            className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
+                              isDarkMode
+                                ? 'bg-gray-700 text-gray-400'
+                                : 'bg-gray-100 text-gray-500'
+                            }`}
+                          >
+                            Inactive
+                          </span>
+                        )}
+                      </div>
+                      <div
+                        className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                      >
+                        {sa.last_authenticated
+                          ? new Date(sa.last_authenticated).toLocaleDateString()
+                          : 'Never'}
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
-            </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
           )}
         </div>
       )}
@@ -906,67 +910,65 @@ export function RoleDetail({
               </div>
             </div>
           ) : (
-            <div
-              className={`overflow-hidden rounded-lg border ${
-                isDarkMode
-                  ? 'border-gray-700 bg-gray-800'
-                  : 'border-gray-200 bg-white'
-              }`}
+            <Card
+              className={`overflow-hidden ${isDarkMode ? 'border-gray-700 bg-gray-800' : ''}`}
             >
-              <div
-                className={`grid grid-cols-[1fr_1fr] gap-4 border-b px-4 py-2.5 text-xs font-medium uppercase tracking-wider ${
-                  isDarkMode
-                    ? 'border-gray-700 bg-gray-800 text-gray-400'
-                    : 'border-gray-200 bg-gray-50 text-gray-500'
-                }`}
-              >
-                <div>Group</div>
-                <div>Description</div>
-              </div>
-              <div
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-100'}`}
-              >
-                {roleGroups.map(
-                  (group: {
-                    name: string
-                    slug: string
-                    description?: string | null
-                  }) => (
-                    <div
-                      key={group.slug}
-                      className="grid grid-cols-[1fr_1fr] items-center gap-4 px-4 py-3"
-                    >
-                      <div className="flex min-w-0 items-center gap-3">
-                        <div
-                          className={`rounded p-1.5 ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}
-                        >
-                          <UsersRound
-                            className={`h-4 w-4 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                          />
-                        </div>
-                        <div className="min-w-0">
-                          <div
-                            className={`truncate text-sm font-medium ${isDarkMode ? 'text-gray-200' : 'text-gray-900'}`}
-                          >
-                            {group.name}
-                          </div>
-                          <div
-                            className={`truncate font-mono text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                          >
-                            {group.slug}
-                          </div>
-                        </div>
-                      </div>
+              <CardContent className="p-0">
+                <div
+                  className={`grid grid-cols-[1fr_1fr] gap-4 border-b px-4 py-2.5 text-xs font-medium uppercase tracking-wider ${
+                    isDarkMode
+                      ? 'border-gray-700 bg-gray-800 text-gray-400'
+                      : 'border-gray-200 bg-gray-50 text-gray-500'
+                  }`}
+                >
+                  <div>Group</div>
+                  <div>Description</div>
+                </div>
+                <div
+                  className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-100'}`}
+                >
+                  {roleGroups.map(
+                    (group: {
+                      name: string
+                      slug: string
+                      description?: string | null
+                    }) => (
                       <div
-                        className={`truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                        key={group.slug}
+                        className="grid grid-cols-[1fr_1fr] items-center gap-4 px-4 py-3"
                       >
-                        {group.description || 'No description'}
+                        <div className="flex min-w-0 items-center gap-3">
+                          <div
+                            className={`rounded p-1.5 ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}
+                          >
+                            <UsersRound
+                              className={`h-4 w-4 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+                            />
+                          </div>
+                          <div className="min-w-0">
+                            <div
+                              className={`truncate text-sm font-medium ${isDarkMode ? 'text-gray-200' : 'text-gray-900'}`}
+                            >
+                              {group.name}
+                            </div>
+                            <div
+                              className={`truncate font-mono text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                            >
+                              {group.slug}
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className={`truncate text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                        >
+                          {group.description || 'No description'}
+                        </div>
                       </div>
-                    </div>
-                  ),
-                )}
-              </div>
-            </div>
+                    ),
+                  )}
+                </div>
+              </CardContent>
+            </Card>
           )}
         </div>
       )}

--- a/src/components/admin/roles/RoleForm.tsx
+++ b/src/components/admin/roles/RoleForm.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { getRole, getAdminSettings } from '@/api/endpoints'
 import type { RoleCreate, Permission } from '@/types'
 
@@ -272,7 +273,7 @@ export function RoleForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit Role' : 'Create New Role'}
           </h2>
@@ -380,339 +381,325 @@ export function RoleForm({
       )}
 
       {/* Role Details */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Role Information
-        </h3>
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="space-y-4 pt-6">
+          <div className="grid grid-cols-2 gap-4">
+            {/* Name */}
+            <div className="col-span-2">
+              <label
+                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              >
+                Name <span className="text-red-500">*</span>
+              </label>
+              <Input
+                value={name}
+                onChange={(e) => handleNameChange(e.target.value)}
+                onBlur={() => {
+                  setTouched({ ...touched, name: true })
+                  const err = validateName(name)
+                  if (err)
+                    setValidationErrors({ ...validationErrors, name: err })
+                }}
+                disabled={isLoading || isSystemRole}
+                placeholder="e.g. Project Manager"
+                className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                  isSystemRole ? 'cursor-not-allowed opacity-60' : ''
+                }`}
+              />
+              {touched.name && validationErrors.name && (
+                <p className="mt-1 text-sm text-red-600">
+                  {validationErrors.name}
+                </p>
+              )}
+            </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          {/* Name */}
-          <div className="col-span-2">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Name <span className="text-red-500">*</span>
-            </label>
-            <Input
-              value={name}
-              onChange={(e) => handleNameChange(e.target.value)}
-              onBlur={() => {
-                setTouched({ ...touched, name: true })
-                const err = validateName(name)
-                if (err) setValidationErrors({ ...validationErrors, name: err })
-              }}
-              disabled={isLoading || isSystemRole}
-              placeholder="e.g. Project Manager"
-              className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                isSystemRole ? 'cursor-not-allowed opacity-60' : ''
-              }`}
-            />
-            {touched.name && validationErrors.name && (
-              <p className="mt-1 text-sm text-red-600">
-                {validationErrors.name}
-              </p>
+            {/* Slug */}
+            {!isEditing && (
+              <div className="col-span-2">
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Slug <span className="text-red-500">*</span>
+                </label>
+                <Input
+                  value={slug}
+                  onChange={(e) => handleSlugChange(e.target.value)}
+                  onBlur={() => {
+                    setTouched({ ...touched, slug: true })
+                    const err = validateSlug(slug)
+                    if (err)
+                      setValidationErrors({ ...validationErrors, slug: err })
+                  }}
+                  disabled={isLoading || isSystemRole}
+                  placeholder="e.g. project-manager"
+                  className={`font-mono ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                    isSystemRole ? 'cursor-not-allowed opacity-60' : ''
+                  }`}
+                />
+                {!slugManuallyEdited && name && (
+                  <p
+                    className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    Auto-generated from name
+                  </p>
+                )}
+                {touched.slug && validationErrors.slug && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {validationErrors.slug}
+                  </p>
+                )}
+              </div>
             )}
-          </div>
 
-          {/* Slug */}
-          <div className="col-span-2">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Slug <span className="text-red-500">*</span>
-            </label>
-            <Input
-              value={slug}
-              onChange={(e) => handleSlugChange(e.target.value)}
-              onBlur={() => {
-                setTouched({ ...touched, slug: true })
-                const err = validateSlug(slug)
-                if (err) setValidationErrors({ ...validationErrors, slug: err })
-              }}
-              disabled={isLoading || isSystemRole}
-              placeholder="e.g. project-manager"
-              className={`font-mono ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                isSystemRole ? 'cursor-not-allowed opacity-60' : ''
-              }`}
-            />
-            {!isEditing && !slugManuallyEdited && name && (
+            {/* Description */}
+            <div className="col-span-2">
+              <label
+                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              >
+                Description
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                disabled={isLoading || isSystemRole}
+                placeholder="Brief description of this role's purpose and scope"
+                rows={3}
+                className={`w-full resize-none rounded-md border px-3 py-2 text-sm ${
+                  isDarkMode
+                    ? 'border-gray-600 bg-gray-700 text-white placeholder-gray-400'
+                    : 'border-gray-300 bg-white text-gray-900 placeholder-gray-500'
+                } ${isSystemRole ? 'cursor-not-allowed opacity-60' : ''}`}
+              />
+            </div>
+
+            {/* Priority */}
+            <div className="col-span-2 sm:col-span-1">
+              <label
+                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              >
+                Priority
+              </label>
+              <Input
+                type="number"
+                value={priority}
+                onChange={(e) => setPriority(parseInt(e.target.value, 10) || 0)}
+                disabled={isLoading || isSystemRole}
+                placeholder="0"
+                className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                  isSystemRole ? 'cursor-not-allowed opacity-60' : ''
+                }`}
+              />
               <p
                 className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
               >
-                Auto-generated from name
+                Higher priority roles take precedence. System roles use
+                100-1000.
               </p>
-            )}
-            {touched.slug && validationErrors.slug && (
-              <p className="mt-1 text-sm text-red-600">
-                {validationErrors.slug}
-              </p>
-            )}
+            </div>
           </div>
-
-          {/* Description */}
-          <div className="col-span-2">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Description
-            </label>
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              disabled={isLoading || isSystemRole}
-              placeholder="Brief description of this role's purpose and scope"
-              rows={3}
-              className={`w-full resize-none rounded-md border px-3 py-2 text-sm ${
-                isDarkMode
-                  ? 'border-gray-600 bg-gray-700 text-white placeholder-gray-400'
-                  : 'border-gray-300 bg-white text-gray-900 placeholder-gray-500'
-              } ${isSystemRole ? 'cursor-not-allowed opacity-60' : ''}`}
-            />
-          </div>
-
-          {/* Priority */}
-          <div className="col-span-2 sm:col-span-1">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Priority
-            </label>
-            <Input
-              type="number"
-              value={priority}
-              onChange={(e) => setPriority(parseInt(e.target.value, 10) || 0)}
-              disabled={isLoading || isSystemRole}
-              placeholder="0"
-              className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                isSystemRole ? 'cursor-not-allowed opacity-60' : ''
-              }`}
-            />
-            <p
-              className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-            >
-              Higher priority roles take precedence. System roles use 100-1000.
-            </p>
-          </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Permissions Selection */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <h3
-            className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Permissions
-          </h3>
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex-row items-center justify-between space-y-0 pb-4">
+          <CardTitle>Permissions</CardTitle>
           <div
             className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
           >
             {selectedPermissions.size} selected
           </div>
-        </div>
-
-        <div
-          className={`mb-4 flex items-start gap-2 rounded-lg p-3 ${
-            isDarkMode
-              ? 'bg-blue-900/20 text-blue-400'
-              : 'bg-blue-50 text-blue-700'
-          }`}
-        >
-          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
-          <div className="text-xs">
-            Select the permissions this role should have. Permissions are
-            grouped by resource type for easier management.
-            {isEditing && existingRole && (
-              <> Changes will affect all users and groups with this role.</>
-            )}
+        </CardHeader>
+        <CardContent>
+          <div
+            className={`mb-4 flex items-start gap-2 rounded-lg p-3 ${
+              isDarkMode
+                ? 'bg-blue-900/20 text-blue-400'
+                : 'bg-blue-50 text-blue-700'
+            }`}
+          >
+            <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div className="text-xs">
+              Select the permissions this role should have. Permissions are
+              grouped by resource type for easier management.
+              {isEditing && existingRole && (
+                <> Changes will affect all users and groups with this role.</>
+              )}
+            </div>
           </div>
-        </div>
 
-        <div className="space-y-3">
-          {adminSettingsLoading && (
-            <div
-              className={`py-6 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-            >
-              Loading permissions...
-            </div>
-          )}
-          {adminSettingsError && (
-            <div
-              className={`py-6 text-center ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
-            >
-              Failed to load permissions. Please retry.
-            </div>
-          )}
-          {Object.entries(groupedPermissions)
-            .sort(([a], [b]) => a.localeCompare(b))
-            .map(([resource, perms]) => {
-              const isExpanded = expandedGroups.has(resource)
-              const selectedCount = perms.filter((p) =>
-                selectedPermissions.has(p.name),
-              ).length
-              const allSelected = selectedCount === perms.length
-              const someSelected =
-                selectedCount > 0 && selectedCount < perms.length
-
-              return (
-                <div
-                  key={resource}
-                  className={`rounded-lg border ${
-                    isDarkMode
-                      ? 'border-gray-600 bg-gray-700'
-                      : 'border-gray-200 bg-gray-50'
-                  }`}
-                >
-                  {/* Group Header */}
-                  <div className="flex items-center gap-3 p-3">
-                    <button
-                      type="button"
-                      onClick={() => toggleGroup(resource)}
-                      aria-label={
-                        isExpanded
-                          ? 'Collapse permissions group'
-                          : 'Expand permissions group'
-                      }
-                      aria-expanded={isExpanded}
-                      className={`rounded p-0.5 ${
-                        isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-200'
-                      }`}
-                    >
-                      {isExpanded ? (
-                        <ChevronDown
-                          className={`h-4 w-4 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                        />
-                      ) : (
-                        <ChevronRight
-                          className={`h-4 w-4 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                        />
-                      )}
-                    </button>
-
-                    <div className="flex flex-1 items-center gap-2">
-                      <Checkbox
-                        id={`group-${resource}`}
-                        checked={
-                          allSelected
-                            ? true
-                            : someSelected
-                              ? 'indeterminate'
-                              : false
-                        }
-                        disabled={isSystemRole}
-                        onCheckedChange={() => toggleAllInGroup(resource)}
-                      />
-                      <label
-                        htmlFor={`group-${resource}`}
-                        className={`flex-1 cursor-pointer select-none ${
-                          isDarkMode ? 'text-white' : 'text-gray-900'
-                        }`}
-                      >
-                        {resourceLabel(resource)}
-                      </label>
-                      <span
-                        className={`rounded-full px-2 py-0.5 text-xs ${
-                          selectedCount > 0
-                            ? isDarkMode
-                              ? 'bg-blue-900/40 text-blue-400'
-                              : 'bg-blue-100 text-blue-700'
-                            : isDarkMode
-                              ? 'bg-gray-700 text-gray-400'
-                              : 'bg-gray-200 text-gray-600'
-                        }`}
-                      >
-                        {selectedCount}/{perms.length}
-                      </span>
-                    </div>
-                  </div>
-
-                  {/* Group Permissions */}
-                  {isExpanded && (
-                    <div
-                      className={`space-y-2 border-t px-3 pb-3 ${
-                        isDarkMode ? 'border-gray-600' : 'border-gray-200'
-                      }`}
-                    >
-                      {perms
-                        .sort((a, b) => a.action.localeCompare(b.action))
-                        .map((perm) => (
-                          <div
-                            key={perm.name}
-                            className={`flex items-start gap-3 rounded p-2.5 ${
-                              isDarkMode
-                                ? 'hover:bg-gray-700'
-                                : 'hover:bg-white'
-                            }`}
-                          >
-                            <Checkbox
-                              id={perm.name}
-                              checked={selectedPermissions.has(perm.name)}
-                              disabled={isSystemRole}
-                              onCheckedChange={() =>
-                                togglePermission(perm.name)
-                              }
-                              className="mt-0.5"
-                            />
-                            <label
-                              htmlFor={perm.name}
-                              className="flex-1 cursor-pointer select-none"
-                            >
-                              <div
-                                className={`text-sm ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                              >
-                                <code
-                                  className={`rounded px-1.5 py-0.5 text-xs ${
-                                    isDarkMode
-                                      ? 'bg-gray-700 text-blue-400'
-                                      : 'bg-gray-200 text-[#2A4DD0]'
-                                  }`}
-                                >
-                                  {perm.action}
-                                </code>
-                              </div>
-                              <div
-                                className={`mt-0.5 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                              >
-                                {perm.description || perm.name}
-                              </div>
-                            </label>
-                          </div>
-                        ))}
-                    </div>
-                  )}
-                </div>
-              )
-            })}
-
-          {!adminSettingsLoading &&
-            !adminSettingsError &&
-            (!adminSettings?.permissions ||
-              adminSettings.permissions.length === 0) && (
+          <div className="space-y-3">
+            {adminSettingsLoading && (
               <div
-                className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                className={`py-6 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
               >
-                <div>No permissions available</div>
-                <div className="mt-1 text-sm">
-                  Permissions are configured in the backend
-                </div>
+                Loading permissions...
               </div>
             )}
-        </div>
-      </div>
+            {adminSettingsError && (
+              <div
+                className={`py-6 text-center ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+              >
+                Failed to load permissions. Please retry.
+              </div>
+            )}
+            {Object.entries(groupedPermissions)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([resource, perms]) => {
+                const isExpanded = expandedGroups.has(resource)
+                const selectedCount = perms.filter((p) =>
+                  selectedPermissions.has(p.name),
+                ).length
+                const allSelected = selectedCount === perms.length
+                const someSelected =
+                  selectedCount > 0 && selectedCount < perms.length
+
+                return (
+                  <div
+                    key={resource}
+                    className={`rounded-lg border ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700'
+                        : 'border-gray-200 bg-gray-50'
+                    }`}
+                  >
+                    {/* Group Header */}
+                    <div className="flex items-center gap-3 p-3">
+                      <button
+                        type="button"
+                        onClick={() => toggleGroup(resource)}
+                        aria-label={
+                          isExpanded
+                            ? 'Collapse permissions group'
+                            : 'Expand permissions group'
+                        }
+                        aria-expanded={isExpanded}
+                        className={`rounded p-0.5 ${
+                          isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-200'
+                        }`}
+                      >
+                        {isExpanded ? (
+                          <ChevronDown
+                            className={`h-4 w-4 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                          />
+                        ) : (
+                          <ChevronRight
+                            className={`h-4 w-4 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                          />
+                        )}
+                      </button>
+
+                      <div className="flex flex-1 items-center gap-2">
+                        <Checkbox
+                          id={`group-${resource}`}
+                          checked={
+                            allSelected
+                              ? true
+                              : someSelected
+                                ? 'indeterminate'
+                                : false
+                          }
+                          disabled={isSystemRole}
+                          onCheckedChange={() => toggleAllInGroup(resource)}
+                        />
+                        <label
+                          htmlFor={`group-${resource}`}
+                          className={`flex-1 cursor-pointer select-none ${
+                            isDarkMode ? 'text-white' : 'text-gray-900'
+                          }`}
+                        >
+                          {resourceLabel(resource)}
+                        </label>
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-xs ${
+                            selectedCount > 0
+                              ? isDarkMode
+                                ? 'bg-blue-900/40 text-blue-400'
+                                : 'bg-blue-100 text-blue-700'
+                              : isDarkMode
+                                ? 'bg-gray-700 text-gray-400'
+                                : 'bg-gray-200 text-gray-600'
+                          }`}
+                        >
+                          {selectedCount}/{perms.length}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Group Permissions */}
+                    {isExpanded && (
+                      <div
+                        className={`space-y-2 border-t px-3 pb-3 ${
+                          isDarkMode ? 'border-gray-600' : 'border-gray-200'
+                        }`}
+                      >
+                        {perms
+                          .sort((a, b) => a.action.localeCompare(b.action))
+                          .map((perm) => (
+                            <div
+                              key={perm.name}
+                              className={`flex items-start gap-3 rounded p-2.5 ${
+                                isDarkMode
+                                  ? 'hover:bg-gray-700'
+                                  : 'hover:bg-white'
+                              }`}
+                            >
+                              <Checkbox
+                                id={perm.name}
+                                checked={selectedPermissions.has(perm.name)}
+                                disabled={isSystemRole}
+                                onCheckedChange={() =>
+                                  togglePermission(perm.name)
+                                }
+                                className="mt-0.5"
+                              />
+                              <label
+                                htmlFor={perm.name}
+                                className="flex-1 cursor-pointer select-none"
+                              >
+                                <div
+                                  className={`text-sm ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                                >
+                                  <code
+                                    className={`rounded px-1.5 py-0.5 text-xs ${
+                                      isDarkMode
+                                        ? 'bg-gray-700 text-blue-400'
+                                        : 'bg-gray-200 text-[#2A4DD0]'
+                                    }`}
+                                  >
+                                    {perm.action}
+                                  </code>
+                                </div>
+                                <div
+                                  className={`mt-0.5 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                                >
+                                  {perm.description || perm.name}
+                                </div>
+                              </label>
+                            </div>
+                          ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+
+            {!adminSettingsLoading &&
+              !adminSettingsError &&
+              (!adminSettings?.permissions ||
+                adminSettings.permissions.length === 0) && (
+                <div
+                  className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+                >
+                  <div>No permissions available</div>
+                  <div className="mt-1 text-sm">
+                    Permissions are configured in the backend
+                  </div>
+                </div>
+              )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/service-accounts/ServiceAccountDetail.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountDetail.tsx
@@ -18,6 +18,13 @@ import {
   Building2,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import {
   listServiceAccountApiKeys,
@@ -406,19 +413,10 @@ export function ServiceAccountDetail({
       </div>
 
       {/* Service Account info card */}
-      <div
-        className={`rounded-lg border ${isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
-      >
-        {/* Title row */}
-        <div
-          className={`flex items-start justify-between border-b px-6 py-5 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-        >
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
           <div>
-            <h2
-              className={`text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-            >
-              {account.display_name}
-            </h2>
+            <CardTitle>{account.display_name}</CardTitle>
             <p
               className={`mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
             >
@@ -432,10 +430,10 @@ export function ServiceAccountDetail({
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Account
           </Button>
-        </div>
+        </CardHeader>
 
         {/* Account Status */}
-        <div className="px-6 py-5">
+        <CardContent className="px-6 py-5">
           <div className="flex items-center gap-6">
             <div
               className={`flex items-center gap-2 rounded px-3 py-1.5 ${
@@ -461,27 +459,17 @@ export function ServiceAccountDetail({
               Service Account
             </div>
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Organization Memberships */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="mb-4 flex items-center justify-between">
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
           <div className="flex items-center gap-2">
             <Building2
               className={`h-5 w-5 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
             />
-            <h3
-              className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-            >
-              Organization Memberships
-            </h3>
+            <CardTitle>Organization Memberships</CardTitle>
           </div>
           {availableOrgs.length > 0 && (
             <Button
@@ -498,201 +486,204 @@ export function ServiceAccountDetail({
               Add to Organization
             </Button>
           )}
-        </div>
-
-        {/* Add to Organization Form */}
-        {showAddOrg && (
-          <div
-            className={`mb-4 rounded-lg border p-4 ${
-              isDarkMode
-                ? 'border-gray-600 bg-gray-700'
-                : 'border-gray-200 bg-gray-50'
-            }`}
-          >
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Organization
-                </label>
-                <select
-                  value={newOrgSlug}
-                  onChange={(e) => setNewOrgSlug(e.target.value)}
-                  className={`w-full rounded-md border px-3 py-2 text-sm ${
-                    isDarkMode
-                      ? 'border-gray-600 bg-gray-700 text-white'
-                      : 'border-gray-300 bg-white text-gray-900'
-                  }`}
-                >
-                  <option value="">Select...</option>
-                  {availableOrgs.map((org) => (
-                    <option key={org.slug} value={org.slug}>
-                      {org.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Role
-                </label>
-                <select
-                  value={newRoleSlug}
-                  onChange={(e) => setNewRoleSlug(e.target.value)}
-                  className={`w-full rounded-md border px-3 py-2 text-sm ${
-                    isDarkMode
-                      ? 'border-gray-600 bg-gray-700 text-white'
-                      : 'border-gray-300 bg-white text-gray-900'
-                  }`}
-                >
-                  <option value="">Select...</option>
-                  {availableRoles.map((role) => (
-                    <option key={role.slug} value={role.slug}>
-                      {role.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-            <div className="mt-3 flex items-center gap-2">
-              <Button
-                onClick={() =>
-                  addOrgMutation.mutate({
-                    organization_slug: newOrgSlug,
-                    role_slug: newRoleSlug,
-                  })
-                }
-                disabled={
-                  !newOrgSlug || !newRoleSlug || addOrgMutation.isPending
-                }
-                className="bg-amber-border text-white hover:bg-amber-border-strong"
-                size="sm"
-              >
-                {addOrgMutation.isPending ? 'Adding...' : 'Add'}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setShowAddOrg(false)
-                  setNewOrgSlug('')
-                  setNewRoleSlug('')
-                }}
-                className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Memberships List */}
-        {(account.organizations ?? []).length > 0 ? (
-          <div className="space-y-2">
-            {(account.organizations ?? []).map((membership: OrgMembership) => (
-              <div
-                key={membership.organization_slug}
-                className={`flex items-center justify-between rounded-lg border p-3 ${
-                  isDarkMode
-                    ? 'border-gray-600 bg-gray-700'
-                    : 'border-gray-200 bg-gray-50'
-                }`}
-              >
-                <div className="flex-1">
-                  <div
-                    className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+        </CardHeader>
+        <CardContent>
+          {/* Add to Organization Form */}
+          {showAddOrg && (
+            <div
+              className={`mb-4 rounded-lg border p-4 ${
+                isDarkMode
+                  ? 'border-gray-600 bg-gray-700'
+                  : 'border-gray-200 bg-gray-50'
+              }`}
+            >
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    {membership.organization_name}
-                  </div>
-                  <div
-                    className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}
-                  >
-                    {membership.organization_slug}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
+                    Organization
+                  </label>
                   <select
-                    value={membership.role}
-                    onChange={(e) =>
-                      updateOrgRoleMutation.mutate({
-                        orgSlug: membership.organization_slug,
-                        roleSlug: e.target.value,
-                      })
-                    }
-                    disabled={updateOrgRoleMutation.isPending}
-                    className={`rounded border px-2 py-1 text-xs ${
+                    value={newOrgSlug}
+                    onChange={(e) => setNewOrgSlug(e.target.value)}
+                    className={`w-full rounded-md border px-3 py-2 text-sm ${
                       isDarkMode
                         ? 'border-gray-600 bg-gray-700 text-white'
                         : 'border-gray-300 bg-white text-gray-900'
                     }`}
                   >
+                    <option value="">Select...</option>
+                    {availableOrgs.map((org) => (
+                      <option key={org.slug} value={org.slug}>
+                        {org.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
+                    Role
+                  </label>
+                  <select
+                    value={newRoleSlug}
+                    onChange={(e) => setNewRoleSlug(e.target.value)}
+                    className={`w-full rounded-md border px-3 py-2 text-sm ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700 text-white'
+                        : 'border-gray-300 bg-white text-gray-900'
+                    }`}
+                  >
+                    <option value="">Select...</option>
                     {availableRoles.map((role) => (
                       <option key={role.slug} value={role.slug}>
                         {role.name}
                       </option>
                     ))}
                   </select>
-                  <button
-                    onClick={() => {
-                      if (
-                        confirm(
-                          `Remove ${account.display_name} from ${membership.organization_name}?`,
-                        )
-                      ) {
-                        removeOrgMutation.mutate(membership.organization_slug)
-                      }
-                    }}
-                    disabled={removeOrgMutation.isPending}
-                    className={`rounded p-1.5 ${
-                      isDarkMode
-                        ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                        : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                    }`}
-                    title="Remove from organization"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
                 </div>
               </div>
-            ))}
-          </div>
-        ) : (
-          <div
-            className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-          >
-            <Building2
-              className={`mx-auto mb-2 h-8 w-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}
-            />
-            <div>Not a member of any organization</div>
-            <div className="mt-1 text-sm">
-              This service account has no permissions until added to an
-              organization
+              <div className="mt-3 flex items-center gap-2">
+                <Button
+                  onClick={() =>
+                    addOrgMutation.mutate({
+                      organization_slug: newOrgSlug,
+                      role_slug: newRoleSlug,
+                    })
+                  }
+                  disabled={
+                    !newOrgSlug || !newRoleSlug || addOrgMutation.isPending
+                  }
+                  className="bg-amber-border text-white hover:bg-amber-border-strong"
+                  size="sm"
+                >
+                  {addOrgMutation.isPending ? 'Adding...' : 'Add'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setShowAddOrg(false)
+                    setNewOrgSlug('')
+                    setNewRoleSlug('')
+                  }}
+                  className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
+                >
+                  Cancel
+                </Button>
+              </div>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+
+          {/* Memberships List */}
+          {(account.organizations ?? []).length > 0 ? (
+            <div className="space-y-2">
+              {(account.organizations ?? []).map(
+                (membership: OrgMembership) => (
+                  <div
+                    key={membership.organization_slug}
+                    className={`flex items-center justify-between rounded-lg border p-3 ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700'
+                        : 'border-gray-200 bg-gray-50'
+                    }`}
+                  >
+                    <div className="flex-1">
+                      <div
+                        className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        {membership.organization_name}
+                      </div>
+                      <div
+                        className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}
+                      >
+                        {membership.organization_slug}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={membership.role}
+                        onChange={(e) =>
+                          updateOrgRoleMutation.mutate({
+                            orgSlug: membership.organization_slug,
+                            roleSlug: e.target.value,
+                          })
+                        }
+                        disabled={updateOrgRoleMutation.isPending}
+                        className={`rounded border px-2 py-1 text-xs ${
+                          isDarkMode
+                            ? 'border-gray-600 bg-gray-700 text-white'
+                            : 'border-gray-300 bg-white text-gray-900'
+                        }`}
+                      >
+                        {availableRoles.map((role) => (
+                          <option key={role.slug} value={role.slug}>
+                            {role.name}
+                          </option>
+                        ))}
+                      </select>
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() => {
+                                if (
+                                  confirm(
+                                    `Remove ${account.display_name} from ${membership.organization_name}?`,
+                                  )
+                                ) {
+                                  removeOrgMutation.mutate(
+                                    membership.organization_slug,
+                                  )
+                                }
+                              }}
+                              disabled={removeOrgMutation.isPending}
+                              className={`rounded p-1.5 ${
+                                isDarkMode
+                                  ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                                  : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                              }`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Remove from organization</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  </div>
+                ),
+              )}
+            </div>
+          ) : (
+            <div
+              className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+            >
+              <Building2
+                className={`mx-auto mb-2 h-8 w-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}
+              />
+              <div>Not a member of any organization</div>
+              <div className="mt-1 text-sm">
+                This service account has no permissions until added to an
+                organization
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Client Credentials */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="mb-4 flex items-center justify-between">
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
           <div className="flex items-center gap-2">
             <Shield
               className={`h-5 w-5 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
             />
-            <h3
-              className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-            >
-              Client Credentials
-            </h3>
+            <CardTitle>Client Credentials</CardTitle>
           </div>
           <Button
             onClick={() => setShowCreateCredential(!showCreateCredential)}
@@ -707,357 +698,387 @@ export function ServiceAccountDetail({
             <Plus className="mr-2 h-4 w-4" />
             Create Credential
           </Button>
-        </div>
-
-        {/* Create Credential Form */}
-        {showCreateCredential && (
-          <div
-            className={`mb-4 rounded-lg border p-4 ${
-              isDarkMode
-                ? 'border-gray-600 bg-gray-700'
-                : 'border-gray-200 bg-gray-50'
-            }`}
-          >
-            <div className="space-y-3">
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Name <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  value={credentialName}
-                  onChange={(e) => setCredentialName(e.target.value)}
-                  placeholder="e.g., production-api"
-                  className={
-                    isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
-                  }
-                />
-              </div>
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Description
-                </label>
-                <Input
-                  value={credentialDescription}
-                  onChange={(e) => setCredentialDescription(e.target.value)}
-                  placeholder="What is this credential used for?"
-                  className={
-                    isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
-                  }
-                />
-              </div>
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Scopes{' '}
-                  <span
-                    className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-                  >
-                    (comma-separated)
-                  </span>
-                </label>
-                <Input
-                  value={credentialScopes}
-                  onChange={(e) => setCredentialScopes(e.target.value)}
-                  placeholder="e.g., read:projects, write:projects"
-                  className={
-                    isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
-                  }
-                />
-              </div>
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Expires in (days){' '}
-                  <span
-                    className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-                  >
-                    (leave empty for no expiration)
-                  </span>
-                </label>
-                <Input
-                  type="number"
-                  min="1"
-                  value={credentialExpiresDays}
-                  onChange={(e) => setCredentialExpiresDays(e.target.value)}
-                  placeholder="e.g., 90"
-                  className={
-                    isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
-                  }
-                />
-              </div>
-              <div className="flex items-center gap-2 pt-2">
-                <Button
-                  onClick={handleCreateCredential}
-                  disabled={
-                    !credentialName.trim() || createCredentialMutation.isPending
-                  }
-                  className="bg-amber-border text-white hover:bg-amber-border-strong"
-                >
-                  {createCredentialMutation.isPending
-                    ? 'Creating...'
-                    : 'Create'}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setShowCreateCredential(false)
-                    resetCredentialForm()
-                  }}
-                  className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Newly Created Credential Banner */}
-        {newlyCreatedCredential && (
-          <div
-            className={`mb-4 rounded-lg border p-4 ${
-              isDarkMode
-                ? 'border-green-700 bg-green-900/20'
-                : 'border-green-200 bg-green-50'
-            }`}
-          >
+        </CardHeader>
+        <CardContent>
+          {/* Create Credential Form */}
+          {showCreateCredential && (
             <div
-              className={`mb-2 font-medium ${isDarkMode ? 'text-green-400' : 'text-green-800'}`}
+              className={`mb-4 rounded-lg border p-4 ${
+                isDarkMode
+                  ? 'border-gray-600 bg-gray-700'
+                  : 'border-gray-200 bg-gray-50'
+              }`}
             >
-              Client Credential Created - Copy the secret now, it will not be
-              shown again!
-            </div>
-            <div className="space-y-2">
-              <div>
-                <span
-                  className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Client ID
-                </span>
-                <div className="flex items-center gap-2">
-                  <code
-                    className={`flex-1 rounded border px-3 py-2 text-sm ${
-                      isDarkMode
-                        ? 'border-gray-600 bg-gray-800 text-green-300'
-                        : 'border-gray-200 bg-white text-green-700'
-                    }`}
+              <div className="space-y-3">
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    {newlyCreatedCredential.client_id}
-                  </code>
-                  <button
-                    onClick={() =>
-                      copyToClipboard(
-                        newlyCreatedCredential.client_id,
-                        'cred-id',
-                      )
+                    Name <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    value={credentialName}
+                    onChange={(e) => setCredentialName(e.target.value)}
+                    placeholder="e.g., production-api"
+                    className={
+                      isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
                     }
-                    className={`rounded-lg p-2 ${
-                      copiedId === 'cred-id'
-                        ? 'bg-green-600 text-white'
-                        : isDarkMode
-                          ? 'text-gray-400 hover:bg-gray-700'
-                          : 'text-gray-600 hover:bg-gray-200'
-                    }`}
-                    title="Copy to clipboard"
-                  >
-                    <Copy className="h-4 w-4" />
-                  </button>
+                  />
                 </div>
-              </div>
-              <div>
-                <span
-                  className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Client Secret
-                </span>
-                <div className="flex items-center gap-2">
-                  <code
-                    className={`flex-1 rounded border px-3 py-2 text-sm ${
-                      isDarkMode
-                        ? 'border-gray-600 bg-gray-800 text-green-300'
-                        : 'border-gray-200 bg-white text-green-700'
-                    }`}
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    {newlyCreatedCredential.client_secret}
-                  </code>
-                  <button
-                    onClick={() =>
-                      copyToClipboard(
-                        newlyCreatedCredential.client_secret,
-                        'cred-secret',
-                      )
+                    Description
+                  </label>
+                  <Input
+                    value={credentialDescription}
+                    onChange={(e) => setCredentialDescription(e.target.value)}
+                    placeholder="What is this credential used for?"
+                    className={
+                      isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
                     }
-                    className={`rounded-lg p-2 ${
-                      copiedId === 'cred-secret'
-                        ? 'bg-green-600 text-white'
-                        : isDarkMode
-                          ? 'text-gray-400 hover:bg-gray-700'
-                          : 'text-gray-600 hover:bg-gray-200'
-                    }`}
-                    title="Copy to clipboard"
-                  >
-                    <Copy className="h-4 w-4" />
-                  </button>
+                  />
                 </div>
-              </div>
-            </div>
-            <button
-              onClick={() => setNewlyCreatedCredential(null)}
-              className={`mt-2 text-sm ${isDarkMode ? 'text-green-400 hover:text-green-300' : 'text-green-700 hover:text-green-800'}`}
-            >
-              Dismiss
-            </button>
-          </div>
-        )}
-
-        {/* Credentials List */}
-        {credentialsLoading ? (
-          <div
-            className={`py-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Loading client credentials...
-          </div>
-        ) : credentialsError ? (
-          <div
-            className={`flex items-center gap-2 rounded-lg p-3 ${
-              isDarkMode
-                ? 'bg-red-900/20 text-red-400'
-                : 'bg-red-50 text-red-700'
-            }`}
-          >
-            <AlertCircle className="h-4 w-4 flex-shrink-0" />
-            <span className="text-sm">Failed to load client credentials</span>
-          </div>
-        ) : credentials.length === 0 ? (
-          <div
-            className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-          >
-            <Shield
-              className={`mx-auto mb-2 h-8 w-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}
-            />
-            <div>No client credentials created yet</div>
-            <div className="mt-1 text-sm">
-              Create a credential for OAuth2 client_credentials flow
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {credentials.map((cred: ClientCredential) => (
-              <div
-                key={cred.client_id}
-                className={`flex items-center justify-between rounded-lg border p-3 ${
-                  cred.revoked
-                    ? isDarkMode
-                      ? 'border-gray-600 bg-gray-700 opacity-50'
-                      : 'border-gray-200 bg-gray-50 opacity-50'
-                    : isDarkMode
-                      ? 'border-gray-600 bg-gray-700'
-                      : 'border-gray-200 bg-gray-50'
-                }`}
-              >
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
+                    Scopes{' '}
                     <span
-                      className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
                     >
-                      {cred.name}
+                      (comma-separated)
                     </span>
+                  </label>
+                  <Input
+                    value={credentialScopes}
+                    onChange={(e) => setCredentialScopes(e.target.value)}
+                    placeholder="e.g., read:projects, write:projects"
+                    className={
+                      isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+                    }
+                  />
+                </div>
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
+                    Expires in (days){' '}
+                    <span
+                      className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                    >
+                      (leave empty for no expiration)
+                    </span>
+                  </label>
+                  <Input
+                    type="number"
+                    min="1"
+                    value={credentialExpiresDays}
+                    onChange={(e) => setCredentialExpiresDays(e.target.value)}
+                    placeholder="e.g., 90"
+                    className={
+                      isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+                    }
+                  />
+                </div>
+                <div className="flex items-center gap-2 pt-2">
+                  <Button
+                    onClick={handleCreateCredential}
+                    disabled={
+                      !credentialName.trim() ||
+                      createCredentialMutation.isPending
+                    }
+                    className="bg-amber-border text-white hover:bg-amber-border-strong"
+                  >
+                    {createCredentialMutation.isPending
+                      ? 'Creating...'
+                      : 'Create'}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setShowCreateCredential(false)
+                      resetCredentialForm()
+                    }}
+                    className={
+                      isDarkMode ? 'border-gray-600 text-gray-300' : ''
+                    }
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Newly Created Credential Banner */}
+          {newlyCreatedCredential && (
+            <div
+              className={`mb-4 rounded-lg border p-4 ${
+                isDarkMode
+                  ? 'border-green-700 bg-green-900/20'
+                  : 'border-green-200 bg-green-50'
+              }`}
+            >
+              <div
+                className={`mb-2 font-medium ${isDarkMode ? 'text-green-400' : 'text-green-800'}`}
+              >
+                Client Credential Created - Copy the secret now, it will not be
+                shown again!
+              </div>
+              <div className="space-y-2">
+                <div>
+                  <span
+                    className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Client ID
+                  </span>
+                  <div className="flex items-center gap-2">
                     <code
-                      className={`rounded px-2 py-0.5 text-xs ${
+                      className={`flex-1 rounded border px-3 py-2 text-sm ${
                         isDarkMode
-                          ? 'bg-gray-700 text-gray-400'
-                          : 'bg-gray-100 text-gray-600'
+                          ? 'border-gray-600 bg-gray-800 text-green-300'
+                          : 'border-gray-200 bg-white text-green-700'
                       }`}
                     >
-                      {truncateClientId(cred.client_id)}
+                      {newlyCreatedCredential.client_id}
                     </code>
-                    {cred.revoked && (
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={() =>
+                              copyToClipboard(
+                                newlyCreatedCredential.client_id,
+                                'cred-id',
+                              )
+                            }
+                            className={`rounded-lg p-2 ${
+                              copiedId === 'cred-id'
+                                ? 'bg-green-600 text-white'
+                                : isDarkMode
+                                  ? 'text-gray-400 hover:bg-gray-700'
+                                  : 'text-gray-600 hover:bg-gray-200'
+                            }`}
+                          >
+                            <Copy className="h-4 w-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Copy to clipboard</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                </div>
+                <div>
+                  <span
+                    className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Client Secret
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <code
+                      className={`flex-1 rounded border px-3 py-2 text-sm ${
+                        isDarkMode
+                          ? 'border-gray-600 bg-gray-800 text-green-300'
+                          : 'border-gray-200 bg-white text-green-700'
+                      }`}
+                    >
+                      {newlyCreatedCredential.client_secret}
+                    </code>
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={() =>
+                              copyToClipboard(
+                                newlyCreatedCredential.client_secret,
+                                'cred-secret',
+                              )
+                            }
+                            className={`rounded-lg p-2 ${
+                              copiedId === 'cred-secret'
+                                ? 'bg-green-600 text-white'
+                                : isDarkMode
+                                  ? 'text-gray-400 hover:bg-gray-700'
+                                  : 'text-gray-600 hover:bg-gray-200'
+                            }`}
+                          >
+                            <Copy className="h-4 w-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Copy to clipboard</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                </div>
+              </div>
+              <button
+                onClick={() => setNewlyCreatedCredential(null)}
+                className={`mt-2 text-sm ${isDarkMode ? 'text-green-400 hover:text-green-300' : 'text-green-700 hover:text-green-800'}`}
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+
+          {/* Credentials List */}
+          {credentialsLoading ? (
+            <div
+              className={`py-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            >
+              Loading client credentials...
+            </div>
+          ) : credentialsError ? (
+            <div
+              className={`flex items-center gap-2 rounded-lg p-3 ${
+                isDarkMode
+                  ? 'bg-red-900/20 text-red-400'
+                  : 'bg-red-50 text-red-700'
+              }`}
+            >
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              <span className="text-sm">Failed to load client credentials</span>
+            </div>
+          ) : credentials.length === 0 ? (
+            <div
+              className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+            >
+              <Shield
+                className={`mx-auto mb-2 h-8 w-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}
+              />
+              <div>No client credentials created yet</div>
+              <div className="mt-1 text-sm">
+                Create a credential for OAuth2 client_credentials flow
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {credentials.map((cred: ClientCredential) => (
+                <div
+                  key={cred.client_id}
+                  className={`flex items-center justify-between rounded-lg border p-3 ${
+                    cred.revoked
+                      ? isDarkMode
+                        ? 'border-gray-600 bg-gray-700 opacity-50'
+                        : 'border-gray-200 bg-gray-50 opacity-50'
+                      : isDarkMode
+                        ? 'border-gray-600 bg-gray-700'
+                        : 'border-gray-200 bg-gray-50'
+                  }`}
+                >
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
                       <span
+                        className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        {cred.name}
+                      </span>
+                      <code
                         className={`rounded px-2 py-0.5 text-xs ${
                           isDarkMode
-                            ? 'bg-red-900/30 text-red-400'
-                            : 'bg-red-100 text-red-600'
+                            ? 'bg-gray-700 text-gray-400'
+                            : 'bg-gray-100 text-gray-600'
                         }`}
                       >
-                        Revoked
-                      </span>
-                    )}
-                    {cred.scopes.length > 0 && cred.scopes[0] !== '*' && (
-                      <span
-                        className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-                      >
-                        {cred.scopes.join(', ')}
-                      </span>
-                    )}
+                        {truncateClientId(cred.client_id)}
+                      </code>
+                      {cred.revoked && (
+                        <span
+                          className={`rounded px-2 py-0.5 text-xs ${
+                            isDarkMode
+                              ? 'bg-red-900/30 text-red-400'
+                              : 'bg-red-100 text-red-600'
+                          }`}
+                        >
+                          Revoked
+                        </span>
+                      )}
+                      {cred.scopes.length > 0 && cred.scopes[0] !== '*' && (
+                        <span
+                          className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                        >
+                          {cred.scopes.join(', ')}
+                        </span>
+                      )}
+                    </div>
+                    <div
+                      className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}
+                    >
+                      Created {formatDate(cred.created_at)}
+                      {cred.last_used &&
+                        ` | Last used ${formatDate(cred.last_used)}`}
+                      {cred.expires_at &&
+                        ` | Expires ${formatDate(cred.expires_at)}`}
+                    </div>
                   </div>
-                  <div
-                    className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}
-                  >
-                    Created {formatDate(cred.created_at)}
-                    {cred.last_used &&
-                      ` | Last used ${formatDate(cred.last_used)}`}
-                    {cred.expires_at &&
-                      ` | Expires ${formatDate(cred.expires_at)}`}
-                  </div>
+                  {!cred.revoked && (
+                    <div className="flex items-center gap-1">
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() =>
+                                handleRotateCredential(cred.client_id)
+                              }
+                              disabled={rotateCredentialMutation.isPending}
+                              className={`rounded p-1.5 ${
+                                isDarkMode
+                                  ? 'text-blue-400 hover:bg-gray-700 hover:text-blue-300'
+                                  : 'text-blue-600 hover:bg-gray-100 hover:text-blue-700'
+                              }`}
+                            >
+                              <RotateCw className="h-4 w-4" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Rotate credential</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() =>
+                                handleRevokeCredential(cred.client_id)
+                              }
+                              disabled={revokeCredentialMutation.isPending}
+                              className={`rounded p-1.5 ${
+                                isDarkMode
+                                  ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                                  : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                              }`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Revoke credential</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  )}
                 </div>
-                {!cred.revoked && (
-                  <div className="flex items-center gap-1">
-                    <button
-                      onClick={() => handleRotateCredential(cred.client_id)}
-                      disabled={rotateCredentialMutation.isPending}
-                      className={`rounded p-1.5 ${
-                        isDarkMode
-                          ? 'text-blue-400 hover:bg-gray-700 hover:text-blue-300'
-                          : 'text-blue-600 hover:bg-gray-100 hover:text-blue-700'
-                      }`}
-                      title="Rotate credential"
-                    >
-                      <RotateCw className="h-4 w-4" />
-                    </button>
-                    <button
-                      onClick={() => handleRevokeCredential(cred.client_id)}
-                      disabled={revokeCredentialMutation.isPending}
-                      className={`rounded p-1.5 ${
-                        isDarkMode
-                          ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                          : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                      }`}
-                      title="Revoke credential"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* API Keys */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="mb-4 flex items-center justify-between">
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
           <div className="flex items-center gap-2">
             <Key
               className={`h-5 w-5 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
             />
-            <h3
-              className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-            >
-              API Keys
-            </h3>
+            <CardTitle>API Keys</CardTitle>
           </div>
           <Button
             onClick={() => setShowCreateKey(!showCreateKey)}
@@ -1072,299 +1093,317 @@ export function ServiceAccountDetail({
             <Plus className="mr-2 h-4 w-4" />
             Create API Key
           </Button>
-        </div>
-
-        {/* Create Key Form */}
-        {showCreateKey && (
-          <div
-            className={`mb-4 rounded-lg border p-4 ${
-              isDarkMode
-                ? 'border-gray-600 bg-gray-700'
-                : 'border-gray-200 bg-gray-50'
-            }`}
-          >
-            <div className="flex items-end gap-3">
-              <div className="flex-1">
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Key Name
-                </label>
-                <input
-                  type="text"
-                  value={newKeyName}
-                  onChange={(e) => setNewKeyName(e.target.value)}
-                  placeholder="e.g., production, staging"
-                  className={`w-full rounded-lg border px-3 py-2 text-sm ${
-                    isDarkMode
-                      ? 'border-gray-600 bg-gray-700 text-white placeholder:text-gray-400'
-                      : 'border-gray-300 bg-white text-gray-900 placeholder:text-gray-500'
-                  }`}
-                />
-              </div>
-              <Button
-                onClick={handleCreateKey}
-                disabled={createKeyMutation.isPending}
-                className="bg-amber-border text-white hover:bg-amber-border-strong"
-              >
-                {createKeyMutation.isPending ? 'Creating...' : 'Create'}
-              </Button>
-              <Button
-                variant="outline"
-                onClick={() => {
-                  setShowCreateKey(false)
-                  setNewKeyName('')
-                }}
-                className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Newly Created Key Banner */}
-        {newlyCreatedKey && (
-          <div
-            className={`mb-4 rounded-lg border p-4 ${
-              isDarkMode
-                ? 'border-green-700 bg-green-900/20'
-                : 'border-green-200 bg-green-50'
-            }`}
-          >
+        </CardHeader>
+        <CardContent>
+          {/* Create Key Form */}
+          {showCreateKey && (
             <div
-              className={`mb-2 font-medium ${isDarkMode ? 'text-green-400' : 'text-green-800'}`}
+              className={`mb-4 rounded-lg border p-4 ${
+                isDarkMode
+                  ? 'border-gray-600 bg-gray-700'
+                  : 'border-gray-200 bg-gray-50'
+              }`}
             >
-              API Key Created - Copy it now, it will not be shown again!
-            </div>
-            <div className="flex items-center gap-2">
-              <code
-                className={`flex-1 rounded border px-3 py-2 text-sm ${
-                  isDarkMode
-                    ? 'border-gray-600 bg-gray-800 text-green-300'
-                    : 'border-gray-200 bg-white text-green-700'
-                }`}
-              >
-                {newlyCreatedKey.key_secret}
-              </code>
-              <button
-                onClick={() =>
-                  copyToClipboard(newlyCreatedKey.key_secret, 'new-key')
-                }
-                className={`rounded-lg p-2 ${
-                  copiedId === 'new-key'
-                    ? 'bg-green-600 text-white'
-                    : isDarkMode
-                      ? 'text-gray-400 hover:bg-gray-700'
-                      : 'text-gray-600 hover:bg-gray-200'
-                }`}
-                title="Copy to clipboard"
-              >
-                <Copy className="h-4 w-4" />
-              </button>
-            </div>
-            <button
-              onClick={() => setNewlyCreatedKey(null)}
-              className={`mt-2 text-sm ${isDarkMode ? 'text-green-400 hover:text-green-300' : 'text-green-700 hover:text-green-800'}`}
-            >
-              Dismiss
-            </button>
-          </div>
-        )}
-
-        {/* Keys List */}
-        {keysLoading ? (
-          <div
-            className={`py-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Loading API keys...
-          </div>
-        ) : keysError ? (
-          <div
-            className={`flex items-center gap-2 rounded-lg p-3 ${
-              isDarkMode
-                ? 'bg-red-900/20 text-red-400'
-                : 'bg-red-50 text-red-700'
-            }`}
-          >
-            <AlertCircle className="h-4 w-4 flex-shrink-0" />
-            <span className="text-sm">Failed to load API keys</span>
-          </div>
-        ) : apiKeys.length === 0 ? (
-          <div
-            className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-          >
-            <Key
-              className={`mx-auto mb-2 h-8 w-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}
-            />
-            <div>No API keys created yet</div>
-            <div className="mt-1 text-sm">
-              Create an API key to enable programmatic access
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {apiKeys.map((key: ApiKey) => (
-              <div
-                key={key.key_id}
-                className={`flex items-center justify-between rounded-lg border p-3 ${
-                  key.revoked
-                    ? isDarkMode
-                      ? 'border-gray-600 bg-gray-700 opacity-50'
-                      : 'border-gray-200 bg-gray-50 opacity-50'
-                    : isDarkMode
-                      ? 'border-gray-600 bg-gray-700'
-                      : 'border-gray-200 bg-gray-50'
-                }`}
-              >
+              <div className="flex items-end gap-3">
                 <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                    >
-                      {key.name}
-                    </span>
-                    <code
-                      className={`rounded px-2 py-0.5 text-xs ${
-                        isDarkMode
-                          ? 'bg-gray-700 text-gray-400'
-                          : 'bg-gray-100 text-gray-600'
-                      }`}
-                    >
-                      {key.key_id.substring(0, 7)}...
-                    </code>
-                    {key.revoked && (
-                      <span
-                        className={`rounded px-2 py-0.5 text-xs ${
-                          isDarkMode
-                            ? 'bg-red-900/30 text-red-400'
-                            : 'bg-red-100 text-red-600'
-                        }`}
-                      >
-                        Revoked
-                      </span>
-                    )}
-                  </div>
-                  <div
-                    className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    Created {formatDate(key.created_at)}
-                    {key.last_used &&
-                      ` | Last used ${formatDate(key.last_used)}`}
-                    {key.expires_at &&
-                      ` | Expires ${formatDate(key.expires_at)}`}
-                  </div>
+                    Key Name
+                  </label>
+                  <input
+                    type="text"
+                    value={newKeyName}
+                    onChange={(e) => setNewKeyName(e.target.value)}
+                    placeholder="e.g., production, staging"
+                    className={`w-full rounded-lg border px-3 py-2 text-sm ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700 text-white placeholder:text-gray-400'
+                        : 'border-gray-300 bg-white text-gray-900 placeholder:text-gray-500'
+                    }`}
+                  />
                 </div>
-                {!key.revoked && (
-                  <div className="flex items-center gap-1">
-                    <button
-                      onClick={() => handleRotateKey(key.key_id)}
-                      disabled={rotateKeyMutation.isPending}
-                      className={`rounded p-1.5 ${
-                        isDarkMode
-                          ? 'text-blue-400 hover:bg-gray-700 hover:text-blue-300'
-                          : 'text-blue-600 hover:bg-gray-100 hover:text-blue-700'
-                      }`}
-                      title="Rotate API key"
-                    >
-                      <RotateCw className="h-4 w-4" />
-                    </button>
-                    <button
-                      onClick={() => handleRevokeKey(key.key_id)}
-                      disabled={revokeKeyMutation.isPending}
-                      className={`rounded p-1.5 ${
-                        isDarkMode
-                          ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                          : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                      }`}
-                      title="Revoke API key"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* Basic Information */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Basic Information
-        </h3>
-
-        <div className="grid grid-cols-2 gap-6">
-          <div>
-            <div
-              className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-            >
-              <Tag className="h-4 w-4" />
-              Slug
-            </div>
-            <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
-              {account.slug}
-            </div>
-          </div>
-
-          <div>
-            <div
-              className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-            >
-              Display Name
-            </div>
-            <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
-              {account.display_name}
-            </div>
-          </div>
-
-          {account.description && (
-            <div className="col-span-2">
-              <div
-                className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-              >
-                Description
-              </div>
-              <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
-                {account.description}
+                <Button
+                  onClick={handleCreateKey}
+                  disabled={createKeyMutation.isPending}
+                  className="bg-amber-border text-white hover:bg-amber-border-strong"
+                >
+                  {createKeyMutation.isPending ? 'Creating...' : 'Create'}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setShowCreateKey(false)
+                    setNewKeyName('')
+                  }}
+                  className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
+                >
+                  Cancel
+                </Button>
               </div>
             </div>
           )}
 
-          <div>
+          {/* Newly Created Key Banner */}
+          {newlyCreatedKey && (
             <div
-              className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              className={`mb-4 rounded-lg border p-4 ${
+                isDarkMode
+                  ? 'border-green-700 bg-green-900/20'
+                  : 'border-green-200 bg-green-50'
+              }`}
             >
-              <Calendar className="h-4 w-4" />
-              Created
+              <div
+                className={`mb-2 font-medium ${isDarkMode ? 'text-green-400' : 'text-green-800'}`}
+              >
+                API Key Created - Copy it now, it will not be shown again!
+              </div>
+              <div className="flex items-center gap-2">
+                <code
+                  className={`flex-1 rounded border px-3 py-2 text-sm ${
+                    isDarkMode
+                      ? 'border-gray-600 bg-gray-800 text-green-300'
+                      : 'border-gray-200 bg-white text-green-700'
+                  }`}
+                >
+                  {newlyCreatedKey.key_secret}
+                </code>
+                <TooltipProvider delayDuration={200}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() =>
+                          copyToClipboard(newlyCreatedKey.key_secret, 'new-key')
+                        }
+                        className={`rounded-lg p-2 ${
+                          copiedId === 'new-key'
+                            ? 'bg-green-600 text-white'
+                            : isDarkMode
+                              ? 'text-gray-400 hover:bg-gray-700'
+                              : 'text-gray-600 hover:bg-gray-200'
+                        }`}
+                      >
+                        <Copy className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Copy to clipboard</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+              <button
+                onClick={() => setNewlyCreatedKey(null)}
+                className={`mt-2 text-sm ${isDarkMode ? 'text-green-400 hover:text-green-300' : 'text-green-700 hover:text-green-800'}`}
+              >
+                Dismiss
+              </button>
             </div>
-            <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
-              {formatDate(account.created_at)}
-            </div>
-          </div>
+          )}
 
-          <div>
+          {/* Keys List */}
+          {keysLoading ? (
             <div
-              className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              className={`py-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
             >
-              <Clock className="h-4 w-4" />
-              Last Authenticated
+              Loading API keys...
             </div>
-            <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
-              {formatDate(account.last_authenticated)}
+          ) : keysError ? (
+            <div
+              className={`flex items-center gap-2 rounded-lg p-3 ${
+                isDarkMode
+                  ? 'bg-red-900/20 text-red-400'
+                  : 'bg-red-50 text-red-700'
+              }`}
+            >
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              <span className="text-sm">Failed to load API keys</span>
+            </div>
+          ) : apiKeys.length === 0 ? (
+            <div
+              className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+            >
+              <Key
+                className={`mx-auto mb-2 h-8 w-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}
+              />
+              <div>No API keys created yet</div>
+              <div className="mt-1 text-sm">
+                Create an API key to enable programmatic access
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {apiKeys.map((key: ApiKey) => (
+                <div
+                  key={key.key_id}
+                  className={`flex items-center justify-between rounded-lg border p-3 ${
+                    key.revoked
+                      ? isDarkMode
+                        ? 'border-gray-600 bg-gray-700 opacity-50'
+                        : 'border-gray-200 bg-gray-50 opacity-50'
+                      : isDarkMode
+                        ? 'border-gray-600 bg-gray-700'
+                        : 'border-gray-200 bg-gray-50'
+                  }`}
+                >
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        {key.name}
+                      </span>
+                      <code
+                        className={`rounded px-2 py-0.5 text-xs ${
+                          isDarkMode
+                            ? 'bg-gray-700 text-gray-400'
+                            : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        {key.key_id.substring(0, 7)}...
+                      </code>
+                      {key.revoked && (
+                        <span
+                          className={`rounded px-2 py-0.5 text-xs ${
+                            isDarkMode
+                              ? 'bg-red-900/30 text-red-400'
+                              : 'bg-red-100 text-red-600'
+                          }`}
+                        >
+                          Revoked
+                        </span>
+                      )}
+                    </div>
+                    <div
+                      className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}
+                    >
+                      Created {formatDate(key.created_at)}
+                      {key.last_used &&
+                        ` | Last used ${formatDate(key.last_used)}`}
+                      {key.expires_at &&
+                        ` | Expires ${formatDate(key.expires_at)}`}
+                    </div>
+                  </div>
+                  {!key.revoked && (
+                    <div className="flex items-center gap-1">
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() => handleRotateKey(key.key_id)}
+                              disabled={rotateKeyMutation.isPending}
+                              className={`rounded p-1.5 ${
+                                isDarkMode
+                                  ? 'text-blue-400 hover:bg-gray-700 hover:text-blue-300'
+                                  : 'text-blue-600 hover:bg-gray-100 hover:text-blue-700'
+                              }`}
+                            >
+                              <RotateCw className="h-4 w-4" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Rotate API key</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() => handleRevokeKey(key.key_id)}
+                              disabled={revokeKeyMutation.isPending}
+                              className={`rounded p-1.5 ${
+                                isDarkMode
+                                  ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                                  : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                              }`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Revoke API key</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Basic Information */}
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="space-y-0 pb-4">
+          <CardTitle>Basic Information</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-6">
+            <div>
+              <div
+                className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                <Tag className="h-4 w-4" />
+                Slug
+              </div>
+              <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                {account.slug}
+              </div>
+            </div>
+
+            <div>
+              <div
+                className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                Display Name
+              </div>
+              <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                {account.display_name}
+              </div>
+            </div>
+
+            {account.description && (
+              <div className="col-span-2">
+                <div
+                  className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                >
+                  Description
+                </div>
+                <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                  {account.description}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <div
+                className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                <Calendar className="h-4 w-4" />
+                Created
+              </div>
+              <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                {formatDate(account.created_at)}
+              </div>
+            </div>
+
+            <div>
+              <div
+                className={`mb-1 flex items-center gap-2 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                <Clock className="h-4 w-4" />
+                Last Authenticated
+              </div>
+              <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                {formatDate(account.last_authenticated)}
+              </div>
             </div>
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/service-accounts/ServiceAccountDetail.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountDetail.tsx
@@ -89,7 +89,7 @@ export function ServiceAccountDetail({
   const [newOrgSlug, setNewOrgSlug] = useState('')
   const [newRoleSlug, setNewRoleSlug] = useState('')
 
-  const { data: availableRoles = [] } = useQuery({
+  const { data: availableRoles = [], isError: rolesError } = useQuery({
     queryKey: ['roles'],
     queryFn: getRoles,
   })
@@ -527,22 +527,30 @@ export function ServiceAccountDetail({
                   >
                     Role
                   </label>
-                  <select
-                    value={newRoleSlug}
-                    onChange={(e) => setNewRoleSlug(e.target.value)}
-                    className={`w-full rounded-md border px-3 py-2 text-sm ${
-                      isDarkMode
-                        ? 'border-gray-600 bg-gray-700 text-white'
-                        : 'border-gray-300 bg-white text-gray-900'
-                    }`}
-                  >
-                    <option value="">Select...</option>
-                    {availableRoles.map((role) => (
-                      <option key={role.slug} value={role.slug}>
-                        {role.name}
-                      </option>
-                    ))}
-                  </select>
+                  {rolesError ? (
+                    <p
+                      className={`text-sm ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                    >
+                      Failed to load roles
+                    </p>
+                  ) : (
+                    <select
+                      value={newRoleSlug}
+                      onChange={(e) => setNewRoleSlug(e.target.value)}
+                      className={`w-full rounded-md border px-3 py-2 text-sm ${
+                        isDarkMode
+                          ? 'border-gray-600 bg-gray-700 text-white'
+                          : 'border-gray-300 bg-white text-gray-900'
+                      }`}
+                    >
+                      <option value="">Select...</option>
+                      {availableRoles.map((role) => (
+                        <option key={role.slug} value={role.slug}>
+                          {role.name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
                 </div>
               </div>
               <div className="mt-3 flex items-center gap-2">
@@ -603,31 +611,42 @@ export function ServiceAccountDetail({
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
-                      <select
-                        value={membership.role}
-                        onChange={(e) =>
-                          updateOrgRoleMutation.mutate({
-                            orgSlug: membership.organization_slug,
-                            roleSlug: e.target.value,
-                          })
-                        }
-                        disabled={updateOrgRoleMutation.isPending}
-                        className={`rounded border px-2 py-1 text-xs ${
-                          isDarkMode
-                            ? 'border-gray-600 bg-gray-700 text-white'
-                            : 'border-gray-300 bg-white text-gray-900'
-                        }`}
-                      >
-                        {availableRoles.map((role) => (
-                          <option key={role.slug} value={role.slug}>
-                            {role.name}
-                          </option>
-                        ))}
-                      </select>
+                      {rolesError ? (
+                        <span
+                          className={`text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                        >
+                          Roles unavailable
+                        </span>
+                      ) : (
+                        <select
+                          value={membership.role}
+                          onChange={(e) =>
+                            updateOrgRoleMutation.mutate({
+                              orgSlug: membership.organization_slug,
+                              roleSlug: e.target.value,
+                            })
+                          }
+                          disabled={updateOrgRoleMutation.isPending}
+                          aria-label={`Role for ${membership.organization_name}`}
+                          className={`rounded border px-2 py-1 text-xs ${
+                            isDarkMode
+                              ? 'border-gray-600 bg-gray-700 text-white'
+                              : 'border-gray-300 bg-white text-gray-900'
+                          }`}
+                        >
+                          {availableRoles.map((role) => (
+                            <option key={role.slug} value={role.slug}>
+                              {role.name}
+                            </option>
+                          ))}
+                        </select>
+                      )}
                       <TooltipProvider delayDuration={200}>
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button
+                              type="button"
+                              aria-label={`Remove from ${membership.organization_name}`}
                               onClick={() => {
                                 if (
                                   confirm(
@@ -848,6 +867,8 @@ export function ServiceAccountDetail({
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <button
+                            type="button"
+                            aria-label="Copy client ID"
                             onClick={() =>
                               copyToClipboard(
                                 newlyCreatedCredential.client_id,
@@ -892,6 +913,8 @@ export function ServiceAccountDetail({
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <button
+                            type="button"
+                            aria-label="Copy client secret"
                             onClick={() =>
                               copyToClipboard(
                                 newlyCreatedCredential.client_secret,
@@ -1022,6 +1045,8 @@ export function ServiceAccountDetail({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button
+                              type="button"
+                              aria-label={`Rotate credential ${cred.name}`}
                               onClick={() =>
                                 handleRotateCredential(cred.client_id)
                               }
@@ -1044,6 +1069,8 @@ export function ServiceAccountDetail({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button
+                              type="button"
+                              aria-label={`Revoke credential ${cred.name}`}
                               onClick={() =>
                                 handleRevokeCredential(cred.client_id)
                               }
@@ -1172,6 +1199,8 @@ export function ServiceAccountDetail({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button
+                        type="button"
+                        aria-label="Copy API key"
                         onClick={() =>
                           copyToClipboard(newlyCreatedKey.key_secret, 'new-key')
                         }
@@ -1290,6 +1319,8 @@ export function ServiceAccountDetail({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button
+                              type="button"
+                              aria-label={`Rotate API key ${key.name}`}
                               onClick={() => handleRotateKey(key.key_id)}
                               disabled={rotateKeyMutation.isPending}
                               className={`rounded p-1.5 ${
@@ -1310,6 +1341,8 @@ export function ServiceAccountDetail({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <button
+                              type="button"
+                              aria-label={`Revoke API key ${key.name}`}
                               onClick={() => handleRevokeKey(key.key_id)}
                               disabled={revokeKeyMutation.isPending}
                               className={`rounded p-1.5 ${

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Card, CardContent } from '@/components/ui/card'
 import { getRoles } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import type { ServiceAccount, ServiceAccountCreate } from '@/types'
@@ -132,7 +133,7 @@ export function ServiceAccountForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit Service Account' : 'Create Service Account'}
           </h2>
@@ -203,203 +204,134 @@ export function ServiceAccountForm({
       )}
 
       {/* Section 1: Basic Information */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Basic Information
-        </h3>
-
-        <div className="grid grid-cols-2 gap-4">
-          {/* Slug */}
-          <div className="col-span-2">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Slug <span className="text-red-500">*</span>
-            </label>
-            <Input
-              value={slug}
-              onChange={(e) => handleSlugChange(e.target.value)}
-              onBlur={() => {
-                setTouched({ ...touched, slug: true })
-                const error = validateSlug(slug)
-                if (error) {
-                  setValidationErrors({
-                    ...validationErrors,
-                    slug: error,
-                  })
-                }
-              }}
-              disabled={isEditing || isLoading}
-              placeholder="my-service-account"
-              className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                isEditing ? 'cursor-not-allowed opacity-60' : ''
-              }`}
-            />
-            {isEditing && (
-              <p
-                className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-              >
-                Slug cannot be changed after creation
-              </p>
-            )}
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="space-y-4 pt-6">
+          <div className="grid grid-cols-2 gap-4">
+            {/* Slug */}
             {!isEditing && (
-              <p
-                className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+              <div className="col-span-2">
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Slug <span className="text-red-500">*</span>
+                </label>
+                <Input
+                  value={slug}
+                  onChange={(e) => handleSlugChange(e.target.value)}
+                  onBlur={() => {
+                    setTouched({ ...touched, slug: true })
+                    const error = validateSlug(slug)
+                    if (error) {
+                      setValidationErrors({
+                        ...validationErrors,
+                        slug: error,
+                      })
+                    }
+                  }}
+                  disabled={isLoading}
+                  placeholder="my-service-account"
+                  className={
+                    isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+                  }
+                />
+                <p
+                  className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                >
+                  Lowercase letters, numbers, and hyphens only. Must start with
+                  a letter.
+                </p>
+                {touched.slug && validationErrors.slug && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {validationErrors.slug}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Display Name */}
+            <div className="col-span-2">
+              <label
+                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
               >
-                Lowercase letters, numbers, and hyphens only. Must start with a
-                letter.
-              </p>
-            )}
-            {touched.slug && validationErrors.slug && (
-              <p className="mt-1 text-sm text-red-600">
-                {validationErrors.slug}
-              </p>
-            )}
-          </div>
-
-          {/* Display Name */}
-          <div className="col-span-2">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Display Name <span className="text-red-500">*</span>
-            </label>
-            <Input
-              value={displayName}
-              onChange={(e) => {
-                setDisplayName(e.target.value)
-                handleFieldChange('display_name')
-              }}
-              onBlur={() => {
-                setTouched({ ...touched, display_name: true })
-                const error = validateDisplayName(displayName)
-                if (error) {
-                  setValidationErrors({
-                    ...validationErrors,
-                    display_name: error,
-                  })
+                Display Name <span className="text-red-500">*</span>
+              </label>
+              <Input
+                value={displayName}
+                onChange={(e) => {
+                  setDisplayName(e.target.value)
+                  handleFieldChange('display_name')
+                }}
+                onBlur={() => {
+                  setTouched({ ...touched, display_name: true })
+                  const error = validateDisplayName(displayName)
+                  if (error) {
+                    setValidationErrors({
+                      ...validationErrors,
+                      display_name: error,
+                    })
+                  }
+                }}
+                disabled={isLoading}
+                placeholder="CI/CD Pipeline"
+                className={
+                  isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
                 }
-              }}
-              disabled={isLoading}
-              placeholder="CI/CD Pipeline"
-              className={
-                isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
-              }
-            />
-            {touched.display_name && validationErrors.display_name && (
-              <p className="mt-1 text-sm text-red-600">
-                {validationErrors.display_name}
-              </p>
-            )}
-          </div>
+              />
+              {touched.display_name && validationErrors.display_name && (
+                <p className="mt-1 text-sm text-red-600">
+                  {validationErrors.display_name}
+                </p>
+              )}
+            </div>
 
-          {/* Description */}
-          <div className="col-span-2">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Description
-            </label>
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              disabled={isLoading}
-              placeholder="What does this service account do?"
-              rows={3}
-              className={`w-full rounded-md border px-3 py-2 text-sm ${
-                isDarkMode
-                  ? 'border-gray-600 bg-gray-700 text-white placeholder:text-gray-400'
-                  : 'border-gray-300 bg-white text-gray-900 placeholder:text-gray-500'
-              } focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
-            />
+            {/* Description */}
+            <div className="col-span-2">
+              <label
+                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              >
+                Description
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                disabled={isLoading}
+                placeholder="What does this service account do?"
+                rows={3}
+                className={`w-full rounded-md border px-3 py-2 text-sm ${
+                  isDarkMode
+                    ? 'border-gray-600 bg-gray-700 text-white placeholder:text-gray-400'
+                    : 'border-gray-300 bg-white text-gray-900 placeholder:text-gray-500'
+                } focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
+              />
+            </div>
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Section 2: Organization Membership (creation only) */}
       {!isEditing && (
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Organization Membership
-          </h3>
-          <p
-            className={`mb-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Service accounts must belong to at least one organization with a
-            role to have any permissions.
-          </p>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="space-y-4 pt-6">
+            <p
+              className={`mb-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            >
+              Service accounts must belong to at least one organization with a
+              role to have any permissions.
+            </p>
 
-          <div className="grid grid-cols-2 gap-4">
-            {/* Organization */}
-            <div>
-              <label
-                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Organization <span className="text-red-500">*</span>
-              </label>
-              <select
-                value={organizationSlug}
-                onChange={(e) => {
-                  setOrganizationSlug(e.target.value)
-                  handleFieldChange('organization_slug')
-                }}
-                disabled={isLoading}
-                className={`w-full rounded-md border px-3 py-2 text-sm ${
-                  isDarkMode
-                    ? 'border-gray-600 bg-gray-700 text-white'
-                    : 'border-gray-300 bg-white text-gray-900'
-                } focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
-              >
-                <option value="">Select an organization...</option>
-                {organizations.map((org) => (
-                  <option key={org.slug} value={org.slug}>
-                    {org.name}
-                  </option>
-                ))}
-              </select>
-              {touched.organization_slug &&
-                validationErrors.organization_slug && (
-                  <p className="mt-1 text-sm text-red-600">
-                    {validationErrors.organization_slug}
-                  </p>
-                )}
-            </div>
-
-            {/* Role */}
-            <div>
-              <label
-                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Role <span className="text-red-500">*</span>
-              </label>
-              {rolesLoading ? (
-                <p
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            <div className="grid grid-cols-2 gap-4">
+              {/* Organization */}
+              <div>
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                 >
-                  Loading roles...
-                </p>
-              ) : (
+                  Organization <span className="text-red-500">*</span>
+                </label>
                 <select
-                  value={roleSlug}
+                  value={organizationSlug}
                   onChange={(e) => {
-                    setRoleSlug(e.target.value)
-                    handleFieldChange('role_slug')
+                    setOrganizationSlug(e.target.value)
+                    handleFieldChange('organization_slug')
                   }}
                   disabled={isLoading}
                   className={`w-full rounded-md border px-3 py-2 text-sm ${
@@ -408,58 +340,91 @@ export function ServiceAccountForm({
                       : 'border-gray-300 bg-white text-gray-900'
                   } focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
                 >
-                  <option value="">Select a role...</option>
-                  {availableRoles.map((role) => (
-                    <option key={role.slug} value={role.slug}>
-                      {role.name}
+                  <option value="">Select an organization...</option>
+                  {organizations.map((org) => (
+                    <option key={org.slug} value={org.slug}>
+                      {org.name}
                     </option>
                   ))}
                 </select>
-              )}
-              {touched.role_slug && validationErrors.role_slug && (
-                <p className="mt-1 text-sm text-red-600">
-                  {validationErrors.role_slug}
-                </p>
-              )}
+                {touched.organization_slug &&
+                  validationErrors.organization_slug && (
+                    <p className="mt-1 text-sm text-red-600">
+                      {validationErrors.organization_slug}
+                    </p>
+                  )}
+              </div>
+
+              {/* Role */}
+              <div>
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Role <span className="text-red-500">*</span>
+                </label>
+                {rolesLoading ? (
+                  <p
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Loading roles...
+                  </p>
+                ) : (
+                  <select
+                    value={roleSlug}
+                    onChange={(e) => {
+                      setRoleSlug(e.target.value)
+                      handleFieldChange('role_slug')
+                    }}
+                    disabled={isLoading}
+                    className={`w-full rounded-md border px-3 py-2 text-sm ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700 text-white'
+                        : 'border-gray-300 bg-white text-gray-900'
+                    } focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                  >
+                    <option value="">Select a role...</option>
+                    {availableRoles.map((role) => (
+                      <option key={role.slug} value={role.slug}>
+                        {role.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+                {touched.role_slug && validationErrors.role_slug && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {validationErrors.role_slug}
+                  </p>
+                )}
+              </div>
             </div>
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       )}
 
       {/* Section 3: Account Status */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Account Status
-        </h3>
-
-        <div>
-          <label className="flex cursor-pointer items-center gap-2">
-            <input
-              type="checkbox"
-              checked={isActive}
-              onChange={(e) => setIsActive(e.target.checked)}
-              disabled={isLoading}
-              className="rounded"
-            />
-            <span className={isDarkMode ? 'text-gray-300' : 'text-gray-700'}>
-              Account Active
-            </span>
-          </label>
-          <p
-            className={`ml-6 mt-1 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Inactive service accounts cannot authenticate via API
-          </p>
-        </div>
-      </div>
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="space-y-4 pt-6">
+          <div>
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={isActive}
+                onChange={(e) => setIsActive(e.target.checked)}
+                disabled={isLoading}
+                className="rounded"
+              />
+              <span className={isDarkMode ? 'text-gray-300' : 'text-gray-700'}>
+                Account Active
+              </span>
+            </label>
+            <p
+              className={`ml-6 mt-1 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            >
+              Inactive service accounts cannot authenticate via API
+            </p>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -43,7 +43,11 @@ export function ServiceAccountForm({
   const [roleSlug, setRoleSlug] = useState('')
 
   // Fetch available roles
-  const { data: availableRoles = [], isLoading: rolesLoading } = useQuery({
+  const {
+    data: availableRoles = [],
+    isLoading: rolesLoading,
+    isError: rolesError,
+  } = useQuery({
     queryKey: ['roles'],
     queryFn: getRoles,
   })
@@ -367,6 +371,12 @@ export function ServiceAccountForm({
                     className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
                   >
                     Loading roles...
+                  </p>
+                ) : rolesError ? (
+                  <p
+                    className={`text-sm ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                  >
+                    Failed to load roles. Please refresh and try again.
                   </p>
                 ) : (
                   <select

--- a/src/components/admin/teams/TeamDetail.tsx
+++ b/src/components/admin/teams/TeamDetail.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Gravatar } from '@/components/ui/gravatar'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
 import {
@@ -24,6 +25,12 @@ import { TEAM_BASE_FIELDS_SET } from '@/lib/constants'
 import { EntityIcon } from '@/components/ui/entity-icon'
 import { extractDynamicFields } from '@/lib/utils'
 import type { Team } from '@/types'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 interface TeamDetailProps {
   team: Team
@@ -111,13 +118,8 @@ export function TeamDetail({
       </div>
 
       {/* Team info card */}
-      <div
-        className={`rounded-lg border ${isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
-      >
-        {/* Title row */}
-        <div
-          className={`flex items-start justify-between border-b px-6 py-5 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-        >
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
           <div>
             <div className="flex items-center gap-3">
               {team.icon && (
@@ -126,11 +128,7 @@ export function TeamDetail({
                   className="h-8 w-8 rounded object-cover"
                 />
               )}
-              <h2
-                className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                {team.name}
-              </h2>
+              <CardTitle>{team.name}</CardTitle>
             </div>
             {team.description && (
               <p
@@ -147,10 +145,9 @@ export function TeamDetail({
             <Edit2 className="mr-2 h-4 w-4" />
             Edit Team
           </Button>
-        </div>
+        </CardHeader>
 
-        {/* Info section */}
-        <div className="p-6">
+        <CardContent className="p-6">
           <div className="grid grid-cols-2 gap-6">
             <div>
               <div
@@ -192,30 +189,18 @@ export function TeamDetail({
               />
             )}
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Team Members */}
-      <div
-        className={`rounded-lg border ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div
-          className={`border-b p-6 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-        >
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="space-y-0 border-b px-6 py-5">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Users
                 className={`h-5 w-5 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
               />
-              <h3
-                className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                Team Members
-              </h3>
+              <CardTitle>Team Members</CardTitle>
               <span
                 className={`ml-2 rounded px-2 py-1 text-sm ${
                   isDarkMode
@@ -283,122 +268,134 @@ export function TeamDetail({
               )}
             </div>
           )}
-        </div>
+        </CardHeader>
 
         {/* Members List */}
-        {membersLoading ? (
-          <div className="p-8 text-center">
-            <div
-              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-            >
-              Loading members...
+        <CardContent className="p-0">
+          {membersLoading ? (
+            <div className="p-8 text-center">
+              <div
+                className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                Loading members...
+              </div>
             </div>
-          </div>
-        ) : members.length === 0 ? (
-          <div
-            className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-          >
-            No members in this team yet. Click "Add Member" to get started.
-          </div>
-        ) : (
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Member
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Email
-                </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Status
-                </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs font-medium uppercase tracking-wider ${
-                    isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                  }`}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+          ) : members.length === 0 ? (
+            <div
+              className={`py-12 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
             >
-              {members.map((member) => (
-                <tr
-                  key={member.email}
-                  className={
-                    isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'
-                  }
-                >
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                      <Gravatar
-                        email={member.email}
-                        size={32}
-                        alt={member.display_name}
-                        className="h-8 w-8 rounded-full"
-                      />
-                      <div
-                        className={isDarkMode ? 'text-white' : 'text-gray-900'}
-                      >
-                        {member.display_name}
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              No members in this team yet. Click "Add Member" to get started.
+            </div>
+          ) : (
+            <table className="w-full">
+              <thead className="border-b border-tertiary bg-secondary">
+                <tr>
+                  <th
+                    className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
                   >
-                    {member.email}
-                  </td>
-                  <td className="px-6 py-4">
-                    <span
-                      className={`inline-flex items-center rounded px-2 py-1 text-xs font-medium ${
-                        member.is_active
-                          ? isDarkMode
-                            ? 'bg-green-900/30 text-green-400'
-                            : 'bg-green-100 text-green-700'
-                          : isDarkMode
-                            ? 'bg-gray-700 text-gray-400'
-                            : 'bg-gray-100 text-gray-600'
-                      }`}
-                    >
-                      {member.is_active ? 'Active' : 'Inactive'}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-right">
-                    <button
-                      onClick={() => handleRemoveMember(member.email)}
-                      disabled={removeMemberMutation.isPending}
-                      className={`rounded p-1.5 ${
-                        isDarkMode
-                          ? 'text-red-400 hover:bg-red-900/20'
-                          : 'text-red-600 hover:bg-red-50'
-                      }`}
-                      title="Remove from team"
-                    >
-                      <X className="h-4 w-4" />
-                    </button>
-                  </td>
+                    Member
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Email
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Status
+                  </th>
+                  <th
+                    className={`px-6 py-3 text-right text-xs font-medium uppercase tracking-wider ${
+                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                    }`}
+                  >
+                    Actions
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
+              </thead>
+              <tbody
+                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+              >
+                {members.map((member) => (
+                  <tr
+                    key={member.email}
+                    className={
+                      isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-50'
+                    }
+                  >
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <Gravatar
+                          email={member.email}
+                          size={32}
+                          alt={member.display_name}
+                          className="h-8 w-8 rounded-full"
+                        />
+                        <div
+                          className={
+                            isDarkMode ? 'text-white' : 'text-gray-900'
+                          }
+                        >
+                          {member.display_name}
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      className={`px-6 py-4 text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                    >
+                      {member.email}
+                    </td>
+                    <td className="px-6 py-4">
+                      <span
+                        className={`inline-flex items-center rounded px-2 py-1 text-xs font-medium ${
+                          member.is_active
+                            ? isDarkMode
+                              ? 'bg-green-900/30 text-green-400'
+                              : 'bg-green-100 text-green-700'
+                            : isDarkMode
+                              ? 'bg-gray-700 text-gray-400'
+                              : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        {member.is_active ? 'Active' : 'Inactive'}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-right">
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() => handleRemoveMember(member.email)}
+                              disabled={removeMemberMutation.isPending}
+                              className={`rounded p-1.5 ${
+                                isDarkMode
+                                  ? 'text-red-400 hover:bg-red-900/20'
+                                  : 'text-red-600 hover:bg-red-50'
+                              }`}
+                            >
+                              <X className="h-4 w-4" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Remove from team</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Save, X, AlertCircle } from 'lucide-react'
 import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
+import { Card, CardContent } from '@/components/ui/card'
 import { IconUpload } from '../../ui/icon-upload'
 import { IconPicker } from '@/components/ui/icon-picker'
 import {
@@ -111,7 +112,7 @@ export function TeamForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit Team' : 'Create New Team'}
           </h2>
@@ -179,20 +180,8 @@ export function TeamForm({
 
       {/* Form */}
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Team Information
-          </h3>
-
-          <div className="space-y-4">
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="space-y-4 pt-6">
             <div>
               <label
                 className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -230,7 +219,9 @@ export function TeamForm({
               )}
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div
+              className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
+            >
               <div>
                 <label
                   className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -258,32 +249,34 @@ export function TeamForm({
                 )}
               </div>
 
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Slug <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  value={slug}
-                  onChange={(e) => setSlug(e.target.value)}
-                  placeholder="e.g., platform-support"
-                  disabled={isLoading}
-                  className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                    errors.slug ? 'border-red-500' : ''
-                  }`}
-                />
-                {errors.slug && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs ${
-                      isDarkMode ? 'text-red-400' : 'text-red-600'
-                    }`}
+              {!isEditing && (
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.slug}
-                  </div>
-                )}
-              </div>
+                    Slug <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="e.g., platform-support"
+                    disabled={isLoading}
+                    className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                      errors.slug ? 'border-red-500' : ''
+                    }`}
+                  />
+                  {errors.slug && (
+                    <div
+                      className={`mt-1 flex items-center gap-1 text-xs ${
+                        isDarkMode ? 'text-red-400' : 'text-red-600'
+                      }`}
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      {errors.slug}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <div>
@@ -363,8 +356,8 @@ export function TeamForm({
                 isLoading={isLoading}
               />
             )}
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       </form>
     </div>
   )

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -251,31 +251,34 @@ export function ApplicationSecretsPanel({
                       value
                     )}
                   </code>
-                  <TooltipProvider delayDuration={200}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleCopy(field, value!)}
-                          className={
-                            isDarkMode
-                              ? 'text-gray-400 hover:text-gray-200'
-                              : ''
-                          }
-                        >
-                          {copiedField === field ? (
-                            <Check className="h-4 w-4 text-green-500" />
-                          ) : (
-                            <Copy className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>Copy to clipboard</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  {value != null && (
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label={`Copy ${FIELD_LABELS[field]}`}
+                            onClick={() => handleCopy(field, value)}
+                            className={
+                              isDarkMode
+                                ? 'text-gray-400 hover:text-gray-200'
+                                : ''
+                            }
+                          >
+                            {copiedField === field ? (
+                              <Check className="h-4 w-4 text-green-500" />
+                            ) : (
+                              <Copy className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Copy to clipboard</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
                 </div>
               </div>
             )

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -17,6 +17,12 @@ import {
   updateApplicationSecrets,
 } from '@/api/endpoints'
 import type { ServiceApplicationSecretsUpdate } from '@/types'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 interface ApplicationSecretsPanelProps {
   orgSlug: string
@@ -132,7 +138,7 @@ export function ApplicationSecretsPanel({
             className={`h-5 w-5 ${isDarkMode ? 'text-yellow-400' : 'text-yellow-600'}`}
           />
           <h3
-            className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             Secrets
           </h3>
@@ -245,21 +251,31 @@ export function ApplicationSecretsPanel({
                       value
                     )}
                   </code>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleCopy(field, value!)}
-                    title="Copy to clipboard"
-                    className={
-                      isDarkMode ? 'text-gray-400 hover:text-gray-200' : ''
-                    }
-                  >
-                    {copiedField === field ? (
-                      <Check className="h-4 w-4 text-green-500" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleCopy(field, value!)}
+                          className={
+                            isDarkMode
+                              ? 'text-gray-400 hover:text-gray-200'
+                              : ''
+                          }
+                        >
+                          {copiedField === field ? (
+                            <Check className="h-4 w-4 text-green-500" />
+                          ) : (
+                            <Copy className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Copy to clipboard</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               </div>
             )

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -157,7 +157,7 @@ export function OAuth2ApplicationForm({
             Back
           </Button>
           <h3
-            className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEdit ? 'Edit Application' : 'New Application'}
           </h3>

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -365,6 +365,7 @@ export function OAuth2ApplicationList({
                                   href={app.application_url}
                                   target="_blank"
                                   rel="noopener noreferrer"
+                                  aria-label={`Open ${app.name} application`}
                                   className={`inline-flex items-center rounded p-1.5 ${
                                     isDarkMode
                                       ? 'text-blue-400 hover:bg-blue-900/20 hover:text-blue-300'

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -16,6 +16,12 @@ import type {
   ServiceApplicationCreate,
   ServiceApplicationUpdate,
 } from '@/types'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 type ViewMode = 'list' | 'create' | 'edit'
 
@@ -352,19 +358,27 @@ export function OAuth2ApplicationList({
                     >
                       <div className="flex items-center justify-end gap-1">
                         {app.application_url && (
-                          <a
-                            href={app.application_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className={`inline-flex items-center rounded p-1.5 ${
-                              isDarkMode
-                                ? 'text-blue-400 hover:bg-blue-900/20 hover:text-blue-300'
-                                : 'text-blue-600 hover:bg-blue-50 hover:text-blue-700'
-                            }`}
-                            title="Open application"
-                          >
-                            <ExternalLink className="h-4 w-4" />
-                          </a>
+                          <TooltipProvider delayDuration={200}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <a
+                                  href={app.application_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className={`inline-flex items-center rounded p-1.5 ${
+                                    isDarkMode
+                                      ? 'text-blue-400 hover:bg-blue-900/20 hover:text-blue-300'
+                                      : 'text-blue-600 hover:bg-blue-50 hover:text-blue-700'
+                                  }`}
+                                >
+                                  <ExternalLink className="h-4 w-4" />
+                                </a>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>Open application</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
                         )}
                         <Button
                           variant="ghost"

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -8,6 +8,7 @@ import {
   Webhook,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { OAuth2ApplicationList } from './OAuth2ApplicationList'
 import { ServiceWebhookList } from './ServiceWebhookList'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -96,11 +97,7 @@ export function ThirdPartyServiceDetail({
                       className="h-8 w-8 rounded object-cover"
                     />
                   )}
-                  <h2
-                    className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                  >
-                    {service.name}
-                  </h2>
+                  <CardTitle>{service.name}</CardTitle>
                   <span
                     className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
                       isDarkMode
@@ -165,152 +162,103 @@ export function ThirdPartyServiceDetail({
       {activeTab === 'details' && (
         <div className="space-y-6">
           {/* Service Info */}
-          <div
-            className={`rounded-lg border p-6 ${
-              isDarkMode
-                ? 'border-gray-700 bg-gray-800'
-                : 'border-gray-200 bg-white'
-            }`}
-          >
-            <div className="grid grid-cols-2 gap-6">
-              <div>
-                <div
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Slug
-                </div>
-                <div
-                  className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                >
-                  <code
-                    className={`rounded px-2 py-1 text-sm ${
-                      isDarkMode
-                        ? 'bg-gray-700 text-gray-300'
-                        : 'bg-gray-100 text-gray-700'
-                    }`}
+          <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+            <CardContent className="p-6">
+              <div className="grid grid-cols-2 gap-6">
+                <div>
+                  <div
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
                   >
-                    {service.slug}
-                  </code>
-                </div>
-              </div>
-              <div>
-                <div
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Vendor
-                </div>
-                <div
-                  className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                >
-                  {service.vendor}
-                </div>
-              </div>
-              <div>
-                <div
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Organization
-                </div>
-                <div
-                  className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                >
-                  {service.organization.name}
-                </div>
-              </div>
-              <div>
-                <div
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Managing Team
-                </div>
-                <div
-                  className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                >
-                  {service.team?.name || (
-                    <span
-                      className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}
-                    >
-                      Not assigned
-                    </span>
-                  )}
-                </div>
-              </div>
-              <div>
-                <div
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Category
-                </div>
-                <div
-                  className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                >
-                  {service.category || (
-                    <span
-                      className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}
-                    >
-                      Not set
-                    </span>
-                  )}
-                </div>
-              </div>
-              <div>
-                <div
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Service URL
-                </div>
-                <div className="mt-1">
-                  {service.service_url ? (
-                    <a
-                      href={service.service_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`inline-flex items-center gap-1 text-sm ${
+                    Slug
+                  </div>
+                  <div
+                    className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    <code
+                      className={`rounded px-2 py-1 text-sm ${
                         isDarkMode
-                          ? 'text-blue-400 hover:text-blue-300'
-                          : 'text-blue-600 hover:text-blue-700'
+                          ? 'bg-gray-700 text-gray-300'
+                          : 'bg-gray-100 text-gray-700'
                       }`}
                     >
-                      {service.service_url}
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  ) : (
-                    <span
-                      className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}
-                    >
-                      Not set
-                    </span>
-                  )}
+                      {service.slug}
+                    </code>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Links */}
-          {linkEntries.length > 0 && (
-            <div
-              className={`rounded-lg border p-6 ${
-                isDarkMode
-                  ? 'border-gray-700 bg-gray-800'
-                  : 'border-gray-200 bg-white'
-              }`}
-            >
-              <h3
-                className={`mb-4 text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                Links
-              </h3>
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                {linkEntries.map(([label, url]) => (
-                  <div key={label}>
-                    <div
-                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                    >
-                      {label}
-                    </div>
-                    <div className="mt-1">
+                <div>
+                  <div
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Vendor
+                  </div>
+                  <div
+                    className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    {service.vendor}
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Organization
+                  </div>
+                  <div
+                    className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    {service.organization.name}
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Managing Team
+                  </div>
+                  <div
+                    className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    {service.team?.name || (
+                      <span
+                        className={
+                          isDarkMode ? 'text-gray-500' : 'text-gray-400'
+                        }
+                      >
+                        Not assigned
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Category
+                  </div>
+                  <div
+                    className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    {service.category || (
+                      <span
+                        className={
+                          isDarkMode ? 'text-gray-500' : 'text-gray-400'
+                        }
+                      >
+                        Not set
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Service URL
+                  </div>
+                  <div className="mt-1">
+                    {service.service_url ? (
                       <a
-                        href={String(url)}
+                        href={service.service_url}
                         target="_blank"
                         rel="noopener noreferrer"
                         className={`inline-flex items-center gap-1 text-sm ${
@@ -319,55 +267,94 @@ export function ThirdPartyServiceDetail({
                             : 'text-blue-600 hover:text-blue-700'
                         }`}
                       >
-                        {String(url)}
+                        {service.service_url}
                         <ExternalLink className="h-3 w-3" />
                       </a>
-                    </div>
+                    ) : (
+                      <span
+                        className={
+                          isDarkMode ? 'text-gray-500' : 'text-gray-400'
+                        }
+                      >
+                        Not set
+                      </span>
+                    )}
                   </div>
-                ))}
+                </div>
               </div>
-            </div>
+            </CardContent>
+          </Card>
+
+          {/* Links */}
+          {linkEntries.length > 0 && (
+            <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+              <CardHeader className="px-6 pb-0 pt-5">
+                <CardTitle>Links</CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  {linkEntries.map(([label, url]) => (
+                    <div key={label}>
+                      <div
+                        className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                      >
+                        {label}
+                      </div>
+                      <div className="mt-1">
+                        <a
+                          href={String(url)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={`inline-flex items-center gap-1 text-sm ${
+                            isDarkMode
+                              ? 'text-blue-400 hover:text-blue-300'
+                              : 'text-blue-600 hover:text-blue-700'
+                          }`}
+                        >
+                          {String(url)}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
           )}
 
           {/* Identifiers */}
           {identifierEntries.length > 0 && (
-            <div
-              className={`rounded-lg border p-6 ${
-                isDarkMode
-                  ? 'border-gray-700 bg-gray-800'
-                  : 'border-gray-200 bg-white'
-              }`}
-            >
-              <h3
-                className={`mb-4 text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                Identifiers
-              </h3>
-              <div className="grid grid-cols-2 gap-4">
-                {identifierEntries.map(([label, val]) => (
-                  <div key={label}>
-                    <div
-                      className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                    >
-                      {label}
-                    </div>
-                    <div
-                      className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                    >
-                      <code
-                        className={`rounded px-2 py-1 text-sm ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
-                        }`}
+            <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+              <CardHeader className="px-6 pb-0 pt-5">
+                <CardTitle>Identifiers</CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                <div className="grid grid-cols-2 gap-4">
+                  {identifierEntries.map(([label, val]) => (
+                    <div key={label}>
+                      <div
+                        className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
                       >
-                        {String(val)}
-                      </code>
+                        {label}
+                      </div>
+                      <div
+                        className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        <code
+                          className={`rounded px-2 py-1 text-sm ${
+                            isDarkMode
+                              ? 'bg-gray-700 text-gray-300'
+                              : 'bg-gray-100 text-gray-700'
+                          }`}
+                        >
+                          {String(val)}
+                        </code>
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
-            </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
           )}
         </div>
       )}

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -121,7 +121,7 @@ export function ThirdPartyServiceForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit Third-Party Service' : 'Add Third-Party Service'}
           </h2>
@@ -200,7 +200,7 @@ export function ThirdPartyServiceForm({
           }`}
         >
           <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`mb-4 text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             Service Information
           </h3>
@@ -227,7 +227,9 @@ export function ThirdPartyServiceForm({
               </select>
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div
+              className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
+            >
               <div>
                 <label
                   className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -253,30 +255,32 @@ export function ThirdPartyServiceForm({
                 )}
               </div>
 
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Slug <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  value={slug}
-                  onChange={(e) => setSlug(e.target.value)}
-                  placeholder="e.g., stripe"
-                  disabled={isLoading}
-                  className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                    errors.slug ? 'border-red-500' : ''
-                  }`}
-                />
-                {errors.slug && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+              {!isEditing && (
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.slug}
-                  </div>
-                )}
-              </div>
+                    Slug <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="e.g., stripe"
+                    disabled={isLoading}
+                    className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                      errors.slug ? 'border-red-500' : ''
+                    }`}
+                  />
+                  {errors.slug && (
+                    <div
+                      className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      {errors.slug}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -447,7 +451,7 @@ export function ThirdPartyServiceForm({
           }`}
         >
           <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`mb-4 text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             Links
           </h3>
@@ -475,7 +479,7 @@ export function ThirdPartyServiceForm({
           }`}
         >
           <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`mb-4 text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             Identifiers
           </h3>

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -15,6 +15,7 @@ import {
   Building2,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
   getRoles,
@@ -24,6 +25,12 @@ import {
 } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import type { AdminUser, OrgMembership } from '@/types'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 interface UserDetailProps {
   user: AdminUser
@@ -130,13 +137,8 @@ export function UserDetail({
       </div>
 
       {/* User info card */}
-      <div
-        className={`rounded-lg border ${isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
-      >
-        {/* Title row */}
-        <div
-          className={`flex items-start justify-between border-b px-6 py-5 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-        >
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
           <div className="flex items-center gap-3">
             <Gravatar
               email={user.email}
@@ -145,11 +147,7 @@ export function UserDetail({
               className="h-12 w-12 rounded-full"
             />
             <div>
-              <h2
-                className={`text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                {user.display_name}
-              </h2>
+              <CardTitle>{user.display_name}</CardTitle>
               <p
                 className={`mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
               >
@@ -164,7 +162,7 @@ export function UserDetail({
             <Edit2 className="mr-2 h-4 w-4" />
             Edit User
           </Button>
-        </div>
+        </CardHeader>
 
         {/* Account Status */}
         <div
@@ -212,7 +210,7 @@ export function UserDetail({
         </div>
 
         {/* Basic Information */}
-        <div className="p-6">
+        <CardContent className="p-6">
           <div className="grid grid-cols-2 gap-6">
             <div>
               <div
@@ -262,27 +260,17 @@ export function UserDetail({
               </div>
             </div>
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Organization Memberships */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <div className="mb-4 flex items-center justify-between">
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
           <div className="flex items-center gap-2">
             <Building2
               className={`h-5 w-5 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
             />
-            <h3
-              className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-            >
-              Organization Memberships
-            </h3>
+            <CardTitle>Organization Memberships</CardTitle>
           </div>
           {availableOrgs.length > 0 && (
             <Button
@@ -299,204 +287,209 @@ export function UserDetail({
               Add to Organization
             </Button>
           )}
-        </div>
-
-        {/* Add to Organization Form */}
-        {showAddOrg && (
-          <div
-            className={`mb-4 rounded-lg border p-4 ${
-              isDarkMode
-                ? 'border-gray-600 bg-gray-700'
-                : 'border-gray-200 bg-gray-50'
-            }`}
-          >
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Organization
-                </label>
-                <select
-                  value={newOrgSlug}
-                  onChange={(e) => setNewOrgSlug(e.target.value)}
-                  className={`w-full rounded-md border px-3 py-2 text-sm ${
-                    isDarkMode
-                      ? 'border-gray-600 bg-gray-700 text-white'
-                      : 'border-gray-300 bg-white text-gray-900'
-                  }`}
-                >
-                  <option value="">Select...</option>
-                  {availableOrgs.map((org) => (
-                    <option key={org.slug} value={org.slug}>
-                      {org.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Role
-                </label>
-                <select
-                  value={newRoleSlug}
-                  onChange={(e) => setNewRoleSlug(e.target.value)}
-                  className={`w-full rounded-md border px-3 py-2 text-sm ${
-                    isDarkMode
-                      ? 'border-gray-600 bg-gray-700 text-white'
-                      : 'border-gray-300 bg-white text-gray-900'
-                  }`}
-                >
-                  <option value="">Select...</option>
-                  {availableRoles.map((role) => (
-                    <option key={role.slug} value={role.slug}>
-                      {role.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-            <div className="mt-3 flex items-center gap-2">
-              <Button
-                onClick={() =>
-                  addOrgMutation.mutate({
-                    organization_slug: newOrgSlug,
-                    role_slug: newRoleSlug,
-                  })
-                }
-                disabled={
-                  !newOrgSlug || !newRoleSlug || addOrgMutation.isPending
-                }
-                className="bg-amber-border text-white hover:bg-amber-border-strong"
-                size="sm"
-              >
-                {addOrgMutation.isPending ? 'Adding...' : 'Add'}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setShowAddOrg(false)
-                  setNewOrgSlug('')
-                  setNewRoleSlug('')
-                }}
-                className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Memberships List */}
-        {(user.organizations ?? []).length > 0 ? (
-          <div className="space-y-2">
-            {(user.organizations ?? []).map((membership: OrgMembership) => (
-              <div
-                key={membership.organization_slug}
-                className={`flex items-center justify-between rounded-lg border p-3 ${
-                  isDarkMode
-                    ? 'border-gray-600 bg-gray-700'
-                    : 'border-gray-200 bg-gray-50'
-                }`}
-              >
-                <div className="flex-1">
-                  <div
-                    className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+        </CardHeader>
+        <CardContent>
+          {/* Add to Organization Form */}
+          {showAddOrg && (
+            <div
+              className={`mb-4 rounded-lg border p-4 ${
+                isDarkMode
+                  ? 'border-gray-600 bg-gray-700'
+                  : 'border-gray-200 bg-gray-50'
+              }`}
+            >
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    {membership.organization_name}
-                  </div>
-                  <div
-                    className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}
-                  >
-                    {membership.organization_slug}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
+                    Organization
+                  </label>
                   <select
-                    value={membership.role}
-                    onChange={(e) =>
-                      updateRoleMutation.mutate({
-                        orgSlug: membership.organization_slug,
-                        roleSlug: e.target.value,
-                      })
-                    }
-                    disabled={updateRoleMutation.isPending}
-                    className={`rounded border px-2 py-1 text-xs ${
+                    value={newOrgSlug}
+                    onChange={(e) => setNewOrgSlug(e.target.value)}
+                    className={`w-full rounded-md border px-3 py-2 text-sm ${
                       isDarkMode
                         ? 'border-gray-600 bg-gray-700 text-white'
                         : 'border-gray-300 bg-white text-gray-900'
                     }`}
                   >
+                    <option value="">Select...</option>
+                    {availableOrgs.map((org) => (
+                      <option key={org.slug} value={org.slug}>
+                        {org.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
+                    Role
+                  </label>
+                  <select
+                    value={newRoleSlug}
+                    onChange={(e) => setNewRoleSlug(e.target.value)}
+                    className={`w-full rounded-md border px-3 py-2 text-sm ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700 text-white'
+                        : 'border-gray-300 bg-white text-gray-900'
+                    }`}
+                  >
+                    <option value="">Select...</option>
                     {availableRoles.map((role) => (
                       <option key={role.slug} value={role.slug}>
                         {role.name}
                       </option>
                     ))}
                   </select>
-                  <button
-                    onClick={() => {
-                      if (
-                        confirm(
-                          `Remove ${user.display_name} from ${membership.organization_name}?`,
-                        )
-                      ) {
-                        removeOrgMutation.mutate(membership.organization_slug)
-                      }
-                    }}
-                    disabled={removeOrgMutation.isPending}
-                    className={`rounded p-1.5 ${
-                      isDarkMode
-                        ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
-                        : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
-                    }`}
-                    title="Remove from organization"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
                 </div>
               </div>
-            ))}
-          </div>
-        ) : (
+              <div className="mt-3 flex items-center gap-2">
+                <Button
+                  onClick={() =>
+                    addOrgMutation.mutate({
+                      organization_slug: newOrgSlug,
+                      role_slug: newRoleSlug,
+                    })
+                  }
+                  disabled={
+                    !newOrgSlug || !newRoleSlug || addOrgMutation.isPending
+                  }
+                  className="bg-amber-border text-white hover:bg-amber-border-strong"
+                  size="sm"
+                >
+                  {addOrgMutation.isPending ? 'Adding...' : 'Add'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setShowAddOrg(false)
+                    setNewOrgSlug('')
+                    setNewRoleSlug('')
+                  }}
+                  className={isDarkMode ? 'border-gray-600 text-gray-300' : ''}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Memberships List */}
+          {(user.organizations ?? []).length > 0 ? (
+            <div className="space-y-2">
+              {(user.organizations ?? []).map((membership: OrgMembership) => (
+                <div
+                  key={membership.organization_slug}
+                  className={`flex items-center justify-between rounded-lg border p-3 ${
+                    isDarkMode
+                      ? 'border-gray-600 bg-gray-700'
+                      : 'border-gray-200 bg-gray-50'
+                  }`}
+                >
+                  <div className="flex-1">
+                    <div
+                      className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                    >
+                      {membership.organization_name}
+                    </div>
+                    <div
+                      className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}
+                    >
+                      {membership.organization_slug}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <select
+                      value={membership.role}
+                      onChange={(e) =>
+                        updateRoleMutation.mutate({
+                          orgSlug: membership.organization_slug,
+                          roleSlug: e.target.value,
+                        })
+                      }
+                      disabled={updateRoleMutation.isPending}
+                      className={`rounded border px-2 py-1 text-xs ${
+                        isDarkMode
+                          ? 'border-gray-600 bg-gray-700 text-white'
+                          : 'border-gray-300 bg-white text-gray-900'
+                      }`}
+                    >
+                      {availableRoles.map((role) => (
+                        <option key={role.slug} value={role.slug}>
+                          {role.name}
+                        </option>
+                      ))}
+                    </select>
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={() => {
+                              if (
+                                confirm(
+                                  `Remove ${user.display_name} from ${membership.organization_name}?`,
+                                )
+                              ) {
+                                removeOrgMutation.mutate(
+                                  membership.organization_slug,
+                                )
+                              }
+                            }}
+                            disabled={removeOrgMutation.isPending}
+                            className={`rounded p-1.5 ${
+                              isDarkMode
+                                ? 'text-red-400 hover:bg-gray-700 hover:text-red-300'
+                                : 'text-red-600 hover:bg-gray-100 hover:text-red-700'
+                            }`}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Remove from organization</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div
+              className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+            >
+              <Building2
+                className={`mx-auto mb-2 h-8 w-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}
+              />
+              <div>Not a member of any organization</div>
+              <div className="mt-1 text-sm">
+                This user has no permissions until added to an organization
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Active Sessions */}
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="pb-4">
+          <CardTitle>Active Sessions</CardTitle>
+        </CardHeader>
+        <CardContent>
           <div
             className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
           >
-            <Building2
-              className={`mx-auto mb-2 h-8 w-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}
-            />
-            <div>Not a member of any organization</div>
+            <div>0 active sessions</div>
             <div className="mt-1 text-sm">
-              This user has no permissions until added to an organization
+              No JWT tokens currently active for this user
             </div>
           </div>
-        )}
-      </div>
-
-      {/* Active Sessions */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Active Sessions
-        </h3>
-        <div
-          className={`py-8 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-        >
-          <div>0 active sessions</div>
-          <div className="mt-1 text-sm">
-            No JWT tokens currently active for this user
-          </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
 import { Gravatar } from '../../ui/gravatar'
+import { Card, CardContent } from '../../ui/card'
 import { getRoles } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import type { AdminUser, AdminUserCreate } from '@/types'
@@ -198,7 +199,7 @@ export function UserForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit User' : 'Create New User'}
           </h2>
@@ -269,344 +270,317 @@ export function UserForm({
       )}
 
       {/* Section 1: Basic Information */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Basic Information
-        </h3>
-
-        <div className="grid grid-cols-2 gap-4">
-          {/* Email */}
-          <div className="col-span-2">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Email <span className="text-red-500">*</span>
-            </label>
-            <Input
-              type="email"
-              value={email}
-              onChange={(e) => {
-                setEmail(e.target.value)
-                handleFieldChange('email')
-              }}
-              onBlur={() => {
-                setTouched({ ...touched, email: true })
-                const error = validateEmail(email)
-                if (error) {
-                  setValidationErrors({ ...validationErrors, email: error })
-                }
-              }}
-              disabled={isEditing || isLoading}
-              placeholder="john.doe@company.com"
-              className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                isEditing ? 'cursor-not-allowed opacity-60' : ''
-              }`}
-            />
-            {isEditing && (
-              <p
-                className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-              >
-                Email cannot be changed after creation
-              </p>
-            )}
-            {touched.email && validationErrors.email && (
-              <p className="mt-1 text-sm text-red-600">
-                {validationErrors.email}
-              </p>
-            )}
-          </div>
-
-          {/* Display Name */}
-          <div className="col-span-2">
-            <label
-              className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-            >
-              Display Name <span className="text-red-500">*</span>
-            </label>
-            <Input
-              value={displayName}
-              onChange={(e) => {
-                setDisplayName(e.target.value)
-                handleFieldChange('display_name')
-              }}
-              onBlur={() => {
-                setTouched({ ...touched, display_name: true })
-                const error = validateDisplayName(displayName)
-                if (error) {
-                  setValidationErrors({
-                    ...validationErrors,
-                    display_name: error,
-                  })
-                }
-              }}
-              disabled={isLoading}
-              placeholder="John Doe"
-              className={
-                isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
-              }
-            />
-            {touched.display_name && validationErrors.display_name && (
-              <p className="mt-1 text-sm text-red-600">
-                {validationErrors.display_name}
-              </p>
-            )}
-          </div>
-
-          {/* Gravatar Preview */}
-          {email && validateEmail(email) === '' && (
-            <div className="col-span-2">
-              <label
-                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Avatar (Gravatar)
-              </label>
-              <div className="flex items-center gap-3">
-                <Gravatar
-                  email={email}
-                  size={64}
-                  className="h-16 w-16 rounded-full border-2 border-gray-300 dark:border-gray-600"
-                />
-                <p
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                >
-                  Avatar will be loaded from{' '}
-                  <a
-                    href="https://gravatar.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-500 hover:underline"
-                  >
-                    Gravatar
-                  </a>{' '}
-                  based on email address
-                </p>
-              </div>
-            </div>
-          )}
-
-          {/* Password Section */}
-          {isEditing && (
-            <div className="col-span-2">
-              <label className="flex cursor-pointer items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={changePassword}
-                  onChange={(e) => setChangePassword(e.target.checked)}
-                  disabled={isLoading}
-                  className="rounded"
-                />
-                <span
-                  className={isDarkMode ? 'text-gray-300' : 'text-gray-700'}
-                >
-                  Change Password
-                </span>
-              </label>
-            </div>
-          )}
-
-          {(changePassword || !isEditing) && (
-            <>
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="space-y-4 pt-6">
+          <div className="grid grid-cols-2 gap-4">
+            {/* Email */}
+            {!isEditing && (
               <div className="col-span-2">
                 <label
                   className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                 >
-                  Password <span className="text-red-500">*</span>
-                </label>
-                <div className="relative">
-                  <Input
-                    type={showPassword ? 'text' : 'password'}
-                    value={password}
-                    onChange={(e) => {
-                      setPassword(e.target.value)
-                      handleFieldChange('password')
-                    }}
-                    onBlur={() => {
-                      setTouched({ ...touched, password: true })
-                      const error = validatePassword(password)
-                      if (error) {
-                        setValidationErrors({
-                          ...validationErrors,
-                          password: error,
-                        })
-                      }
-                    }}
-                    disabled={isLoading}
-                    placeholder="Minimum 12 characters"
-                    className={`pr-10 ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''}`}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    disabled={isLoading}
-                    className={`absolute right-3 top-1/2 -translate-y-1/2 ${
-                      isDarkMode
-                        ? 'text-gray-400 hover:text-gray-200'
-                        : 'text-gray-500 hover:text-gray-700'
-                    }`}
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </button>
-                </div>
-                {touched.password && validationErrors.password && (
-                  <p className="mt-1 text-sm text-red-600">
-                    {validationErrors.password}
-                  </p>
-                )}
-                {password && !validationErrors.password && (
-                  <div className="mt-2">
-                    <div className="mb-1 flex items-center gap-2">
-                      <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-                        <div
-                          className={`h-full transition-all ${
-                            passwordStrength.color === 'red'
-                              ? 'bg-red-500'
-                              : passwordStrength.color === 'yellow'
-                                ? 'bg-yellow-500'
-                                : 'bg-green-500'
-                          }`}
-                          style={{
-                            width: `${(passwordStrength.score / 6) * 100}%`,
-                          }}
-                        />
-                      </div>
-                      <span
-                        className={`text-xs ${
-                          passwordStrength.color === 'red'
-                            ? 'text-red-500'
-                            : passwordStrength.color === 'yellow'
-                              ? 'text-yellow-500'
-                              : 'text-green-500'
-                        }`}
-                      >
-                        {passwordStrength.label}
-                      </span>
-                    </div>
-                    <ul
-                      className={`space-y-0.5 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                    >
-                      <li
-                        className={`flex items-center gap-1 ${password.length >= 12 ? 'text-green-600 dark:text-green-400' : ''}`}
-                      >
-                        {password.length >= 12 ? (
-                          <Check className="h-3 w-3" />
-                        ) : (
-                          <XIcon className="h-3 w-3" />
-                        )}
-                        At least 12 characters
-                      </li>
-                      <li
-                        className={`flex items-center gap-1 ${/[A-Z]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
-                      >
-                        {/[A-Z]/.test(password) ? (
-                          <Check className="h-3 w-3" />
-                        ) : (
-                          <XIcon className="h-3 w-3" />
-                        )}
-                        Uppercase letter
-                      </li>
-                      <li
-                        className={`flex items-center gap-1 ${/[a-z]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
-                      >
-                        {/[a-z]/.test(password) ? (
-                          <Check className="h-3 w-3" />
-                        ) : (
-                          <XIcon className="h-3 w-3" />
-                        )}
-                        Lowercase letter
-                      </li>
-                      <li
-                        className={`flex items-center gap-1 ${/[0-9]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
-                      >
-                        {/[0-9]/.test(password) ? (
-                          <Check className="h-3 w-3" />
-                        ) : (
-                          <XIcon className="h-3 w-3" />
-                        )}
-                        Number
-                      </li>
-                      <li
-                        className={`flex items-center gap-1 ${/[^a-zA-Z0-9]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
-                      >
-                        {/[^a-zA-Z0-9]/.test(password) ? (
-                          <Check className="h-3 w-3" />
-                        ) : (
-                          <XIcon className="h-3 w-3" />
-                        )}
-                        Special character
-                      </li>
-                    </ul>
-                  </div>
-                )}
-              </div>
-
-              <div className="col-span-2">
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Confirm Password <span className="text-red-500">*</span>
+                  Email <span className="text-red-500">*</span>
                 </label>
                 <Input
-                  type={showPassword ? 'text' : 'password'}
-                  value={confirmPassword}
+                  type="email"
+                  value={email}
                   onChange={(e) => {
-                    setConfirmPassword(e.target.value)
-                    handleFieldChange('confirmPassword')
+                    setEmail(e.target.value)
+                    handleFieldChange('email')
                   }}
                   onBlur={() => {
-                    setTouched({ ...touched, confirmPassword: true })
-                    const error = validateConfirmPassword(confirmPassword)
+                    setTouched({ ...touched, email: true })
+                    const error = validateEmail(email)
                     if (error) {
-                      setValidationErrors({
-                        ...validationErrors,
-                        confirmPassword: error,
-                      })
+                      setValidationErrors({ ...validationErrors, email: error })
                     }
                   }}
                   disabled={isLoading}
-                  placeholder="Re-enter password"
+                  placeholder="john.doe@company.com"
                   className={
                     isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
                   }
                 />
-                {touched.confirmPassword &&
-                  validationErrors.confirmPassword && (
+                {touched.email && validationErrors.email && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {validationErrors.email}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Display Name */}
+            <div className="col-span-2">
+              <label
+                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+              >
+                Display Name <span className="text-red-500">*</span>
+              </label>
+              <Input
+                value={displayName}
+                onChange={(e) => {
+                  setDisplayName(e.target.value)
+                  handleFieldChange('display_name')
+                }}
+                onBlur={() => {
+                  setTouched({ ...touched, display_name: true })
+                  const error = validateDisplayName(displayName)
+                  if (error) {
+                    setValidationErrors({
+                      ...validationErrors,
+                      display_name: error,
+                    })
+                  }
+                }}
+                disabled={isLoading}
+                placeholder="John Doe"
+                className={
+                  isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+                }
+              />
+              {touched.display_name && validationErrors.display_name && (
+                <p className="mt-1 text-sm text-red-600">
+                  {validationErrors.display_name}
+                </p>
+              )}
+            </div>
+
+            {/* Gravatar Preview */}
+            {email && validateEmail(email) === '' && (
+              <div className="col-span-2">
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Avatar (Gravatar)
+                </label>
+                <div className="flex items-center gap-3">
+                  <Gravatar
+                    email={email}
+                    size={64}
+                    className="h-16 w-16 rounded-full border-2 border-gray-300 dark:border-gray-600"
+                  />
+                  <p
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Avatar will be loaded from{' '}
+                    <a
+                      href="https://gravatar.com"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 hover:underline"
+                    >
+                      Gravatar
+                    </a>{' '}
+                    based on email address
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Password Section */}
+            {isEditing && (
+              <div className="col-span-2">
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={changePassword}
+                    onChange={(e) => setChangePassword(e.target.checked)}
+                    disabled={isLoading}
+                    className="rounded"
+                  />
+                  <span
+                    className={isDarkMode ? 'text-gray-300' : 'text-gray-700'}
+                  >
+                    Change Password
+                  </span>
+                </label>
+              </div>
+            )}
+
+            {(changePassword || !isEditing) && (
+              <>
+                <div className="col-span-2">
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
+                    Password <span className="text-red-500">*</span>
+                  </label>
+                  <div className="relative">
+                    <Input
+                      type={showPassword ? 'text' : 'password'}
+                      value={password}
+                      onChange={(e) => {
+                        setPassword(e.target.value)
+                        handleFieldChange('password')
+                      }}
+                      onBlur={() => {
+                        setTouched({ ...touched, password: true })
+                        const error = validatePassword(password)
+                        if (error) {
+                          setValidationErrors({
+                            ...validationErrors,
+                            password: error,
+                          })
+                        }
+                      }}
+                      disabled={isLoading}
+                      placeholder="Minimum 12 characters"
+                      className={`pr-10 ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''}`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      disabled={isLoading}
+                      className={`absolute right-3 top-1/2 -translate-y-1/2 ${
+                        isDarkMode
+                          ? 'text-gray-400 hover:text-gray-200'
+                          : 'text-gray-500 hover:text-gray-700'
+                      }`}
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                  {touched.password && validationErrors.password && (
                     <p className="mt-1 text-sm text-red-600">
-                      {validationErrors.confirmPassword}
+                      {validationErrors.password}
                     </p>
                   )}
-              </div>
-            </>
-          )}
-        </div>
-      </div>
+                  {password && !validationErrors.password && (
+                    <div className="mt-2">
+                      <div className="mb-1 flex items-center gap-2">
+                        <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                          <div
+                            className={`h-full transition-all ${
+                              passwordStrength.color === 'red'
+                                ? 'bg-red-500'
+                                : passwordStrength.color === 'yellow'
+                                  ? 'bg-yellow-500'
+                                  : 'bg-green-500'
+                            }`}
+                            style={{
+                              width: `${(passwordStrength.score / 6) * 100}%`,
+                            }}
+                          />
+                        </div>
+                        <span
+                          className={`text-xs ${
+                            passwordStrength.color === 'red'
+                              ? 'text-red-500'
+                              : passwordStrength.color === 'yellow'
+                                ? 'text-yellow-500'
+                                : 'text-green-500'
+                          }`}
+                        >
+                          {passwordStrength.label}
+                        </span>
+                      </div>
+                      <ul
+                        className={`space-y-0.5 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                      >
+                        <li
+                          className={`flex items-center gap-1 ${password.length >= 12 ? 'text-green-600 dark:text-green-400' : ''}`}
+                        >
+                          {password.length >= 12 ? (
+                            <Check className="h-3 w-3" />
+                          ) : (
+                            <XIcon className="h-3 w-3" />
+                          )}
+                          At least 12 characters
+                        </li>
+                        <li
+                          className={`flex items-center gap-1 ${/[A-Z]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
+                        >
+                          {/[A-Z]/.test(password) ? (
+                            <Check className="h-3 w-3" />
+                          ) : (
+                            <XIcon className="h-3 w-3" />
+                          )}
+                          Uppercase letter
+                        </li>
+                        <li
+                          className={`flex items-center gap-1 ${/[a-z]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
+                        >
+                          {/[a-z]/.test(password) ? (
+                            <Check className="h-3 w-3" />
+                          ) : (
+                            <XIcon className="h-3 w-3" />
+                          )}
+                          Lowercase letter
+                        </li>
+                        <li
+                          className={`flex items-center gap-1 ${/[0-9]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
+                        >
+                          {/[0-9]/.test(password) ? (
+                            <Check className="h-3 w-3" />
+                          ) : (
+                            <XIcon className="h-3 w-3" />
+                          )}
+                          Number
+                        </li>
+                        <li
+                          className={`flex items-center gap-1 ${/[^a-zA-Z0-9]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
+                        >
+                          {/[^a-zA-Z0-9]/.test(password) ? (
+                            <Check className="h-3 w-3" />
+                          ) : (
+                            <XIcon className="h-3 w-3" />
+                          )}
+                          Special character
+                        </li>
+                      </ul>
+                    </div>
+                  )}
+                </div>
+
+                <div className="col-span-2">
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
+                    Confirm Password <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    type={showPassword ? 'text' : 'password'}
+                    value={confirmPassword}
+                    onChange={(e) => {
+                      setConfirmPassword(e.target.value)
+                      handleFieldChange('confirmPassword')
+                    }}
+                    onBlur={() => {
+                      setTouched({ ...touched, confirmPassword: true })
+                      const error = validateConfirmPassword(confirmPassword)
+                      if (error) {
+                        setValidationErrors({
+                          ...validationErrors,
+                          confirmPassword: error,
+                        })
+                      }
+                    }}
+                    disabled={isLoading}
+                    placeholder="Re-enter password"
+                    className={
+                      isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''
+                    }
+                  />
+                  {touched.confirmPassword &&
+                    validationErrors.confirmPassword && (
+                      <p className="mt-1 text-sm text-red-600">
+                        {validationErrors.confirmPassword}
+                      </p>
+                    )}
+                </div>
+              </>
+            )}
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Section 2: Account Type */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Account Type & Status
-        </h3>
-
-        <div className="space-y-4">
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardContent className="space-y-4 pt-6">
           <div>
             <label
               className={`mb-2 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -741,85 +715,33 @@ export function UserForm({
               Inactive accounts cannot authenticate
             </p>
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Section 3: Organization Membership (creation only) */}
       {!isEditing && (
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Organization Membership
-          </h3>
-          <p
-            className={`mb-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Users must belong to at least one organization with a role to have
-            any permissions.
-          </p>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="space-y-4 pt-6">
+            <p
+              className={`mb-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            >
+              Users must belong to at least one organization with a role to have
+              any permissions.
+            </p>
 
-          <div className="grid grid-cols-2 gap-4">
-            {/* Organization */}
-            <div>
-              <label
-                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Organization <span className="text-red-500">*</span>
-              </label>
-              <select
-                value={organizationSlug}
-                onChange={(e) => {
-                  setOrganizationSlug(e.target.value)
-                  handleFieldChange('organization_slug')
-                }}
-                disabled={isLoading}
-                className={`w-full rounded-md border px-3 py-2 text-sm ${
-                  isDarkMode
-                    ? 'border-gray-600 bg-gray-700 text-white'
-                    : 'border-gray-300 bg-white text-gray-900'
-                } focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
-              >
-                <option value="">Select an organization...</option>
-                {organizations.map((org) => (
-                  <option key={org.slug} value={org.slug}>
-                    {org.name}
-                  </option>
-                ))}
-              </select>
-              {touched.organization_slug &&
-                validationErrors.organization_slug && (
-                  <p className="mt-1 text-sm text-red-600">
-                    {validationErrors.organization_slug}
-                  </p>
-                )}
-            </div>
-
-            {/* Role */}
-            <div>
-              <label
-                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Role <span className="text-red-500">*</span>
-              </label>
-              {rolesLoading ? (
-                <p
-                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            <div className="grid grid-cols-2 gap-4">
+              {/* Organization */}
+              <div>
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                 >
-                  Loading roles...
-                </p>
-              ) : (
+                  Organization <span className="text-red-500">*</span>
+                </label>
                 <select
-                  value={roleSlug}
+                  value={organizationSlug}
                   onChange={(e) => {
-                    setRoleSlug(e.target.value)
-                    handleFieldChange('role_slug')
+                    setOrganizationSlug(e.target.value)
+                    handleFieldChange('organization_slug')
                   }}
                   disabled={isLoading}
                   className={`w-full rounded-md border px-3 py-2 text-sm ${
@@ -828,22 +750,65 @@ export function UserForm({
                       : 'border-gray-300 bg-white text-gray-900'
                   } focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
                 >
-                  <option value="">Select a role...</option>
-                  {availableRoles.map((role) => (
-                    <option key={role.slug} value={role.slug}>
-                      {role.name}
+                  <option value="">Select an organization...</option>
+                  {organizations.map((org) => (
+                    <option key={org.slug} value={org.slug}>
+                      {org.name}
                     </option>
                   ))}
                 </select>
-              )}
-              {touched.role_slug && validationErrors.role_slug && (
-                <p className="mt-1 text-sm text-red-600">
-                  {validationErrors.role_slug}
-                </p>
-              )}
+                {touched.organization_slug &&
+                  validationErrors.organization_slug && (
+                    <p className="mt-1 text-sm text-red-600">
+                      {validationErrors.organization_slug}
+                    </p>
+                  )}
+              </div>
+
+              {/* Role */}
+              <div>
+                <label
+                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  Role <span className="text-red-500">*</span>
+                </label>
+                {rolesLoading ? (
+                  <p
+                    className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                  >
+                    Loading roles...
+                  </p>
+                ) : (
+                  <select
+                    value={roleSlug}
+                    onChange={(e) => {
+                      setRoleSlug(e.target.value)
+                      handleFieldChange('role_slug')
+                    }}
+                    disabled={isLoading}
+                    className={`w-full rounded-md border px-3 py-2 text-sm ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700 text-white'
+                        : 'border-gray-300 bg-white text-gray-900'
+                    } focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                  >
+                    <option value="">Select a role...</option>
+                    {availableRoles.map((role) => (
+                      <option key={role.slug} value={role.slug}>
+                        {role.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+                {touched.role_slug && validationErrors.role_slug && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {validationErrors.role_slug}
+                  </p>
+                )}
+              </div>
             </div>
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       )}
     </div>
   )

--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Edit2, Webhook } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EntityIcon } from '@/components/ui/entity-icon'
 import type { Webhook as WebhookType } from '@/types'
 
@@ -47,11 +48,7 @@ export function WebhookDetail({
                   />
                 </div>
               )}
-              <h2
-                className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                {webhook.name}
-              </h2>
+              <CardTitle>{webhook.name}</CardTitle>
             </div>
             {webhook.description && (
               <p
@@ -72,79 +69,17 @@ export function WebhookDetail({
       </div>
 
       {/* Webhook Info */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Configuration
-        </h3>
-        <div className="grid grid-cols-2 gap-6">
-          <div>
-            <div
-              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-            >
-              Slug
-            </div>
-            <div className="mt-1">
-              <code
-                className={`rounded px-2 py-1 text-sm ${
-                  isDarkMode
-                    ? 'bg-gray-700 text-gray-300'
-                    : 'bg-gray-100 text-gray-700'
-                }`}
-              >
-                {webhook.slug}
-              </code>
-            </div>
-          </div>
-          <div>
-            <div
-              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-            >
-              Notification Path
-            </div>
-            <div className="mt-1">
-              <code
-                className={`rounded px-2 py-1 text-sm ${
-                  isDarkMode
-                    ? 'bg-gray-700 text-gray-300'
-                    : 'bg-gray-100 text-gray-700'
-                }`}
-              >
-                {webhook.notification_path}
-              </code>
-            </div>
-          </div>
-          <div>
-            <div
-              className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-            >
-              Third-Party Service
-            </div>
-            <div
-              className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-            >
-              {webhook.third_party_service?.name || (
-                <span
-                  className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}
-                >
-                  None
-                </span>
-              )}
-            </div>
-          </div>
-          {webhook.identifier_selector && (
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="pb-4">
+          <CardTitle>Configuration</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-6">
             <div>
               <div
                 className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
               >
-                Identifier Selector
+                Slug
               </div>
               <div className="mt-1">
                 <code
@@ -154,108 +89,130 @@ export function WebhookDetail({
                       : 'bg-gray-100 text-gray-700'
                   }`}
                 >
-                  {webhook.identifier_selector}
+                  {webhook.slug}
                 </code>
               </div>
             </div>
-          )}
-        </div>
-      </div>
+            <div>
+              <div
+                className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                Notification Path
+              </div>
+              <div className="mt-1">
+                <code
+                  className={`rounded px-2 py-1 text-sm ${
+                    isDarkMode
+                      ? 'bg-gray-700 text-gray-300'
+                      : 'bg-gray-100 text-gray-700'
+                  }`}
+                >
+                  {webhook.notification_path}
+                </code>
+              </div>
+            </div>
+            <div>
+              <div
+                className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+              >
+                Third-Party Service
+              </div>
+              <div
+                className={`mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                {webhook.third_party_service?.name || (
+                  <span
+                    className={isDarkMode ? 'text-gray-500' : 'text-gray-400'}
+                  >
+                    None
+                  </span>
+                )}
+              </div>
+            </div>
+            {webhook.identifier_selector && (
+              <div>
+                <div
+                  className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                >
+                  Identifier Selector
+                </div>
+                <div className="mt-1">
+                  <code
+                    className={`rounded px-2 py-1 text-sm ${
+                      isDarkMode
+                        ? 'bg-gray-700 text-gray-300'
+                        : 'bg-gray-100 text-gray-700'
+                    }`}
+                  >
+                    {webhook.identifier_selector}
+                  </code>
+                </div>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Rules */}
-      <div
-        className={`rounded-lg border p-6 ${
-          isDarkMode
-            ? 'border-gray-700 bg-gray-800'
-            : 'border-gray-200 bg-white'
-        }`}
-      >
-        <h3
-          className={`mb-4 text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-        >
-          Rules ({webhook.rules.length})
-        </h3>
-
-        {webhook.rules.length === 0 ? (
-          <div
-            className={`py-6 text-center text-sm ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-          >
-            No rules defined for this webhook.
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead
-                className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
-              >
-                <tr>
-                  <th
-                    className={`w-12 px-4 py-2 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    #
-                  </th>
-                  <th
-                    className={`px-4 py-2 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Filter Expression
-                  </th>
-                  <th
-                    className={`px-4 py-2 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Handler
-                  </th>
-                  <th
-                    className={`px-4 py-2 text-left text-xs uppercase tracking-wider ${
-                      isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                    }`}
-                  >
-                    Config
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
-              >
-                {webhook.rules.map((rule, index) => (
-                  <tr key={index}>
-                    <td
-                      className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
+      <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+        <CardHeader className="pb-4">
+          <CardTitle>Rules ({webhook.rules.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {webhook.rules.length === 0 ? (
+            <div
+              className={`py-6 text-center text-sm ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+            >
+              No rules defined for this webhook.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead
+                  className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
+                >
+                  <tr>
+                    <th
+                      className={`w-12 px-4 py-2 text-left text-xs uppercase tracking-wider ${
+                        isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                      }`}
                     >
-                      {index + 1}
-                    </td>
-                    <td className="px-4 py-3">
-                      <code
-                        className={`rounded px-2 py-1 text-sm ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
-                        }`}
+                      #
+                    </th>
+                    <th
+                      className={`px-4 py-2 text-left text-xs uppercase tracking-wider ${
+                        isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                      }`}
+                    >
+                      Filter Expression
+                    </th>
+                    <th
+                      className={`px-4 py-2 text-left text-xs uppercase tracking-wider ${
+                        isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                      }`}
+                    >
+                      Handler
+                    </th>
+                    <th
+                      className={`px-4 py-2 text-left text-xs uppercase tracking-wider ${
+                        isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                      }`}
+                    >
+                      Config
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  className={`divide-y ${isDarkMode ? 'divide-gray-700' : 'divide-gray-200'}`}
+                >
+                  {webhook.rules.map((rule, index) => (
+                    <tr key={index}>
+                      <td
+                        className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
                       >
-                        {rule.filter_expression}
-                      </code>
-                    </td>
-                    <td className="px-4 py-3">
-                      <code
-                        className={`rounded px-2 py-1 text-sm ${
-                          isDarkMode
-                            ? 'bg-gray-700 text-gray-300'
-                            : 'bg-gray-100 text-gray-700'
-                        }`}
-                      >
-                        {rule.handler}
-                      </code>
-                    </td>
-                    <td className="px-4 py-3">
-                      {rule.handler_config &&
-                      (Array.isArray(rule.handler_config)
-                        ? rule.handler_config.length > 0
-                        : Object.keys(rule.handler_config).length > 0) ? (
+                        {index + 1}
+                      </td>
+                      <td className="px-4 py-3">
                         <code
                           className={`rounded px-2 py-1 text-sm ${
                             isDarkMode
@@ -263,25 +220,52 @@ export function WebhookDetail({
                               : 'bg-gray-100 text-gray-700'
                           }`}
                         >
-                          {JSON.stringify(rule.handler_config)}
+                          {rule.filter_expression}
                         </code>
-                      ) : (
-                        <span
-                          className={
-                            isDarkMode ? 'text-gray-500' : 'text-gray-400'
-                          }
+                      </td>
+                      <td className="px-4 py-3">
+                        <code
+                          className={`rounded px-2 py-1 text-sm ${
+                            isDarkMode
+                              ? 'bg-gray-700 text-gray-300'
+                              : 'bg-gray-100 text-gray-700'
+                          }`}
                         >
-                          --
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+                          {rule.handler}
+                        </code>
+                      </td>
+                      <td className="px-4 py-3">
+                        {rule.handler_config &&
+                        (Array.isArray(rule.handler_config)
+                          ? rule.handler_config.length > 0
+                          : Object.keys(rule.handler_config).length > 0) ? (
+                          <code
+                            className={`rounded px-2 py-1 text-sm ${
+                              isDarkMode
+                                ? 'bg-gray-700 text-gray-300'
+                                : 'bg-gray-100 text-gray-700'
+                            }`}
+                          >
+                            {JSON.stringify(rule.handler_config)}
+                          </code>
+                        ) : (
+                          <span
+                            className={
+                              isDarkMode ? 'text-gray-500' : 'text-gray-400'
+                            }
+                          >
+                            --
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -187,7 +188,7 @@ export function WebhookForm({
       <div className="flex items-center justify-between">
         <div>
           <h2
-            className={`text-2xl font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
             {isEditing ? 'Edit Webhook' : 'Add Webhook'}
           </h2>
@@ -260,21 +261,11 @@ export function WebhookForm({
       {/* Form */}
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Basic Information */}
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Webhook Information
-          </h3>
-
-          <div className="space-y-4">
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="space-y-4 pt-6">
+            <div
+              className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
+            >
               <div>
                 <label
                   className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
@@ -300,30 +291,32 @@ export function WebhookForm({
                 )}
               </div>
 
-              <div>
-                <label
-                  className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-                >
-                  Slug <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  value={slug}
-                  onChange={(e) => setSlug(e.target.value)}
-                  placeholder="e.g., github-push-events"
-                  disabled={isLoading}
-                  className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                    errors.slug ? 'border-red-500' : ''
-                  }`}
-                />
-                {errors.slug && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+              {!isEditing && (
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                   >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.slug}
-                  </div>
-                )}
-              </div>
+                    Slug <span className="text-red-500">*</span>
+                  </label>
+                  <Input
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="e.g., github-push-events"
+                    disabled={isLoading}
+                    className={`${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                      errors.slug ? 'border-red-500' : ''
+                    }`}
+                  />
+                  {errors.slug && (
+                    <div
+                      className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      {errors.slug}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -445,104 +438,85 @@ export function WebhookForm({
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          </CardContent>
+        </Card>
 
         {/* Third-Party Service Binding */}
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <h3
-            className={`mb-4 font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-          >
-            Third-Party Service
-          </h3>
-          <p
-            className={`mb-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-          >
-            Optionally link this webhook to a third-party service for automatic
-            project resolution.
-          </p>
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardContent className="space-y-4 pt-6">
+            <p
+              className={`mb-4 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            >
+              Optionally link this webhook to a third-party service for
+              automatic project resolution.
+            </p>
 
-          <div className="space-y-4">
-            <div>
-              <label
-                className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
-              >
-                Third-Party Service
-              </label>
-              <select
-                value={tpsSlug}
-                onChange={(e) => {
-                  setTpsSlug(e.target.value)
-                  if (!e.target.value) setIdentifierSelector('')
-                }}
-                disabled={isLoading}
-                className={selectClass}
-              >
-                <option value="">None</option>
-                {services.map((svc) => (
-                  <option key={svc.slug} value={svc.slug}>
-                    {svc.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {tpsSlug && (
+            <div className="space-y-4">
               <div>
                 <label
                   className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
                 >
-                  Identifier Selector (JSON Path)
+                  Third-Party Service
                 </label>
-                <Input
-                  value={identifierSelector}
-                  onChange={(e) => setIdentifierSelector(e.target.value)}
-                  placeholder="e.g., $.repository.full_name"
+                <select
+                  value={tpsSlug}
+                  onChange={(e) => {
+                    setTpsSlug(e.target.value)
+                    if (!e.target.value) setIdentifierSelector('')
+                  }}
                   disabled={isLoading}
-                  className={`font-mono text-sm ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                    errors.identifier_selector ? 'border-red-500' : ''
-                  }`}
-                />
-                {errors.identifier_selector && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
-                  >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.identifier_selector}
-                  </div>
-                )}
-                <p
-                  className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  className={selectClass}
                 >
-                  JSON Path expression to extract the project identifier from
-                  the webhook payload.
-                </p>
+                  <option value="">None</option>
+                  {services.map((svc) => (
+                    <option key={svc.slug} value={svc.slug}>
+                      {svc.name}
+                    </option>
+                  ))}
+                </select>
               </div>
-            )}
-          </div>
-        </div>
+
+              {tpsSlug && (
+                <div>
+                  <label
+                    className={`mb-1.5 block text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
+                    Identifier Selector (JSON Path)
+                  </label>
+                  <Input
+                    value={identifierSelector}
+                    onChange={(e) => setIdentifierSelector(e.target.value)}
+                    placeholder="e.g., $.repository.full_name"
+                    disabled={isLoading}
+                    className={`font-mono text-sm ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                      errors.identifier_selector ? 'border-red-500' : ''
+                    }`}
+                  />
+                  {errors.identifier_selector && (
+                    <div
+                      className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      {errors.identifier_selector}
+                    </div>
+                  )}
+                  <p
+                    className={`mt-1 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+                  >
+                    JSON Path expression to extract the project identifier from
+                    the webhook payload.
+                  </p>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Rules */}
-        <div
-          className={`rounded-lg border p-6 ${
-            isDarkMode
-              ? 'border-gray-700 bg-gray-800'
-              : 'border-gray-200 bg-white'
-          }`}
-        >
-          <div className="mb-4 flex items-center justify-between">
+        <Card className={isDarkMode ? 'border-gray-700 bg-gray-800' : ''}>
+          <CardHeader className="flex-row items-center justify-between space-y-0 pb-4">
             <div>
-              <h3
-                className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                Rules
-              </h3>
+              <CardTitle>Rules</CardTitle>
               <p
                 className={`mt-1 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
               >
@@ -561,188 +535,193 @@ export function WebhookForm({
               <Plus className="mr-1 h-4 w-4" />
               Add Rule
             </Button>
-          </div>
-
-          {rules.length === 0 ? (
-            <div
-              className={`py-8 text-center text-sm ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
-            >
-              No rules defined. Click "Add Rule" to get started.
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {rules.map((rule, index) => (
-                <div
-                  key={index}
-                  className={`rounded-lg border p-4 ${
-                    isDarkMode
-                      ? 'border-gray-600 bg-gray-700/50'
-                      : 'border-gray-200 bg-gray-50'
-                  }`}
-                >
-                  <div className="flex items-start gap-3">
-                    {/* Order controls */}
-                    <div className="flex flex-col gap-1 pt-1">
-                      <button
-                        type="button"
-                        onClick={() => moveRule(index, 'up')}
-                        disabled={index === 0 || isLoading}
-                        className={`rounded p-1 transition-colors ${
-                          index === 0
-                            ? 'cursor-not-allowed opacity-30'
-                            : isDarkMode
-                              ? 'text-gray-400 hover:bg-gray-600'
-                              : 'text-gray-500 hover:bg-gray-200'
-                        }`}
-                      >
-                        <ArrowUp className="h-3 w-3" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => moveRule(index, 'down')}
-                        disabled={index === rules.length - 1 || isLoading}
-                        className={`rounded p-1 transition-colors ${
-                          index === rules.length - 1
-                            ? 'cursor-not-allowed opacity-30'
-                            : isDarkMode
-                              ? 'text-gray-400 hover:bg-gray-600'
-                              : 'text-gray-500 hover:bg-gray-200'
-                        }`}
-                      >
-                        <ArrowDown className="h-3 w-3" />
-                      </button>
-                    </div>
-
-                    {/* Rule number */}
-                    <div
-                      className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
-                        isDarkMode
-                          ? 'bg-gray-600 text-gray-300'
-                          : 'bg-gray-200 text-gray-600'
-                      }`}
-                    >
-                      {index + 1}
-                    </div>
-
-                    {/* Fields */}
-                    <div className="flex-1 space-y-3">
-                      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                        <div>
-                          <label
-                            className={`mb-1 block text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                          >
-                            Filter Expression (CEL){' '}
-                            <span className="text-red-500">*</span>
-                          </label>
-                          <Input
-                            value={rule.filter_expression}
-                            onChange={(e) =>
-                              updateRuleField(
-                                index,
-                                'filter_expression',
-                                e.target.value,
-                              )
-                            }
-                            placeholder='e.g., body.action == "push"'
-                            disabled={isLoading}
-                            className={`font-mono text-sm ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                              errors[`rule_${index}_filter`]
-                                ? 'border-red-500'
-                                : ''
-                            }`}
-                          />
-                          {errors[`rule_${index}_filter`] && (
-                            <div
-                              className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
-                            >
-                              <AlertCircle className="h-3 w-3" />
-                              {errors[`rule_${index}_filter`]}
-                            </div>
-                          )}
-                        </div>
-                        <div>
-                          <label
-                            className={`mb-1 block text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
-                          >
-                            Handler <span className="text-red-500">*</span>
-                          </label>
-                          <Input
-                            value={rule.handler}
-                            onChange={(e) =>
-                              updateRuleField(index, 'handler', e.target.value)
-                            }
-                            placeholder="e.g., imbi_gateway.handlers.sync_project"
-                            disabled={isLoading}
-                            className={`font-mono text-sm ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
-                              errors[`rule_${index}_handler`]
-                                ? 'border-red-500'
-                                : ''
-                            }`}
-                          />
-                          {errors[`rule_${index}_handler`] && (
-                            <div
-                              className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
-                            >
-                              <AlertCircle className="h-3 w-3" />
-                              {errors[`rule_${index}_handler`]}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                      <div>
-                        <label
-                          className={`mb-1 block text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+          </CardHeader>
+          <CardContent>
+            {rules.length === 0 ? (
+              <div
+                className={`py-8 text-center text-sm ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}
+              >
+                No rules defined. Click "Add Rule" to get started.
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {rules.map((rule, index) => (
+                  <div
+                    key={index}
+                    className={`rounded-lg border p-4 ${
+                      isDarkMode
+                        ? 'border-gray-600 bg-gray-700/50'
+                        : 'border-gray-200 bg-gray-50'
+                    }`}
+                  >
+                    <div className="flex items-start gap-3">
+                      {/* Order controls */}
+                      <div className="flex flex-col gap-1 pt-1">
+                        <button
+                          type="button"
+                          onClick={() => moveRule(index, 'up')}
+                          disabled={index === 0 || isLoading}
+                          className={`rounded p-1 transition-colors ${
+                            index === 0
+                              ? 'cursor-not-allowed opacity-30'
+                              : isDarkMode
+                                ? 'text-gray-400 hover:bg-gray-600'
+                                : 'text-gray-500 hover:bg-gray-200'
+                          }`}
                         >
-                          Handler Config (JSON)
-                        </label>
-                        <textarea
-                          defaultValue={JSON.stringify(
-                            rule.handler_config,
-                            null,
-                            2,
-                          )}
-                          onBlur={(e) =>
-                            updateRuleConfig(index, e.target.value)
-                          }
-                          rows={6}
-                          disabled={isLoading}
-                          placeholder="{}"
-                          className={`w-full resize-y rounded-lg border px-3 py-2 font-mono text-sm ${
-                            isDarkMode
-                              ? 'border-gray-600 bg-gray-700 text-white placeholder:text-gray-400'
-                              : 'border-gray-300 bg-white text-gray-900 placeholder:text-gray-500'
-                          } ${errors[`rule_${index}_config`] ? 'border-red-500' : ''}`}
-                        />
-                        {errors[`rule_${index}_config`] && (
-                          <div
-                            className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
-                          >
-                            <AlertCircle className="h-3 w-3" />
-                            {errors[`rule_${index}_config`]}
-                          </div>
-                        )}
+                          <ArrowUp className="h-3 w-3" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => moveRule(index, 'down')}
+                          disabled={index === rules.length - 1 || isLoading}
+                          className={`rounded p-1 transition-colors ${
+                            index === rules.length - 1
+                              ? 'cursor-not-allowed opacity-30'
+                              : isDarkMode
+                                ? 'text-gray-400 hover:bg-gray-600'
+                                : 'text-gray-500 hover:bg-gray-200'
+                          }`}
+                        >
+                          <ArrowDown className="h-3 w-3" />
+                        </button>
                       </div>
-                    </div>
 
-                    {/* Delete */}
-                    <button
-                      type="button"
-                      onClick={() => removeRule(index)}
-                      disabled={isLoading}
-                      className={`rounded p-1.5 transition-colors ${
-                        isDarkMode
-                          ? 'text-red-400 hover:bg-red-900/20'
-                          : 'text-red-500 hover:bg-red-50'
-                      }`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
+                      {/* Rule number */}
+                      <div
+                        className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
+                          isDarkMode
+                            ? 'bg-gray-600 text-gray-300'
+                            : 'bg-gray-200 text-gray-600'
+                        }`}
+                      >
+                        {index + 1}
+                      </div>
+
+                      {/* Fields */}
+                      <div className="flex-1 space-y-3">
+                        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                          <div>
+                            <label
+                              className={`mb-1 block text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                            >
+                              Filter Expression (CEL){' '}
+                              <span className="text-red-500">*</span>
+                            </label>
+                            <Input
+                              value={rule.filter_expression}
+                              onChange={(e) =>
+                                updateRuleField(
+                                  index,
+                                  'filter_expression',
+                                  e.target.value,
+                                )
+                              }
+                              placeholder='e.g., body.action == "push"'
+                              disabled={isLoading}
+                              className={`font-mono text-sm ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                                errors[`rule_${index}_filter`]
+                                  ? 'border-red-500'
+                                  : ''
+                              }`}
+                            />
+                            {errors[`rule_${index}_filter`] && (
+                              <div
+                                className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                              >
+                                <AlertCircle className="h-3 w-3" />
+                                {errors[`rule_${index}_filter`]}
+                              </div>
+                            )}
+                          </div>
+                          <div>
+                            <label
+                              className={`mb-1 block text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                            >
+                              Handler <span className="text-red-500">*</span>
+                            </label>
+                            <Input
+                              value={rule.handler}
+                              onChange={(e) =>
+                                updateRuleField(
+                                  index,
+                                  'handler',
+                                  e.target.value,
+                                )
+                              }
+                              placeholder="e.g., imbi_gateway.handlers.sync_project"
+                              disabled={isLoading}
+                              className={`font-mono text-sm ${isDarkMode ? 'border-gray-600 bg-gray-700 text-white' : ''} ${
+                                errors[`rule_${index}_handler`]
+                                  ? 'border-red-500'
+                                  : ''
+                              }`}
+                            />
+                            {errors[`rule_${index}_handler`] && (
+                              <div
+                                className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                              >
+                                <AlertCircle className="h-3 w-3" />
+                                {errors[`rule_${index}_handler`]}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <label
+                            className={`mb-1 block text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+                          >
+                            Handler Config (JSON)
+                          </label>
+                          <textarea
+                            defaultValue={JSON.stringify(
+                              rule.handler_config,
+                              null,
+                              2,
+                            )}
+                            onBlur={(e) =>
+                              updateRuleConfig(index, e.target.value)
+                            }
+                            rows={6}
+                            disabled={isLoading}
+                            placeholder="{}"
+                            className={`w-full resize-y rounded-lg border px-3 py-2 font-mono text-sm ${
+                              isDarkMode
+                                ? 'border-gray-600 bg-gray-700 text-white placeholder:text-gray-400'
+                                : 'border-gray-300 bg-white text-gray-900 placeholder:text-gray-500'
+                            } ${errors[`rule_${index}_config`] ? 'border-red-500' : ''}`}
+                          />
+                          {errors[`rule_${index}_config`] && (
+                            <div
+                              className={`mt-1 flex items-center gap-1 text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                            >
+                              <AlertCircle className="h-3 w-3" />
+                              {errors[`rule_${index}_config`]}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Delete */}
+                      <button
+                        type="button"
+                        onClick={() => removeRule(index)}
+                        disabled={isLoading}
+                        className={`rounded p-1.5 transition-colors ${
+                          isDarkMode
+                            ? 'text-red-400 hover:bg-red-900/20'
+                            : 'text-red-500 hover:bg-red-50'
+                        }`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </form>
     </div>
   )

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, type MouseEvent, type ReactNode } from 'react'
 import { Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from './button'
@@ -33,7 +33,7 @@ export interface AdminTableColumn<T> {
   header: string
   headerAlign?: 'left' | 'center' | 'right'
   cellAlign?: 'left' | 'center' | 'right'
-  render: (row: T) => React.ReactNode
+  render: (row: T) => ReactNode
 }
 
 export interface CanDeleteResult {
@@ -51,7 +51,7 @@ interface AdminTableProps<T> {
   onDelete: (row: T) => void
   canDelete?: (row: T) => CanDeleteResult
   isDeleting?: boolean
-  actions?: (row: T) => React.ReactNode
+  actions?: (row: T) => ReactNode
   emptyMessage?: string
 }
 
@@ -81,8 +81,18 @@ export function AdminTable<T>({
   emptyMessage = 'No items found.',
 }: AdminTableProps<T>) {
   const [deleteTarget, setDeleteTarget] = useState<T | null>(null)
+  const [wasDeleting, setWasDeleting] = useState(false)
 
-  const handleDeleteClick = (row: T, e: React.MouseEvent) => {
+  useEffect(() => {
+    if (isDeleting) {
+      setWasDeleting(true)
+    } else if (wasDeleting) {
+      setWasDeleting(false)
+      setDeleteTarget(null)
+    }
+  }, [isDeleting, wasDeleting])
+
+  const handleDeleteClick = (row: T, e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     setDeleteTarget(row)
   }
@@ -90,7 +100,7 @@ export function AdminTable<T>({
   const handleDeleteConfirm = () => {
     if (deleteTarget) {
       onDelete(deleteTarget)
-      setDeleteTarget(null)
+      // Don't close here — caller signals success by completing the mutation
     }
   }
 
@@ -99,7 +109,7 @@ export function AdminTable<T>({
       <AlertDialog
         open={deleteTarget !== null}
         onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null)
+          if (!open && !isDeleting) setDeleteTarget(null)
         }}
       >
         <AlertDialogContent>

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -48,6 +48,7 @@ interface AdminTableProps<T> {
   getRowLabel?: (row: T) => string
   getDeleteLabel: (row: T) => string
   onRowClick?: (row: T) => void
+  isRowClickable?: (row: T) => boolean
   onDelete: (row: T) => void
   canDelete?: (row: T) => CanDeleteResult
   isDeleting?: boolean
@@ -74,6 +75,7 @@ export function AdminTable<T>({
   getRowLabel,
   getDeleteLabel,
   onRowClick,
+  isRowClickable,
   onDelete,
   canDelete,
   isDeleting = false,
@@ -171,13 +173,15 @@ export function AdminTable<T>({
                     : { allowed: true }
                   const canDeleteRow = deleteCheck.allowed
                   const deleteReason = deleteCheck.reason
+                  const rowClickable =
+                    onRowClick && (isRowClickable ? isRowClickable(row) : true)
 
                   return (
                     <TableRow
                       key={key}
-                      onClick={onRowClick ? () => onRowClick(row) : undefined}
+                      onClick={rowClickable ? () => onRowClick(row) : undefined}
                       onKeyDown={
-                        onRowClick
+                        rowClickable
                           ? (e) => {
                               if (e.currentTarget !== e.target) return
                               if (e.key === 'Enter' || e.key === ' ') {
@@ -187,9 +191,9 @@ export function AdminTable<T>({
                             }
                           : undefined
                       }
-                      tabIndex={onRowClick ? 0 : undefined}
-                      aria-label={onRowClick ? `Edit ${label}` : undefined}
-                      className={cn(onRowClick && 'cursor-pointer')}
+                      tabIndex={rowClickable ? 0 : undefined}
+                      aria-label={rowClickable ? `Edit ${label}` : undefined}
+                      className={cn(rowClickable && 'cursor-pointer')}
                     >
                       {columns.map((col) => (
                         <TableCell

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -1,0 +1,238 @@
+import { useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from './button'
+import { Card, CardContent } from './card'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './alert-dialog'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './tooltip'
+
+export interface AdminTableColumn<T> {
+  key: string
+  header: string
+  headerAlign?: 'left' | 'center' | 'right'
+  cellAlign?: 'left' | 'center' | 'right'
+  render: (row: T) => React.ReactNode
+}
+
+export interface CanDeleteResult {
+  allowed: boolean
+  reason?: string
+}
+
+interface AdminTableProps<T> {
+  columns: AdminTableColumn<T>[]
+  rows: T[]
+  getRowKey: (row: T) => string
+  getRowLabel?: (row: T) => string
+  getDeleteLabel: (row: T) => string
+  onRowClick?: (row: T) => void
+  onDelete: (row: T) => void
+  canDelete?: (row: T) => CanDeleteResult
+  isDeleting?: boolean
+  actions?: (row: T) => React.ReactNode
+  emptyMessage?: string
+}
+
+const HEADER_ALIGN: Record<string, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+}
+
+const CELL_ALIGN: Record<string, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+}
+
+export function AdminTable<T>({
+  columns,
+  rows,
+  getRowKey,
+  getRowLabel,
+  getDeleteLabel,
+  onRowClick,
+  onDelete,
+  canDelete,
+  isDeleting = false,
+  actions,
+  emptyMessage = 'No items found.',
+}: AdminTableProps<T>) {
+  const [deleteTarget, setDeleteTarget] = useState<T | null>(null)
+
+  const handleDeleteClick = (row: T, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setDeleteTarget(row)
+  }
+
+  const handleDeleteConfirm = () => {
+    if (deleteTarget) {
+      onDelete(deleteTarget)
+      setDeleteTarget(null)
+    }
+  }
+
+  return (
+    <>
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete &quot;{deleteTarget ? getDeleteLabel(deleteTarget) : ''}
+              &quot;?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                {columns.map((col) => (
+                  <TableHead
+                    key={col.key}
+                    className={HEADER_ALIGN[col.headerAlign ?? 'left']}
+                  >
+                    {col.header}
+                  </TableHead>
+                ))}
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={columns.length + 1}
+                    className="py-12 text-center text-muted-foreground"
+                  >
+                    {emptyMessage}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((row) => {
+                  const key = getRowKey(row)
+                  const label = getRowLabel
+                    ? getRowLabel(row)
+                    : getDeleteLabel(row)
+                  const deleteCheck = canDelete
+                    ? canDelete(row)
+                    : { allowed: true }
+                  const canDeleteRow = deleteCheck.allowed
+                  const deleteReason = deleteCheck.reason
+
+                  return (
+                    <TableRow
+                      key={key}
+                      onClick={onRowClick ? () => onRowClick(row) : undefined}
+                      onKeyDown={
+                        onRowClick
+                          ? (e) => {
+                              if (e.currentTarget !== e.target) return
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                onRowClick(row)
+                              }
+                            }
+                          : undefined
+                      }
+                      tabIndex={onRowClick ? 0 : undefined}
+                      aria-label={onRowClick ? `Edit ${label}` : undefined}
+                      className={cn(onRowClick && 'cursor-pointer')}
+                    >
+                      {columns.map((col) => (
+                        <TableCell
+                          key={col.key}
+                          className={CELL_ALIGN[col.cellAlign ?? 'left']}
+                        >
+                          {col.render(row)}
+                        </TableCell>
+                      ))}
+                      <TableCell
+                        className="text-right"
+                        onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => e.stopPropagation()}
+                      >
+                        <div className="flex items-center justify-end gap-2">
+                          {actions && actions(row)}
+                          <TooltipProvider delayDuration={200}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="inline-flex">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    aria-label={`Delete ${label}`}
+                                    onClick={(e) => handleDeleteClick(row, e)}
+                                    disabled={isDeleting || !canDeleteRow}
+                                    className={cn(
+                                      'text-destructive hover:bg-destructive/10 hover:text-destructive',
+                                      (!canDeleteRow || isDeleting) &&
+                                        'pointer-events-none opacity-30',
+                                    )}
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </Button>
+                                </span>
+                              </TooltipTrigger>
+                              {deleteReason && (
+                                <TooltipContent>
+                                  <p>{deleteReason}</p>
+                                </TooltipContent>
+                              )}
+                            </Tooltip>
+                          </TooltipProvider>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </>
+  )
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react'
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/ui/button'
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-2 text-center sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = 'AlertDialogHeader'
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = 'AlertDialogFooter'
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold', className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: 'outline' }),
+      'mt-2 sm:mt-0',
+      className,
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -34,10 +34,7 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn(
-      'text-2xl font-semibold leading-none tracking-tight',
-      className,
-    )}
+    className={cn('text-sm font-medium leading-none', className)}
     {...props}
   />
 ))

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,51 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './dialog'
+import { Button } from './button'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  description?: string
+  confirmLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description = 'This action cannot be undone.',
+  confirmLabel = 'Delete',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(open) => {
+        if (!open) onCancel()
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn('w-full caption-bottom text-sm', className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = 'Table'
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+))
+TableHeader.displayName = 'TableHeader'
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+))
+TableBody.displayName = 'TableBody'
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
+      className,
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = 'TableFooter'
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+      className,
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = 'TableRow'
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      className,
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = 'TableHead'
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    {...props}
+  />
+))
+TableCell.displayName = 'TableCell'
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn('mt-4 text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+TableCaption.displayName = 'TableCaption'
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/hooks/useAdminNav.ts
+++ b/src/hooks/useAdminNav.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 
 export type ViewMode = 'list' | 'create' | 'edit' | 'detail'
@@ -48,6 +48,12 @@ export function useAdminNav(): AdminNavState {
     (s: string) => navigate(`${base}/${encodeURIComponent(s)}/edit`),
     [navigate, base],
   )
+
+  useEffect(() => {
+    if (viewMode === 'edit' || viewMode === 'create') {
+      window.scrollTo({ top: 0, behavior: 'instant' })
+    }
+  }, [viewMode])
 
   return {
     viewMode,


### PR DESCRIPTION
## Summary
Prevent accidental deletion of entities that still have associated data by disabling the trash icon when dependent records exist.

## Problem
The delete button in admin tables was always enabled regardless of whether the entity had associated items. Deleting a project type with active projects, or a team with members or projects, would either fail with an error or cause data integrity issues.

## Solution
- **Project Types**: disable the trash icon when `relationships.projects.count > 0`; hovering shows "Cannot delete: has N project(s)"
- **Teams**: disable the trash icon when `relationships.members.count > 0` or `relationships.projects.count > 0`; tooltip lists whichever counts are non-zero

Both buttons use `disabled:opacity-30` so the visual state clearly communicates that deletion is blocked.

## Impact
Users can only delete project types and teams with zero associated items. The tooltip on hover explains why deletion is blocked.