### PR TITLE
Use project ID for update and delete API calls

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,6 +26,7 @@ test-coverage:
 
 # Run TypeScript type checking and build for production
 build:
+    [ -e ./node_modules/.bin/browserslist ] || npm ci
     npm run build
 
 # Preview production build

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -161,22 +161,17 @@ export const createProject = (
 
 export const updateProject = (
   orgSlug: string,
-  projectTypeSlug: string,
-  slug: string,
+  projectId: string,
   project: Partial<ProjectCreate>,
 ) =>
   apiClient.put<Project>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectTypeSlug)}/${encodeURIComponent(slug)}`,
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
     project,
   )
 
-export const deleteProject = (
-  orgSlug: string,
-  projectTypeSlug: string,
-  slug: string,
-) =>
+export const deleteProject = (orgSlug: string, projectId: string) =>
   apiClient.delete<void>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectTypeSlug)}/${encodeURIComponent(slug)}`,
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
   )
 
 // Link Definitions (org-scoped)

--- a/src/components/EditProjectForm.tsx
+++ b/src/components/EditProjectForm.tsx
@@ -89,12 +89,9 @@ export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
     setDynamicData(initial)
   }, [editableSchema, project])
 
-  const projectTypeSlug =
-    project.project_type?.slug ?? project.project_types?.[0]?.slug ?? ''
-
   const mutation = useMutation({
     mutationFn: (payload: Record<string, unknown>) =>
-      updateProject(orgSlug, projectTypeSlug, project.slug, payload),
+      updateProject(orgSlug, project.id, payload),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['project', orgSlug, project.id],
@@ -107,10 +104,6 @@ export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
 
   const handleSave = () => {
     const newErrors: Record<string, string> = {}
-
-    if (!projectTypeSlug) {
-      newErrors.projectType = 'Project type is missing'
-    }
 
     if (!name.trim()) {
       newErrors.name = 'Name is required'
@@ -246,7 +239,7 @@ export function EditProjectForm({ project, isDarkMode }: EditProjectFormProps) {
           size="sm"
           className="border-amber-border bg-amber-bg text-amber-text hover:bg-amber-bg/80"
           onClick={handleSave}
-          disabled={mutation.isPending || !projectTypeSlug}
+          disabled={mutation.isPending}
         >
           {mutation.isPending ? 'Saving...' : 'Save'}
         </Button>

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1110,8 +1110,6 @@ function SettingsTab({
   const orgSlug = selectedOrganization?.slug || ''
   const queryClient = useQueryClient()
   const navigate = useNavigate()
-  const projectTypeSlug =
-    project.project_type?.slug ?? project.project_types?.[0]?.slug ?? ''
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
@@ -1132,45 +1130,28 @@ function SettingsTab({
   }
 
   const linksMutation = useMutation({
-    mutationFn: (links: Record<string, string>) => {
-      if (!orgSlug || !projectTypeSlug)
-        return Promise.reject(new Error('Missing project type'))
-      return updateProject(orgSlug, projectTypeSlug, project.slug, { links })
-    },
+    mutationFn: (links: Record<string, string>) =>
+      updateProject(orgSlug, project.id, { links }),
     onSuccess: invalidateProject,
     onError: mutationErrorHandler('save links'),
   })
 
   const identifiersMutation = useMutation({
-    mutationFn: (identifiers: Record<string, string>) => {
-      if (!orgSlug || !projectTypeSlug)
-        return Promise.reject(new Error('Missing project type'))
-      return updateProject(orgSlug, projectTypeSlug, project.slug, {
-        identifiers,
-      })
-    },
+    mutationFn: (identifiers: Record<string, string>) =>
+      updateProject(orgSlug, project.id, { identifiers }),
     onSuccess: invalidateProject,
     onError: mutationErrorHandler('save identifiers'),
   })
 
   const envMutation = useMutation({
-    mutationFn: (environments: Record<string, Record<string, string>>) => {
-      if (!orgSlug || !projectTypeSlug)
-        return Promise.reject(new Error('Missing project type'))
-      return updateProject(orgSlug, projectTypeSlug, project.slug, {
-        environments,
-      })
-    },
+    mutationFn: (environments: Record<string, Record<string, string>>) =>
+      updateProject(orgSlug, project.id, { environments }),
     onSuccess: invalidateProject,
     onError: mutationErrorHandler('save environments'),
   })
 
   const deleteMutation = useMutation({
-    mutationFn: () => {
-      if (!orgSlug || !projectTypeSlug)
-        return Promise.reject(new Error('Missing project type'))
-      return deleteProject(orgSlug, projectTypeSlug, project.slug)
-    },
+    mutationFn: () => deleteProject(orgSlug, project.id),
     onSuccess: () => navigate('/'),
     onError: mutationErrorHandler('delete project'),
   })
@@ -1290,7 +1271,7 @@ function SettingsTab({
               size="sm"
               className={`bg-red-700 text-white hover:bg-red-800 ${isDarkMode ? 'border-red-700' : 'border-red-300'}`}
               onClick={() => setShowDeleteConfirm(true)}
-              disabled={!projectTypeSlug}
+              disabled={!project.id}
             >
               Delete Project
             </Button>
@@ -1324,8 +1305,7 @@ function SettingsTab({
                   onClick={() => deleteMutation.mutate()}
                   disabled={
                     deleteConfirmSlug !== project.slug ||
-                    deleteMutation.isPending ||
-                    !projectTypeSlug
+                    deleteMutation.isPending
                   }
                 >
                   {deleteMutation.isPending ? 'Deleting...' : 'Confirm Delete'}


### PR DESCRIPTION
## Summary
Switch project update and delete API calls to use the project's numeric ID instead of a compound path of project-type slug and project slug.

## Problem
The `updateProject` and `deleteProject` endpoint functions were building URLs from two path segments — `projectTypeSlug` and `slug` — requiring callers to derive `projectTypeSlug` from the project object before every mutation. This made each mutation site more complex and introduced guards against a "Missing project type" error that should never occur in practice once a project is loaded.

## Solution
- Simplify `updateProject` and `deleteProject` signatures to accept `projectId` only
- Remove `projectTypeSlug` derivation logic from `EditProjectForm` and `ProjectDetail` `SettingsTab`
- Remove now-unnecessary `!projectTypeSlug` disabled states and error guards
- Add a `node_modules` presence check in the `justfile` build recipe to skip redundant `npm ci` runs

## Impact
No user-visible behaviour change. Mutations are simpler and the disabled-button logic is more straightforward.