### PR TITLE
Add per-page document title and drop ops-log day header rule

### DIFF
--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -475,7 +475,7 @@ export function OperationsLog() {
               day: 'numeric',
             })}
           </span>
-          <span className="h-px flex-1 bg-tertiary" />
+          <span className="flex-1" />
           <span className="font-mono text-[11px] text-tertiary">
             {vi.count} {vi.count === 1 ? 'event' : 'events'}
           </span>

--- a/src/hooks/usePageTitle.ts
+++ b/src/hooks/usePageTitle.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react'
+
+export function usePageTitle(title: string | undefined | null) {
+  useEffect(() => {
+    if (!title) return
+    const previous = document.title
+    document.title = `Imbi ⸱ ${title}`
+    return () => {
+      document.title = previous
+    }
+  }, [title])
+}

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,8 +1,10 @@
 import { Navigation } from '@/components/Navigation'
 import { CommandBar } from '@/components/CommandBar'
 import { Admin } from '@/components/Admin'
+import { usePageTitle } from '@/hooks/usePageTitle'
 
 export function AdminPage() {
+  usePageTitle('Admin')
   return (
     <div className="min-h-screen bg-tertiary text-primary">
       <Navigation currentView="admin" />

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,8 +1,10 @@
 import { Navigation } from '@/components/Navigation'
 import { Dashboard } from '@/components/Dashboard'
 import { CommandBar } from '@/components/CommandBar'
+import { usePageTitle } from '@/hooks/usePageTitle'
 
 export function DashboardPage() {
+  usePageTitle('Dashboard')
   return (
     <div className="min-h-screen bg-tertiary text-primary">
       <Navigation />

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -7,12 +7,14 @@ import { OAuthButton } from '@/components/auth/OAuthButton'
 import { LocalLoginForm } from '@/components/auth/LocalLoginForm'
 import { AuthDivider } from '@/components/auth/AuthDivider'
 import { useTheme } from '@/contexts/ThemeContext'
+import { usePageTitle } from '@/hooks/usePageTitle'
 import logoLight from '@/assets/logo-light.svg'
 import logoDark from '@/assets/logo-dark.svg'
 
 const REMEMBERED_EMAIL_KEY = 'imbi_remembered_email'
 
 export function LoginPage() {
+  usePageTitle('Login')
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const { isDarkMode } = useTheme()

--- a/src/pages/OperationsLogPage.tsx
+++ b/src/pages/OperationsLogPage.tsx
@@ -1,8 +1,10 @@
 import { Navigation } from '@/components/Navigation'
 import { OperationsLog } from '@/components/OperationsLog'
 import { CommandBar } from '@/components/CommandBar'
+import { usePageTitle } from '@/hooks/usePageTitle'
 
 export function OperationsLogPage() {
+  usePageTitle('Operations Log')
   return (
     <div className="min-h-screen bg-tertiary text-primary">
       <Navigation currentView="operations" />

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -4,6 +4,7 @@ import { Navigation } from '@/components/Navigation'
 import { ProjectDetail } from '@/components/ProjectDetail'
 import { CommandBar } from '@/components/CommandBar'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { usePageTitle } from '@/hooks/usePageTitle'
 import { getProject } from '@/api/endpoints'
 
 export function ProjectDetailPage() {
@@ -21,6 +22,8 @@ export function ProjectDetailPage() {
     queryFn: () => getProject(orgSlug, projectId!),
     enabled: !!orgSlug && !!projectId,
   })
+
+  usePageTitle(project?.name ?? 'Project')
 
   return (
     <div className="min-h-screen bg-tertiary text-primary">

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,8 +1,10 @@
 import { Navigation } from '@/components/Navigation'
 import { ProjectsView } from '@/components/ProjectsView'
 import { CommandBar } from '@/components/CommandBar'
+import { usePageTitle } from '@/hooks/usePageTitle'
 
 export function ProjectsPage() {
+  usePageTitle('Projects')
   return (
     <div className="min-h-screen bg-tertiary text-primary">
       <Navigation currentView="projects" />

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,8 +1,10 @@
 import { Navigation } from '@/components/Navigation'
 import { Settings } from '@/components/Settings'
 import { CommandBar } from '@/components/CommandBar'
+import { usePageTitle } from '@/hooks/usePageTitle'
 
 export function SettingsPage() {
+  usePageTitle('Settings')
   return (
     <div className="min-h-screen bg-tertiary text-primary">
       <Navigation />


### PR DESCRIPTION
## Summary

- New `usePageTitle` hook sets `document.title` to `Imbi ⸱ <Page Title>` and restores the previous value on unmount.
- Wired into every page: Dashboard, Projects, Project Detail (uses the project name when loaded, `Project` while loading), Operations Log, Admin, Settings, Login.
- Removes the 1px divider (`<span className="h-px flex-1 bg-tertiary" />`) from the Operations Log day-group header — a plain flex spacer keeps the event count right-aligned.

## Test plan

- [ ] Navigate between pages and confirm the browser tab title updates (e.g. `Imbi ⸱ Dashboard`, `Imbi ⸱ Operations Log`, `Imbi ⸱ <Project Name>`).
- [ ] Visit Operations Log and confirm day headers (`YESTERDAY`, `TODAY`, etc.) no longer show a faint horizontal line between the date and the event count.