### PR TITLE
Improve delete UX and icon picker experience

### DIFF
--- a/src/components/admin/EnvironmentManagement.tsx
+++ b/src/components/admin/EnvironmentManagement.tsx
@@ -118,7 +118,10 @@ export function EnvironmentManagement({
   const canDeleteEnvironment = (env: Environment): CanDeleteResult => {
     const projects = env.relationships?.projects?.count ?? 0
     if (projects === 0) return { allowed: true }
-    return { allowed: false, reason: `Has ${projects} project(s)` }
+    return {
+      allowed: false,
+      blockedBy: [{ count: projects, label: 'project', href: '/projects' }],
+    }
   }
 
   const handleSave = (formOrgSlug: string, envData: EnvironmentCreate) => {
@@ -277,7 +280,7 @@ export function EnvironmentManagement({
             render: (env) =>
               env.label_color ? (
                 <span
-                  className="rounded px-2 py-1 text-xs font-medium"
+                  className="whitespace-nowrap rounded px-2 py-1 text-xs font-medium"
                   style={{
                     backgroundColor: env.label_color + '20',
                     color: env.label_color,
@@ -288,7 +291,7 @@ export function EnvironmentManagement({
                 </span>
               ) : (
                 <code
-                  className={`rounded px-2 py-1 ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`}
+                  className={`whitespace-nowrap rounded px-2 py-1 ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`}
                 >
                   {env.slug}
                 </code>

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiError } from '@/api/client'
 import { Plus, Search, Link2, AlertCircle } from 'lucide-react'
-import { getIcon } from '@/lib/icons'
+import { EntityIcon } from '@/components/ui/entity-icon'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -116,7 +116,10 @@ export function LinkDefinitionManagement({
   ): CanDeleteResult => {
     const projects = ld.relationships?.projects?.count ?? 0
     if (projects === 0) return { allowed: true }
-    return { allowed: false, reason: `Has ${projects} project(s)` }
+    return {
+      allowed: false,
+      blockedBy: [{ count: projects, label: 'project', href: '/projects' }],
+    }
   }
 
   const handleSave = (formOrgSlug: string, data: LinkDefinitionCreate) => {
@@ -243,9 +246,16 @@ export function LinkDefinitionManagement({
                 <div
                   className={`flex size-8 flex-shrink-0 items-center justify-center rounded-lg ${isDarkMode ? 'bg-blue-900/30' : 'bg-blue-50'}`}
                 >
-                  <Link2
-                    className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
-                  />
+                  {ld.icon ? (
+                    <EntityIcon
+                      icon={ld.icon}
+                      className="size-5 object-cover"
+                    />
+                  ) : (
+                    <Link2
+                      className={`h-4 w-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+                    />
+                  )}
                 </div>
                 <div>
                   <div className={isDarkMode ? 'text-white' : 'text-gray-900'}>
@@ -274,34 +284,6 @@ export function LinkDefinitionManagement({
                 {ld.slug}
               </code>
             ),
-          },
-          {
-            key: 'icon',
-            header: 'Icon',
-            headerAlign: 'center',
-            cellAlign: 'center',
-            render: (ld) => {
-              if (!ld.icon)
-                return (
-                  <span
-                    className={isDarkMode ? 'text-gray-600' : 'text-gray-400'}
-                  >
-                    --
-                  </span>
-                )
-              const Icon = getIcon(ld.icon, null)
-              return Icon ? (
-                <Icon
-                  className={`mx-auto h-5 w-5 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
-                />
-              ) : (
-                <span
-                  className={`text-xs ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
-                >
-                  {ld.icon}
-                </span>
-              )
-            },
           },
           {
             key: 'url_template',

--- a/src/components/admin/OrganizationManagement.tsx
+++ b/src/components/admin/OrganizationManagement.tsx
@@ -55,7 +55,7 @@ export function OrganizationManagement({
     if (teamCount > 0) {
       return {
         allowed: false,
-        blockedBy: [{ count: teamCount, label: 'team' }],
+        blockedBy: [{ count: teamCount, label: 'team', href: '/admin/teams' }],
       }
     }
     return { allowed: true }

--- a/src/components/admin/OrganizationManagement.tsx
+++ b/src/components/admin/OrganizationManagement.tsx
@@ -53,7 +53,10 @@ export function OrganizationManagement({
     }
     const teamCount = org.relationships?.teams?.count ?? 0
     if (teamCount > 0) {
-      return { allowed: false, reason: `Has ${teamCount} team(s)` }
+      return {
+        allowed: false,
+        blockedBy: [{ count: teamCount, label: 'team' }],
+      }
     }
     return { allowed: true }
   }

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -113,7 +113,10 @@ export function ProjectTypeManagement({
   ): CanDeleteResult => {
     const projects = pt.relationships?.projects?.count ?? 0
     if (projects === 0) return { allowed: true }
-    return { allowed: false, reason: `Has ${projects} project(s)` }
+    return {
+      allowed: false,
+      blockedBy: [{ count: projects, label: 'project', href: '/projects' }],
+    }
   }
 
   const handleSave = (formOrgSlug: string, ptData: ProjectTypeCreate) => {

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -107,11 +107,13 @@ export function TeamManagement({ isDarkMode }: TeamManagementProps) {
     const projects = team.relationships?.projects?.count ?? 0
     const members = team.relationships?.members?.count ?? 0
     if (projects === 0 && members === 0) return { allowed: true }
-    const parts = [
-      projects > 0 ? `${projects} project(s)` : '',
-      members > 0 ? `${members} member(s)` : '',
-    ].filter(Boolean)
-    return { allowed: false, reason: `Has ${parts.join(' and ')}` }
+    const blockedBy = [
+      ...(projects > 0
+        ? [{ count: projects, label: 'project', href: '/projects' }]
+        : []),
+      ...(members > 0 ? [{ count: members, label: 'member' }] : []),
+    ]
+    return { allowed: false, blockedBy }
   }
 
   const handleSave = (formOrgSlug: string, teamData: TeamCreate) => {

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -350,9 +350,7 @@ export function EnvironmentForm({
                   </p>
                   <IconPicker
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
+                      !icon.startsWith('/') && !icon.startsWith('http')
                         ? icon
                         : ''
                     }
@@ -368,11 +366,9 @@ export function EnvironmentForm({
                   </p>
                   <IconUpload
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
-                        ? ''
-                        : icon
+                      icon.startsWith('/') || icon.startsWith('http')
+                        ? icon
+                        : ''
                     }
                     onChange={handleIconChange}
                     isDarkMode={isDarkMode}

--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -283,9 +283,7 @@ export function LinkDefinitionForm({
                   </p>
                   <IconPicker
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
+                      !icon.startsWith('/') && !icon.startsWith('http')
                         ? icon
                         : ''
                     }
@@ -301,11 +299,9 @@ export function LinkDefinitionForm({
                   </p>
                   <IconUpload
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
-                        ? ''
-                        : icon
+                      icon.startsWith('/') || icon.startsWith('http')
+                        ? icon
+                        : ''
                     }
                     onChange={handleIconChange}
                     isDarkMode={isDarkMode}

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -320,9 +320,7 @@ export function ProjectTypeForm({
                   </p>
                   <IconPicker
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
+                      !icon.startsWith('/') && !icon.startsWith('http')
                         ? icon
                         : ''
                     }
@@ -338,11 +336,9 @@ export function ProjectTypeForm({
                   </p>
                   <IconUpload
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
-                        ? ''
-                        : icon
+                      icon.startsWith('/') || icon.startsWith('http')
+                        ? icon
+                        : ''
                     }
                     onChange={handleIconChange}
                     isDarkMode={isDarkMode}

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -314,9 +314,7 @@ export function TeamForm({
                   </p>
                   <IconPicker
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
+                      !icon.startsWith('/') && !icon.startsWith('http')
                         ? icon
                         : ''
                     }
@@ -332,11 +330,9 @@ export function TeamForm({
                   </p>
                   <IconUpload
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
-                        ? ''
-                        : icon
+                      icon.startsWith('/') || icon.startsWith('http')
+                        ? icon
+                        : ''
                     }
                     onChange={handleIconChange}
                     isDarkMode={isDarkMode}

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -409,9 +409,7 @@ export function ThirdPartyServiceForm({
                   </p>
                   <IconPicker
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
+                      !icon.startsWith('/') && !icon.startsWith('http')
                         ? icon
                         : ''
                     }
@@ -427,11 +425,9 @@ export function ThirdPartyServiceForm({
                   </p>
                   <IconUpload
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
-                        ? ''
-                        : icon
+                      icon.startsWith('/') || icon.startsWith('http')
+                        ? icon
+                        : ''
                     }
                     onChange={handleIconChange}
                     isDarkMode={isDarkMode}

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -408,9 +408,7 @@ export function WebhookForm({
                   </p>
                   <IconPicker
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
+                      !icon.startsWith('/') && !icon.startsWith('http')
                         ? icon
                         : ''
                     }
@@ -426,11 +424,9 @@ export function WebhookForm({
                   </p>
                   <IconUpload
                     value={
-                      icon.startsWith('si-') ||
-                      icon.startsWith('lucide-') ||
-                      icon.startsWith('aws-')
-                        ? ''
-                        : icon
+                      icon.startsWith('/') || icon.startsWith('http')
+                        ? icon
+                        : ''
                     }
                     onChange={handleIconChange}
                     isDarkMode={isDarkMode}

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, type MouseEvent, type ReactNode } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from './button'
@@ -13,6 +14,14 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from './alert-dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './dialog'
 import {
   Table,
   TableBody,
@@ -36,9 +45,16 @@ export interface AdminTableColumn<T> {
   render: (row: T) => ReactNode
 }
 
+export interface BlockedReason {
+  count: number
+  label: string // e.g. "project", "team", "member"
+  href?: string // optional link to filtered view
+}
+
 export interface CanDeleteResult {
   allowed: boolean
-  reason?: string
+  reason?: string // free-form fallback (system roles, etc.)
+  blockedBy?: BlockedReason[] // structured blocking conditions
 }
 
 interface AdminTableProps<T> {
@@ -82,7 +98,12 @@ export function AdminTable<T>({
   actions,
   emptyMessage = 'No items found.',
 }: AdminTableProps<T>) {
+  const navigate = useNavigate()
   const [deleteTarget, setDeleteTarget] = useState<T | null>(null)
+  const [blockedTarget, setBlockedTarget] = useState<{
+    row: T
+    result: CanDeleteResult
+  } | null>(null)
   const [wasDeleting, setWasDeleting] = useState(false)
 
   useEffect(() => {
@@ -94,9 +115,17 @@ export function AdminTable<T>({
     }
   }, [isDeleting, wasDeleting])
 
-  const handleDeleteClick = (row: T, e: MouseEvent<HTMLButtonElement>) => {
+  const handleDeleteClick = (
+    row: T,
+    e: MouseEvent<HTMLButtonElement>,
+    deleteCheck: CanDeleteResult,
+  ) => {
     e.stopPropagation()
-    setDeleteTarget(row)
+    if (!deleteCheck.allowed) {
+      setBlockedTarget({ row, result: deleteCheck })
+    } else {
+      setDeleteTarget(row)
+    }
   }
 
   const handleDeleteConfirm = () => {
@@ -108,6 +137,78 @@ export function AdminTable<T>({
 
   return (
     <>
+      <Dialog
+        open={blockedTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setBlockedTarget(null)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Restricted</DialogTitle>
+            <DialogDescription>
+              This item cannot be deleted at this time.
+            </DialogDescription>
+          </DialogHeader>
+          {blockedTarget &&
+            (() => {
+              const name = getDeleteLabel(blockedTarget.row)
+              const { blockedBy, reason } = blockedTarget.result
+              if (blockedBy && blockedBy.length > 0) {
+                const parts = blockedBy.map((b, i) => (
+                  <span key={i}>
+                    {b.href ? (
+                      <button
+                        className="font-medium text-primary underline underline-offset-2 hover:opacity-80"
+                        onClick={() => {
+                          setBlockedTarget(null)
+                          navigate(b.href!)
+                        }}
+                      >
+                        {b.count} {b.label}
+                        {b.count !== 1 ? 's' : ''}
+                      </button>
+                    ) : (
+                      <span className="font-medium">
+                        {b.count} {b.label}
+                        {b.count !== 1 ? 's' : ''}
+                      </span>
+                    )}
+                  </span>
+                ))
+                const joined = parts.reduce<ReactNode[]>((acc, el, i) => {
+                  if (i === 0) return [el]
+                  if (i === parts.length - 1) return [...acc, ' and ', el]
+                  return [...acc, ', ', el]
+                }, [])
+                return (
+                  <p className="text-sm">
+                    <span className="font-semibold">{name}</span> cannot be
+                    deleted because it is referenced by {joined}. Remove or
+                    reassign
+                    {blockedBy.length === 1
+                      ? ` those ${blockedBy[0].label}s`
+                      : ' them'}{' '}
+                    before deleting this item.
+                  </p>
+                )
+              }
+              return (
+                <p className="text-sm">
+                  <span className="font-semibold">{name}</span> cannot be
+                  deleted
+                  {reason
+                    ? `: ${reason.toLowerCase().replace(/^cannot delete the only /, 'because it is the only ')}.`
+                    : '.'}
+                </p>
+              )
+            })()}
+          <DialogFooter>
+            <Button onClick={() => setBlockedTarget(null)}>OK</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <AlertDialog
         open={deleteTarget !== null}
         onOpenChange={(open) => {
@@ -218,12 +319,15 @@ export function AdminTable<T>({
                                     variant="ghost"
                                     size="sm"
                                     aria-label={`Delete ${label}`}
-                                    onClick={(e) => handleDeleteClick(row, e)}
-                                    disabled={isDeleting || !canDeleteRow}
+                                    onClick={(e) =>
+                                      handleDeleteClick(row, e, deleteCheck)
+                                    }
+                                    disabled={isDeleting}
                                     className={cn(
                                       'text-destructive hover:bg-destructive/10 hover:text-destructive',
-                                      (!canDeleteRow || isDeleting) &&
+                                      isDeleting &&
                                         'pointer-events-none opacity-30',
+                                      !canDeleteRow && 'opacity-30',
                                     )}
                                   >
                                     <Trash2 className="h-4 w-4" />

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -187,7 +187,9 @@ export function AdminTable<T>({
                     deleted because it is referenced by {joined}. Remove or
                     reassign
                     {blockedBy.length === 1
-                      ? ` those ${blockedBy[0].label}s`
+                      ? blockedBy[0].count === 1
+                        ? ` that ${blockedBy[0].label}`
+                        : ` those ${blockedBy[0].label}s`
                       : ' them'}{' '}
                     before deleting this item.
                   </p>

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card'
+import { cn } from '@/lib/utils'
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/src/components/ui/icon-picker.tsx
+++ b/src/components/ui/icon-picker.tsx
@@ -2,6 +2,11 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { Search, X } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from '@/components/ui/hover-card'
 import { getIcon, iconRegistry } from '@/lib/icons'
 import type { IconComponent } from '@/lib/icons'
 
@@ -143,7 +148,6 @@ export function IconPicker({ value, onChange, isDarkMode }: IconPickerProps) {
                   type="button"
                   onClick={() => {
                     setIconSet(set.id)
-                    setQuery('')
                   }}
                   className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
                     iconSet === set.id
@@ -192,27 +196,43 @@ export function IconPicker({ value, onChange, isDarkMode }: IconPickerProps) {
                   if (!Icon) return null
                   const isSelected = value === icon.value
                   return (
-                    <button
+                    <HoverCard
                       key={icon.value}
-                      type="button"
-                      title={icon.value}
-                      onClick={() => handleSelect(icon.value)}
-                      className={`flex h-10 w-full items-center justify-center rounded-md transition-colors ${
-                        isSelected
-                          ? isDarkMode
-                            ? 'bg-blue-600/30 ring-1 ring-blue-500'
-                            : 'bg-blue-50 ring-1 ring-blue-400'
-                          : isDarkMode
-                            ? 'hover:bg-gray-700'
-                            : 'hover:bg-gray-100'
-                      }`}
+                      openDelay={300}
+                      closeDelay={100}
                     >
-                      <Icon
-                        className={`h-5 w-5 ${
-                          isDarkMode ? 'text-gray-300' : 'text-gray-700'
-                        }`}
-                      />
-                    </button>
+                      <HoverCardTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => handleSelect(icon.value)}
+                          className={`flex h-10 w-full items-center justify-center rounded-md transition-colors ${
+                            isSelected
+                              ? isDarkMode
+                                ? 'bg-blue-600/30 ring-1 ring-blue-500'
+                                : 'bg-blue-50 ring-1 ring-blue-400'
+                              : isDarkMode
+                                ? 'hover:bg-gray-700'
+                                : 'hover:bg-gray-100'
+                          }`}
+                        >
+                          <Icon
+                            className={`h-5 w-5 ${
+                              isDarkMode ? 'text-gray-300' : 'text-gray-700'
+                            }`}
+                          />
+                        </button>
+                      </HoverCardTrigger>
+                      <HoverCardContent className="w-auto p-4" side="top">
+                        <div className="flex flex-col items-center gap-3">
+                          <Icon
+                            className={`h-20 w-20 ${isDarkMode ? 'text-gray-200' : 'text-gray-800'}`}
+                          />
+                          <span className="max-w-[180px] break-all text-center text-sm text-muted-foreground">
+                            {icon.label}
+                          </span>
+                        </div>
+                      </HoverCardContent>
+                    </HoverCard>
                   )
                 })}
               </div>

--- a/src/components/ui/icon-upload.tsx
+++ b/src/components/ui/icon-upload.tsx
@@ -32,7 +32,8 @@ export function IconUpload({
     mutationFn: deleteUpload,
   })
 
-  const isImageUrl = value && value.length > 0
+  const isImageUrl =
+    value != null && (value.startsWith('/') || value.startsWith('http'))
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,14 +18,14 @@ export const NODE_BASE_FIELDS = [
 export const NODE_BASE_FIELDS_SET = new Set(NODE_BASE_FIELDS)
 
 // Re-export under model-specific names for clarity in imports
-export const TEAM_BASE_FIELDS = NODE_BASE_FIELDS
-export const TEAM_BASE_FIELDS_SET = NODE_BASE_FIELDS_SET
+export const TEAM_BASE_FIELDS = [...NODE_BASE_FIELDS, 'id']
+export const TEAM_BASE_FIELDS_SET = new Set(TEAM_BASE_FIELDS)
 
 export const ENVIRONMENT_BASE_FIELDS = [...NODE_BASE_FIELDS, 'sort_order', 'id']
 export const ENVIRONMENT_BASE_FIELDS_SET = new Set(ENVIRONMENT_BASE_FIELDS)
 
-export const PROJECT_TYPE_BASE_FIELDS = NODE_BASE_FIELDS
-export const PROJECT_TYPE_BASE_FIELDS_SET = NODE_BASE_FIELDS_SET
+export const PROJECT_TYPE_BASE_FIELDS = [...NODE_BASE_FIELDS, 'id']
+export const PROJECT_TYPE_BASE_FIELDS_SET = new Set(PROJECT_TYPE_BASE_FIELDS)
 
 export const PROJECT_BASE_FIELDS = [
   ...NODE_BASE_FIELDS,

--- a/src/lib/icon-sets/devicon.ts
+++ b/src/lib/icon-sets/devicon.ts
@@ -1,6 +1,6 @@
+import { createElement } from 'react'
 import { iconRegistry } from '@/lib/icon-registry'
 import type { IconComponent, IconEntry } from '@/lib/icon-registry'
-import { createImgComponent } from '@/lib/icon-sets/utils'
 
 const deviconGlob = import.meta.glob<string>(
   '/node_modules/devicon/icons/**/*.svg',
@@ -15,17 +15,53 @@ for (const [path, url] of Object.entries(deviconGlob)) {
   deviconIndex[`devicon-${name}`] = url
 }
 
-export const DEVICON_ICONS: IconEntry[] = Object.entries(deviconIndex)
-  .map(([value]) => ({
-    label: value.slice(8).replace(/-/g, ' '), // strip "devicon-" → "javascript original"
-    value,
-  }))
+// For the picker: one monochrome icon per tech, preferring -plain over -line.
+// Collect which techs have plain/line variants, then pick one per tech.
+const techVariants: Record<string, { plain?: string; line?: string }> = {}
+for (const key of Object.keys(deviconIndex)) {
+  if (key.endsWith('-plain')) {
+    const tech = key.slice(8, -6) // strip "devicon-" and "-plain"
+    if (!techVariants[tech]) techVariants[tech] = {}
+    techVariants[tech].plain = key
+  } else if (key.endsWith('-line')) {
+    const tech = key.slice(8, -5) // strip "devicon-" and "-line"
+    if (!techVariants[tech]) techVariants[tech] = {}
+    techVariants[tech].line = key
+  }
+}
+
+export const DEVICON_ICONS: IconEntry[] = Object.entries(techVariants)
+  .map(([, variants]) => {
+    const value = variants.line ?? variants.plain!
+    const tech = value.slice(8).replace(/-plain$|-line$/, '') // strip prefix+variant
+    return { label: tech.replace(/-/g, ' '), value }
+  })
   .sort((a, b) => a.label.localeCompare(b.label))
+
+function createGrayscaleImg(url: string): IconComponent {
+  const Img: IconComponent = (props) => {
+    const { className, width, height, ...rest } = props as Record<
+      string,
+      unknown
+    >
+    return createElement('img', {
+      src: url,
+      alt: '',
+      className,
+      style: { filter: 'brightness(0)' },
+      width: width ?? 16,
+      height: height ?? 16,
+      ...rest,
+    })
+  }
+  return Img
+}
 
 function resolve(value: string): IconComponent | null {
   if (!value.startsWith('devicon-')) return null
   const url = deviconIndex[value]
-  return url ? createImgComponent(url) : null
+  if (!url) return null
+  return createGrayscaleImg(url)
 }
 
 function resolveUrl(value: string): string | null {


### PR DESCRIPTION
## Summary

- Replace disabled delete buttons with a \"Delete Restricted\" dialog that explains what is blocking deletion and links to those items
- Deduplicate Devicon entries to one monochrome icon per technology with a grayscale filter
- Add HoverCard preview to the icon picker showing an enlarged icon on hover
- Simplify icon-vs-upload detection in all admin forms to use URL prefix instead of enumerating icon set prefixes

## Problem

The delete button being silently disabled gave no feedback about *why* an item couldn't be deleted or what to do about it. Icon picker showed all Devicon variants (colored originals plus plain/line duplicates), making it hard to browse. The icon/upload split logic in forms enumerated specific icon set prefixes (`si-`, `lucide-`, `aws-`) which broke when Devicon (`devicon-`) icons were added.

## Solution

- `AdminTable` now allows clicking the delete button regardless of `canDelete` result. If deletion is blocked, a modal explains the reason with structured `BlockedReason` entries (count, label, optional navigation link). The `CanDeleteResult` type gains `blockedBy?: BlockedReason[]` alongside the existing free-form `reason` fallback.
- All admin management components updated to return structured `blockedBy` arrays instead of string reasons.
- Devicon set now picks one icon per technology (preferring `-line` over `-plain`) and renders it with `filter: brightness(0)` for consistent monochrome display.
- Icon picker wraps each icon button in a `HoverCard` showing a large (80×80) preview with the icon name on hover.
- Forms now detect uploaded images by checking `startsWith('/')` or `startsWith('http')` instead of checking known named-icon prefixes — future icon sets work automatically.
- `TEAM_BASE_FIELDS` and `PROJECT_TYPE_BASE_FIELDS` were sharing the `NODE_BASE_FIELDS` reference; fixed to be independent arrays that include `'id'`.
- Link definition list row now shows the icon inline using `EntityIcon` and removes the redundant separate Icon column.

## Impact

Admin table delete interactions are more informative — users see what is blocking deletion and can navigate directly to the blocking items. Icon picker is cleaner and easier to browse. No API or data-model changes.