### PR TITLE
Add Operations Log screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@react-three/fiber": "^9.5.0",
         "@tabler/icons-react": "^3.41.1",
         "@tanstack/react-query": "^5.66.1",
+        "@tanstack/react-virtual": "^3.13.24",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "aws-svg-icons": "^3.0.0-2021-07-30",
@@ -3834,6 +3835,33 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@react-three/fiber": "^9.5.0",
     "@tabler/icons-react": "^3.41.1",
     "@tanstack/react-query": "^5.66.1",
+    "@tanstack/react-virtual": "^3.13.24",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "aws-svg-icons": "^3.0.0-2021-07-30",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster } from 'sonner'
 import { DashboardPage } from './pages/DashboardPage'
 import { ProjectsPage } from './pages/ProjectsPage'
 import { ProjectDetailPage } from './pages/ProjectDetailPage'
+import { OperationsLogPage } from './pages/OperationsLogPage'
 import { AdminPage } from './pages/AdminPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { LoginPage } from './pages/LoginPage'
@@ -102,6 +103,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <ProjectDetailPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/opslog"
+            element={
+              <ProtectedRoute>
+                <OperationsLogPage />
               </ProtectedRoute>
             }
           />

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -251,9 +251,24 @@ export const getActivityFeed = async (params?: {
 }
 
 // Operations Log
+export interface OperationsLogMetrics {
+  event_count: number
+  deploys: number
+  projects: number
+  environments: number
+  team_members: number
+  deploys_by_environment: Record<string, number>
+}
+
 export interface OperationsLogPage {
   entries: OperationsLogRecord[]
+  metrics?: OperationsLogMetrics
   nextCursor?: string
+}
+
+interface OperationsLogEnvelope {
+  metrics: OperationsLogMetrics | null
+  data: OperationsLogRecord[]
 }
 
 function parseNextCursor(headers: Headers): string | undefined {
@@ -277,11 +292,14 @@ export const listOperationsLog = async (params: {
       if (v) query[k] = v
     }
   }
-  const { data, headers } = await apiClient.getWithHeaders<
-    OperationsLogRecord[]
-  >('/operations-log/', query)
+  const { data, headers } =
+    await apiClient.getWithHeaders<OperationsLogEnvelope>(
+      '/operations-log/',
+      query,
+    )
   return {
-    entries: Array.isArray(data) ? data : [],
+    entries: Array.isArray(data?.data) ? data.data : [],
+    metrics: data?.metrics ?? undefined,
     nextCursor: parseNextCursor(headers),
   }
 }

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -276,8 +276,12 @@ function parseNextCursor(headers: Headers): string | undefined {
   if (!link) return undefined
   const match = link.match(/<([^>]+)>;\s*rel="next"/)
   if (!match) return undefined
-  const url = new URL(match[1], window.location.origin)
-  return url.searchParams.get('cursor') || undefined
+  try {
+    const url = new URL(match[1], window.location.origin)
+    return url.searchParams.get('cursor') || undefined
+  } catch {
+    return undefined
+  }
 }
 
 export const listOperationsLog = async (params: {

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -58,6 +58,8 @@ import type {
   ProjectServiceCreate,
   ProjectRelationshipsResponse,
   PatchOperation,
+  OperationsLogRecord,
+  OperationsLogFilters,
 } from '@/types'
 
 // Re-export for backward compatibility with modules that import from here.
@@ -247,6 +249,47 @@ export const getActivityFeed = async (params?: {
     return []
   }
 }
+
+// Operations Log
+export interface OperationsLogPage {
+  entries: OperationsLogRecord[]
+  nextCursor?: string
+}
+
+function parseNextCursor(headers: Headers): string | undefined {
+  const link = headers.get('link')
+  if (!link) return undefined
+  const match = link.match(/<([^>]+)>;\s*rel="next"/)
+  if (!match) return undefined
+  const url = new URL(match[1], window.location.origin)
+  return url.searchParams.get('cursor') || undefined
+}
+
+export const listOperationsLog = async (params: {
+  limit?: number
+  cursor?: string
+  filters?: OperationsLogFilters
+}): Promise<OperationsLogPage> => {
+  const query: Record<string, unknown> = { limit: params.limit ?? 50 }
+  if (params.cursor) query.cursor = params.cursor
+  if (params.filters) {
+    for (const [k, v] of Object.entries(params.filters)) {
+      if (v) query[k] = v
+    }
+  }
+  const { data, headers } = await apiClient.getWithHeaders<
+    OperationsLogRecord[]
+  >('/operations-log/', query)
+  return {
+    entries: Array.isArray(data) ? data : [],
+    nextCursor: parseNextCursor(headers),
+  }
+}
+
+export const getOperationsLogEntry = (entryId: string) =>
+  apiClient.get<OperationsLogRecord>(
+    `/operations-log/${encodeURIComponent(entryId)}`,
+  )
 
 // Metadata
 export const getEnvironments = async (): Promise<Environment[]> => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -75,7 +75,7 @@ export function Navigation({
         id: 'operations',
         label: 'Operations Log',
         icon: Activity,
-        path: '/operations',
+        path: '/opslog',
       },
       { id: 'reports', label: 'Reports', icon: BarChart3, path: '/reports' },
     ]

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -1,6 +1,15 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { GitBranch, List, Search, SearchX, X } from 'lucide-react'
+import {
+  Activity,
+  Download,
+  GitBranch,
+  List,
+  LoaderCircle,
+  Search,
+  SearchX,
+  X,
+} from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -15,9 +24,9 @@ import type {
   Project,
 } from '@/types'
 import {
-  OperationsLogSidebar,
-  type SidebarCounts,
-} from './operations-log/OperationsLogSidebar'
+  OperationsLogToolbar,
+  type ToolbarCounts,
+} from './operations-log/OperationsLogToolbar'
 import { OperationsLogSummary } from './operations-log/OperationsLogSummary'
 import { OperationsLogStreamRow } from './operations-log/OperationsLogStreamRow'
 import { OperationsLogReleaseCard } from './operations-log/OperationsLogReleaseCard'
@@ -25,24 +34,79 @@ import {
   bucketByDay,
   cleanName,
   groupReleases,
-  parseUtcIso,
+  toMs,
   type FeedItem,
   type OperationsLogView,
   type TimeRange,
 } from './operations-log/opsLogHelpers'
 
+// Memoised + WAAPI-driven so the spin animation has its own lifetime
+// independent of React's render cycle and runs on the compositor thread.
+// The CSS `animate-spin` class would be re-applied on every render and
+// can visually stutter / appear to reverse when the main thread blocks;
+// `element.animate(...)` is installed once on mount and never restarts.
+const LoadingIndicator = memo(function LoadingIndicator({
+  loading,
+}: {
+  loading: boolean
+}) {
+  const spinnerRef = useRef<SVGSVGElement | null>(null)
+  useEffect(() => {
+    const el = spinnerRef.current
+    if (!el || typeof el.animate !== 'function') return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    const animation = el.animate(
+      [{ transform: 'rotate(0deg)' }, { transform: 'rotate(360deg)' }],
+      { duration: 1200, iterations: Infinity, easing: 'linear' },
+    )
+    return () => animation.cancel()
+  }, [])
+  return (
+    <span
+      className="relative inline-block h-5 w-5"
+      style={{
+        contain: 'layout paint',
+        transform: 'translateZ(0)',
+        willChange: 'transform',
+      }}
+      aria-label={loading ? 'Loading' : undefined}
+    >
+      <Activity
+        className={cn(
+          'absolute inset-0 h-5 w-5 text-secondary transition-opacity duration-200',
+          loading && 'opacity-0',
+        )}
+        aria-hidden
+      />
+      <LoaderCircle
+        ref={spinnerRef}
+        className={cn(
+          'absolute inset-0 h-5 w-5 text-secondary transition-opacity duration-200',
+          !loading && 'opacity-0',
+        )}
+        style={{
+          transformOrigin: 'center',
+          willChange: 'transform',
+          backfaceVisibility: 'hidden',
+        }}
+        aria-hidden
+      />
+    </span>
+  )
+})
+
 const RANGE_DELTA: Record<Exclude<TimeRange, 'all'>, number> = {
   '24h': 24 * 60 * 60 * 1000,
-  '3d': 3 * 24 * 60 * 60 * 1000,
   '7d': 7 * 24 * 60 * 60 * 1000,
   '30d': 30 * 24 * 60 * 60 * 1000,
+  '90d': 90 * 24 * 60 * 60 * 1000,
 }
 
 const RANGE_LABEL: Record<TimeRange, string> = {
   '24h': 'last 24h',
-  '3d': 'last 3 days',
   '7d': 'last 7 days',
   '30d': 'last 30 days',
+  '90d': 'last 90 days',
   all: 'all time',
 }
 
@@ -60,7 +124,7 @@ interface ScreenFilters {
   q?: string
 }
 
-const DEFAULT_FILTERS: ScreenFilters = { range: '3d' }
+const DEFAULT_FILTERS: ScreenFilters = { range: '30d' }
 
 export function OperationsLog() {
   const { selectedOrganization } = useOrganization()
@@ -69,6 +133,11 @@ export function OperationsLog() {
   const [filters, setFilters] = useState<ScreenFilters>(DEFAULT_FILTERS)
   const [view, setView] = useState<OperationsLogView>('grouped')
   const [openId, setOpenId] = useState<string | undefined>(undefined)
+  // Stable dispatcher — lets memoised row components compare props by
+  // reference without creating a new closure per row per render.
+  const toggleOpen = useCallback((id: string) => {
+    setOpenId((prev) => (prev === id ? undefined : id))
+  }, [])
 
   const { data: projects = [] } = useQuery({
     queryKey: ['projects', orgSlug],
@@ -118,19 +187,25 @@ export function OperationsLog() {
     [data],
   )
 
-  // Eagerly walk all pages so the sidebar counts, summary strip, and env
-  // filter see the full universe for the selected range — not just the
-  // first page. Bounded ranges are naturally capped by the `since` filter;
-  // only 'all time' needs a safety cap to avoid pulling the entire DB.
+  // Eagerly walk all pages so the summary strip sees the full universe
+  // for the selected range — not just the first page. Bounded ranges
+  // are naturally capped by the `since` filter; only 'all time' needs a
+  // safety cap to avoid pulling the entire DB.
+  //
+  // The fetch is deferred one frame so the browser can paint between
+  // pages. Firing synchronously starves the compositor and visibly
+  // stutters the loading spinner during long fetches.
   const autoFetchCap = filters.range === 'all' ? 5000 : Infinity
   useEffect(() => {
     if (
-      hasNextPage &&
-      !isFetchingNextPage &&
-      rawEntries.length < autoFetchCap
+      !hasNextPage ||
+      isFetchingNextPage ||
+      rawEntries.length >= autoFetchCap
     ) {
-      fetchNextPage()
+      return
     }
+    const id = window.setTimeout(() => fetchNextPage(), 16)
+    return () => window.clearTimeout(id)
   }, [
     hasNextPage,
     isFetchingNextPage,
@@ -168,26 +243,24 @@ export function OperationsLog() {
   const visibleEntries = useMemo(() => {
     let xs = rawEntries
     if (sinceCutoffMs > 0) {
-      xs = xs.filter(
-        (e) => parseUtcIso(e.occurred_at).getTime() >= sinceCutoffMs,
-      )
+      xs = xs.filter((e) => toMs(e.occurred_at) >= sinceCutoffMs)
     }
     const q = filters.q?.toLowerCase().trim()
     if (q) {
-      xs = xs.filter((e) =>
-        [
-          e.project_slug,
-          e.description,
-          e.version ?? '',
-          e.ticket_slug ?? '',
-          e.notes ?? '',
-          e.performed_by ?? '',
-          e.recorded_by,
-        ]
-          .join(' ')
-          .toLowerCase()
-          .includes(q),
-      )
+      xs = xs.filter((e) => {
+        // Avoid .join().includes() on every entry — it builds a throwaway
+        // string per row. Short-circuit on first hit instead.
+        if (e.project_slug.toLowerCase().includes(q)) return true
+        if (e.description.toLowerCase().includes(q)) return true
+        if (e.version && e.version.toLowerCase().includes(q)) return true
+        if (e.ticket_slug && e.ticket_slug.toLowerCase().includes(q))
+          return true
+        if (e.notes && e.notes.toLowerCase().includes(q)) return true
+        if (e.performed_by && e.performed_by.toLowerCase().includes(q))
+          return true
+        if (e.recorded_by.toLowerCase().includes(q)) return true
+        return false
+      })
     }
     return xs
   }, [rawEntries, sinceCutoffMs, filters.q])
@@ -208,38 +281,44 @@ export function OperationsLog() {
     return m
   }, [users])
 
-  // Sidebar counts: derived from the date-filtered set (pre type/env/project/person)
-  // so the numbers reflect the universe the other filters select from.
-  const counts: SidebarCounts = useMemo(() => {
-    const type: SidebarCounts['type'] = {}
-    const env: SidebarCounts['env'] = {}
+  // Toolbar counts — one pass over the date-filtered universe, built
+  // independently of the search/env filters so the other facets show
+  // the full set they're picking from.
+  const counts: ToolbarCounts = useMemo(() => {
+    const type: ToolbarCounts['type'] = {}
+    const env: ToolbarCounts['env'] = {}
     const project: Record<string, number> = {}
-    const person: Record<string, number> = {}
     for (const e of rawEntries) {
-      if (
-        sinceCutoffMs > 0 &&
-        parseUtcIso(e.occurred_at).getTime() < sinceCutoffMs
-      ) {
-        continue
-      }
+      if (sinceCutoffMs > 0 && toMs(e.occurred_at) < sinceCutoffMs) continue
       type[e.entry_type] = (type[e.entry_type] ?? 0) + 1
       if (e.environment_slug) {
         env[e.environment_slug] = (env[e.environment_slug] ?? 0) + 1
       }
       project[e.project_slug] = (project[e.project_slug] ?? 0) + 1
-      if (e.performed_by) {
-        person[e.performed_by] = (person[e.performed_by] ?? 0) + 1
-      }
     }
-    return { type, env, project, person }
+    return { type, env, project }
   }, [rawEntries, sinceCutoffMs])
 
+  // Stable Map so the sidebar's project section doesn't see a new ref
+  // on every parent render and the section's own memoised filter runs
+  // on a stable input.
+  const projectNames = useMemo(
+    () =>
+      new Map(
+        Array.from(projectsBySlug.entries()).map(([k, v]) => [k, v.name]),
+      ),
+    [projectsBySlug],
+  )
+
   const items: FeedItem[] = useMemo(() => {
-    const sorted = [...visibleEntries].sort(
-      (a, b) =>
-        parseUtcIso(b.occurred_at).getTime() -
-        parseUtcIso(a.occurred_at).getTime(),
+    // Decorate-sort-undecorate: parse each timestamp exactly once rather
+    // than twice per comparator call. Cuts parse count from 2·N·log N to
+    // N — roughly 20× fewer parses at 5000 entries.
+    const decorated = visibleEntries.map(
+      (entry) => [toMs(entry.occurred_at), entry] as const,
     )
+    decorated.sort((a, b) => b[0] - a[0])
+    const sorted = decorated.map(([, entry]) => entry)
     if (view === 'grouped') return groupReleases(sorted)
     return sorted.map((entry) => ({ kind: 'single', entry }) as FeedItem)
   }, [visibleEntries, view])
@@ -282,35 +361,17 @@ export function OperationsLog() {
 
   return (
     <div className="mx-auto max-w-[1400px] px-6 py-6">
-      <div className="grid items-start gap-7 lg:grid-cols-[232px_1fr]">
-        <OperationsLogSidebar
-          counts={counts}
-          range={filters.range}
-          onRange={(range) => setFilters({ ...filters, range })}
-          entryType={filters.entry_type}
-          onEntryType={(entry_type) => setFilters({ ...filters, entry_type })}
-          environmentSlug={filters.environment_slug}
-          onEnvironment={(environment_slug) =>
-            setFilters({ ...filters, environment_slug })
-          }
-          environments={environments}
-          projectSlug={filters.project_slug}
-          onProject={(project_slug) => setFilters({ ...filters, project_slug })}
-          projectNames={
-            new Map(
-              Array.from(projectsBySlug.entries()).map(([k, v]) => [k, v.name]),
-            )
-          }
-          performer={filters.performed_by}
-          onPerformer={(performed_by) =>
-            setFilters({ ...filters, performed_by })
-          }
-          performerDisplayNames={performerDisplayNames}
-        />
-
+      <div className="grid items-start gap-7">
         <main className="min-w-0">
           <header className="mb-4 flex flex-wrap items-end justify-between gap-3">
-            <h1 className="text-h1 text-primary">Operations log</h1>
+            <h1 className="flex items-center gap-2 text-h1 text-primary">
+              <LoadingIndicator
+                loading={Boolean(
+                  isLoading || isFetchingNextPage || hasNextPage,
+                )}
+              />
+              Operations log
+            </h1>
             <div className="flex items-center gap-2">
               <div className="relative w-[260px]">
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
@@ -353,6 +414,16 @@ export function OperationsLog() {
                   <GitBranch className="h-3.5 w-3.5" /> Releases
                 </button>
               </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-10 gap-1.5"
+                disabled
+                title="Export coming soon"
+              >
+                <Download className="h-3.5 w-3.5" />
+                Export
+              </Button>
             </div>
           </header>
 
@@ -360,6 +431,25 @@ export function OperationsLog() {
             entries={visibleEntries}
             rangeLabel={RANGE_LABEL[filters.range]}
             range={filters.range}
+            loading={Boolean(isLoading || isFetchingNextPage || hasNextPage)}
+          />
+
+          <OperationsLogToolbar
+            counts={counts}
+            range={filters.range}
+            onRange={(range) => setFilters({ ...filters, range })}
+            entryType={filters.entry_type}
+            onEntryType={(entry_type) => setFilters({ ...filters, entry_type })}
+            environmentSlug={filters.environment_slug}
+            onEnvironment={(environment_slug) =>
+              setFilters({ ...filters, environment_slug })
+            }
+            environments={environments}
+            projectSlug={filters.project_slug}
+            onProject={(project_slug) =>
+              setFilters({ ...filters, project_slug })
+            }
+            projectNames={projectNames}
           />
 
           {activeChips.length > 0 && (
@@ -447,15 +537,14 @@ export function OperationsLog() {
                           return (
                             <OperationsLogReleaseCard
                               key={`rel-${id}`}
+                              id={id}
                               group={it.group}
                               project={projectsBySlug.get(
                                 it.group.project_slug,
                               )}
                               environmentsBySlug={environmentsBySlug}
                               isOpen={isOpen}
-                              onToggle={() =>
-                                setOpenId(isOpen ? undefined : id)
-                              }
+                              onToggle={toggleOpen}
                               performerDisplayNames={performerDisplayNames}
                             />
                           )
@@ -465,13 +554,14 @@ export function OperationsLog() {
                         return (
                           <OperationsLogStreamRow
                             key={`evt-${id}`}
+                            id={id}
                             entry={it.entry}
                             project={projectsBySlug.get(it.entry.project_slug)}
                             environment={environmentsBySlug.get(
                               it.entry.environment_slug,
                             )}
                             isOpen={isOpen}
-                            onToggle={() => setOpenId(isOpen ? undefined : id)}
+                            onToggle={toggleOpen}
                             performerDisplayNames={performerDisplayNames}
                           />
                         )

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -462,6 +462,57 @@ export function OperationsLog() {
   // overlay on forever — just tie loading to active network activity.
   const isPageLoading = Boolean(isLoading || isFetchingNextPage)
 
+  const renderFeedItem = (vi: VItem) => {
+    if (vi.kind === 'header') {
+      return (
+        <div className="flex items-center gap-2.5 border-b border-tertiary bg-secondary px-3 py-1.5">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
+            {vi.label}
+          </span>
+          <span className="font-mono text-[11px] text-tertiary">
+            {vi.date.toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+            })}
+          </span>
+          <span className="h-px flex-1 bg-tertiary" />
+          <span className="font-mono text-[11px] text-tertiary">
+            {vi.count} {vi.count === 1 ? 'event' : 'events'}
+          </span>
+        </div>
+      )
+    }
+    const feed = groupsById.get(vi.id)
+    if (!feed) return null
+    if (vi.kind === 'rel' && feed.kind === 'release') {
+      return (
+        <OperationsLogReleaseCard
+          id={vi.id}
+          group={feed.group}
+          project={projectsBySlug.get(feed.group.project_slug)}
+          environmentsBySlug={environmentsBySlug}
+          isOpen={vi.isOpen}
+          onToggle={toggleOpen}
+          performerDisplayNames={performerDisplayNames}
+        />
+      )
+    }
+    if (vi.kind === 'evt' && feed.kind === 'single') {
+      return (
+        <OperationsLogStreamRow
+          id={vi.id}
+          entry={feed.entry}
+          project={projectsBySlug.get(feed.entry.project_slug)}
+          environment={environmentsBySlug.get(feed.entry.environment_slug)}
+          isOpen={vi.isOpen}
+          onToggle={toggleOpen}
+          performerDisplayNames={performerDisplayNames}
+        />
+      )
+    }
+    return null
+  }
+
   return (
     <div className="mx-auto max-w-[1400px] px-6 py-6">
       <div className="grid items-start gap-7">
@@ -605,61 +656,7 @@ export function OperationsLog() {
                           className="absolute left-0 right-0 top-0"
                           style={{ transform: `translateY(${v.start}px)` }}
                         >
-                          {vi.kind === 'header' ? (
-                            <div className="flex items-center gap-2.5 border-b border-tertiary bg-secondary px-3 py-1.5">
-                              <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
-                                {vi.label}
-                              </span>
-                              <span className="font-mono text-[11px] text-tertiary">
-                                {vi.date.toLocaleDateString(undefined, {
-                                  month: 'short',
-                                  day: 'numeric',
-                                })}
-                              </span>
-                              <span className="h-px flex-1 bg-tertiary" />
-                              <span className="font-mono text-[11px] text-tertiary">
-                                {vi.count} {vi.count === 1 ? 'event' : 'events'}
-                              </span>
-                            </div>
-                          ) : vi.kind === 'rel' ? (
-                            (() => {
-                              const feed = groupsById.get(vi.id)
-                              if (!feed || feed.kind !== 'release') return null
-                              return (
-                                <OperationsLogReleaseCard
-                                  id={vi.id}
-                                  group={feed.group}
-                                  project={projectsBySlug.get(
-                                    feed.group.project_slug,
-                                  )}
-                                  environmentsBySlug={environmentsBySlug}
-                                  isOpen={vi.isOpen}
-                                  onToggle={toggleOpen}
-                                  performerDisplayNames={performerDisplayNames}
-                                />
-                              )
-                            })()
-                          ) : (
-                            (() => {
-                              const feed = groupsById.get(vi.id)
-                              if (!feed || feed.kind !== 'single') return null
-                              return (
-                                <OperationsLogStreamRow
-                                  id={vi.id}
-                                  entry={feed.entry}
-                                  project={projectsBySlug.get(
-                                    feed.entry.project_slug,
-                                  )}
-                                  environment={environmentsBySlug.get(
-                                    feed.entry.environment_slug,
-                                  )}
-                                  isOpen={vi.isOpen}
-                                  onToggle={toggleOpen}
-                                  performerDisplayNames={performerDisplayNames}
-                                />
-                              )
-                            })()
-                          )}
+                          {renderFeedItem(vi)}
                         </div>
                       )
                     })}

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import { Activity, LoaderCircle, SearchX, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -175,51 +176,11 @@ export function OperationsLog() {
     () => data?.entries ?? [],
     [data],
   )
+  const serverMetrics = data?.metrics
 
-  // Eagerly walk all pages so the summary strip sees the full universe
-  // for the selected range — not just the first page. Bounded ranges
-  // are naturally capped by the `since` filter; only 'all time' needs a
-  // safety cap to avoid pulling the entire DB.
-  //
-  // The fetch is deferred one frame so the browser can paint between
-  // pages. Firing synchronously starves the compositor and visibly
-  // stutters the loading spinner during long fetches.
-  const autoFetchCap = filters.range === 'all' ? 5000 : Infinity
-  useEffect(() => {
-    if (
-      !hasNextPage ||
-      isFetchingNextPage ||
-      rawEntries.length >= autoFetchCap
-    ) {
-      return
-    }
-    const id = window.setTimeout(() => fetchNextPage(), 16)
-    return () => window.clearTimeout(id)
-  }, [
-    hasNextPage,
-    isFetchingNextPage,
-    rawEntries.length,
-    autoFetchCap,
-    fetchNextPage,
-  ])
-
-  // Also trigger another page load as the user nears the bottom of the list.
-  const sentinelRef = useRef<HTMLDivElement | null>(null)
-  useEffect(() => {
-    if (!hasNextPage) return
-    const node = sentinelRef.current
-    if (!node) return
-    const obs = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((e) => e.isIntersecting) && !isFetchingNextPage) {
-          fetchNextPage()
-        }
-      },
-      { rootMargin: '400px 0px' },
-    )
-    obs.observe(node)
-    return () => obs.disconnect()
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+  // Next-page fetch is driven by the virtualizer overscanning past the
+  // end of the list, rather than eagerly paginating every page. See the
+  // effect below the virtualizer setup.
 
   // Also enforce the `since` cutoff client-side. Defense in depth: if the
   // backend ever drifts, a stale cached page reappears, or the clock skews,
@@ -343,6 +304,75 @@ export function OperationsLog() {
 
   const buckets = useMemo(() => bucketByDay(items), [items])
 
+  // Flatten buckets into a single list for the virtualizer: one entry
+  // per day header plus one entry per row. Each virtual item renders
+  // independently so the only DOM nodes on screen at once are those in
+  // (or near) the viewport, regardless of how many rows we have loaded.
+  type VItem =
+    | { kind: 'header'; key: string; label: string; date: Date; count: number }
+    | { kind: 'rel'; key: string; id: string; isOpen: boolean }
+    | { kind: 'evt'; key: string; id: string; isOpen: boolean }
+  const virtualItems: VItem[] = useMemo(() => {
+    const out: VItem[] = []
+    for (const bucket of buckets) {
+      out.push({
+        kind: 'header',
+        key: `h-${bucket.key}`,
+        label: bucket.label,
+        date: bucket.date,
+        count: bucket.items.length,
+      })
+      for (const it of bucket.items) {
+        if (it.kind === 'release') {
+          const id = it.group.latestEntry.id
+          const isOpen =
+            openId === id || it.group.stops.some((s) => s.entry.id === openId)
+          out.push({ kind: 'rel', key: `rel-${id}`, id, isOpen })
+        } else {
+          const id = it.entry.id
+          out.push({ kind: 'evt', key: `evt-${id}`, id, isOpen: openId === id })
+        }
+      }
+    }
+    return out
+  }, [buckets, openId])
+
+  // Reverse index so the virtualizer's absolutely-positioned row can
+  // look up its FeedItem payload by id without scanning `items` each render.
+  const groupsById = useMemo(() => {
+    const m = new Map<string, FeedItem>()
+    for (const it of items) {
+      const id = it.kind === 'release' ? it.group.latestEntry.id : it.entry.id
+      m.set(id, it)
+    }
+    return m
+  }, [items])
+
+  const virtualizer = useWindowVirtualizer({
+    count: virtualItems.length,
+    estimateSize: (index) => (virtualItems[index]?.kind === 'header' ? 34 : 72),
+    overscan: 8,
+    getItemKey: (index) => virtualItems[index]?.key ?? index,
+  })
+
+  // Pull the next page as soon as the virtualizer renders within a few
+  // rows of the end of the current list. Replaces the prior eager loop
+  // that fetched every page back-to-back.
+  const virtualRows = virtualizer.getVirtualItems()
+  const lastVisibleIndex =
+    virtualRows.length > 0 ? virtualRows[virtualRows.length - 1].index : -1
+  useEffect(() => {
+    if (!hasNextPage || isFetchingNextPage) return
+    if (lastVisibleIndex < virtualItems.length - 5) return
+    fetchNextPage()
+  }, [
+    lastVisibleIndex,
+    virtualItems.length,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  ])
+
   const activeChips = useMemo(() => {
     const chips: { key: string; label: string; clear: () => void }[] = []
     for (const t of filters.entry_types) {
@@ -398,7 +428,10 @@ export function OperationsLog() {
     performerDisplayNames,
   ])
 
-  const isPageLoading = Boolean(isLoading || isFetchingNextPage || hasNextPage)
+  // With on-demand pagination, hasNextPage stays true until the user
+  // scrolls to the end. Don't let that keep the spinner and inert
+  // overlay on forever — just tie loading to active network activity.
+  const isPageLoading = Boolean(isLoading || isFetchingNextPage)
 
   return (
     <div className="mx-auto max-w-[1400px] px-6 py-6">
@@ -425,6 +458,7 @@ export function OperationsLog() {
               rangeLabel={RANGE_LABEL[filters.range]}
               range={filters.range}
               loading={isPageLoading}
+              serverMetrics={serverMetrics}
             />
 
             <OperationsLogToolbar
@@ -505,98 +539,95 @@ export function OperationsLog() {
 
             {!isLoading &&
               !isError &&
-              (buckets.length === 0 ? (
+              (virtualItems.length === 0 ? (
                 <div className="rounded-md border border-tertiary bg-primary px-6 py-16 text-center text-sm text-tertiary">
                   <SearchX className="mx-auto mb-2 h-7 w-7 text-tertiary" />
                   No events match these filters.
                 </div>
               ) : (
-                <div className="space-y-4">
-                  {buckets.map((bucket) => (
-                    <section key={bucket.key}>
-                      <div className="mb-1.5 flex items-center gap-2.5 px-0.5">
-                        <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
-                          {bucket.label}
-                        </span>
-                        <span className="font-mono text-[11px] text-tertiary">
-                          {bucket.date.toLocaleDateString(undefined, {
-                            month: 'short',
-                            day: 'numeric',
-                          })}
-                        </span>
-                        <span className="h-px flex-1 bg-tertiary" />
-                        <span className="font-mono text-[11px] text-tertiary">
-                          {bucket.items.length}{' '}
-                          {bucket.items.length === 1 ? 'event' : 'events'}
-                        </span>
-                      </div>
-                      <div className="overflow-hidden rounded-md border border-tertiary bg-primary">
-                        {bucket.items.map((it) => {
-                          if (it.kind === 'release') {
-                            const id = it.group.latestEntry.id
-                            const isOpen =
-                              openId === id ||
-                              it.group.stops.some((s) => s.entry.id === openId)
-                            return (
-                              <OperationsLogReleaseCard
-                                key={`rel-${id}`}
-                                id={id}
-                                group={it.group}
-                                project={projectsBySlug.get(
-                                  it.group.project_slug,
-                                )}
-                                environmentsBySlug={environmentsBySlug}
-                                isOpen={isOpen}
-                                onToggle={toggleOpen}
-                                performerDisplayNames={performerDisplayNames}
-                              />
-                            )
-                          }
-                          const id = it.entry.id
-                          const isOpen = openId === id
-                          return (
-                            <OperationsLogStreamRow
-                              key={`evt-${id}`}
-                              id={id}
-                              entry={it.entry}
-                              project={projectsBySlug.get(
-                                it.entry.project_slug,
-                              )}
-                              environment={environmentsBySlug.get(
-                                it.entry.environment_slug,
-                              )}
-                              isOpen={isOpen}
-                              onToggle={toggleOpen}
-                              performerDisplayNames={performerDisplayNames}
-                            />
-                          )
-                        })}
-                      </div>
-                    </section>
-                  ))}
+                <>
                   <div
-                    ref={sentinelRef}
-                    className="py-3 text-center text-xs text-tertiary"
+                    className="relative w-full overflow-hidden rounded-md border border-tertiary bg-primary"
+                    style={{ height: virtualizer.getTotalSize() }}
                   >
-                    {isFetchingNextPage ? (
-                      'Loading more…'
-                    ) : hasNextPage ? (
-                      rawEntries.length >= autoFetchCap ? (
-                        <button
-                          type="button"
-                          onClick={() => fetchNextPage()}
-                          className="rounded px-3 py-1 text-[12px] hover:bg-secondary hover:text-primary"
+                    {virtualizer.getVirtualItems().map((v) => {
+                      const vi = virtualItems[v.index]
+                      if (!vi) return null
+                      return (
+                        <div
+                          key={v.key}
+                          data-index={v.index}
+                          ref={virtualizer.measureElement}
+                          className="absolute left-0 right-0 top-0"
+                          style={{ transform: `translateY(${v.start}px)` }}
                         >
-                          Load more (showing {rawEntries.length})
-                        </button>
-                      ) : (
-                        'Loading…'
+                          {vi.kind === 'header' ? (
+                            <div className="flex items-center gap-2.5 border-b border-tertiary bg-secondary px-3 py-1.5">
+                              <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
+                                {vi.label}
+                              </span>
+                              <span className="font-mono text-[11px] text-tertiary">
+                                {vi.date.toLocaleDateString(undefined, {
+                                  month: 'short',
+                                  day: 'numeric',
+                                })}
+                              </span>
+                              <span className="h-px flex-1 bg-tertiary" />
+                              <span className="font-mono text-[11px] text-tertiary">
+                                {vi.count} {vi.count === 1 ? 'event' : 'events'}
+                              </span>
+                            </div>
+                          ) : vi.kind === 'rel' ? (
+                            (() => {
+                              const feed = groupsById.get(vi.id)
+                              if (!feed || feed.kind !== 'release') return null
+                              return (
+                                <OperationsLogReleaseCard
+                                  id={vi.id}
+                                  group={feed.group}
+                                  project={projectsBySlug.get(
+                                    feed.group.project_slug,
+                                  )}
+                                  environmentsBySlug={environmentsBySlug}
+                                  isOpen={vi.isOpen}
+                                  onToggle={toggleOpen}
+                                  performerDisplayNames={performerDisplayNames}
+                                />
+                              )
+                            })()
+                          ) : (
+                            (() => {
+                              const feed = groupsById.get(vi.id)
+                              if (!feed || feed.kind !== 'single') return null
+                              return (
+                                <OperationsLogStreamRow
+                                  id={vi.id}
+                                  entry={feed.entry}
+                                  project={projectsBySlug.get(
+                                    feed.entry.project_slug,
+                                  )}
+                                  environment={environmentsBySlug.get(
+                                    feed.entry.environment_slug,
+                                  )}
+                                  isOpen={vi.isOpen}
+                                  onToggle={toggleOpen}
+                                  performerDisplayNames={performerDisplayNames}
+                                />
+                              )
+                            })()
+                          )}
+                        </div>
                       )
-                    ) : (
-                      `End of log · ${visibleEntries.length} entries`
-                    )}
+                    })}
                   </div>
-                </div>
+                  <div className="py-3 text-center text-xs text-tertiary">
+                    {isFetchingNextPage
+                      ? 'Loading more…'
+                      : hasNextPage
+                        ? null
+                        : `End of log · ${visibleEntries.length} entries`}
+                  </div>
+                </>
               ))}
           </div>
         </main>

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -1,0 +1,510 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { GitBranch, List, Search, SearchX, X } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { useInfiniteOperationsLog } from '@/hooks/useInfiniteOperationsLog'
+import { listEnvironments, getProjects, listAdminUsers } from '@/api/endpoints'
+import type {
+  Environment,
+  OperationsLogEntryType,
+  OperationsLogFilters,
+  OperationsLogRecord,
+  Project,
+} from '@/types'
+import {
+  OperationsLogSidebar,
+  type SidebarCounts,
+} from './operations-log/OperationsLogSidebar'
+import { OperationsLogSummary } from './operations-log/OperationsLogSummary'
+import { OperationsLogStreamRow } from './operations-log/OperationsLogStreamRow'
+import { OperationsLogReleaseCard } from './operations-log/OperationsLogReleaseCard'
+import {
+  bucketByDay,
+  cleanName,
+  groupReleases,
+  parseUtcIso,
+  type FeedItem,
+  type OperationsLogView,
+  type TimeRange,
+} from './operations-log/opsLogHelpers'
+
+const RANGE_DELTA: Record<Exclude<TimeRange, 'all'>, number> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '3d': 3 * 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+}
+
+const RANGE_LABEL: Record<TimeRange, string> = {
+  '24h': 'last 24h',
+  '3d': 'last 3 days',
+  '7d': 'last 7 days',
+  '30d': 'last 30 days',
+  all: 'all time',
+}
+
+function rangeToSince(range: TimeRange): string | undefined {
+  if (range === 'all') return undefined
+  return new Date(Date.now() - RANGE_DELTA[range]).toISOString()
+}
+
+interface ScreenFilters {
+  range: TimeRange
+  entry_type?: OperationsLogEntryType
+  environment_slug?: string
+  project_slug?: string
+  performed_by?: string
+  q?: string
+}
+
+const DEFAULT_FILTERS: ScreenFilters = { range: '3d' }
+
+export function OperationsLog() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug || ''
+
+  const [filters, setFilters] = useState<ScreenFilters>(DEFAULT_FILTERS)
+  const [view, setView] = useState<OperationsLogView>('grouped')
+  const [openId, setOpenId] = useState<string | undefined>(undefined)
+
+  const { data: projects = [] } = useQuery({
+    queryKey: ['projects', orgSlug],
+    queryFn: () => getProjects(orgSlug),
+    enabled: !!orgSlug,
+  })
+  const { data: environments = [] } = useQuery({
+    queryKey: ['environments', orgSlug],
+    queryFn: () => listEnvironments(orgSlug),
+    enabled: !!orgSlug,
+  })
+  const { data: users = [] } = useQuery({
+    queryKey: ['admin-users', 'active'],
+    queryFn: () => listAdminUsers({ is_active: true }),
+  })
+
+  // API filters exclude env bucket (client-side) and search text so typing
+  // or toggling env bucket doesn't refetch.
+  const apiFilters: OperationsLogFilters = useMemo(
+    () => ({
+      project_slug: filters.project_slug,
+      environment_slug: filters.environment_slug,
+      entry_type: filters.entry_type,
+      performed_by: filters.performed_by,
+      since: rangeToSince(filters.range),
+    }),
+    [
+      filters.project_slug,
+      filters.environment_slug,
+      filters.entry_type,
+      filters.performed_by,
+      filters.range,
+    ],
+  )
+
+  const {
+    data,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteOperationsLog(apiFilters)
+
+  const rawEntries: OperationsLogRecord[] = useMemo(
+    () => data?.entries ?? [],
+    [data],
+  )
+
+  // Eagerly walk all pages so the sidebar counts, summary strip, and env
+  // filter see the full universe for the selected range — not just the
+  // first page. Bounded ranges are naturally capped by the `since` filter;
+  // only 'all time' needs a safety cap to avoid pulling the entire DB.
+  const autoFetchCap = filters.range === 'all' ? 5000 : Infinity
+  useEffect(() => {
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      rawEntries.length < autoFetchCap
+    ) {
+      fetchNextPage()
+    }
+  }, [
+    hasNextPage,
+    isFetchingNextPage,
+    rawEntries.length,
+    autoFetchCap,
+    fetchNextPage,
+  ])
+
+  // Also trigger another page load as the user nears the bottom of the list.
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (!hasNextPage) return
+    const node = sentinelRef.current
+    if (!node) return
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting) && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { rootMargin: '400px 0px' },
+    )
+    obs.observe(node)
+    return () => obs.disconnect()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // Also enforce the `since` cutoff client-side. Defense in depth: if the
+  // backend ever drifts, a stale cached page reappears, or the clock skews,
+  // we still only ever display entries inside the selected window.
+  const sinceCutoffMs = useMemo(() => {
+    if (filters.range === 'all') return 0
+    return Date.now() - RANGE_DELTA[filters.range]
+  }, [filters.range])
+
+  const visibleEntries = useMemo(() => {
+    let xs = rawEntries
+    if (sinceCutoffMs > 0) {
+      xs = xs.filter(
+        (e) => parseUtcIso(e.occurred_at).getTime() >= sinceCutoffMs,
+      )
+    }
+    const q = filters.q?.toLowerCase().trim()
+    if (q) {
+      xs = xs.filter((e) =>
+        [
+          e.project_slug,
+          e.description,
+          e.version ?? '',
+          e.ticket_slug ?? '',
+          e.notes ?? '',
+          e.performed_by ?? '',
+          e.recorded_by,
+        ]
+          .join(' ')
+          .toLowerCase()
+          .includes(q),
+      )
+    }
+    return xs
+  }, [rawEntries, sinceCutoffMs, filters.q])
+
+  const projectsBySlug = useMemo(
+    () => new Map(projects.map((p: Project) => [p.slug, p])),
+    [projects],
+  )
+  const environmentsBySlug = useMemo(
+    () => new Map(environments.map((e: Environment) => [e.slug, e])),
+    [environments],
+  )
+  const performerDisplayNames = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const u of users) {
+      if (u.email && u.display_name) m.set(u.email, u.display_name)
+    }
+    return m
+  }, [users])
+
+  // Sidebar counts: derived from the date-filtered set (pre type/env/project/person)
+  // so the numbers reflect the universe the other filters select from.
+  const counts: SidebarCounts = useMemo(() => {
+    const type: SidebarCounts['type'] = {}
+    const env: SidebarCounts['env'] = {}
+    const project: Record<string, number> = {}
+    const person: Record<string, number> = {}
+    for (const e of rawEntries) {
+      if (
+        sinceCutoffMs > 0 &&
+        parseUtcIso(e.occurred_at).getTime() < sinceCutoffMs
+      ) {
+        continue
+      }
+      type[e.entry_type] = (type[e.entry_type] ?? 0) + 1
+      if (e.environment_slug) {
+        env[e.environment_slug] = (env[e.environment_slug] ?? 0) + 1
+      }
+      project[e.project_slug] = (project[e.project_slug] ?? 0) + 1
+      if (e.performed_by) {
+        person[e.performed_by] = (person[e.performed_by] ?? 0) + 1
+      }
+    }
+    return { type, env, project, person }
+  }, [rawEntries, sinceCutoffMs])
+
+  const items: FeedItem[] = useMemo(() => {
+    const sorted = [...visibleEntries].sort(
+      (a, b) =>
+        parseUtcIso(b.occurred_at).getTime() -
+        parseUtcIso(a.occurred_at).getTime(),
+    )
+    if (view === 'grouped') return groupReleases(sorted)
+    return sorted.map((entry) => ({ kind: 'single', entry }) as FeedItem)
+  }, [visibleEntries, view])
+
+  const buckets = useMemo(() => bucketByDay(items), [items])
+
+  const activeChips: { key: string; label: string; clear: () => void }[] = []
+  if (filters.entry_type) {
+    activeChips.push({
+      key: 'type',
+      label: filters.entry_type,
+      clear: () => setFilters({ ...filters, entry_type: undefined }),
+    })
+  }
+  if (filters.environment_slug) {
+    const env = environmentsBySlug.get(filters.environment_slug)
+    activeChips.push({
+      key: 'env',
+      label: env?.name ?? filters.environment_slug,
+      clear: () => setFilters({ ...filters, environment_slug: undefined }),
+    })
+  }
+  if (filters.project_slug) {
+    activeChips.push({
+      key: 'project',
+      label:
+        projectsBySlug.get(filters.project_slug)?.name ?? filters.project_slug,
+      clear: () => setFilters({ ...filters, project_slug: undefined }),
+    })
+  }
+  if (filters.performed_by) {
+    activeChips.push({
+      key: 'person',
+      label:
+        performerDisplayNames.get(filters.performed_by) ??
+        cleanName(filters.performed_by),
+      clear: () => setFilters({ ...filters, performed_by: undefined }),
+    })
+  }
+
+  return (
+    <div className="mx-auto max-w-[1400px] px-6 py-6">
+      <div className="grid items-start gap-7 lg:grid-cols-[232px_1fr]">
+        <OperationsLogSidebar
+          counts={counts}
+          range={filters.range}
+          onRange={(range) => setFilters({ ...filters, range })}
+          entryType={filters.entry_type}
+          onEntryType={(entry_type) => setFilters({ ...filters, entry_type })}
+          environmentSlug={filters.environment_slug}
+          onEnvironment={(environment_slug) =>
+            setFilters({ ...filters, environment_slug })
+          }
+          environments={environments}
+          projectSlug={filters.project_slug}
+          onProject={(project_slug) => setFilters({ ...filters, project_slug })}
+          projectNames={
+            new Map(
+              Array.from(projectsBySlug.entries()).map(([k, v]) => [k, v.name]),
+            )
+          }
+          performer={filters.performed_by}
+          onPerformer={(performed_by) =>
+            setFilters({ ...filters, performed_by })
+          }
+          performerDisplayNames={performerDisplayNames}
+        />
+
+        <main className="min-w-0">
+          <header className="mb-4 flex flex-wrap items-end justify-between gap-3">
+            <h1 className="text-h1 text-primary">Operations log</h1>
+            <div className="flex items-center gap-2">
+              <div className="relative w-[260px]">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
+                <Input
+                  value={filters.q ?? ''}
+                  onChange={(e) =>
+                    setFilters({ ...filters, q: e.target.value || undefined })
+                  }
+                  placeholder="Search project, version, description…"
+                  className="pl-9"
+                />
+              </div>
+              <div
+                role="group"
+                aria-label="View"
+                className="inline-flex h-10 items-center rounded-md border border-tertiary bg-secondary p-1"
+              >
+                <button
+                  type="button"
+                  onClick={() => setView('stream')}
+                  className={cn(
+                    'inline-flex h-full items-center gap-1.5 rounded px-3 text-xs font-medium transition-colors',
+                    view === 'stream'
+                      ? 'bg-primary text-primary shadow-sm'
+                      : 'text-secondary hover:text-primary',
+                  )}
+                >
+                  <List className="h-3.5 w-3.5" /> Stream
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setView('grouped')}
+                  className={cn(
+                    'inline-flex h-full items-center gap-1.5 rounded px-3 text-xs font-medium transition-colors',
+                    view === 'grouped'
+                      ? 'bg-primary text-primary shadow-sm'
+                      : 'text-secondary hover:text-primary',
+                  )}
+                >
+                  <GitBranch className="h-3.5 w-3.5" /> Releases
+                </button>
+              </div>
+            </div>
+          </header>
+
+          <OperationsLogSummary
+            entries={visibleEntries}
+            rangeLabel={RANGE_LABEL[filters.range]}
+            range={filters.range}
+          />
+
+          {activeChips.length > 0 && (
+            <div className="mb-3 flex flex-wrap items-center gap-1.5">
+              <span className="mr-1 text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
+                Filters
+              </span>
+              {activeChips.map((c) => (
+                <button
+                  key={c.key}
+                  type="button"
+                  onClick={c.clear}
+                  className="inline-flex h-6 items-center gap-1 rounded bg-secondary px-2 text-[12px] text-secondary hover:text-primary"
+                >
+                  <span className="truncate">{c.label}</span>
+                  <X className="h-3 w-3" />
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() =>
+                  setFilters({ range: filters.range, q: filters.q })
+                }
+                className="ml-1 rounded px-2 py-0.5 text-[12px] text-tertiary hover:bg-secondary hover:text-primary"
+              >
+                Clear all
+              </button>
+            </div>
+          )}
+
+          {isError && (
+            <div className="bg-danger/10 mb-3 rounded-md border border-danger px-3 py-2 text-sm text-danger">
+              Failed to load operations log.{' '}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => fetchNextPage()}
+                className="ml-2"
+              >
+                Retry
+              </Button>
+            </div>
+          )}
+
+          {isLoading && (
+            <div className="rounded-md border border-tertiary bg-primary px-4 py-16 text-center text-secondary">
+              Loading operations log…
+            </div>
+          )}
+
+          {!isLoading &&
+            !isError &&
+            (buckets.length === 0 ? (
+              <div className="rounded-md border border-tertiary bg-primary px-6 py-16 text-center text-sm text-tertiary">
+                <SearchX className="mx-auto mb-2 h-7 w-7 text-tertiary" />
+                No events match these filters.
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {buckets.map((bucket) => (
+                  <section key={bucket.key}>
+                    <div className="mb-1.5 flex items-center gap-2.5 px-0.5">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
+                        {bucket.label}
+                      </span>
+                      <span className="font-mono text-[11px] text-tertiary">
+                        {bucket.date.toLocaleDateString(undefined, {
+                          month: 'short',
+                          day: 'numeric',
+                        })}
+                      </span>
+                      <span className="h-px flex-1 bg-tertiary" />
+                      <span className="font-mono text-[11px] text-tertiary">
+                        {bucket.items.length}{' '}
+                        {bucket.items.length === 1 ? 'event' : 'events'}
+                      </span>
+                    </div>
+                    <div className="overflow-hidden rounded-md border border-tertiary bg-primary">
+                      {bucket.items.map((it) => {
+                        if (it.kind === 'release') {
+                          const id = it.group.latestEntry.id
+                          const isOpen =
+                            openId === id ||
+                            it.group.stops.some((s) => s.entry.id === openId)
+                          return (
+                            <OperationsLogReleaseCard
+                              key={`rel-${id}`}
+                              group={it.group}
+                              project={projectsBySlug.get(
+                                it.group.project_slug,
+                              )}
+                              environmentsBySlug={environmentsBySlug}
+                              isOpen={isOpen}
+                              onToggle={() =>
+                                setOpenId(isOpen ? undefined : id)
+                              }
+                              performerDisplayNames={performerDisplayNames}
+                            />
+                          )
+                        }
+                        const id = it.entry.id
+                        const isOpen = openId === id
+                        return (
+                          <OperationsLogStreamRow
+                            key={`evt-${id}`}
+                            entry={it.entry}
+                            project={projectsBySlug.get(it.entry.project_slug)}
+                            environment={environmentsBySlug.get(
+                              it.entry.environment_slug,
+                            )}
+                            isOpen={isOpen}
+                            onToggle={() => setOpenId(isOpen ? undefined : id)}
+                            performerDisplayNames={performerDisplayNames}
+                          />
+                        )
+                      })}
+                    </div>
+                  </section>
+                ))}
+                <div
+                  ref={sentinelRef}
+                  className="py-3 text-center text-xs text-tertiary"
+                >
+                  {isFetchingNextPage ? (
+                    'Loading more…'
+                  ) : hasNextPage ? (
+                    rawEntries.length >= autoFetchCap ? (
+                      <button
+                        type="button"
+                        onClick={() => fetchNextPage()}
+                        className="rounded px-3 py-1 text-[12px] hover:bg-secondary hover:text-primary"
+                      >
+                        Load more (showing {rawEntries.length})
+                      </button>
+                    ) : (
+                      'Loading…'
+                    )
+                  ) : (
+                    `End of log · ${visibleEntries.length} entries`
+                  )}
+                </div>
+              </div>
+            ))}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -1,16 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import {
-  Activity,
-  Download,
-  GitBranch,
-  List,
-  LoaderCircle,
-  Search,
-  SearchX,
-  X,
-} from 'lucide-react'
-import { Input } from '@/components/ui/input'
+import { Activity, LoaderCircle, SearchX, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -117,14 +107,19 @@ function rangeToSince(range: TimeRange): string | undefined {
 
 interface ScreenFilters {
   range: TimeRange
-  entry_type?: OperationsLogEntryType
-  environment_slug?: string
-  project_slug?: string
+  entry_types: OperationsLogEntryType[]
+  environment_slugs: string[]
+  project_slugs: string[]
   performed_by?: string
   q?: string
 }
 
-const DEFAULT_FILTERS: ScreenFilters = { range: '30d' }
+const DEFAULT_FILTERS: ScreenFilters = {
+  range: '30d',
+  entry_types: [],
+  environment_slugs: [],
+  project_slugs: [],
+}
 
 export function OperationsLog() {
   const { selectedOrganization } = useOrganization()
@@ -154,23 +149,17 @@ export function OperationsLog() {
     queryFn: () => listAdminUsers({ is_active: true }),
   })
 
-  // API filters exclude env bucket (client-side) and search text so typing
-  // or toggling env bucket doesn't refetch.
+  // Only the time-range boundary is pushed to the server. Facet filters
+  // (entry_types / environment_slugs / project_slugs) are applied
+  // client-side in `visibleEntries` so the toolbar dropdowns always
+  // show the full set of options for the selected range — applying a
+  // filter does not shrink the choices in the other dropdowns.
   const apiFilters: OperationsLogFilters = useMemo(
     () => ({
-      project_slug: filters.project_slug,
-      environment_slug: filters.environment_slug,
-      entry_type: filters.entry_type,
       performed_by: filters.performed_by,
       since: rangeToSince(filters.range),
     }),
-    [
-      filters.project_slug,
-      filters.environment_slug,
-      filters.entry_type,
-      filters.performed_by,
-      filters.range,
-    ],
+    [filters.performed_by, filters.range],
   )
 
   const {
@@ -245,6 +234,28 @@ export function OperationsLog() {
     if (sinceCutoffMs > 0) {
       xs = xs.filter((e) => toMs(e.occurred_at) >= sinceCutoffMs)
     }
+    // Multi-select facets: treat each selected set as an OR within a
+    // facet and AND across facets. An empty set means "no restriction".
+    // Use Sets for O(1) membership; only allocate when we actually need
+    // to filter on that facet.
+    const typeSet =
+      filters.entry_types.length > 0 ? new Set(filters.entry_types) : undefined
+    const envSet =
+      filters.environment_slugs.length > 0
+        ? new Set(filters.environment_slugs)
+        : undefined
+    const projectSet =
+      filters.project_slugs.length > 0
+        ? new Set(filters.project_slugs)
+        : undefined
+    if (typeSet || envSet || projectSet) {
+      xs = xs.filter((e) => {
+        if (typeSet && !typeSet.has(e.entry_type)) return false
+        if (envSet && !envSet.has(e.environment_slug)) return false
+        if (projectSet && !projectSet.has(e.project_slug)) return false
+        return true
+      })
+    }
     const q = filters.q?.toLowerCase().trim()
     if (q) {
       xs = xs.filter((e) => {
@@ -263,7 +274,14 @@ export function OperationsLog() {
       })
     }
     return xs
-  }, [rawEntries, sinceCutoffMs, filters.q])
+  }, [
+    rawEntries,
+    sinceCutoffMs,
+    filters.entry_types,
+    filters.environment_slugs,
+    filters.project_slugs,
+    filters.q,
+  ])
 
   const projectsBySlug = useMemo(
     () => new Map(projects.map((p: Project) => [p.slug, p])),
@@ -325,39 +343,62 @@ export function OperationsLog() {
 
   const buckets = useMemo(() => bucketByDay(items), [items])
 
-  const activeChips: { key: string; label: string; clear: () => void }[] = []
-  if (filters.entry_type) {
-    activeChips.push({
-      key: 'type',
-      label: filters.entry_type,
-      clear: () => setFilters({ ...filters, entry_type: undefined }),
-    })
-  }
-  if (filters.environment_slug) {
-    const env = environmentsBySlug.get(filters.environment_slug)
-    activeChips.push({
-      key: 'env',
-      label: env?.name ?? filters.environment_slug,
-      clear: () => setFilters({ ...filters, environment_slug: undefined }),
-    })
-  }
-  if (filters.project_slug) {
-    activeChips.push({
-      key: 'project',
-      label:
-        projectsBySlug.get(filters.project_slug)?.name ?? filters.project_slug,
-      clear: () => setFilters({ ...filters, project_slug: undefined }),
-    })
-  }
-  if (filters.performed_by) {
-    activeChips.push({
-      key: 'person',
-      label:
-        performerDisplayNames.get(filters.performed_by) ??
-        cleanName(filters.performed_by),
-      clear: () => setFilters({ ...filters, performed_by: undefined }),
-    })
-  }
+  const activeChips = useMemo(() => {
+    const chips: { key: string; label: string; clear: () => void }[] = []
+    for (const t of filters.entry_types) {
+      chips.push({
+        key: `type-${t}`,
+        label: t,
+        clear: () =>
+          setFilters((f) => ({
+            ...f,
+            entry_types: f.entry_types.filter((x) => x !== t),
+          })),
+      })
+    }
+    for (const slug of filters.environment_slugs) {
+      const env = environmentsBySlug.get(slug)
+      chips.push({
+        key: `env-${slug}`,
+        label: env?.name ?? slug,
+        clear: () =>
+          setFilters((f) => ({
+            ...f,
+            environment_slugs: f.environment_slugs.filter((x) => x !== slug),
+          })),
+      })
+    }
+    for (const slug of filters.project_slugs) {
+      chips.push({
+        key: `project-${slug}`,
+        label: projectsBySlug.get(slug)?.name ?? slug,
+        clear: () =>
+          setFilters((f) => ({
+            ...f,
+            project_slugs: f.project_slugs.filter((x) => x !== slug),
+          })),
+      })
+    }
+    if (filters.performed_by) {
+      const pb = filters.performed_by
+      chips.push({
+        key: 'person',
+        label: performerDisplayNames.get(pb) ?? cleanName(pb),
+        clear: () => setFilters((f) => ({ ...f, performed_by: undefined })),
+      })
+    }
+    return chips
+  }, [
+    filters.entry_types,
+    filters.environment_slugs,
+    filters.project_slugs,
+    filters.performed_by,
+    environmentsBySlug,
+    projectsBySlug,
+    performerDisplayNames,
+  ])
+
+  const isPageLoading = Boolean(isLoading || isFetchingNextPage || hasNextPage)
 
   return (
     <div className="mx-auto max-w-[1400px] px-6 py-6">
@@ -365,234 +406,199 @@ export function OperationsLog() {
         <main className="min-w-0">
           <header className="mb-4 flex flex-wrap items-end justify-between gap-3">
             <h1 className="flex items-center gap-2 text-h1 text-primary">
-              <LoadingIndicator
-                loading={Boolean(
-                  isLoading || isFetchingNextPage || hasNextPage,
-                )}
-              />
-              Operations log
+              <LoadingIndicator loading={isPageLoading} />
+              Operations Log
             </h1>
-            <div className="flex items-center gap-2">
-              <div className="relative w-[260px]">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
-                <Input
-                  value={filters.q ?? ''}
-                  onChange={(e) =>
-                    setFilters({ ...filters, q: e.target.value || undefined })
-                  }
-                  placeholder="Search project, version, description…"
-                  className="pl-9"
-                />
-              </div>
-              <div
-                role="group"
-                aria-label="View"
-                className="inline-flex h-10 items-center rounded-md border border-tertiary bg-secondary p-1"
-              >
-                <button
-                  type="button"
-                  onClick={() => setView('stream')}
-                  className={cn(
-                    'inline-flex h-full items-center gap-1.5 rounded px-3 text-xs font-medium transition-colors',
-                    view === 'stream'
-                      ? 'bg-primary text-primary shadow-sm'
-                      : 'text-secondary hover:text-primary',
-                  )}
-                >
-                  <List className="h-3.5 w-3.5" /> Stream
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setView('grouped')}
-                  className={cn(
-                    'inline-flex h-full items-center gap-1.5 rounded px-3 text-xs font-medium transition-colors',
-                    view === 'grouped'
-                      ? 'bg-primary text-primary shadow-sm'
-                      : 'text-secondary hover:text-primary',
-                  )}
-                >
-                  <GitBranch className="h-3.5 w-3.5" /> Releases
-                </button>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-10 gap-1.5"
-                disabled
-                title="Export coming soon"
-              >
-                <Download className="h-3.5 w-3.5" />
-                Export
-              </Button>
-            </div>
           </header>
 
-          <OperationsLogSummary
-            entries={visibleEntries}
-            rangeLabel={RANGE_LABEL[filters.range]}
-            range={filters.range}
-            loading={Boolean(isLoading || isFetchingNextPage || hasNextPage)}
-          />
+          <div
+            inert={isPageLoading}
+            aria-busy={isPageLoading}
+            className={cn(
+              'transition-opacity duration-200',
+              isPageLoading && 'cursor-wait opacity-50',
+            )}
+          >
+            <OperationsLogSummary
+              entries={visibleEntries}
+              environments={environments}
+              rangeLabel={RANGE_LABEL[filters.range]}
+              range={filters.range}
+              loading={isPageLoading}
+            />
 
-          <OperationsLogToolbar
-            counts={counts}
-            range={filters.range}
-            onRange={(range) => setFilters({ ...filters, range })}
-            entryType={filters.entry_type}
-            onEntryType={(entry_type) => setFilters({ ...filters, entry_type })}
-            environmentSlug={filters.environment_slug}
-            onEnvironment={(environment_slug) =>
-              setFilters({ ...filters, environment_slug })
-            }
-            environments={environments}
-            projectSlug={filters.project_slug}
-            onProject={(project_slug) =>
-              setFilters({ ...filters, project_slug })
-            }
-            projectNames={projectNames}
-          />
+            <OperationsLogToolbar
+              counts={counts}
+              range={filters.range}
+              onRange={(range) => setFilters({ ...filters, range })}
+              entryTypes={filters.entry_types}
+              onEntryTypes={(entry_types) =>
+                setFilters({ ...filters, entry_types })
+              }
+              view={view}
+              onView={setView}
+              environmentSlugs={filters.environment_slugs}
+              onEnvironmentSlugs={(environment_slugs) =>
+                setFilters({ ...filters, environment_slugs })
+              }
+              environments={environments}
+              projectSlugs={filters.project_slugs}
+              onProjectSlugs={(project_slugs) =>
+                setFilters({ ...filters, project_slugs })
+              }
+              projectNames={projectNames}
+            />
 
-          {activeChips.length > 0 && (
-            <div className="mb-3 flex flex-wrap items-center gap-1.5">
-              <span className="mr-1 text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
-                Filters
-              </span>
-              {activeChips.map((c) => (
+            {activeChips.length > 0 && (
+              <div className="mb-3 flex flex-wrap items-center gap-1.5">
+                <span className="mr-1 text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
+                  Filters
+                </span>
+                {activeChips.map((c) => (
+                  <button
+                    key={c.key}
+                    type="button"
+                    onClick={c.clear}
+                    className="inline-flex h-6 items-center gap-1 rounded bg-secondary px-2 text-[12px] text-secondary hover:text-primary"
+                  >
+                    <span className="truncate">{c.label}</span>
+                    <X className="h-3 w-3" />
+                  </button>
+                ))}
                 <button
-                  key={c.key}
                   type="button"
-                  onClick={c.clear}
-                  className="inline-flex h-6 items-center gap-1 rounded bg-secondary px-2 text-[12px] text-secondary hover:text-primary"
+                  onClick={() =>
+                    setFilters({
+                      range: filters.range,
+                      q: filters.q,
+                      entry_types: [],
+                      environment_slugs: [],
+                      project_slugs: [],
+                    })
+                  }
+                  className="ml-1 rounded px-2 py-0.5 text-[12px] text-tertiary hover:bg-secondary hover:text-primary"
                 >
-                  <span className="truncate">{c.label}</span>
-                  <X className="h-3 w-3" />
+                  Clear all
                 </button>
-              ))}
-              <button
-                type="button"
-                onClick={() =>
-                  setFilters({ range: filters.range, q: filters.q })
-                }
-                className="ml-1 rounded px-2 py-0.5 text-[12px] text-tertiary hover:bg-secondary hover:text-primary"
-              >
-                Clear all
-              </button>
-            </div>
-          )}
-
-          {isError && (
-            <div className="bg-danger/10 mb-3 rounded-md border border-danger px-3 py-2 text-sm text-danger">
-              Failed to load operations log.{' '}
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => fetchNextPage()}
-                className="ml-2"
-              >
-                Retry
-              </Button>
-            </div>
-          )}
-
-          {isLoading && (
-            <div className="rounded-md border border-tertiary bg-primary px-4 py-16 text-center text-secondary">
-              Loading operations log…
-            </div>
-          )}
-
-          {!isLoading &&
-            !isError &&
-            (buckets.length === 0 ? (
-              <div className="rounded-md border border-tertiary bg-primary px-6 py-16 text-center text-sm text-tertiary">
-                <SearchX className="mx-auto mb-2 h-7 w-7 text-tertiary" />
-                No events match these filters.
               </div>
-            ) : (
-              <div className="space-y-4">
-                {buckets.map((bucket) => (
-                  <section key={bucket.key}>
-                    <div className="mb-1.5 flex items-center gap-2.5 px-0.5">
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
-                        {bucket.label}
-                      </span>
-                      <span className="font-mono text-[11px] text-tertiary">
-                        {bucket.date.toLocaleDateString(undefined, {
-                          month: 'short',
-                          day: 'numeric',
-                        })}
-                      </span>
-                      <span className="h-px flex-1 bg-tertiary" />
-                      <span className="font-mono text-[11px] text-tertiary">
-                        {bucket.items.length}{' '}
-                        {bucket.items.length === 1 ? 'event' : 'events'}
-                      </span>
-                    </div>
-                    <div className="overflow-hidden rounded-md border border-tertiary bg-primary">
-                      {bucket.items.map((it) => {
-                        if (it.kind === 'release') {
-                          const id = it.group.latestEntry.id
-                          const isOpen =
-                            openId === id ||
-                            it.group.stops.some((s) => s.entry.id === openId)
+            )}
+
+            {isError && (
+              <div className="bg-danger/10 mb-3 rounded-md border border-danger px-3 py-2 text-sm text-danger">
+                Failed to load operations log.{' '}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => fetchNextPage()}
+                  className="ml-2"
+                >
+                  Retry
+                </Button>
+              </div>
+            )}
+
+            {isLoading && (
+              <div className="rounded-md border border-tertiary bg-primary px-4 py-16 text-center text-secondary">
+                Loading operations log…
+              </div>
+            )}
+
+            {!isLoading &&
+              !isError &&
+              (buckets.length === 0 ? (
+                <div className="rounded-md border border-tertiary bg-primary px-6 py-16 text-center text-sm text-tertiary">
+                  <SearchX className="mx-auto mb-2 h-7 w-7 text-tertiary" />
+                  No events match these filters.
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {buckets.map((bucket) => (
+                    <section key={bucket.key}>
+                      <div className="mb-1.5 flex items-center gap-2.5 px-0.5">
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-tertiary">
+                          {bucket.label}
+                        </span>
+                        <span className="font-mono text-[11px] text-tertiary">
+                          {bucket.date.toLocaleDateString(undefined, {
+                            month: 'short',
+                            day: 'numeric',
+                          })}
+                        </span>
+                        <span className="h-px flex-1 bg-tertiary" />
+                        <span className="font-mono text-[11px] text-tertiary">
+                          {bucket.items.length}{' '}
+                          {bucket.items.length === 1 ? 'event' : 'events'}
+                        </span>
+                      </div>
+                      <div className="overflow-hidden rounded-md border border-tertiary bg-primary">
+                        {bucket.items.map((it) => {
+                          if (it.kind === 'release') {
+                            const id = it.group.latestEntry.id
+                            const isOpen =
+                              openId === id ||
+                              it.group.stops.some((s) => s.entry.id === openId)
+                            return (
+                              <OperationsLogReleaseCard
+                                key={`rel-${id}`}
+                                id={id}
+                                group={it.group}
+                                project={projectsBySlug.get(
+                                  it.group.project_slug,
+                                )}
+                                environmentsBySlug={environmentsBySlug}
+                                isOpen={isOpen}
+                                onToggle={toggleOpen}
+                                performerDisplayNames={performerDisplayNames}
+                              />
+                            )
+                          }
+                          const id = it.entry.id
+                          const isOpen = openId === id
                           return (
-                            <OperationsLogReleaseCard
-                              key={`rel-${id}`}
+                            <OperationsLogStreamRow
+                              key={`evt-${id}`}
                               id={id}
-                              group={it.group}
+                              entry={it.entry}
                               project={projectsBySlug.get(
-                                it.group.project_slug,
+                                it.entry.project_slug,
                               )}
-                              environmentsBySlug={environmentsBySlug}
+                              environment={environmentsBySlug.get(
+                                it.entry.environment_slug,
+                              )}
                               isOpen={isOpen}
                               onToggle={toggleOpen}
                               performerDisplayNames={performerDisplayNames}
                             />
                           )
-                        }
-                        const id = it.entry.id
-                        const isOpen = openId === id
-                        return (
-                          <OperationsLogStreamRow
-                            key={`evt-${id}`}
-                            id={id}
-                            entry={it.entry}
-                            project={projectsBySlug.get(it.entry.project_slug)}
-                            environment={environmentsBySlug.get(
-                              it.entry.environment_slug,
-                            )}
-                            isOpen={isOpen}
-                            onToggle={toggleOpen}
-                            performerDisplayNames={performerDisplayNames}
-                          />
-                        )
-                      })}
-                    </div>
-                  </section>
-                ))}
-                <div
-                  ref={sentinelRef}
-                  className="py-3 text-center text-xs text-tertiary"
-                >
-                  {isFetchingNextPage ? (
-                    'Loading more…'
-                  ) : hasNextPage ? (
-                    rawEntries.length >= autoFetchCap ? (
-                      <button
-                        type="button"
-                        onClick={() => fetchNextPage()}
-                        className="rounded px-3 py-1 text-[12px] hover:bg-secondary hover:text-primary"
-                      >
-                        Load more (showing {rawEntries.length})
-                      </button>
+                        })}
+                      </div>
+                    </section>
+                  ))}
+                  <div
+                    ref={sentinelRef}
+                    className="py-3 text-center text-xs text-tertiary"
+                  >
+                    {isFetchingNextPage ? (
+                      'Loading more…'
+                    ) : hasNextPage ? (
+                      rawEntries.length >= autoFetchCap ? (
+                        <button
+                          type="button"
+                          onClick={() => fetchNextPage()}
+                          className="rounded px-3 py-1 text-[12px] hover:bg-secondary hover:text-primary"
+                        >
+                          Load more (showing {rawEntries.length})
+                        </button>
+                      ) : (
+                        'Loading…'
+                      )
                     ) : (
-                      'Loading…'
-                    )
-                  ) : (
-                    `End of log · ${visibleEntries.length} entries`
-                  )}
+                      `End of log · ${visibleEntries.length} entries`
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+          </div>
         </main>
       </div>
     </div>

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -135,20 +135,48 @@ export function OperationsLog() {
     setOpenId((prev) => (prev === id ? undefined : id))
   }, [])
 
-  const { data: projects = [] } = useQuery({
+  const {
+    data: projects = [],
+    isError: projectsError,
+    refetch: refetchProjects,
+  } = useQuery({
     queryKey: ['projects', orgSlug],
     queryFn: () => getProjects(orgSlug),
     enabled: !!orgSlug,
   })
-  const { data: environments = [] } = useQuery({
+  const {
+    data: environments = [],
+    isError: environmentsError,
+    refetch: refetchEnvironments,
+  } = useQuery({
     queryKey: ['environments', orgSlug],
     queryFn: () => listEnvironments(orgSlug),
     enabled: !!orgSlug,
   })
-  const { data: users = [] } = useQuery({
+  const {
+    data: users = [],
+    isError: usersError,
+    refetch: refetchUsers,
+  } = useQuery({
     queryKey: ['admin-users', 'active'],
     queryFn: () => listAdminUsers({ is_active: true }),
   })
+  // Metadata queries back the filter dropdowns and the slug→name
+  // lookups. When any of them fail we surface a non-blocking banner so
+  // the user can retry rather than silently falling back to raw slugs.
+  const metadataError = projectsError || environmentsError || usersError
+  const retryMetadata = useCallback(() => {
+    if (projectsError) refetchProjects()
+    if (environmentsError) refetchEnvironments()
+    if (usersError) refetchUsers()
+  }, [
+    projectsError,
+    environmentsError,
+    usersError,
+    refetchProjects,
+    refetchEnvironments,
+    refetchUsers,
+  ])
 
   // Only the time-range boundary is pushed to the server. Facet filters
   // (entry_types / environment_slugs / project_slugs) are applied
@@ -170,6 +198,7 @@ export function OperationsLog() {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    refetch,
   } = useInfiniteOperationsLog(apiFilters)
 
   const rawEntries: OperationsLogRecord[] = useMemo(
@@ -523,7 +552,22 @@ export function OperationsLog() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => fetchNextPage()}
+                  onClick={() => refetch()}
+                  className="ml-2"
+                >
+                  Retry
+                </Button>
+              </div>
+            )}
+
+            {metadataError && (
+              <div className="bg-warning/10 mb-3 rounded-md border border-warning px-3 py-2 text-sm text-warning">
+                Some filter metadata failed to load — projects, environments, or
+                users may show as slugs.{' '}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={retryMetadata}
                   className="ml-2"
                 >
                   Retry

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -479,10 +479,10 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
   return (
     <div className="mx-auto max-w-[1600px] px-6 py-8">
       {/* Project Header */}
-      <div className="mb-6 pl-4">
+      <div className="mb-6">
         <div className="flex items-start justify-between">
-          <div>
-            <div className="mb-1 flex items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="-ml-[18px] mb-1 flex items-center gap-3">
               <InlineText
                 value={project.name}
                 onCommit={(v) => patch('/name', v ?? '')}
@@ -533,7 +533,7 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
           </div>
         </div>
 
-        <div className="mt-3 text-secondary">
+        <div className="-ml-[18px] mt-3 text-secondary">
           <InlineTextarea
             value={project.description ?? null}
             onCommit={(v) => patch('/description', v)}

--- a/src/components/operations-log/OperationsLogEntryDetails.tsx
+++ b/src/components/operations-log/OperationsLogEntryDetails.tsx
@@ -1,0 +1,140 @@
+import { useQuery } from '@tanstack/react-query'
+import { ExternalLink } from 'lucide-react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { getOperationsLogEntry } from '@/api/endpoints'
+import type { OperationsLogRecord } from '@/types'
+
+interface Props {
+  entry: OperationsLogRecord
+}
+
+function parseUtcIso(iso: string): Date {
+  const hasOffset = /(Z|[+-]\d\d:?\d\d)$/.test(iso)
+  return new Date(hasOffset ? iso : iso + 'Z')
+}
+
+function formatAbsolute(iso: string): string {
+  try {
+    return parseUtcIso(iso).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function MetaChip({
+  label,
+  children,
+  title,
+}: {
+  label: string
+  children: React.ReactNode
+  title?: string
+}) {
+  return (
+    <span className="inline-flex items-baseline gap-1.5" title={title}>
+      <span className="text-overline uppercase text-tertiary">{label}</span>
+      <span className="text-primary">{children}</span>
+    </span>
+  )
+}
+
+export function OperationsLogEntryDetails({ entry }: Props) {
+  const { data } = useQuery({
+    queryKey: ['operationsLog', 'entry', entry.id],
+    queryFn: () => getOperationsLogEntry(entry.id),
+    initialData: entry,
+    staleTime: 30_000,
+  })
+
+  const record = data ?? entry
+  const performer = record.performed_by ?? record.recorded_by
+
+  // Notes from the v1 migration often duplicate the description; suppress
+  // identical notes so the panel shows real long-form content only.
+  const hasNotes =
+    !!record.notes && record.notes.trim() !== record.description.trim()
+
+  const hasExtras =
+    hasNotes ||
+    !!record.link ||
+    !!record.ticket_slug ||
+    !!record.completed_at ||
+    record.recorded_by !== performer
+
+  return (
+    <div className="space-y-4 py-4 pl-[60px] pr-4">
+      {hasNotes && (
+        <div>
+          <h3 className="mb-1.5 text-overline uppercase text-tertiary">
+            Notes
+          </h3>
+          <div className="prose prose-sm dark:prose-invert max-w-none rounded-md border border-tertiary bg-primary p-3 text-primary [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+            <Markdown remarkPlugins={[remarkGfm]}>{record.notes}</Markdown>
+          </div>
+        </div>
+      )}
+
+      {record.link && (
+        <div>
+          <h3 className="mb-1.5 text-overline uppercase text-tertiary">Link</h3>
+          <a
+            href={record.link}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 break-all text-sm text-amber-text hover:underline"
+          >
+            <ExternalLink className="h-3.5 w-3.5 flex-shrink-0" />
+            {record.link}
+          </a>
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-baseline gap-x-5 gap-y-2 text-xs">
+        {record.ticket_slug && (
+          <MetaChip label="Ticket">
+            <code className="font-mono">{record.ticket_slug}</code>
+          </MetaChip>
+        )}
+
+        {record.completed_at && (
+          <MetaChip label="Completed">
+            {formatAbsolute(record.completed_at)}
+          </MetaChip>
+        )}
+
+        {record.recorded_by !== performer && (
+          <MetaChip label="Recorded by">
+            <span className="text-secondary">{record.recorded_by}</span>
+          </MetaChip>
+        )}
+
+        <MetaChip label="Occurred">
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>{formatAbsolute(record.occurred_at)}</span>
+              </TooltipTrigger>
+              <TooltipContent>{record.occurred_at}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </MetaChip>
+      </div>
+
+      {!hasExtras && (
+        <p className="text-sm text-tertiary">
+          No additional notes, link, or ticket for this entry.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/operations-log/OperationsLogReleaseCard.tsx
+++ b/src/components/operations-log/OperationsLogReleaseCard.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Rocket } from 'lucide-react'
-import { useEffect, useRef } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
   ReleaseTrain,
@@ -26,15 +26,17 @@ import {
 } from './opsLogHelpers'
 
 interface Props {
+  id: string
   group: ReleaseGroup
   project?: Project
   environmentsBySlug: Map<string, Environment>
   isOpen: boolean
-  onToggle: () => void
+  onToggle: (id: string) => void
   performerDisplayNames: Map<string, string>
 }
 
-export function OperationsLogReleaseCard({
+export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
+  id,
   group,
   project,
   environmentsBySlug,
@@ -98,7 +100,7 @@ export function OperationsLogReleaseCard({
     if (isOpen) return
     if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
     hoverTimer.current = window.setTimeout(() => {
-      onToggle()
+      onToggle(id)
     }, 100)
   }
   const onMouseLeave = () => {
@@ -106,7 +108,7 @@ export function OperationsLogReleaseCard({
       window.clearTimeout(hoverTimer.current)
       hoverTimer.current = null
     }
-    if (isOpen) onToggle()
+    if (isOpen) onToggle(id)
   }
 
   return (
@@ -117,6 +119,10 @@ export function OperationsLogReleaseCard({
         'border-b border-tertiary last:border-b-0',
         isOpen && 'bg-secondary',
       )}
+      style={{
+        contentVisibility: 'auto',
+        containIntrinsicSize: 'auto 72px',
+      }}
     >
       <div
         className={cn(
@@ -293,4 +299,4 @@ export function OperationsLogReleaseCard({
       ) : null}
     </div>
   )
-}
+})

--- a/src/components/operations-log/OperationsLogReleaseCard.tsx
+++ b/src/components/operations-log/OperationsLogReleaseCard.tsx
@@ -104,6 +104,8 @@ export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
       <button
         type="button"
         onClick={() => onToggle(id)}
+        aria-expanded={isOpen}
+        aria-controls={`ops-log-details-${id}`}
         className={cn(
           'group grid w-full cursor-pointer items-center gap-x-3 gap-y-1 text-left transition-colors',
           OPS_ROW_PAD,
@@ -147,7 +149,7 @@ export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
         </span>
         {desc ? null : (
           <span
-            className="min-w-0 truncate text-sm text-secondary text-tertiary"
+            className="min-w-0 truncate text-sm text-tertiary"
             style={{ gridColumn: 5 }}
           >
             —
@@ -204,7 +206,10 @@ export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
         ) : null}
       </button>
       {isOpen ? (
-        <div className="border-t border-dashed border-tertiary">
+        <div
+          id={`ops-log-details-${id}`}
+          className="border-t border-dashed border-tertiary"
+        >
           <OperationsLogEntryDetails entry={latest} />
           <div className="space-y-2 px-4 pb-4 pl-[60px]">
             <div className="text-overline uppercase text-tertiary">

--- a/src/components/operations-log/OperationsLogReleaseCard.tsx
+++ b/src/components/operations-log/OperationsLogReleaseCard.tsx
@@ -1,0 +1,296 @@
+import { ChevronDown, Rocket } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { Gravatar } from '@/components/ui/gravatar'
+import {
+  ReleaseTrain,
+  type ReleaseTrainStop,
+} from '@/components/ui/release-train'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useTheme } from '@/contexts/ThemeContext'
+import { deriveChipColors } from '@/lib/chip-colors'
+import { cn } from '@/lib/utils'
+import type { Environment, Project } from '@/types'
+import { OperationsLogEntryDetails } from './OperationsLogEntryDetails'
+import { OPS_ROW_GRID, OPS_ROW_PAD } from './opsRowLayout'
+import {
+  absTime,
+  cleanDescription,
+  cleanName,
+  relTime,
+  type ReleaseGroup,
+} from './opsLogHelpers'
+
+interface Props {
+  group: ReleaseGroup
+  project?: Project
+  environmentsBySlug: Map<string, Environment>
+  isOpen: boolean
+  onToggle: () => void
+  performerDisplayNames: Map<string, string>
+}
+
+export function OperationsLogReleaseCard({
+  group,
+  project,
+  environmentsBySlug,
+  isOpen,
+  onToggle,
+  performerDisplayNames,
+}: Props) {
+  const { isDarkMode } = useTheme()
+  const latest = group.latestEntry
+  const performer = latest.performed_by ?? latest.recorded_by
+  const displayName = performerDisplayNames.get(performer) ?? performer
+  const version = group.stops[0]?.entry.version ?? latest.version ?? ''
+  const desc = cleanDescription(group.description, version)
+  const projectLabel = project?.name ?? group.project_slug
+
+  // Pipeline = this project's own environments, unioned with any
+  // environments that actually received a deploy in this release group
+  // (so an out-of-pipeline prod deploy still shows in the train instead
+  // of leaving Testing/Staging pending with no Production chip).
+  const stopByEnvSlug = new Map(
+    group.stops.map((s) => [s.entry.environment_slug, s]),
+  )
+  const envBySlug = new Map<string, Environment>()
+  for (const env of project?.environments ?? []) envBySlug.set(env.slug, env)
+  for (const s of group.stops) {
+    const slug = s.entry.environment_slug
+    if (envBySlug.has(slug)) continue
+    const env = environmentsBySlug.get(slug)
+    if (env) envBySlug.set(slug, env)
+  }
+  const trainEnvironments: Environment[] = Array.from(envBySlug.values())
+
+  const trainStops: ReleaseTrainStop[] = trainEnvironments.map((env) => {
+    const stop = stopByEnvSlug.get(env.slug)
+    return {
+      environment: env,
+      value: stop?.entry.version ?? null,
+      title: stop
+        ? `${env.name}: ${stop.entry.version ?? '—'} · ${absTime(stop.entry.occurred_at)}`
+        : `${env.name} · not deployed`,
+    }
+  })
+
+  // Rail colour: the highest-sort_order environment the release has
+  // reached. Zero hard-coded env names.
+  const reachedEnvs = group.stops
+    .map((s) => environmentsBySlug.get(s.entry.environment_slug))
+    .filter((e): e is Environment => !!e)
+    .sort((a, b) => (b.sort_order ?? 0) - (a.sort_order ?? 0))
+  const railColors = reachedEnvs[0]?.label_color
+    ? deriveChipColors(reachedEnvs[0]!.label_color!, isDarkMode)
+    : null
+  const hoverTimer = useRef<number | null>(null)
+  useEffect(
+    () => () => {
+      if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
+    },
+    [],
+  )
+  const onMouseEnter = () => {
+    if (isOpen) return
+    if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
+    hoverTimer.current = window.setTimeout(() => {
+      onToggle()
+    }, 100)
+  }
+  const onMouseLeave = () => {
+    if (hoverTimer.current) {
+      window.clearTimeout(hoverTimer.current)
+      hoverTimer.current = null
+    }
+    if (isOpen) onToggle()
+  }
+
+  return (
+    <div
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className={cn(
+        'border-b border-tertiary last:border-b-0',
+        isOpen && 'bg-secondary',
+      )}
+    >
+      <div
+        className={cn(
+          'group grid w-full items-center gap-x-3 gap-y-1 text-left transition-colors',
+          OPS_ROW_PAD,
+          !isOpen && 'hover:bg-secondary',
+        )}
+        style={{
+          gridTemplateColumns: OPS_ROW_GRID,
+          gridTemplateRows: desc ? 'auto auto' : 'auto',
+        }}
+      >
+        <span
+          className={cn(
+            'self-stretch rounded-r-sm',
+            !railColors && 'bg-tertiary',
+          )}
+          style={{
+            ...(railColors ? { backgroundColor: railColors.border } : {}),
+            gridColumn: 1,
+            gridRow: '1 / -1',
+          }}
+          aria-hidden
+        />
+        <span
+          className="flex h-[26px] w-[26px] items-center justify-center rounded-md bg-success text-success"
+          style={{ gridColumn: 2, gridRow: 1 }}
+        >
+          <Rocket className="h-3.5 w-3.5" />
+        </span>
+        <span
+          className="truncate text-sm font-medium text-primary"
+          style={{ gridColumn: 3, gridRow: 1 }}
+          title={projectLabel}
+        >
+          {projectLabel}
+        </span>
+        <span
+          className="truncate font-mono text-xs text-secondary"
+          style={{ gridColumn: 4, gridRow: 1 }}
+        >
+          {version || '—'}
+        </span>
+        {desc ? null : (
+          <span
+            className="min-w-0 truncate text-sm text-secondary text-tertiary"
+            style={{ gridColumn: 5 }}
+          >
+            —
+          </span>
+        )}
+        <span
+          className="flex items-center justify-center"
+          style={{ gridColumn: 6, gridRow: '1 / -1' }}
+        >
+          <ReleaseTrain stops={trainStops} size="compact" />
+        </span>
+        <span
+          className="self-center justify-self-end"
+          style={{ gridColumn: 7, gridRow: '1 / -1' }}
+          title={displayName}
+        >
+          <Gravatar
+            email={performer}
+            size={22}
+            className="h-[22px] w-[22px] rounded-full"
+          />
+        </span>
+        <TooltipProvider delayDuration={250}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="self-center whitespace-nowrap text-right text-xs tabular-nums text-tertiary"
+                style={{ gridColumn: 8, gridRow: '1 / -1' }}
+              >
+                {relTime(latest.occurred_at)}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{absTime(latest.occurred_at)}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <span
+          className="flex items-center justify-center self-center text-tertiary"
+          style={{ gridColumn: 9, gridRow: '1 / -1' }}
+        >
+          <ChevronDown
+            className={cn(
+              'h-3.5 w-3.5 transition-transform',
+              isOpen && 'rotate-180 text-primary',
+            )}
+          />
+        </span>
+        {desc ? (
+          <span
+            className="min-w-0 truncate text-sm text-secondary"
+            style={{ gridColumn: '3 / 6', gridRow: 2 }}
+          >
+            {desc}
+          </span>
+        ) : null}
+      </div>
+      {isOpen ? (
+        <div className="border-t border-dashed border-tertiary">
+          <OperationsLogEntryDetails entry={latest} />
+          <div className="space-y-2 px-4 pb-4 pl-[60px]">
+            <div className="text-overline uppercase text-tertiary">
+              Promotion timeline
+            </div>
+            {group.stops
+              .slice()
+              .sort((a, b) => {
+                const ea = environmentsBySlug.get(a.entry.environment_slug)
+                const eb = environmentsBySlug.get(b.entry.environment_slug)
+                return (ea?.sort_order ?? 0) - (eb?.sort_order ?? 0)
+              })
+              .map((s) => {
+                const env = environmentsBySlug.get(s.entry.environment_slug)
+                const colors = env?.label_color
+                  ? deriveChipColors(env.label_color, isDarkMode)
+                  : null
+                return (
+                  <div
+                    key={s.entry.environment_slug}
+                    className="grid grid-cols-[24px_120px_1fr_auto] items-center gap-3 rounded-md border border-tertiary bg-primary px-3 py-2 text-sm"
+                  >
+                    <Rocket className="h-3.5 w-3.5 text-tertiary" />
+                    <span
+                      className="inline-flex items-center justify-center rounded border px-2 py-0.5 text-xs font-medium"
+                      style={
+                        colors
+                          ? {
+                              backgroundColor: colors.bg,
+                              color: colors.fg,
+                              borderColor: colors.border,
+                            }
+                          : undefined
+                      }
+                    >
+                      {env?.name ?? s.entry.environment_slug}
+                    </span>
+                    <div className="min-w-0">
+                      <div className="font-mono text-xs">
+                        {s.entry.version || '—'}
+                      </div>
+                      {s.entry.link ? (
+                        <a
+                          href={s.entry.link}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="mt-0.5 block truncate text-xs text-amber-text hover:underline"
+                        >
+                          {s.entry.link}
+                        </a>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-col items-end gap-0.5">
+                      <span className="text-xs text-tertiary">
+                        {absTime(s.entry.occurred_at)}
+                      </span>
+                      <span className="text-xs text-secondary">
+                        {performerDisplayNames.get(
+                          s.entry.performed_by ?? s.entry.recorded_by,
+                        ) ??
+                          cleanName(
+                            s.entry.performed_by ?? s.entry.recorded_by,
+                          )}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/operations-log/OperationsLogReleaseCard.tsx
+++ b/src/components/operations-log/OperationsLogReleaseCard.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Rocket } from 'lucide-react'
-import { memo, useEffect, useRef } from 'react'
+import { memo } from 'react'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
   ReleaseTrain,
@@ -89,32 +89,9 @@ export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
   const railColors = reachedEnvs[0]?.label_color
     ? deriveChipColors(reachedEnvs[0]!.label_color!, isDarkMode)
     : null
-  const hoverTimer = useRef<number | null>(null)
-  useEffect(
-    () => () => {
-      if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
-    },
-    [],
-  )
-  const onMouseEnter = () => {
-    if (isOpen) return
-    if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
-    hoverTimer.current = window.setTimeout(() => {
-      onToggle(id)
-    }, 100)
-  }
-  const onMouseLeave = () => {
-    if (hoverTimer.current) {
-      window.clearTimeout(hoverTimer.current)
-      hoverTimer.current = null
-    }
-    if (isOpen) onToggle(id)
-  }
 
   return (
     <div
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
       className={cn(
         'border-b border-tertiary last:border-b-0',
         isOpen && 'bg-secondary',
@@ -124,9 +101,11 @@ export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
         containIntrinsicSize: 'auto 72px',
       }}
     >
-      <div
+      <button
+        type="button"
+        onClick={() => onToggle(id)}
         className={cn(
-          'group grid w-full items-center gap-x-3 gap-y-1 text-left transition-colors',
+          'group grid w-full cursor-pointer items-center gap-x-3 gap-y-1 text-left transition-colors',
           OPS_ROW_PAD,
           !isOpen && 'hover:bg-secondary',
         )}
@@ -223,7 +202,7 @@ export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
             {desc}
           </span>
         ) : null}
-      </div>
+      </button>
       {isOpen ? (
         <div className="border-t border-dashed border-tertiary">
           <OperationsLogEntryDetails entry={latest} />

--- a/src/components/operations-log/OperationsLogSidebar.tsx
+++ b/src/components/operations-log/OperationsLogSidebar.tsx
@@ -1,0 +1,252 @@
+import { Box, Clock } from 'lucide-react'
+import { useTheme } from '@/contexts/ThemeContext'
+import { deriveChipColors } from '@/lib/chip-colors'
+import { cn } from '@/lib/utils'
+import { Gravatar } from '@/components/ui/gravatar'
+import { ENTRY_TYPE_ICONS } from '@/lib/ops-log-icons'
+import { sortEnvironments } from '@/lib/utils'
+import {
+  OPERATIONS_LOG_ENTRY_TYPES,
+  type Environment,
+  type OperationsLogEntryType,
+} from '@/types'
+import type { TimeRange } from './opsLogHelpers'
+import { cleanName } from './opsLogHelpers'
+
+export interface SidebarCounts {
+  type: Partial<Record<OperationsLogEntryType, number>>
+  env: Record<string, number>
+  project: Record<string, number>
+  person: Record<string, number>
+}
+
+interface SidebarProps {
+  counts: SidebarCounts
+  range: TimeRange
+  onRange: (r: TimeRange) => void
+  entryType?: OperationsLogEntryType
+  onEntryType: (t: OperationsLogEntryType | undefined) => void
+  environmentSlug: string | undefined
+  onEnvironment: (slug: string | undefined) => void
+  environments: Environment[]
+  projectSlug: string | undefined
+  onProject: (slug: string | undefined) => void
+  projectNames: Map<string, string>
+  performer: string | undefined
+  onPerformer: (email: string | undefined) => void
+  performerDisplayNames: Map<string, string>
+}
+
+const RANGES: { key: TimeRange; label: string }[] = [
+  { key: '24h', label: 'Last 24 hours' },
+  { key: '3d', label: 'Last 3 days' },
+  { key: '7d', label: 'Last 7 days' },
+  { key: '30d', label: 'Last 30 days' },
+  { key: 'all', label: 'All time' },
+]
+
+function SideButton({
+  active,
+  onClick,
+  icon,
+  children,
+  count,
+  title,
+}: {
+  active?: boolean
+  onClick: () => void
+  icon?: React.ReactNode
+  children: React.ReactNode
+  count?: number
+  title?: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={cn(
+        'flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+        'hover:bg-secondary',
+        active ? 'bg-secondary font-medium text-primary' : 'text-secondary',
+      )}
+    >
+      {icon ? (
+        <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-tertiary">
+          {icon}
+        </span>
+      ) : null}
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+      {count != null ? (
+        <span className="text-xs text-tertiary">{count}</span>
+      ) : null}
+    </button>
+  )
+}
+
+function Section({
+  title,
+  rightMeta,
+  children,
+}: {
+  title: string
+  rightMeta?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h3 className="mx-2 mb-1 flex items-center justify-between text-overline uppercase tracking-[0.06em] text-tertiary">
+        <span>{title}</span>
+        {rightMeta}
+      </h3>
+      {children}
+    </div>
+  )
+}
+
+export function OperationsLogSidebar({
+  counts,
+  range,
+  onRange,
+  entryType,
+  onEntryType,
+  environmentSlug,
+  onEnvironment,
+  environments,
+  projectSlug,
+  onProject,
+  projectNames,
+  performer,
+  onPerformer,
+  performerDisplayNames,
+}: SidebarProps) {
+  const { isDarkMode } = useTheme()
+  const topProjects = Object.entries(counts.project)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+
+  const topPeople = Object.entries(counts.person)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+
+  const orderedEnvironments = sortEnvironments(environments).filter(
+    (env) => (counts.env[env.slug] ?? 0) > 0 || environmentSlug === env.slug,
+  )
+
+  return (
+    <aside className="sticky top-20 flex flex-col gap-5 self-start text-sm">
+      <Section title="Time range">
+        {RANGES.map((r) => (
+          <SideButton
+            key={r.key}
+            active={range === r.key}
+            onClick={() => onRange(r.key)}
+            icon={<Clock className="h-3.5 w-3.5" />}
+          >
+            {r.label}
+          </SideButton>
+        ))}
+      </Section>
+
+      <Section title="Event type">
+        {OPERATIONS_LOG_ENTRY_TYPES.filter(
+          (t) => (counts.type[t] ?? 0) > 0,
+        ).map((t) => {
+          const Icon = ENTRY_TYPE_ICONS[t]
+          return (
+            <SideButton
+              key={t}
+              active={entryType === t}
+              onClick={() => onEntryType(entryType === t ? undefined : t)}
+              icon={<Icon className="h-3.5 w-3.5" />}
+              count={counts.type[t]}
+            >
+              {t}
+            </SideButton>
+          )
+        })}
+      </Section>
+
+      {orderedEnvironments.length > 0 && (
+        <Section title="Environment">
+          {orderedEnvironments.map((env) => {
+            const colors = env.label_color
+              ? deriveChipColors(env.label_color, isDarkMode)
+              : null
+            return (
+              <SideButton
+                key={env.slug}
+                active={environmentSlug === env.slug}
+                onClick={() =>
+                  onEnvironment(
+                    environmentSlug === env.slug ? undefined : env.slug,
+                  )
+                }
+                icon={
+                  <span
+                    className="h-2 w-2 rounded-full"
+                    style={{
+                      backgroundColor: colors?.border ?? 'currentColor',
+                    }}
+                    aria-hidden
+                  />
+                }
+                count={counts.env[env.slug] ?? 0}
+              >
+                {env.name}
+              </SideButton>
+            )
+          })}
+        </Section>
+      )}
+
+      {topProjects.length > 0 && (
+        <Section
+          title="Projects"
+          rightMeta={
+            <span className="text-xs font-normal tracking-normal text-tertiary">
+              {Object.keys(counts.project).length}
+            </span>
+          }
+        >
+          {topProjects.map(([slug, c]) => (
+            <SideButton
+              key={slug}
+              active={projectSlug === slug}
+              onClick={() => onProject(projectSlug === slug ? undefined : slug)}
+              icon={<Box className="h-3.5 w-3.5" />}
+              count={c}
+              title={projectNames.get(slug) ?? slug}
+            >
+              {projectNames.get(slug) ?? slug}
+            </SideButton>
+          ))}
+        </Section>
+      )}
+
+      {topPeople.length > 0 && (
+        <Section title="People">
+          {topPeople.map(([email, c]) => (
+            <SideButton
+              key={email}
+              active={performer === email}
+              onClick={() =>
+                onPerformer(performer === email ? undefined : email)
+              }
+              icon={
+                <Gravatar
+                  email={email}
+                  size={18}
+                  className="h-4 w-4 rounded-full"
+                />
+              }
+              count={c}
+            >
+              {performerDisplayNames.get(email) ?? cleanName(email)}
+            </SideButton>
+          ))}
+        </Section>
+      )}
+    </aside>
+  )
+}

--- a/src/components/operations-log/OperationsLogSidebar.tsx
+++ b/src/components/operations-log/OperationsLogSidebar.tsx
@@ -1,4 +1,6 @@
-import { Box, Clock } from 'lucide-react'
+import { Search } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Input } from '@/components/ui/input'
 import { useTheme } from '@/contexts/ThemeContext'
 import { deriveChipColors } from '@/lib/chip-colors'
 import { cn } from '@/lib/utils'
@@ -38,11 +40,11 @@ interface SidebarProps {
 }
 
 const RANGES: { key: TimeRange; label: string }[] = [
-  { key: '24h', label: 'Last 24 hours' },
-  { key: '3d', label: 'Last 3 days' },
-  { key: '7d', label: 'Last 7 days' },
-  { key: '30d', label: 'Last 30 days' },
-  { key: 'all', label: 'All time' },
+  { key: '24h', label: '24h' },
+  { key: '7d', label: '7d' },
+  { key: '30d', label: '30d' },
+  { key: '90d', label: '90d' },
+  { key: 'all', label: 'All' },
 ]
 
 function SideButton({
@@ -121,9 +123,26 @@ export function OperationsLogSidebar({
   performerDisplayNames,
 }: SidebarProps) {
   const { isDarkMode } = useTheme()
-  const topProjects = Object.entries(counts.project)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 8)
+  const [projectFilter, setProjectFilter] = useState('')
+  const projectEntries = useMemo(
+    () =>
+      Object.entries(counts.project).sort(
+        (a, b) =>
+          b[1] - a[1] ||
+          (projectNames.get(a[0]) ?? a[0]).localeCompare(
+            projectNames.get(b[0]) ?? b[0],
+          ),
+      ),
+    [counts.project, projectNames],
+  )
+  const filteredProjects = useMemo(() => {
+    const q = projectFilter.toLowerCase().trim()
+    if (!q) return projectEntries
+    return projectEntries.filter(([slug]) => {
+      const name = (projectNames.get(slug) ?? slug).toLowerCase()
+      return slug.toLowerCase().includes(q) || name.includes(q)
+    })
+  }, [projectEntries, projectFilter, projectNames])
 
   const topPeople = Object.entries(counts.person)
     .sort((a, b) => b[1] - a[1])
@@ -136,16 +155,27 @@ export function OperationsLogSidebar({
   return (
     <aside className="sticky top-20 flex flex-col gap-5 self-start text-sm">
       <Section title="Time range">
-        {RANGES.map((r) => (
-          <SideButton
-            key={r.key}
-            active={range === r.key}
-            onClick={() => onRange(r.key)}
-            icon={<Clock className="h-3.5 w-3.5" />}
-          >
-            {r.label}
-          </SideButton>
-        ))}
+        <div
+          role="group"
+          aria-label="Time range"
+          className="mx-2 flex items-center rounded-md border border-tertiary bg-secondary p-0.5"
+        >
+          {RANGES.map((r) => (
+            <button
+              key={r.key}
+              type="button"
+              onClick={() => onRange(r.key)}
+              className={cn(
+                'flex-1 rounded px-2 py-1 text-xs font-medium transition-colors',
+                range === r.key
+                  ? 'bg-primary text-primary shadow-sm'
+                  : 'text-secondary hover:text-primary',
+              )}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
       </Section>
 
       <Section title="Event type">
@@ -200,25 +230,33 @@ export function OperationsLogSidebar({
         </Section>
       )}
 
-      {topProjects.length > 0 && (
+      {projectEntries.length > 0 && (
         <Section
           title="Projects"
           rightMeta={
             <span className="text-xs font-normal tracking-normal text-tertiary">
-              {Object.keys(counts.project).length}
+              {projectEntries.length}
             </span>
           }
         >
-          {topProjects.map(([slug, c]) => (
+          <div className="relative mx-2 mb-1">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
+            <Input
+              value={projectFilter}
+              onChange={(e) => setProjectFilter(e.target.value)}
+              placeholder="Filter projects…"
+              className="h-8 pl-8 text-sm"
+            />
+          </div>
+          {filteredProjects.map(([slug, c]) => (
             <SideButton
               key={slug}
               active={projectSlug === slug}
               onClick={() => onProject(projectSlug === slug ? undefined : slug)}
-              icon={<Box className="h-3.5 w-3.5" />}
               count={c}
               title={projectNames.get(slug) ?? slug}
             >
-              {projectNames.get(slug) ?? slug}
+              <span className="font-mono text-[13px]">{slug}</span>
             </SideButton>
           ))}
         </Section>

--- a/src/components/operations-log/OperationsLogStreamRow.tsx
+++ b/src/components/operations-log/OperationsLogStreamRow.tsx
@@ -63,6 +63,8 @@ export const OperationsLogStreamRow = memo(function OperationsLogStreamRow({
       <button
         type="button"
         onClick={() => onToggle(id)}
+        aria-expanded={isOpen}
+        aria-controls={`ops-log-details-${id}`}
         className={cn(
           'group grid w-full cursor-pointer items-center gap-x-3 gap-y-1 text-left transition-colors',
           OPS_ROW_PAD,
@@ -114,7 +116,7 @@ export const OperationsLogStreamRow = memo(function OperationsLogStreamRow({
         </span>
         {desc ? null : (
           <span
-            className="min-w-0 truncate text-sm text-secondary text-tertiary"
+            className="min-w-0 truncate text-sm text-tertiary"
             style={{ gridColumn: 5 }}
           >
             —
@@ -184,7 +186,10 @@ export const OperationsLogStreamRow = memo(function OperationsLogStreamRow({
         ) : null}
       </button>
       {isOpen ? (
-        <div className="border-t border-dashed border-tertiary">
+        <div
+          id={`ops-log-details-${id}`}
+          className="border-t border-dashed border-tertiary"
+        >
           <OperationsLogEntryDetails entry={entry} />
         </div>
       ) : null}

--- a/src/components/operations-log/OperationsLogStreamRow.tsx
+++ b/src/components/operations-log/OperationsLogStreamRow.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from 'lucide-react'
-import { memo, useEffect, useRef } from 'react'
+import { memo } from 'react'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
   Tooltip,
@@ -48,32 +48,9 @@ export const OperationsLogStreamRow = memo(function OperationsLogStreamRow({
     ? deriveChipColors(environment.label_color, isDarkMode)
     : null
   const railColor = isRestart ? undefined : envColors?.border
-  const hoverTimer = useRef<number | null>(null)
-  useEffect(
-    () => () => {
-      if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
-    },
-    [],
-  )
-  const onMouseEnter = () => {
-    if (isOpen) return
-    if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
-    hoverTimer.current = window.setTimeout(() => {
-      onToggle(id)
-    }, 100)
-  }
-  const onMouseLeave = () => {
-    if (hoverTimer.current) {
-      window.clearTimeout(hoverTimer.current)
-      hoverTimer.current = null
-    }
-    if (isOpen) onToggle(id)
-  }
 
   return (
     <div
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
       className={cn(
         'border-b border-tertiary last:border-b-0',
         isOpen && 'bg-secondary',
@@ -83,9 +60,11 @@ export const OperationsLogStreamRow = memo(function OperationsLogStreamRow({
         containIntrinsicSize: 'auto 72px',
       }}
     >
-      <div
+      <button
+        type="button"
+        onClick={() => onToggle(id)}
         className={cn(
-          'group grid w-full items-center gap-x-3 gap-y-1 text-left transition-colors',
+          'group grid w-full cursor-pointer items-center gap-x-3 gap-y-1 text-left transition-colors',
           OPS_ROW_PAD,
           !isOpen && 'hover:bg-secondary',
         )}
@@ -203,7 +182,7 @@ export const OperationsLogStreamRow = memo(function OperationsLogStreamRow({
             {desc}
           </span>
         ) : null}
-      </div>
+      </button>
       {isOpen ? (
         <div className="border-t border-dashed border-tertiary">
           <OperationsLogEntryDetails entry={entry} />

--- a/src/components/operations-log/OperationsLogStreamRow.tsx
+++ b/src/components/operations-log/OperationsLogStreamRow.tsx
@@ -1,0 +1,208 @@
+import { ChevronDown } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { Gravatar } from '@/components/ui/gravatar'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useTheme } from '@/contexts/ThemeContext'
+import { deriveChipColors } from '@/lib/chip-colors'
+import { ENTRY_TYPE_ICONS } from '@/lib/ops-log-icons'
+import { cn } from '@/lib/utils'
+import type { Environment, OperationsLogRecord, Project } from '@/types'
+import { OperationsLogEntryDetails } from './OperationsLogEntryDetails'
+import { OPS_ROW_GRID, OPS_ROW_PAD } from './opsRowLayout'
+import { absTime, cleanDescription, relTime } from './opsLogHelpers'
+
+interface Props {
+  entry: OperationsLogRecord
+  project?: Project
+  environment?: Environment
+  isOpen: boolean
+  onToggle: () => void
+  performerDisplayNames: Map<string, string>
+}
+
+export function OperationsLogStreamRow({
+  entry,
+  project,
+  environment,
+  isOpen,
+  onToggle,
+  performerDisplayNames,
+}: Props) {
+  const { isDarkMode } = useTheme()
+  const performer = entry.performed_by ?? entry.recorded_by
+  const displayName = performerDisplayNames.get(performer) ?? performer
+  const isDeploy = entry.entry_type === 'Deployed'
+  const isRestart = entry.entry_type === 'Restarted'
+  const Icon = ENTRY_TYPE_ICONS[entry.entry_type]
+  const desc = cleanDescription(entry.description, entry.version)
+  const projectLabel = project?.name ?? entry.project_slug
+  const envDisplay = environment?.name ?? entry.environment_slug
+  const envColors = environment?.label_color
+    ? deriveChipColors(environment.label_color, isDarkMode)
+    : null
+  const railColor = isRestart ? undefined : envColors?.border
+  const hoverTimer = useRef<number | null>(null)
+  useEffect(
+    () => () => {
+      if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
+    },
+    [],
+  )
+  const onMouseEnter = () => {
+    if (isOpen) return
+    if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
+    hoverTimer.current = window.setTimeout(() => {
+      onToggle()
+    }, 100)
+  }
+  const onMouseLeave = () => {
+    if (hoverTimer.current) {
+      window.clearTimeout(hoverTimer.current)
+      hoverTimer.current = null
+    }
+    if (isOpen) onToggle()
+  }
+
+  return (
+    <div
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className={cn(
+        'border-b border-tertiary last:border-b-0',
+        isOpen && 'bg-secondary',
+      )}
+    >
+      <div
+        className={cn(
+          'group grid w-full items-center gap-x-3 gap-y-1 text-left transition-colors',
+          OPS_ROW_PAD,
+          !isOpen && 'hover:bg-secondary',
+        )}
+        style={{
+          gridTemplateColumns: OPS_ROW_GRID,
+          gridTemplateRows: desc ? 'auto auto' : 'auto',
+        }}
+      >
+        <span
+          className={cn(
+            'self-stretch rounded-r-sm',
+            isRestart && 'bg-danger',
+            !isRestart && !railColor && 'bg-tertiary',
+          )}
+          style={{
+            ...(railColor ? { backgroundColor: railColor } : {}),
+            gridColumn: 1,
+            gridRow: '1 / -1',
+          }}
+          aria-hidden
+        />
+        <span
+          className={cn(
+            'flex h-[26px] w-[26px] items-center justify-center rounded-md',
+            isDeploy
+              ? 'bg-success text-success'
+              : isRestart
+                ? 'bg-danger text-danger'
+                : 'bg-secondary text-secondary',
+          )}
+          style={{ gridColumn: 2, gridRow: 1 }}
+        >
+          <Icon className="h-3.5 w-3.5" />
+        </span>
+        <span
+          className="truncate text-sm font-medium text-primary"
+          style={{ gridColumn: 3, gridRow: 1 }}
+          title={projectLabel}
+        >
+          {projectLabel}
+        </span>
+        <span
+          className="truncate font-mono text-xs text-secondary"
+          style={{ gridColumn: 4, gridRow: 1 }}
+        >
+          {entry.version || '—'}
+        </span>
+        {desc ? null : (
+          <span
+            className="min-w-0 truncate text-sm text-secondary text-tertiary"
+            style={{ gridColumn: 5 }}
+          >
+            —
+          </span>
+        )}
+        <span
+          className="flex items-center justify-center"
+          style={{ gridColumn: 6, gridRow: '1 / -1' }}
+        >
+          <span
+            className="inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium"
+            style={
+              envColors
+                ? {
+                    backgroundColor: envColors.bg,
+                    color: envColors.fg,
+                    borderColor: envColors.border,
+                  }
+                : undefined
+            }
+          >
+            {envDisplay}
+          </span>
+        </span>
+        <span
+          className="self-center justify-self-end"
+          style={{ gridColumn: 7, gridRow: '1 / -1' }}
+          title={displayName}
+        >
+          <Gravatar
+            email={performer}
+            size={22}
+            className="h-[22px] w-[22px] rounded-full"
+          />
+        </span>
+        <TooltipProvider delayDuration={250}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="self-center whitespace-nowrap text-right text-xs tabular-nums text-tertiary"
+                style={{ gridColumn: 8, gridRow: '1 / -1' }}
+              >
+                {relTime(entry.occurred_at)}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{absTime(entry.occurred_at)}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <span
+          className="flex items-center justify-center self-center text-tertiary"
+          style={{ gridColumn: 9, gridRow: '1 / -1' }}
+        >
+          <ChevronDown
+            className={cn(
+              'h-3.5 w-3.5 transition-transform',
+              isOpen && 'rotate-180 text-primary',
+            )}
+          />
+        </span>
+        {desc ? (
+          <span
+            className="min-w-0 truncate text-sm text-secondary"
+            style={{ gridColumn: '3 / 6', gridRow: 2 }}
+          >
+            {desc}
+          </span>
+        ) : null}
+      </div>
+      {isOpen ? (
+        <div className="border-t border-dashed border-tertiary">
+          <OperationsLogEntryDetails entry={entry} />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/operations-log/OperationsLogStreamRow.tsx
+++ b/src/components/operations-log/OperationsLogStreamRow.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from 'lucide-react'
-import { useEffect, useRef } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
   Tooltip,
@@ -17,15 +17,17 @@ import { OPS_ROW_GRID, OPS_ROW_PAD } from './opsRowLayout'
 import { absTime, cleanDescription, relTime } from './opsLogHelpers'
 
 interface Props {
+  id: string
   entry: OperationsLogRecord
   project?: Project
   environment?: Environment
   isOpen: boolean
-  onToggle: () => void
+  onToggle: (id: string) => void
   performerDisplayNames: Map<string, string>
 }
 
-export function OperationsLogStreamRow({
+export const OperationsLogStreamRow = memo(function OperationsLogStreamRow({
+  id,
   entry,
   project,
   environment,
@@ -57,7 +59,7 @@ export function OperationsLogStreamRow({
     if (isOpen) return
     if (hoverTimer.current) window.clearTimeout(hoverTimer.current)
     hoverTimer.current = window.setTimeout(() => {
-      onToggle()
+      onToggle(id)
     }, 100)
   }
   const onMouseLeave = () => {
@@ -65,7 +67,7 @@ export function OperationsLogStreamRow({
       window.clearTimeout(hoverTimer.current)
       hoverTimer.current = null
     }
-    if (isOpen) onToggle()
+    if (isOpen) onToggle(id)
   }
 
   return (
@@ -76,6 +78,10 @@ export function OperationsLogStreamRow({
         'border-b border-tertiary last:border-b-0',
         isOpen && 'bg-secondary',
       )}
+      style={{
+        contentVisibility: 'auto',
+        containIntrinsicSize: 'auto 72px',
+      }}
     >
       <div
         className={cn(
@@ -205,4 +211,4 @@ export function OperationsLogStreamRow({
       ) : null}
     </div>
   )
-}
+})

--- a/src/components/operations-log/OperationsLogSummary.tsx
+++ b/src/components/operations-log/OperationsLogSummary.tsx
@@ -74,7 +74,10 @@ export function OperationsLogSummary({
       if (range === 'all' && t < earliest) earliest = t
       projectSlugs.add(e.project_slug)
       if (e.environment_slug) envSlugs.add(e.environment_slug)
-      if (e.performed_by) people.add(e.performed_by)
+      // Match the row UI's performer fallback so the "Team members"
+      // count doesn't underreport entries that show recorded_by.
+      const performer = e.performed_by ?? e.recorded_by
+      if (performer) people.add(performer)
       if (e.entry_type === 'Deployed') {
         deploys += 1
         if (terminalEnvSlug && e.environment_slug === terminalEnvSlug) {
@@ -150,7 +153,9 @@ export function OperationsLogSummary({
                 <span
                   key={i}
                   className="flex-1 rounded-[1px] bg-amber-bg"
-                  style={{ height: `${Math.max(8, (v / max) * 100)}%` }}
+                  style={{
+                    height: v === 0 ? '0%' : `${Math.max(8, (v / max) * 100)}%`,
+                  }}
                 />
               ))}
         </div>

--- a/src/components/operations-log/OperationsLogSummary.tsx
+++ b/src/components/operations-log/OperationsLogSummary.tsx
@@ -1,118 +1,194 @@
 import type { OperationsLogRecord } from '@/types'
-import { parseUtcIso, type TimeRange } from './opsLogHelpers'
+import { useMemo } from 'react'
+import { toMs, type TimeRange } from './opsLogHelpers'
 
 interface SummaryProps {
   entries: OperationsLogRecord[]
   rangeLabel: string
   range: TimeRange
+  loading?: boolean
+}
+
+function SkeletonBlock({ className }: { className: string }) {
+  return (
+    <span
+      className={`bg-tertiary/40 inline-block animate-pulse rounded ${className}`}
+      aria-hidden
+    />
+  )
 }
 
 const RANGE_WINDOW_MS: Record<Exclude<TimeRange, 'all'>, number> = {
   '24h': 24 * 60 * 60 * 1000,
-  '3d': 3 * 24 * 60 * 60 * 1000,
   '7d': 7 * 24 * 60 * 60 * 1000,
   '30d': 30 * 24 * 60 * 60 * 1000,
+  '90d': 90 * 24 * 60 * 60 * 1000,
 }
+
+const BARS = 12
 
 export function OperationsLogSummary({
   entries,
   rangeLabel,
   range,
+  loading = false,
 }: SummaryProps) {
-  const deploys = entries.filter((e) => e.entry_type === 'Deployed').length
-  const prod = entries.filter(
-    (e) => e.entry_type === 'Deployed' && e.environment_slug === 'production',
-  ).length
-  const projects = new Set(entries.map((e) => e.project_slug)).size
-  const envCount = new Set(
-    entries.map((e) => e.environment_slug).filter((s): s is string => !!s),
-  ).size
-  const people = new Set(
-    entries.map((e) => e.performed_by).filter((p): p is string => !!p),
-  ).size
-
-  // Deploys-per-bucket sparkline scaled to the selected time range so the
-  // graph spans exactly what the user is looking at. For "all time" it
-  // spans from the earliest visible entry to now.
-  const now = Date.now()
-  const bars = 12
-  let windowMs: number
-  if (range === 'all') {
+  // Single-pass aggregation: counts, uniques, sparkline buckets, and the
+  // earliest-timestamp scan (for 'all time') all read the entries array
+  // exactly once. Previously we did 4 filter/map passes plus 3 Set
+  // allocations per render, all running again on every auto-fetch page.
+  const stats = useMemo(() => {
+    const now = Date.now()
+    const windowMs =
+      range === 'all' ? 0 /* resolved after the pass */ : RANGE_WINDOW_MS[range]
+    let effectiveWindowMs = windowMs
     let earliest = now
-    for (const e of entries) {
-      const t = parseUtcIso(e.occurred_at).getTime()
-      if (t < earliest) earliest = t
+
+    const projectSlugs = new Set<string>()
+    const envSlugs = new Set<string>()
+    const people = new Set<string>()
+    let deploys = 0
+    let prod = 0
+    let occurredMs: number[] = []
+    occurredMs = new Array(entries.length)
+    for (let i = 0; i < entries.length; i++) {
+      const e = entries[i]
+      const t = toMs(e.occurred_at)
+      occurredMs[i] = t
+      if (range === 'all' && t < earliest) earliest = t
+      projectSlugs.add(e.project_slug)
+      if (e.environment_slug) envSlugs.add(e.environment_slug)
+      if (e.performed_by) people.add(e.performed_by)
+      if (e.entry_type === 'Deployed') {
+        deploys += 1
+        if (e.environment_slug === 'production') prod += 1
+      }
     }
-    windowMs = Math.max(60 * 60 * 1000, now - earliest)
-  } else {
-    windowMs = RANGE_WINDOW_MS[range]
-  }
-  const bucketMs = windowMs / bars
-  const start = now - windowMs
-  const buckets = new Array<number>(bars).fill(0)
-  for (const e of entries) {
-    if (e.entry_type !== 'Deployed') continue
-    const t = parseUtcIso(e.occurred_at).getTime()
-    if (t < start || t > now) continue
-    const idx = Math.min(bars - 1, Math.floor((t - start) / bucketMs))
-    buckets[idx] += 1
-  }
-  const max = Math.max(1, ...buckets)
+    if (range === 'all') {
+      effectiveWindowMs = Math.max(60 * 60 * 1000, now - earliest)
+    }
+    const bucketMs = effectiveWindowMs / BARS
+    const start = now - effectiveWindowMs
+    const buckets = new Array<number>(BARS).fill(0)
+    for (let i = 0; i < entries.length; i++) {
+      const e = entries[i]
+      if (e.entry_type !== 'Deployed') continue
+      const t = occurredMs[i]
+      if (t < start || t > now) continue
+      const idx = Math.min(BARS - 1, Math.floor((t - start) / bucketMs))
+      buckets[idx] += 1
+    }
+    let max = 1
+    for (const v of buckets) if (v > max) max = v
+    return {
+      deploys,
+      prod,
+      projects: projectSlugs.size,
+      envCount: envSlugs.size,
+      people: people.size,
+      buckets,
+      max,
+    }
+  }, [entries, range])
+
+  const { deploys, prod, projects, envCount, people, buckets, max } = stats
+  const bars = BARS
 
   return (
-    <div className="mb-4 grid grid-cols-2 overflow-hidden rounded-md border border-tertiary bg-primary md:grid-cols-4">
+    <div
+      className={`mb-4 grid grid-cols-2 overflow-hidden rounded-md border border-tertiary bg-primary md:grid-cols-4 ${loading ? 'opacity-60' : ''}`}
+    >
       <div className="flex flex-col gap-1 border-b border-r border-tertiary p-3 md:border-b-0">
         <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
           Events
         </span>
-        <span className="flex items-baseline gap-1.5 font-medium tabular-nums text-primary">
-          <span className="text-xl leading-none">{entries.length}</span>
-          <span className="text-[11px] uppercase tracking-wide text-tertiary">
-            in {rangeLabel}
+        {loading ? (
+          <SkeletonBlock className="mt-0.5 h-5 w-16" />
+        ) : (
+          <span className="flex items-baseline gap-1.5 font-medium tabular-nums text-primary">
+            <span className="text-xl leading-none">{entries.length}</span>
+            <span className="text-[11px] uppercase tracking-wide text-tertiary">
+              in {rangeLabel}
+            </span>
           </span>
-        </span>
+        )}
         <div className="mt-1 flex h-4 items-end gap-[2px]" aria-hidden="true">
-          {buckets.map((v, i) => (
-            <span
-              key={i}
-              className="flex-1 rounded-[1px] bg-amber-bg"
-              style={{ height: `${Math.max(8, (v / max) * 100)}%` }}
-            />
-          ))}
+          {loading
+            ? Array.from({ length: bars }).map((_, i) => (
+                <span
+                  key={i}
+                  className="bg-tertiary/30 h-full flex-1 rounded-[1px]"
+                />
+              ))
+            : buckets.map((v, i) => (
+                <span
+                  key={i}
+                  className="flex-1 rounded-[1px] bg-amber-bg"
+                  style={{ height: `${Math.max(8, (v / max) * 100)}%` }}
+                />
+              ))}
         </div>
       </div>
       <div className="flex flex-col gap-1 border-b border-tertiary p-3 md:border-b-0 md:border-r">
         <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
           Deploys
         </span>
-        <span className="text-xl font-medium tabular-nums leading-none text-primary">
-          {deploys}
-        </span>
-        <span className="text-[11.5px] text-secondary">
-          {prod} to production
-        </span>
+        {loading ? (
+          <>
+            <SkeletonBlock className="mt-0.5 h-5 w-12" />
+            <SkeletonBlock className="mt-1 h-3 w-24" />
+          </>
+        ) : (
+          <>
+            <span className="text-xl font-medium tabular-nums leading-none text-primary">
+              {deploys}
+            </span>
+            <span className="text-[11.5px] text-secondary">
+              {prod} to production
+            </span>
+          </>
+        )}
       </div>
       <div className="flex flex-col gap-1 border-r border-tertiary p-3">
         <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
           Projects touched
         </span>
-        <span className="text-xl font-medium tabular-nums leading-none text-primary">
-          {projects}
-        </span>
-        <span className="text-[11.5px] text-secondary">
-          across {envCount} {envCount === 1 ? 'environment' : 'environments'}
-        </span>
+        {loading ? (
+          <>
+            <SkeletonBlock className="mt-0.5 h-5 w-10" />
+            <SkeletonBlock className="mt-1 h-3 w-32" />
+          </>
+        ) : (
+          <>
+            <span className="text-xl font-medium tabular-nums leading-none text-primary">
+              {projects}
+            </span>
+            <span className="text-[11.5px] text-secondary">
+              across {envCount}{' '}
+              {envCount === 1 ? 'environment' : 'environments'}
+            </span>
+          </>
+        )}
       </div>
       <div className="flex flex-col gap-1 p-3">
         <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
           Team members
         </span>
-        <span className="text-xl font-medium tabular-nums leading-none text-primary">
-          {people}
-        </span>
-        <span className="text-[11.5px] text-secondary">
-          active in {rangeLabel}
-        </span>
+        {loading ? (
+          <>
+            <SkeletonBlock className="mt-0.5 h-5 w-10" />
+            <SkeletonBlock className="mt-1 h-3 w-28" />
+          </>
+        ) : (
+          <>
+            <span className="text-xl font-medium tabular-nums leading-none text-primary">
+              {people}
+            </span>
+            <span className="text-[11.5px] text-secondary">
+              active in {rangeLabel}
+            </span>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/components/operations-log/OperationsLogSummary.tsx
+++ b/src/components/operations-log/OperationsLogSummary.tsx
@@ -1,9 +1,11 @@
-import type { OperationsLogRecord } from '@/types'
+import type { Environment, OperationsLogRecord } from '@/types'
 import { useMemo } from 'react'
+import { sortEnvironments } from '@/lib/utils'
 import { toMs, type TimeRange } from './opsLogHelpers'
 
 interface SummaryProps {
   entries: OperationsLogRecord[]
+  environments: Environment[]
   rangeLabel: string
   range: TimeRange
   loading?: boolean
@@ -29,14 +31,23 @@ const BARS = 12
 
 export function OperationsLogSummary({
   entries,
+  environments,
   rangeLabel,
   range,
   loading = false,
 }: SummaryProps) {
+  // Terminal promotion target = highest sort_order env, matching the
+  // release train. Avoids a hard-coded "production" slug so custom
+  // pipelines with a final stage named e.g. "Live" pick up automatically.
+  const terminalEnv = useMemo<Environment | undefined>(() => {
+    const sorted = sortEnvironments(environments)
+    return sorted[sorted.length - 1]
+  }, [environments])
   // Single-pass aggregation: counts, uniques, sparkline buckets, and the
   // earliest-timestamp scan (for 'all time') all read the entries array
   // exactly once. Previously we did 4 filter/map passes plus 3 Set
   // allocations per render, all running again on every auto-fetch page.
+  const terminalEnvSlug = terminalEnv?.slug
   const stats = useMemo(() => {
     const now = Date.now()
     const windowMs =
@@ -48,9 +59,8 @@ export function OperationsLogSummary({
     const envSlugs = new Set<string>()
     const people = new Set<string>()
     let deploys = 0
-    let prod = 0
-    let occurredMs: number[] = []
-    occurredMs = new Array(entries.length)
+    let terminalDeploys = 0
+    const occurredMs = new Array<number>(entries.length)
     for (let i = 0; i < entries.length; i++) {
       const e = entries[i]
       const t = toMs(e.occurred_at)
@@ -61,7 +71,9 @@ export function OperationsLogSummary({
       if (e.performed_by) people.add(e.performed_by)
       if (e.entry_type === 'Deployed') {
         deploys += 1
-        if (e.environment_slug === 'production') prod += 1
+        if (terminalEnvSlug && e.environment_slug === terminalEnvSlug) {
+          terminalDeploys += 1
+        }
       }
     }
     if (range === 'all') {
@@ -82,22 +94,20 @@ export function OperationsLogSummary({
     for (const v of buckets) if (v > max) max = v
     return {
       deploys,
-      prod,
+      terminalDeploys,
       projects: projectSlugs.size,
       envCount: envSlugs.size,
       people: people.size,
       buckets,
       max,
     }
-  }, [entries, range])
+  }, [entries, range, terminalEnvSlug])
 
-  const { deploys, prod, projects, envCount, people, buckets, max } = stats
-  const bars = BARS
+  const { deploys, terminalDeploys, projects, envCount, people, buckets, max } =
+    stats
 
   return (
-    <div
-      className={`mb-4 grid grid-cols-2 overflow-hidden rounded-md border border-tertiary bg-primary md:grid-cols-4 ${loading ? 'opacity-60' : ''}`}
-    >
+    <div className="mb-4 grid grid-cols-2 overflow-hidden rounded-md border border-tertiary bg-primary md:grid-cols-4">
       <div className="flex flex-col gap-1 border-b border-r border-tertiary p-3 md:border-b-0">
         <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
           Events
@@ -114,7 +124,7 @@ export function OperationsLogSummary({
         )}
         <div className="mt-1 flex h-4 items-end gap-[2px]" aria-hidden="true">
           {loading
-            ? Array.from({ length: bars }).map((_, i) => (
+            ? Array.from({ length: BARS }).map((_, i) => (
                 <span
                   key={i}
                   className="bg-tertiary/30 h-full flex-1 rounded-[1px]"
@@ -144,7 +154,9 @@ export function OperationsLogSummary({
               {deploys}
             </span>
             <span className="text-[11.5px] text-secondary">
-              {prod} to production
+              {terminalEnv
+                ? `${terminalDeploys} to ${terminalEnv.name}`
+                : `${deploys} total`}
             </span>
           </>
         )}

--- a/src/components/operations-log/OperationsLogSummary.tsx
+++ b/src/components/operations-log/OperationsLogSummary.tsx
@@ -1,0 +1,119 @@
+import type { OperationsLogRecord } from '@/types'
+import { parseUtcIso, type TimeRange } from './opsLogHelpers'
+
+interface SummaryProps {
+  entries: OperationsLogRecord[]
+  rangeLabel: string
+  range: TimeRange
+}
+
+const RANGE_WINDOW_MS: Record<Exclude<TimeRange, 'all'>, number> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '3d': 3 * 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+}
+
+export function OperationsLogSummary({
+  entries,
+  rangeLabel,
+  range,
+}: SummaryProps) {
+  const deploys = entries.filter((e) => e.entry_type === 'Deployed').length
+  const prod = entries.filter(
+    (e) => e.entry_type === 'Deployed' && e.environment_slug === 'production',
+  ).length
+  const projects = new Set(entries.map((e) => e.project_slug)).size
+  const envCount = new Set(
+    entries.map((e) => e.environment_slug).filter((s): s is string => !!s),
+  ).size
+  const people = new Set(
+    entries.map((e) => e.performed_by).filter((p): p is string => !!p),
+  ).size
+
+  // Deploys-per-bucket sparkline scaled to the selected time range so the
+  // graph spans exactly what the user is looking at. For "all time" it
+  // spans from the earliest visible entry to now.
+  const now = Date.now()
+  const bars = 12
+  let windowMs: number
+  if (range === 'all') {
+    let earliest = now
+    for (const e of entries) {
+      const t = parseUtcIso(e.occurred_at).getTime()
+      if (t < earliest) earliest = t
+    }
+    windowMs = Math.max(60 * 60 * 1000, now - earliest)
+  } else {
+    windowMs = RANGE_WINDOW_MS[range]
+  }
+  const bucketMs = windowMs / bars
+  const start = now - windowMs
+  const buckets = new Array<number>(bars).fill(0)
+  for (const e of entries) {
+    if (e.entry_type !== 'Deployed') continue
+    const t = parseUtcIso(e.occurred_at).getTime()
+    if (t < start || t > now) continue
+    const idx = Math.min(bars - 1, Math.floor((t - start) / bucketMs))
+    buckets[idx] += 1
+  }
+  const max = Math.max(1, ...buckets)
+
+  return (
+    <div className="mb-4 grid grid-cols-2 overflow-hidden rounded-md border border-tertiary bg-primary md:grid-cols-4">
+      <div className="flex flex-col gap-1 border-b border-r border-tertiary p-3 md:border-b-0">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
+          Events
+        </span>
+        <span className="flex items-baseline gap-1.5 font-medium tabular-nums text-primary">
+          <span className="text-xl leading-none">{entries.length}</span>
+          <span className="text-[11px] uppercase tracking-wide text-tertiary">
+            in {rangeLabel}
+          </span>
+        </span>
+        <div className="mt-1 flex h-4 items-end gap-[2px]" aria-hidden="true">
+          {buckets.map((v, i) => (
+            <span
+              key={i}
+              className="flex-1 rounded-[1px] bg-amber-bg"
+              style={{ height: `${Math.max(8, (v / max) * 100)}%` }}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1 border-b border-tertiary p-3 md:border-b-0 md:border-r">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
+          Deploys
+        </span>
+        <span className="text-xl font-medium tabular-nums leading-none text-primary">
+          {deploys}
+        </span>
+        <span className="text-[11.5px] text-secondary">
+          {prod} to production
+        </span>
+      </div>
+      <div className="flex flex-col gap-1 border-r border-tertiary p-3">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
+          Projects touched
+        </span>
+        <span className="text-xl font-medium tabular-nums leading-none text-primary">
+          {projects}
+        </span>
+        <span className="text-[11.5px] text-secondary">
+          across {envCount} {envCount === 1 ? 'environment' : 'environments'}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1 p-3">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-tertiary">
+          Team members
+        </span>
+        <span className="text-xl font-medium tabular-nums leading-none text-primary">
+          {people}
+        </span>
+        <span className="text-[11.5px] text-secondary">
+          active in {rangeLabel}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/operations-log/OperationsLogSummary.tsx
+++ b/src/components/operations-log/OperationsLogSummary.tsx
@@ -1,3 +1,4 @@
+import type { OperationsLogMetrics } from '@/api/endpoints'
 import type { Environment, OperationsLogRecord } from '@/types'
 import { useMemo } from 'react'
 import { sortEnvironments } from '@/lib/utils'
@@ -9,6 +10,10 @@ interface SummaryProps {
   rangeLabel: string
   range: TimeRange
   loading?: boolean
+  // When the backend returns aggregate metrics for the full filter
+  // universe, the tiles display those numbers rather than stats derived
+  // only from `entries` (which is just the loaded pages).
+  serverMetrics?: OperationsLogMetrics
 }
 
 function SkeletonBlock({ className }: { className: string }) {
@@ -35,6 +40,7 @@ export function OperationsLogSummary({
   rangeLabel,
   range,
   loading = false,
+  serverMetrics,
 }: SummaryProps) {
   // Terminal promotion target = highest sort_order env, matching the
   // release train. Avoids a hard-coded "production" slug so custom
@@ -103,8 +109,18 @@ export function OperationsLogSummary({
     }
   }, [entries, range, terminalEnvSlug])
 
-  const { deploys, terminalDeploys, projects, envCount, people, buckets, max } =
-    stats
+  const { buckets, max } = stats
+  // Prefer server-computed metrics (which cover the full filter
+  // universe) over numbers derived from just the loaded pages.
+  const events = serverMetrics?.event_count ?? entries.length
+  const deploys = serverMetrics?.deploys ?? stats.deploys
+  const projects = serverMetrics?.projects ?? stats.projects
+  const envCount = serverMetrics?.environments ?? stats.envCount
+  const people = serverMetrics?.team_members ?? stats.people
+  const terminalDeploys = terminalEnvSlug
+    ? (serverMetrics?.deploys_by_environment?.[terminalEnvSlug] ??
+      stats.terminalDeploys)
+    : stats.terminalDeploys
 
   return (
     <div className="mb-4 grid grid-cols-2 overflow-hidden rounded-md border border-tertiary bg-primary md:grid-cols-4">
@@ -116,7 +132,7 @@ export function OperationsLogSummary({
           <SkeletonBlock className="mt-0.5 h-5 w-16" />
         ) : (
           <span className="flex items-baseline gap-1.5 font-medium tabular-nums text-primary">
-            <span className="text-xl leading-none">{entries.length}</span>
+            <span className="text-xl leading-none">{events}</span>
             <span className="text-[11px] uppercase tracking-wide text-tertiary">
               in {rangeLabel}
             </span>

--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -1,0 +1,314 @@
+import { useMemo, useState } from 'react'
+import { Box, Check, ChevronDown, Filter, Layers, Search } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import { sortEnvironments } from '@/lib/utils'
+import {
+  OPERATIONS_LOG_ENTRY_TYPES,
+  type Environment,
+  type OperationsLogEntryType,
+} from '@/types'
+import type { TimeRange } from './opsLogHelpers'
+
+const RANGES: { key: TimeRange; label: string }[] = [
+  { key: '24h', label: '24h' },
+  { key: '7d', label: '7d' },
+  { key: '30d', label: '30d' },
+  { key: '90d', label: '90d' },
+  { key: 'all', label: 'All' },
+]
+
+export interface ToolbarCounts {
+  type: Partial<Record<OperationsLogEntryType, number>>
+  env: Record<string, number>
+  project: Record<string, number>
+}
+
+interface ToolbarProps {
+  counts: ToolbarCounts
+  range: TimeRange
+  onRange: (r: TimeRange) => void
+  entryType?: OperationsLogEntryType
+  onEntryType: (t: OperationsLogEntryType | undefined) => void
+  environmentSlug?: string
+  onEnvironment: (slug: string | undefined) => void
+  environments: Environment[]
+  projectSlug?: string
+  onProject: (slug: string | undefined) => void
+  projectNames: Map<string, string>
+}
+
+function TriggerButton({
+  icon,
+  label,
+  value,
+  count,
+  onClick,
+}: {
+  icon: React.ReactNode
+  label: string
+  value?: string
+  count?: number
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex h-9 items-center gap-2 rounded-md border border-tertiary bg-primary px-3 text-sm text-secondary transition-colors hover:bg-secondary hover:text-primary"
+    >
+      <span className="flex h-4 w-4 items-center justify-center text-tertiary">
+        {icon}
+      </span>
+      <span className={cn(value && 'text-primary')}>{value ?? label}</span>
+      {count !== undefined ? (
+        <span className="ml-0.5 rounded bg-secondary px-1.5 text-[11px] tabular-nums text-tertiary">
+          {count}
+        </span>
+      ) : null}
+      <ChevronDown className="h-3.5 w-3.5 text-tertiary" />
+    </button>
+  )
+}
+
+export function OperationsLogToolbar({
+  counts,
+  range,
+  onRange,
+  entryType,
+  onEntryType,
+  environmentSlug,
+  onEnvironment,
+  environments,
+  projectSlug,
+  onProject,
+  projectNames,
+}: ToolbarProps) {
+  const [projectQuery, setProjectQuery] = useState('')
+
+  const entryTypes = useMemo(
+    () => OPERATIONS_LOG_ENTRY_TYPES.filter((t) => (counts.type[t] ?? 0) > 0),
+    [counts.type],
+  )
+  const orderedEnvs = useMemo(
+    () =>
+      sortEnvironments(environments).filter(
+        (env) =>
+          (counts.env[env.slug] ?? 0) > 0 || environmentSlug === env.slug,
+      ),
+    [environments, counts.env, environmentSlug],
+  )
+  const projectEntries = useMemo(() => {
+    const all = Object.entries(counts.project).sort(
+      (a, b) =>
+        b[1] - a[1] ||
+        (projectNames.get(a[0]) ?? a[0]).localeCompare(
+          projectNames.get(b[0]) ?? b[0],
+        ),
+    )
+    const q = projectQuery.toLowerCase().trim()
+    if (!q) return all
+    return all.filter(([slug]) => {
+      const name = (projectNames.get(slug) ?? slug).toLowerCase()
+      return slug.toLowerCase().includes(q) || name.includes(q)
+    })
+  }, [counts.project, projectNames, projectQuery])
+
+  const selectedEnv = environmentSlug
+    ? environments.find((e) => e.slug === environmentSlug)
+    : undefined
+  const selectedProjectLabel = projectSlug
+    ? (projectNames.get(projectSlug) ?? projectSlug)
+    : undefined
+
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2">
+      <div
+        role="group"
+        aria-label="Time range"
+        className="inline-flex items-center rounded-md border border-tertiary bg-secondary p-0.5"
+      >
+        {RANGES.map((r) => (
+          <button
+            key={r.key}
+            type="button"
+            onClick={() => onRange(r.key)}
+            className={cn(
+              'rounded px-2.5 py-1 text-xs font-medium transition-colors',
+              range === r.key
+                ? 'bg-primary text-primary shadow-sm'
+                : 'text-secondary hover:text-primary',
+            )}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      <span className="mx-1 h-6 w-px bg-tertiary" aria-hidden />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <div>
+            <TriggerButton
+              icon={<Filter className="h-3.5 w-3.5" />}
+              label="Entry Type"
+              value={entryType}
+            />
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-[200px]">
+          <DropdownMenuCheckboxItem
+            checked={!entryType}
+            onSelect={(e) => {
+              e.preventDefault()
+              onEntryType(undefined)
+            }}
+          >
+            All entry types
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuSeparator />
+          {entryTypes.map((t) => (
+            <DropdownMenuCheckboxItem
+              key={t}
+              checked={entryType === t}
+              onSelect={(e) => {
+                e.preventDefault()
+                onEntryType(entryType === t ? undefined : t)
+              }}
+            >
+              <span className="flex-1">{t}</span>
+              <span className="ml-3 text-xs text-tertiary">
+                {counts.type[t] ?? 0}
+              </span>
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <div>
+            <TriggerButton
+              icon={<Layers className="h-3.5 w-3.5" />}
+              label="Environment"
+              value={selectedEnv?.name}
+            />
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-[220px]">
+          <DropdownMenuCheckboxItem
+            checked={!environmentSlug}
+            onSelect={(e) => {
+              e.preventDefault()
+              onEnvironment(undefined)
+            }}
+          >
+            All environments
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuSeparator />
+          {orderedEnvs.map((env) => (
+            <DropdownMenuCheckboxItem
+              key={env.slug}
+              checked={environmentSlug === env.slug}
+              onSelect={(e) => {
+                e.preventDefault()
+                onEnvironment(
+                  environmentSlug === env.slug ? undefined : env.slug,
+                )
+              }}
+            >
+              <span className="flex-1">{env.name}</span>
+              <span className="ml-3 text-xs text-tertiary">
+                {counts.env[env.slug] ?? 0}
+              </span>
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (!open) setProjectQuery('')
+        }}
+      >
+        <DropdownMenuTrigger asChild>
+          <div>
+            <TriggerButton
+              icon={<Box className="h-3.5 w-3.5" />}
+              label="Project"
+              value={selectedProjectLabel}
+              count={selectedProjectLabel ? undefined : projectEntries.length}
+            />
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-[260px] p-0">
+          <div className="relative border-b border-tertiary p-2">
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
+            <Input
+              value={projectQuery}
+              onChange={(e) => setProjectQuery(e.target.value)}
+              placeholder="Filter projects…"
+              className="h-8 pl-7 text-sm"
+              autoFocus
+            />
+          </div>
+          <div className="max-h-72 overflow-y-auto py-1">
+            <button
+              type="button"
+              onClick={() => onProject(undefined)}
+              className={cn(
+                'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
+                !projectSlug && 'bg-secondary text-primary',
+                projectSlug && 'text-secondary hover:bg-secondary',
+              )}
+            >
+              <Check
+                className={cn('h-3.5 w-3.5', projectSlug && 'invisible')}
+              />
+              All projects
+            </button>
+            {projectEntries.map(([slug, c]) => (
+              <button
+                key={slug}
+                type="button"
+                onClick={() =>
+                  onProject(projectSlug === slug ? undefined : slug)
+                }
+                className={cn(
+                  'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
+                  projectSlug === slug && 'bg-secondary text-primary',
+                  projectSlug !== slug && 'text-secondary hover:bg-secondary',
+                )}
+                title={projectNames.get(slug) ?? slug}
+              >
+                <Check
+                  className={cn(
+                    'h-3.5 w-3.5',
+                    projectSlug !== slug && 'invisible',
+                  )}
+                />
+                <span className="flex-1 truncate font-mono text-[13px]">
+                  {slug}
+                </span>
+                <span className="ml-3 text-xs text-tertiary">{c}</span>
+              </button>
+            ))}
+            {projectEntries.length === 0 ? (
+              <div className="px-3 py-2 text-xs text-tertiary">
+                No projects match.
+              </div>
+            ) : null}
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useState } from 'react'
+import {
+  forwardRef,
+  useMemo,
+  useState,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from 'react'
 import {
   Box,
   Check,
@@ -70,35 +76,46 @@ function pluralLabel(
   return `${count} selected`
 }
 
-function TriggerButton({
-  icon,
-  label,
-  value,
-  count,
-}: {
-  icon: React.ReactNode
+type TriggerButtonProps = ComponentPropsWithoutRef<'button'> & {
+  icon: ReactNode
   label: string
   value?: string
   count?: number
-}) {
-  return (
-    <button
-      type="button"
-      className="inline-flex h-9 items-center gap-2 rounded-md border border-tertiary bg-primary px-3 text-sm text-secondary transition-colors hover:bg-secondary hover:text-primary"
-    >
-      <span className="flex h-4 w-4 items-center justify-center text-tertiary">
-        {icon}
-      </span>
-      <span className={cn(value && 'text-primary')}>{value ?? label}</span>
-      {count !== undefined ? (
-        <span className="ml-0.5 rounded bg-secondary px-1.5 text-[11px] tabular-nums text-tertiary">
-          {count}
-        </span>
-      ) : null}
-      <ChevronDown className="h-3.5 w-3.5 text-tertiary" />
-    </button>
-  )
 }
+
+// Radix's DropdownMenuTrigger (used with `asChild`) composes its ref and
+// event handlers onto the direct child. Using forwardRef and spreading
+// the received props lets Radix wire open/close, focus, and a11y
+// attributes onto the real <button>.
+const TriggerButton = forwardRef<HTMLButtonElement, TriggerButtonProps>(
+  function TriggerButton(
+    { icon, label, value, count, className, ...props },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(
+          'inline-flex h-9 items-center gap-2 rounded-md border border-tertiary bg-primary px-3 text-sm text-secondary transition-colors hover:bg-secondary hover:text-primary',
+          className,
+        )}
+        {...props}
+      >
+        <span className="flex h-4 w-4 items-center justify-center text-tertiary">
+          {icon}
+        </span>
+        <span className={cn(value && 'text-primary')}>{value ?? label}</span>
+        {count !== undefined ? (
+          <span className="ml-0.5 rounded bg-secondary px-1.5 text-[11px] tabular-nums text-tertiary">
+            {count}
+          </span>
+        ) : null}
+        <ChevronDown className="h-3.5 w-3.5 text-tertiary" />
+      </button>
+    )
+  },
+)
 
 interface FacetOption {
   key: string
@@ -130,17 +147,15 @@ function FacetDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <div>
-          <TriggerButton
-            icon={icon}
-            label={label}
-            value={
-              selected.length === 0
-                ? undefined
-                : (single ?? `${selected.length} selected`)
-            }
-          />
-        </div>
+        <TriggerButton
+          icon={icon}
+          label={label}
+          value={
+            selected.length === 0
+              ? undefined
+              : (single ?? `${selected.length} selected`)
+          }
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
@@ -298,16 +313,12 @@ export function OperationsLogToolbar({
         }}
       >
         <DropdownMenuTrigger asChild>
-          <div>
-            <TriggerButton
-              icon={<Box className="h-3.5 w-3.5" />}
-              label="Project"
-              value={projectSlugs.length > 0 ? projectTriggerValue : undefined}
-              count={
-                projectSlugs.length > 0 ? undefined : projectEntries.length
-              }
-            />
-          </div>
+          <TriggerButton
+            icon={<Box className="h-3.5 w-3.5" />}
+            label="Project"
+            value={projectSlugs.length > 0 ? projectTriggerValue : undefined}
+            count={projectSlugs.length > 0 ? undefined : projectEntries.length}
+          />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="min-w-[260px] p-0">
           <div className="relative border-b border-tertiary p-2">

--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -1,5 +1,14 @@
 import { useMemo, useState } from 'react'
-import { Box, Check, ChevronDown, Filter, Layers, Search } from 'lucide-react'
+import {
+  Box,
+  Check,
+  ChevronDown,
+  Filter,
+  GitBranch,
+  Layers,
+  List,
+  Search,
+} from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -15,7 +24,7 @@ import {
   type Environment,
   type OperationsLogEntryType,
 } from '@/types'
-import type { TimeRange } from './opsLogHelpers'
+import type { OperationsLogView, TimeRange } from './opsLogHelpers'
 
 const RANGES: { key: TimeRange; label: string }[] = [
   { key: '24h', label: '24h' },
@@ -35,14 +44,30 @@ interface ToolbarProps {
   counts: ToolbarCounts
   range: TimeRange
   onRange: (r: TimeRange) => void
-  entryType?: OperationsLogEntryType
-  onEntryType: (t: OperationsLogEntryType | undefined) => void
-  environmentSlug?: string
-  onEnvironment: (slug: string | undefined) => void
+  entryTypes: OperationsLogEntryType[]
+  onEntryTypes: (ts: OperationsLogEntryType[]) => void
+  environmentSlugs: string[]
+  onEnvironmentSlugs: (slugs: string[]) => void
   environments: Environment[]
-  projectSlug?: string
-  onProject: (slug: string | undefined) => void
+  projectSlugs: string[]
+  onProjectSlugs: (slugs: string[]) => void
   projectNames: Map<string, string>
+  view: OperationsLogView
+  onView: (v: OperationsLogView) => void
+}
+
+function toggle<T>(arr: T[], value: T): T[] {
+  return arr.includes(value) ? arr.filter((x) => x !== value) : [...arr, value]
+}
+
+function pluralLabel(
+  singular: string,
+  count: number,
+  selectedLabel?: string,
+): string {
+  if (count === 0) return singular
+  if (count === 1 && selectedLabel) return selectedLabel
+  return `${count} selected`
 }
 
 function TriggerButton({
@@ -50,18 +75,15 @@ function TriggerButton({
   label,
   value,
   count,
-  onClick,
 }: {
   icon: React.ReactNode
   label: string
   value?: string
   count?: number
-  onClick?: () => void
 }) {
   return (
     <button
       type="button"
-      onClick={onClick}
       className="inline-flex h-9 items-center gap-2 rounded-md border border-tertiary bg-primary px-3 text-sm text-secondary transition-colors hover:bg-secondary hover:text-primary"
     >
       <span className="flex h-4 w-4 items-center justify-center text-tertiary">
@@ -78,22 +100,98 @@ function TriggerButton({
   )
 }
 
+interface FacetOption {
+  key: string
+  label: string
+  count: number
+}
+
+function FacetDropdown({
+  icon,
+  label,
+  allLabel,
+  selected,
+  onChange,
+  options,
+  contentClassName,
+}: {
+  icon: React.ReactNode
+  label: string
+  allLabel: string
+  selected: string[]
+  onChange: (next: string[]) => void
+  options: FacetOption[]
+  contentClassName?: string
+}) {
+  const single =
+    selected.length === 1
+      ? (options.find((o) => o.key === selected[0])?.label ?? selected[0])
+      : undefined
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <div>
+          <TriggerButton
+            icon={icon}
+            label={label}
+            value={
+              selected.length === 0
+                ? undefined
+                : (single ?? `${selected.length} selected`)
+            }
+          />
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className={contentClassName ?? 'min-w-[200px]'}
+      >
+        <DropdownMenuCheckboxItem
+          checked={selected.length === 0}
+          onSelect={(e) => {
+            e.preventDefault()
+            onChange([])
+          }}
+        >
+          {allLabel}
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        {options.map((o) => (
+          <DropdownMenuCheckboxItem
+            key={o.key}
+            checked={selected.includes(o.key)}
+            onSelect={(e) => {
+              e.preventDefault()
+              onChange(toggle(selected, o.key))
+            }}
+          >
+            <span className="flex-1">{o.label}</span>
+            <span className="ml-3 text-xs text-tertiary">{o.count}</span>
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
 export function OperationsLogToolbar({
   counts,
   range,
   onRange,
-  entryType,
-  onEntryType,
-  environmentSlug,
-  onEnvironment,
+  entryTypes,
+  onEntryTypes,
+  environmentSlugs,
+  onEnvironmentSlugs,
   environments,
-  projectSlug,
-  onProject,
+  projectSlugs,
+  onProjectSlugs,
   projectNames,
+  view,
+  onView,
 }: ToolbarProps) {
   const [projectQuery, setProjectQuery] = useState('')
 
-  const entryTypes = useMemo(
+  const availableEntryTypes = useMemo(
     () => OPERATIONS_LOG_ENTRY_TYPES.filter((t) => (counts.type[t] ?? 0) > 0),
     [counts.type],
   )
@@ -101,9 +199,10 @@ export function OperationsLogToolbar({
     () =>
       sortEnvironments(environments).filter(
         (env) =>
-          (counts.env[env.slug] ?? 0) > 0 || environmentSlug === env.slug,
+          (counts.env[env.slug] ?? 0) > 0 ||
+          environmentSlugs.includes(env.slug),
       ),
-    [environments, counts.env, environmentSlug],
+    [environments, counts.env, environmentSlugs],
   )
   const projectEntries = useMemo(() => {
     const all = Object.entries(counts.project).sort(
@@ -121,12 +220,32 @@ export function OperationsLogToolbar({
     })
   }, [counts.project, projectNames, projectQuery])
 
-  const selectedEnv = environmentSlug
-    ? environments.find((e) => e.slug === environmentSlug)
-    : undefined
-  const selectedProjectLabel = projectSlug
-    ? (projectNames.get(projectSlug) ?? projectSlug)
-    : undefined
+  const entryTypeOptions: FacetOption[] = useMemo(
+    () =>
+      availableEntryTypes.map((t) => ({
+        key: t,
+        label: t,
+        count: counts.type[t] ?? 0,
+      })),
+    [availableEntryTypes, counts.type],
+  )
+  const environmentOptions: FacetOption[] = useMemo(
+    () =>
+      orderedEnvs.map((env) => ({
+        key: env.slug,
+        label: env.name,
+        count: counts.env[env.slug] ?? 0,
+      })),
+    [orderedEnvs, counts.env],
+  )
+
+  const projectTriggerValue = pluralLabel(
+    'Project',
+    projectSlugs.length,
+    projectSlugs[0]
+      ? (projectNames.get(projectSlugs[0]) ?? projectSlugs[0])
+      : undefined,
+  )
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-2">
@@ -154,85 +273,24 @@ export function OperationsLogToolbar({
 
       <span className="mx-1 h-6 w-px bg-tertiary" aria-hidden />
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <div>
-            <TriggerButton
-              icon={<Filter className="h-3.5 w-3.5" />}
-              label="Entry Type"
-              value={entryType}
-            />
-          </div>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="min-w-[200px]">
-          <DropdownMenuCheckboxItem
-            checked={!entryType}
-            onSelect={(e) => {
-              e.preventDefault()
-              onEntryType(undefined)
-            }}
-          >
-            All entry types
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuSeparator />
-          {entryTypes.map((t) => (
-            <DropdownMenuCheckboxItem
-              key={t}
-              checked={entryType === t}
-              onSelect={(e) => {
-                e.preventDefault()
-                onEntryType(entryType === t ? undefined : t)
-              }}
-            >
-              <span className="flex-1">{t}</span>
-              <span className="ml-3 text-xs text-tertiary">
-                {counts.type[t] ?? 0}
-              </span>
-            </DropdownMenuCheckboxItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <FacetDropdown
+        icon={<Filter className="h-3.5 w-3.5" />}
+        label="Entry Type"
+        allLabel="All entry types"
+        selected={entryTypes}
+        onChange={(next) => onEntryTypes(next as OperationsLogEntryType[])}
+        options={entryTypeOptions}
+      />
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <div>
-            <TriggerButton
-              icon={<Layers className="h-3.5 w-3.5" />}
-              label="Environment"
-              value={selectedEnv?.name}
-            />
-          </div>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="min-w-[220px]">
-          <DropdownMenuCheckboxItem
-            checked={!environmentSlug}
-            onSelect={(e) => {
-              e.preventDefault()
-              onEnvironment(undefined)
-            }}
-          >
-            All environments
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuSeparator />
-          {orderedEnvs.map((env) => (
-            <DropdownMenuCheckboxItem
-              key={env.slug}
-              checked={environmentSlug === env.slug}
-              onSelect={(e) => {
-                e.preventDefault()
-                onEnvironment(
-                  environmentSlug === env.slug ? undefined : env.slug,
-                )
-              }}
-            >
-              <span className="flex-1">{env.name}</span>
-              <span className="ml-3 text-xs text-tertiary">
-                {counts.env[env.slug] ?? 0}
-              </span>
-            </DropdownMenuCheckboxItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <FacetDropdown
+        icon={<Layers className="h-3.5 w-3.5" />}
+        label="Environment"
+        allLabel="All environments"
+        selected={environmentSlugs}
+        onChange={onEnvironmentSlugs}
+        options={environmentOptions}
+        contentClassName="min-w-[220px]"
+      />
 
       <DropdownMenu
         onOpenChange={(open) => {
@@ -244,8 +302,10 @@ export function OperationsLogToolbar({
             <TriggerButton
               icon={<Box className="h-3.5 w-3.5" />}
               label="Project"
-              value={selectedProjectLabel}
-              count={selectedProjectLabel ? undefined : projectEntries.length}
+              value={projectSlugs.length > 0 ? projectTriggerValue : undefined}
+              count={
+                projectSlugs.length > 0 ? undefined : projectEntries.length
+              }
             />
           </div>
         </DropdownMenuTrigger>
@@ -263,44 +323,45 @@ export function OperationsLogToolbar({
           <div className="max-h-72 overflow-y-auto py-1">
             <button
               type="button"
-              onClick={() => onProject(undefined)}
+              onClick={() => onProjectSlugs([])}
               className={cn(
                 'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
-                !projectSlug && 'bg-secondary text-primary',
-                projectSlug && 'text-secondary hover:bg-secondary',
+                projectSlugs.length === 0 && 'bg-secondary text-primary',
+                projectSlugs.length > 0 && 'text-secondary hover:bg-secondary',
               )}
             >
               <Check
-                className={cn('h-3.5 w-3.5', projectSlug && 'invisible')}
+                className={cn(
+                  'h-3.5 w-3.5',
+                  projectSlugs.length > 0 && 'invisible',
+                )}
               />
               All projects
             </button>
-            {projectEntries.map(([slug, c]) => (
-              <button
-                key={slug}
-                type="button"
-                onClick={() =>
-                  onProject(projectSlug === slug ? undefined : slug)
-                }
-                className={cn(
-                  'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
-                  projectSlug === slug && 'bg-secondary text-primary',
-                  projectSlug !== slug && 'text-secondary hover:bg-secondary',
-                )}
-                title={projectNames.get(slug) ?? slug}
-              >
-                <Check
+            {projectEntries.map(([slug, c]) => {
+              const checked = projectSlugs.includes(slug)
+              return (
+                <button
+                  key={slug}
+                  type="button"
+                  onClick={() => onProjectSlugs(toggle(projectSlugs, slug))}
                   className={cn(
-                    'h-3.5 w-3.5',
-                    projectSlug !== slug && 'invisible',
+                    'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
+                    checked && 'bg-secondary text-primary',
+                    !checked && 'text-secondary hover:bg-secondary',
                   )}
-                />
-                <span className="flex-1 truncate font-mono text-[13px]">
-                  {slug}
-                </span>
-                <span className="ml-3 text-xs text-tertiary">{c}</span>
-              </button>
-            ))}
+                  title={projectNames.get(slug) ?? slug}
+                >
+                  <Check
+                    className={cn('h-3.5 w-3.5', !checked && 'invisible')}
+                  />
+                  <span className="flex-1 truncate font-mono text-[13px]">
+                    {slug}
+                  </span>
+                  <span className="ml-3 text-xs text-tertiary">{c}</span>
+                </button>
+              )
+            })}
             {projectEntries.length === 0 ? (
               <div className="px-3 py-2 text-xs text-tertiary">
                 No projects match.
@@ -309,6 +370,37 @@ export function OperationsLogToolbar({
           </div>
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <div
+        role="group"
+        aria-label="View"
+        className="ml-auto inline-flex h-9 items-center rounded-md border border-tertiary bg-secondary p-1"
+      >
+        <button
+          type="button"
+          onClick={() => onView('stream')}
+          className={cn(
+            'inline-flex h-full items-center gap-1.5 rounded px-3 text-xs font-medium transition-colors',
+            view === 'stream'
+              ? 'bg-primary text-primary shadow-sm'
+              : 'text-secondary hover:text-primary',
+          )}
+        >
+          <List className="h-3.5 w-3.5" /> Stream
+        </button>
+        <button
+          type="button"
+          onClick={() => onView('grouped')}
+          className={cn(
+            'inline-flex h-full items-center gap-1.5 rounded px-3 text-xs font-medium transition-colors',
+            view === 'grouped'
+              ? 'bg-primary text-primary shadow-sm'
+              : 'text-secondary hover:text-primary',
+          )}
+        >
+          <GitBranch className="h-3.5 w-3.5" /> Releases
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/components/operations-log/opsLogHelpers.ts
+++ b/src/components/operations-log/opsLogHelpers.ts
@@ -1,15 +1,23 @@
 import type { OperationsLogRecord } from '@/types'
 
-export type TimeRange = '24h' | '3d' | '7d' | '30d' | 'all'
+export type TimeRange = '24h' | '7d' | '30d' | '90d' | 'all'
 export type OperationsLogView = 'stream' | 'grouped'
 
 export function parseUtcIso(iso: string): Date {
-  const hasOffset = /(Z|[+-]\d\d:?\d\d)$/.test(iso)
-  return new Date(hasOffset ? iso : iso + 'Z')
+  return new Date(iso)
+}
+
+// Return occurred_at as milliseconds without allocating a Date object.
+// Hot path: called from sort comparators and filter loops over thousands
+// of entries per incremental page. `Date.parse` is native-optimised for
+// ISO 8601 and is ~2× faster than `new Date(s).getTime()` while skipping
+// the allocation that causes GC pressure during bulk loads.
+export function toMs(iso: string): number {
+  return Date.parse(iso)
 }
 
 export function relTime(iso: string, now: number = Date.now()): string {
-  const t = parseUtcIso(iso).getTime()
+  const t = toMs(iso)
   const diff = Math.max(0, now - t)
   const m = Math.floor(diff / 60_000)
   if (m < 1) return 'now'
@@ -41,12 +49,16 @@ export function dayKey(iso: string, now: number = Date.now()): DayBucketKey {
   const d = parseUtcIso(iso)
   const n = new Date(now)
   const today = new Date(n.getFullYear(), n.getMonth(), n.getDate()).getTime()
+  return dayKeyFromDate(d, today)
+}
+
+function dayKeyFromDate(d: Date, todayMs: number): DayBucketKey {
   const eventDay = new Date(
     d.getFullYear(),
     d.getMonth(),
     d.getDate(),
   ).getTime()
-  const diffDays = Math.round((today - eventDay) / 86_400_000)
+  const diffDays = Math.round((todayMs - eventDay) / 86_400_000)
   if (diffDays === 0) return { key: 'today', label: 'Today', date: d }
   if (diffDays === 1) return { key: 'yesterday', label: 'Yesterday', date: d }
   return {
@@ -90,7 +102,14 @@ export type FeedItem =
 // release train. Keys by `project_slug::description` — the API emits the
 // same description for each env a single release moves through.
 export function groupReleases(entries: OperationsLogRecord[]): FeedItem[] {
+  // envIndexByGroup tracks env→stops index so the "earliest-wins" merge
+  // is O(1) instead of findIndex (avoids O(stops²) per group).
+  // latestMs tracks the group's current newest occurred_at in ms so we
+  // avoid re-parsing on every comparison.
   const groups = new Map<string, ReleaseGroup>()
+  const envIndexByGroup = new Map<string, Map<string, number>>()
+  const latestMsByGroup = new Map<string, number>()
+  const stopMsByGroup = new Map<string, number[]>()
   const order: FeedItem[] = []
   for (const e of entries) {
     if (e.entry_type !== 'Deployed') {
@@ -99,6 +118,7 @@ export function groupReleases(entries: OperationsLogRecord[]): FeedItem[] {
     }
     const descKey = (e.description || '').trim()
     const key = `${e.project_slug}::${descKey}`
+    const occurredMs = toMs(e.occurred_at)
     let g = groups.get(key)
     if (!g) {
       g = {
@@ -108,24 +128,30 @@ export function groupReleases(entries: OperationsLogRecord[]): FeedItem[] {
         latestEntry: e,
       }
       groups.set(key, g)
+      envIndexByGroup.set(key, new Map())
+      latestMsByGroup.set(key, occurredMs)
+      stopMsByGroup.set(key, [])
       order.push({ kind: 'release', group: g })
     }
+    const envIndex = envIndexByGroup.get(key)!
+    const stopMs = stopMsByGroup.get(key)!
     const envSlug = e.environment_slug
-    const existingIdx = g.stops.findIndex((s) => s.environment_slug === envSlug)
-    if (existingIdx >= 0) {
-      // Keep the earliest deploy into each env — it's when the release
-      // first reached that stop.
-      if (
-        parseUtcIso(e.occurred_at) <
-        parseUtcIso(g.stops[existingIdx].entry.occurred_at)
-      ) {
+    const existingIdx = envIndex.get(envSlug)
+    if (existingIdx !== undefined) {
+      // Keep the earliest deploy into each env.
+      if (occurredMs < stopMs[existingIdx]) {
         g.stops[existingIdx] = { environment_slug: envSlug, entry: e }
+        stopMs[existingIdx] = occurredMs
       }
     } else {
+      envIndex.set(envSlug, g.stops.length)
       g.stops.push({ environment_slug: envSlug, entry: e })
+      stopMs.push(occurredMs)
     }
-    if (parseUtcIso(e.occurred_at) > parseUtcIso(g.latestEntry.occurred_at)) {
+    const latestMs = latestMsByGroup.get(key)!
+    if (occurredMs > latestMs) {
       g.latestEntry = e
+      latestMsByGroup.set(key, occurredMs)
     }
   }
   return order
@@ -142,6 +168,10 @@ export function bucketByDay(
   items: FeedItem[],
   now: number = Date.now(),
 ): DayBucket[] {
+  // Compute today's local-midnight once — `dayKey` used to redo this per
+  // call, allocating 2 Date objects per item.
+  const n = new Date(now)
+  const todayMs = new Date(n.getFullYear(), n.getMonth(), n.getDate()).getTime()
   const buckets: DayBucket[] = []
   let current: DayBucket | null = null
   for (const it of items) {
@@ -149,7 +179,7 @@ export function bucketByDay(
       it.kind === 'release'
         ? it.group.latestEntry.occurred_at
         : it.entry.occurred_at
-    const dk = dayKey(iso, now)
+    const dk = dayKeyFromDate(parseUtcIso(iso), todayMs)
     if (!current || current.key !== dk.key) {
       current = { key: dk.key, label: dk.label, date: dk.date, items: [] }
       buckets.push(current)

--- a/src/components/operations-log/opsLogHelpers.ts
+++ b/src/components/operations-log/opsLogHelpers.ts
@@ -1,0 +1,179 @@
+import type { OperationsLogRecord } from '@/types'
+
+export type TimeRange = '24h' | '3d' | '7d' | '30d' | 'all'
+export type OperationsLogView = 'stream' | 'grouped'
+
+export function parseUtcIso(iso: string): Date {
+  const hasOffset = /(Z|[+-]\d\d:?\d\d)$/.test(iso)
+  return new Date(hasOffset ? iso : iso + 'Z')
+}
+
+export function relTime(iso: string, now: number = Date.now()): string {
+  const t = parseUtcIso(iso).getTime()
+  const diff = Math.max(0, now - t)
+  const m = Math.floor(diff / 60_000)
+  if (m < 1) return 'now'
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h`
+  const d = Math.floor(h / 24)
+  if (d < 7) return `${d}d`
+  return `${Math.floor(d / 7)}w`
+}
+
+export function absTime(iso: string): string {
+  return parseUtcIso(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+export interface DayBucketKey {
+  key: string
+  label: string
+  date: Date
+}
+
+export function dayKey(iso: string, now: number = Date.now()): DayBucketKey {
+  const d = parseUtcIso(iso)
+  const n = new Date(now)
+  const today = new Date(n.getFullYear(), n.getMonth(), n.getDate()).getTime()
+  const eventDay = new Date(
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+  ).getTime()
+  const diffDays = Math.round((today - eventDay) / 86_400_000)
+  if (diffDays === 0) return { key: 'today', label: 'Today', date: d }
+  if (diffDays === 1) return { key: 'yesterday', label: 'Yesterday', date: d }
+  return {
+    key: d.toDateString(),
+    label: d.toLocaleDateString(undefined, { weekday: 'long' }),
+    date: d,
+  }
+}
+
+export function cleanName(email: string | null | undefined): string {
+  if (!email) return 'system'
+  const part = email.split('@')[0]
+  return part || email
+}
+
+export function initials(email: string | null | undefined): string {
+  if (!email) return 'SY'
+  const part = email.split('@')[0]
+  if (!part) return email[0]?.toUpperCase() ?? '?'
+  if (part.length >= 2) return (part[0] + part[part.length - 1]).toUpperCase()
+  return part[0].toUpperCase()
+}
+
+export interface ReleaseStop {
+  environment_slug: string
+  entry: OperationsLogRecord
+}
+
+export interface ReleaseGroup {
+  project_slug: string
+  description: string
+  stops: ReleaseStop[]
+  latestEntry: OperationsLogRecord
+}
+
+export type FeedItem =
+  | { kind: 'single'; entry: OperationsLogRecord }
+  | { kind: 'release'; group: ReleaseGroup }
+
+// Group contiguous same-version deploys of one project into a single
+// release train. Keys by `project_slug::description` — the API emits the
+// same description for each env a single release moves through.
+export function groupReleases(entries: OperationsLogRecord[]): FeedItem[] {
+  const groups = new Map<string, ReleaseGroup>()
+  const order: FeedItem[] = []
+  for (const e of entries) {
+    if (e.entry_type !== 'Deployed') {
+      order.push({ kind: 'single', entry: e })
+      continue
+    }
+    const descKey = (e.description || '').trim()
+    const key = `${e.project_slug}::${descKey}`
+    let g = groups.get(key)
+    if (!g) {
+      g = {
+        project_slug: e.project_slug,
+        description: descKey,
+        stops: [],
+        latestEntry: e,
+      }
+      groups.set(key, g)
+      order.push({ kind: 'release', group: g })
+    }
+    const envSlug = e.environment_slug
+    const existingIdx = g.stops.findIndex((s) => s.environment_slug === envSlug)
+    if (existingIdx >= 0) {
+      // Keep the earliest deploy into each env — it's when the release
+      // first reached that stop.
+      if (
+        parseUtcIso(e.occurred_at) <
+        parseUtcIso(g.stops[existingIdx].entry.occurred_at)
+      ) {
+        g.stops[existingIdx] = { environment_slug: envSlug, entry: e }
+      }
+    } else {
+      g.stops.push({ environment_slug: envSlug, entry: e })
+    }
+    if (parseUtcIso(e.occurred_at) > parseUtcIso(g.latestEntry.occurred_at)) {
+      g.latestEntry = e
+    }
+  }
+  return order
+}
+
+export interface DayBucket {
+  key: string
+  label: string
+  date: Date
+  items: FeedItem[]
+}
+
+export function bucketByDay(
+  items: FeedItem[],
+  now: number = Date.now(),
+): DayBucket[] {
+  const buckets: DayBucket[] = []
+  let current: DayBucket | null = null
+  for (const it of items) {
+    const iso =
+      it.kind === 'release'
+        ? it.group.latestEntry.occurred_at
+        : it.entry.occurred_at
+    const dk = dayKey(iso, now)
+    if (!current || current.key !== dk.key) {
+      current = { key: dk.key, label: dk.label, date: dk.date, items: [] }
+      buckets.push(current)
+    }
+    current.items.push(it)
+  }
+  return buckets
+}
+
+// Strip a leading "release X.Y.Z" / "release X.Y.Z - " from a description
+// when it just repeats the version already shown in the row.
+export function cleanDescription(
+  description: string | null | undefined,
+  version: string | null | undefined,
+): string {
+  const desc = (description || '').trim()
+  if (!version) return desc
+  const lower = desc.toLowerCase()
+  const prefix = `release ${version.toLowerCase()}`
+  if (lower.startsWith(prefix)) {
+    return desc
+      .substring(`release ${version}`.length)
+      .replace(/^\s*[-–—:]\s*/, '')
+      .trim()
+  }
+  return desc
+}

--- a/src/components/operations-log/opsRowLayout.ts
+++ b/src/components/operations-log/opsRowLayout.ts
@@ -6,4 +6,4 @@
 export const OPS_ROW_GRID =
   '4px 26px minmax(140px,180px) auto minmax(0,1fr) minmax(560px,4fr) 46px 44px 20px'
 
-export const OPS_ROW_PAD = 'py-2 pr-3.5 pl-0'
+export const OPS_ROW_PAD = 'py-4 pr-3.5 pl-0'

--- a/src/components/operations-log/opsRowLayout.ts
+++ b/src/components/operations-log/opsRowLayout.ts
@@ -1,0 +1,9 @@
+// Shared 9-column grid for both Stream and Release rows so their columns
+// line up vertically. The env/train column (col 6) is rendered rowspan=2
+// so single-line envs stay centred and multi-line release trains get
+// room alongside the description row.
+//   rail | icon | project | version | desc | env/train | avatar | time | chevron
+export const OPS_ROW_GRID =
+  '4px 26px minmax(140px,180px) auto minmax(0,1fr) minmax(560px,4fr) 46px 44px 20px'
+
+export const OPS_ROW_PAD = 'py-2 pr-3.5 pl-0'

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import * as AccordionPrimitive from '@radix-ui/react-accordion'
+import { ChevronDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative border-b border-tertiary last:border-0 data-[state=open]:bg-secondary',
+      // Amber accent bar on the left; visible on hover for closed items and
+      // always visible for open items. Rendered via ::before so it overlays
+      // children instead of being painted over by the trigger.
+      "before:pointer-events-none before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:bg-[theme(colors.amber.border)] before:opacity-0 before:transition-opacity before:content-['']",
+      'hover:before:opacity-100 data-[state=open]:before:opacity-100',
+      className,
+    )}
+    {...props}
+  />
+))
+AccordionItem.displayName = 'AccordionItem'
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger> & {
+    hideChevron?: boolean
+  }
+>(({ className, children, hideChevron = false, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'group flex flex-1 items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-secondary focus:bg-secondary focus:outline-none',
+        'data-[state=open]:hover:bg-transparent',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {!hideChevron && (
+        <ChevronDown className="mt-1.5 h-4 w-4 flex-shrink-0 text-tertiary transition-transform duration-200 group-data-[state=open]:rotate-180" />
+      )}
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={className}>{children}</div>
+  </AccordionPrimitive.Content>
+))
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/src/components/ui/release-train.tsx
+++ b/src/components/ui/release-train.tsx
@@ -1,0 +1,127 @@
+/* eslint-disable react-refresh/only-export-components */
+import { ArrowRight } from 'lucide-react'
+import type { CSSProperties } from 'react'
+import { useTheme } from '@/contexts/ThemeContext'
+import { deriveChipColors } from '@/lib/chip-colors'
+import { cn } from '@/lib/utils'
+import { sortEnvironments } from '@/lib/utils'
+import type { Environment } from '@/types'
+
+export interface ReleaseTrainStop {
+  environment: Environment
+  // Short value displayed next to the environment name (e.g. a version or
+  // SHA). Absent means the stop is shown as pending.
+  value?: string | null
+  // Optional override — treat the stop as done without a value.
+  done?: boolean
+  title?: string
+}
+
+interface ReleaseTrainProps {
+  // Caller decides which environments appear; the component orders them
+  // by each environment's sort_order.
+  stops: ReleaseTrainStop[]
+  // Compact = ops-log sized; default = project-header sized.
+  size?: 'compact' | 'default'
+  className?: string
+}
+
+const SIZE_STYLES: Record<
+  NonNullable<ReleaseTrainProps['size']>,
+  { chip: string; arrow: string; gap: string }
+> = {
+  default: {
+    chip: 'rounded-md px-3 py-1.5 text-sm',
+    arrow: 'h-4 w-4',
+    gap: 'gap-2',
+  },
+  compact: {
+    chip: 'rounded px-2 py-0.5 text-[11px] font-mono',
+    arrow: 'h-3 w-3',
+    gap: 'gap-1.5',
+  },
+}
+
+export function ReleaseTrain({
+  stops,
+  size = 'default',
+  className,
+}: ReleaseTrainProps) {
+  const { isDarkMode } = useTheme()
+  const s = SIZE_STYLES[size]
+  const ordered = [...stops].sort(
+    (a, b) =>
+      (a.environment.sort_order ?? 0) - (b.environment.sort_order ?? 0) ||
+      a.environment.name.localeCompare(b.environment.name),
+  )
+
+  if (ordered.length === 0) return null
+
+  return (
+    <div className={cn('flex flex-wrap items-center', s.gap, className)}>
+      {ordered.map((stop, idx) => {
+        const done = stop.done ?? stop.value != null
+        const color = stop.environment.label_color
+        const derived =
+          done && color ? deriveChipColors(color, isDarkMode) : null
+        const style: CSSProperties | undefined = derived
+          ? {
+              backgroundColor: derived.bg,
+              color: derived.fg,
+              borderColor: derived.border,
+            }
+          : undefined
+        const title =
+          stop.title ??
+          `${stop.environment.name}${stop.value ? `: ${stop.value}` : ' · not deployed'}`
+        return (
+          <span key={stop.environment.slug} className="flex items-center">
+            {idx > 0 ? (
+              <ArrowRight
+                className={cn('mr-2 text-tertiary', s.arrow)}
+                style={size === 'compact' ? { marginRight: 6 } : undefined}
+                aria-hidden
+              />
+            ) : null}
+            <span
+              className={cn(
+                'inline-flex items-center whitespace-nowrap border font-medium',
+                s.chip,
+                !done &&
+                  'border-dashed border-tertiary text-tertiary opacity-60',
+              )}
+              style={style}
+              title={title}
+            >
+              <span className="font-medium">{stop.environment.name}</span>
+              {stop.value ? (
+                <span
+                  className={cn(
+                    'ml-1.5 font-mono',
+                    size === 'compact' ? 'text-[11px]' : 'text-xs',
+                  )}
+                >
+                  {stop.value}
+                </span>
+              ) : null}
+            </span>
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+// Convenience helper: given a project's environments and a map of
+// env_slug → value (version/SHA), produce the stops array sorted for the
+// train. Environments with no matching value render as pending.
+export function buildReleaseTrainStops(
+  environments: Environment[] | undefined,
+  valueBySlug: Map<string, string | null | undefined>,
+): ReleaseTrainStop[] {
+  if (!environments?.length) return []
+  return sortEnvironments(environments).map((env) => ({
+    environment: env,
+    value: valueBySlug.get(env.slug) ?? null,
+  }))
+}

--- a/src/hooks/useInfiniteOperationsLog.ts
+++ b/src/hooks/useInfiniteOperationsLog.ts
@@ -1,0 +1,45 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { listOperationsLog } from '@/api/endpoints'
+import type { OperationsLogFilters } from '@/types'
+
+const PAGE_SIZE = 200
+
+export function useInfiniteOperationsLog(filters: OperationsLogFilters) {
+  return useInfiniteQuery({
+    queryKey: ['operationsLog', 'infinite', filters],
+    queryFn: ({ pageParam }) =>
+      listOperationsLog({
+        limit: PAGE_SIZE,
+        cursor: pageParam as string | undefined,
+        filters,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (!lastPage.nextCursor) return undefined
+      // Guard against a stuck cursor: if the API returns the same cursor
+      // it just received, stop paging to prevent an infinite fetch loop.
+      if (lastPage.nextCursor === lastPageParam) return undefined
+      return lastPage.nextCursor
+    },
+    select: (data) => {
+      // Dedupe entries by id. Defends against a backend glitch where the
+      // same row slips into multiple cursor pages (observed with the
+      // ReplacingMergeTree FINAL cursor), which would otherwise inflate
+      // sidebar counts and trigger more auto-fetches.
+      const seen = new Set<string>()
+      const entries = []
+      for (const page of data.pages) {
+        for (const entry of page.entries) {
+          if (seen.has(entry.id)) continue
+          seen.add(entry.id)
+          entries.push(entry)
+        }
+      }
+      return {
+        pages: data.pages,
+        pageParams: data.pageParams,
+        entries,
+      }
+    },
+  })
+}

--- a/src/hooks/useInfiniteOperationsLog.ts
+++ b/src/hooks/useInfiniteOperationsLog.ts
@@ -35,10 +35,13 @@ export function useInfiniteOperationsLog(filters: OperationsLogFilters) {
           entries.push(entry)
         }
       }
+      // Metrics are returned only on page 1; hold onto that one.
+      const metrics = data.pages.find((p) => p.metrics)?.metrics
       return {
         pages: data.pages,
         pageParams: data.pageParams,
         entries,
+        metrics,
       }
     },
   })

--- a/src/lib/ops-log-icons.ts
+++ b/src/lib/ops-log-icons.ts
@@ -1,0 +1,25 @@
+import {
+  ArrowRightLeft,
+  ArrowUp,
+  PackagePlus,
+  Rocket,
+  RotateCw,
+  Scale,
+  SlidersHorizontal,
+  Trash2,
+  Undo2,
+  type LucideIcon,
+} from 'lucide-react'
+import type { OperationsLogEntryType } from '@/types'
+
+export const ENTRY_TYPE_ICONS: Record<OperationsLogEntryType, LucideIcon> = {
+  Configured: SlidersHorizontal,
+  Decommissioned: Trash2,
+  Deployed: Rocket,
+  Migrated: ArrowRightLeft,
+  Provisioned: PackagePlus,
+  Restarted: RotateCw,
+  'Rolled Back': Undo2,
+  Scaled: Scale,
+  Upgraded: ArrowUp,
+}

--- a/src/pages/OperationsLogPage.tsx
+++ b/src/pages/OperationsLogPage.tsx
@@ -1,0 +1,18 @@
+import { Navigation } from '@/components/Navigation'
+import { OperationsLog } from '@/components/OperationsLog'
+import { CommandBar } from '@/components/CommandBar'
+
+export function OperationsLogPage() {
+  return (
+    <div className="min-h-screen bg-tertiary text-primary">
+      <Navigation currentView="operations" />
+      <main
+        className="pt-16"
+        style={{ paddingBottom: 'var(--assistant-height, 64px)' }}
+      >
+        <OperationsLog />
+      </main>
+      <CommandBar />
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -221,6 +221,50 @@ export interface OperationsLogEntry {
 
 export type ActivityFeedEntry = ProjectFeedEntry | OperationsLogEntry
 
+export const OPERATIONS_LOG_ENTRY_TYPES = [
+  'Configured',
+  'Decommissioned',
+  'Deployed',
+  'Migrated',
+  'Provisioned',
+  'Restarted',
+  'Rolled Back',
+  'Scaled',
+  'Upgraded',
+] as const
+
+export type OperationsLogEntryType = (typeof OPERATIONS_LOG_ENTRY_TYPES)[number]
+
+// Raw record returned by the /operations-log/ API (distinct from the
+// activity-feed projection defined above in `OperationsLogEntry`).
+export interface OperationsLogRecord {
+  id: string
+  occurred_at: string
+  recorded_at: string
+  recorded_by: string
+  performed_by?: string | null
+  completed_at?: string | null
+  project_id: string
+  project_slug: string
+  environment_slug: string
+  entry_type: OperationsLogEntryType
+  description: string
+  link?: string | null
+  notes?: string | null
+  ticket_slug?: string | null
+  version?: string | null
+}
+
+export interface OperationsLogFilters {
+  project_slug?: string
+  environment_slug?: string
+  entry_type?: OperationsLogEntryType
+  ticket_slug?: string
+  performed_by?: string
+  since?: string
+  until?: string
+}
+
 export interface DashboardStats {
   total_projects: number
   projects_by_namespace: Record<string, number>


### PR DESCRIPTION
## Summary
- Adds a dedicated `/opslog` screen with a faceted sidebar (time range, entry type, environment, project, performer) and a summary strip (events, deploys, projects touched, team members).
- Stream view shows per-entry rows; Releases view groups deploys by project+version into a release train with a promotion timeline.
- Rows open on hover with a 100ms dwell (no click, collapse on leave).

## Notes
- Client pagination uses the API's `Link: rel="next"` header via a cursor.
- Release-train environments are the union of the project's pipeline and any env that received a deploy, so out-of-pipeline deploys still surface.
- Left (description) / right (release-train) halves share flex space so row widths stay consistent across time groupings; release train is center-aligned in its column.

## Test plan
- [ ] Visit `/opslog` and verify filters/time ranges update the list.
- [ ] Toggle Stream/Releases; confirm train chips line up and the promotion timeline env chips are centered in the fixed-width column.
- [ ] Hover a row for ~100ms; it expands. Mouse-leave collapses without delay.