### PR TITLE
Add project-scoped Operations Log tab and rename route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,7 @@ function App() {
             }
           />
           <Route
-            path="/opslog"
+            path="/operations-log"
             element={
               <ProtectedRoute>
                 <OperationsLogPage />
@@ -129,6 +129,10 @@ function App() {
                 <AdminPage />
               </AdminProtectedRoute>
             }
+          />
+          <Route
+            path="/opslog"
+            element={<Navigate to="/operations-log" replace />}
           />
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/src/components/EditEnvironmentsCard.tsx
+++ b/src/components/EditEnvironmentsCard.tsx
@@ -1,15 +1,26 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Card } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { EnvironmentBadge } from '@/components/ui/environment-badge'
+import { Input } from '@/components/ui/input'
+import { SavedIndicator } from '@/components/ui/saved-indicator'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useSavedFlash } from '@/hooks/useSavedFlash'
 import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
 import type { Environment } from '@/types'
 
 interface EditEnvironmentsCardProps {
   environments: Environment[]
-  isSaving: boolean
-  onSave: (envData: Record<string, Record<string, string>>) => void
+  availableEnvironments: Environment[]
+  onPatch: (envData: Record<string, Record<string, string>>) => Promise<void>
 }
 
 function toLabel(key: string): string {
@@ -19,62 +30,133 @@ function toLabel(key: string): string {
     .join(' ')
 }
 
+function extractFields(env: Environment): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, val] of Object.entries(env)) {
+    if (ENVIRONMENT_BASE_FIELDS_SET.has(key)) continue
+    out[key] = val != null ? String(val) : ''
+  }
+  return out
+}
+
+function buildEnvMap(
+  envs: Environment[],
+): Record<string, Record<string, string>> {
+  const map: Record<string, Record<string, string>> = {}
+  for (const env of envs) map[env.slug] = extractFields(env)
+  return map
+}
+
 export function EditEnvironmentsCard({
   environments,
-  isSaving,
-  onSave,
+  availableEnvironments,
+  onPatch,
 }: EditEnvironmentsCardProps) {
   const dynamicFields = useMemo(() => {
     const fieldSet = new Set<string>()
     for (const env of environments) {
       for (const key of Object.keys(env)) {
-        if (!ENVIRONMENT_BASE_FIELDS_SET.has(key)) {
-          fieldSet.add(key)
-        }
+        if (!ENVIRONMENT_BASE_FIELDS_SET.has(key)) fieldSet.add(key)
       }
     }
     return [...fieldSet].sort()
   }, [environments])
 
-  const [data, setData] = useState<Record<string, Record<string, string>>>({})
+  const serverMap = useMemo(() => buildEnvMap(environments), [environments])
+  const [drafts, setDrafts] =
+    useState<Record<string, Record<string, string>>>(serverMap)
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null)
+  const { saved, flash } = useSavedFlash()
 
   useEffect(() => {
-    const initial: Record<string, Record<string, string>> = {}
-    for (const env of environments) {
-      const fields: Record<string, string> = {}
-      for (const key of dynamicFields) {
-        const val = env[key]
-        fields[key] = val != null ? String(val) : ''
-      }
-      initial[env.slug] = fields
-    }
-    setData(initial)
-  }, [environments, dynamicFields])
+    setDrafts(serverMap)
+  }, [serverMap])
 
-  const updateField = (envSlug: string, field: string, value: string) => {
-    setData((prev) => ({
-      ...prev,
-      [envSlug]: { ...prev[envSlug], [field]: value },
-    }))
+  const envBySlug = useMemo(() => {
+    const m = new Map<string, Environment>()
+    for (const e of environments) m.set(e.slug, e)
+    return m
+  }, [environments])
+
+  const currentSlugs = useMemo(
+    () => new Set(environments.map((e) => e.slug)),
+    [environments],
+  )
+
+  const unassignedEnvs = useMemo(
+    () =>
+      availableEnvironments
+        .filter((e) => !currentSlugs.has(e.slug))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [availableEnvironments, currentSlugs],
+  )
+
+  const buildBaseline = (): Record<string, Record<string, string>> => {
+    const out: Record<string, Record<string, string>> = {}
+    for (const env of environments) {
+      out[env.slug] = { ...serverMap[env.slug] }
+    }
+    return out
   }
 
-  const handleSave = () => {
-    const result: Record<string, Record<string, string>> = {}
-    for (const env of environments) {
-      result[env.slug] = data[env.slug] ?? {}
+  const handleBlur = async (slug: string, field: string) => {
+    const next = (drafts[slug]?.[field] ?? '').trim()
+    const current = serverMap[slug]?.[field] ?? ''
+    if (next === current) return
+    const payload = buildBaseline()
+    payload[slug] = { ...payload[slug], [field]: next }
+    try {
+      await onPatch(payload)
+      flash(`${slug}:${field}`)
+    } catch {
+      // Parent surfaces the error; keep the draft for retry.
     }
-    onSave(result)
   }
 
-  if (dynamicFields.length === 0) return null
+  const requestDelete = (slug: string) => {
+    setPendingDelete(slug)
+  }
+
+  const cancelDelete = () => {
+    setPendingDelete(null)
+  }
+
+  const confirmDelete = async () => {
+    const slug = pendingDelete
+    if (!slug) return
+    const payload = buildBaseline()
+    delete payload[slug]
+    try {
+      await onPatch(payload)
+    } catch {
+      // Parent surfaces the error.
+    } finally {
+      setPendingDelete(null)
+    }
+  }
+
+  const handleAdd = async (slug: string) => {
+    if (!slug || currentSlugs.has(slug)) return
+    const payload = buildBaseline()
+    payload[slug] = {}
+    try {
+      await onPatch(payload)
+    } catch {
+      // Parent surfaces the error.
+    }
+  }
+
+  const pendingEnv = pendingDelete ? envBySlug.get(pendingDelete) : undefined
+
+  if (environments.length === 0 && unassignedEnvs.length === 0) return null
 
   return (
     <Card className="p-6">
-      <h3 className="mb-4 text-primary">Environment Specific Details</h3>
+      <h3 className="mb-4 text-primary">Environments</h3>
 
-      <div className="space-y-4">
+      <div className="divide-y divide-border">
         {environments.map((env) => (
-          <div key={env.slug} className="flex gap-3">
+          <div key={env.slug} className="flex gap-3 py-4 first:pt-0 last:pb-0">
             <div className="w-[15%] flex-shrink-0 pt-1">
               <EnvironmentBadge
                 name={env.name}
@@ -83,37 +165,97 @@ export function EditEnvironmentsCard({
               />
             </div>
             <div className="flex-1 space-y-2">
-              {dynamicFields.map((field) => (
-                <div key={field}>
-                  <label className="mb-1 block text-xs font-medium text-tertiary">
-                    {toLabel(field)}
-                  </label>
-                  <Input
-                    value={data[env.slug]?.[field] ?? ''}
-                    onChange={(e) =>
-                      updateField(env.slug, field, e.target.value)
-                    }
-                    disabled={isSaving}
-                    placeholder={toLabel(field)}
-                    className="text-sm"
-                  />
-                </div>
-              ))}
+              {dynamicFields.length === 0 ? (
+                <p className="text-xs text-tertiary">
+                  No blueprint fields for this environment.
+                </p>
+              ) : (
+                dynamicFields.map((field) => (
+                  <div key={field} className="flex items-center gap-3">
+                    <label
+                      htmlFor={`env-${env.slug}-${field}`}
+                      className="w-20 flex-shrink-0 text-xs font-medium text-tertiary"
+                    >
+                      {toLabel(field)}
+                    </label>
+                    <div className="relative flex-1">
+                      <Input
+                        id={`env-${env.slug}-${field}`}
+                        value={drafts[env.slug]?.[field] ?? ''}
+                        onChange={(e) =>
+                          setDrafts((prev) => ({
+                            ...prev,
+                            [env.slug]: {
+                              ...(prev[env.slug] ?? {}),
+                              [field]: e.target.value,
+                            },
+                          }))
+                        }
+                        onBlur={() => handleBlur(env.slug, field)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault()
+                            e.currentTarget.blur()
+                          }
+                        }}
+                        placeholder={toLabel(field)}
+                        className="pr-8 text-sm"
+                      />
+                      <SavedIndicator show={!!saved[`${env.slug}:${field}`]} />
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="flex-shrink-0 pt-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove ${env.name} environment`}
+                className="h-8 w-8 text-secondary hover:text-danger"
+                onClick={() => requestDelete(env.slug)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
             </div>
           </div>
         ))}
+
+        {unassignedEnvs.length > 0 && (
+          <div className="flex items-center gap-3 pt-4">
+            <div className="w-[15%] flex-shrink-0">
+              <Select value="" onValueChange={handleAdd}>
+                <SelectTrigger className="text-sm">
+                  <SelectValue placeholder="Add environment…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {unassignedEnvs.map((env) => (
+                    <SelectItem key={env.slug} value={env.slug}>
+                      {env.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex-1" />
+            <div className="h-8 w-8 flex-shrink-0" aria-hidden />
+          </div>
+        )}
       </div>
 
-      <div className="mt-4 flex justify-end">
-        <Button
-          size="sm"
-          className="bg-action text-action-foreground hover:bg-action-hover"
-          onClick={handleSave}
-          disabled={isSaving}
-        >
-          {isSaving ? 'Saving...' : 'Save'}
-        </Button>
-      </div>
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title={
+          pendingEnv
+            ? `Remove ${pendingEnv.name} environment?`
+            : 'Remove environment?'
+        }
+        description="This will remove the environment from the project along with any environment-specific field values."
+        confirmLabel="Remove"
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
+      />
     </Card>
   )
 }

--- a/src/components/EditIdentifiersCard.tsx
+++ b/src/components/EditIdentifiersCard.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { Input } from '@/components/ui/input'
+import { SavedIndicator } from '@/components/ui/saved-indicator'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useSavedFlash } from '@/hooks/useSavedFlash'
+
+interface EditIdentifiersCardProps {
+  identifiers: Record<string, string | number>
+  onPatch: (identifiers: Record<string, string>) => Promise<void>
+}
+
+function toLabel(key: string): string {
+  return key
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+function normalize(
+  identifiers: Record<string, string | number>,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(identifiers)) {
+    out[k] = v == null ? '' : String(v)
+  }
+  return out
+}
+
+export function EditIdentifiersCard({
+  identifiers,
+  onPatch,
+}: EditIdentifiersCardProps) {
+  const serverMap = useMemo(() => normalize(identifiers), [identifiers])
+  const [drafts, setDrafts] = useState<Record<string, string>>(serverMap)
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null)
+  const [newKey, setNewKey] = useState<string | null>(null)
+  const [newValue, setNewValue] = useState('')
+  const [selectKey, setSelectKey] = useState(0)
+  const newValueRef = useRef<HTMLInputElement>(null)
+  const shouldFocusNewValue = useRef(false)
+  const { saved, flash } = useSavedFlash()
+
+  useEffect(() => {
+    setDrafts(serverMap)
+  }, [serverMap])
+
+  useEffect(() => {
+    if (shouldFocusNewValue.current) {
+      newValueRef.current?.focus()
+      shouldFocusNewValue.current = false
+    }
+  })
+
+  const visibleKeys = useMemo(
+    () =>
+      Object.keys(serverMap)
+        .filter((k) => (serverMap[k] ?? '').trim() !== '')
+        .sort((a, b) => a.localeCompare(b)),
+    [serverMap],
+  )
+
+  const unassignedKeys = useMemo(
+    () =>
+      Object.keys(serverMap)
+        .filter((k) => (serverMap[k] ?? '').trim() === '')
+        .sort((a, b) => a.localeCompare(b)),
+    [serverMap],
+  )
+
+  const handleBlur = async (key: string) => {
+    const next = (drafts[key] ?? '').trim()
+    const current = serverMap[key] ?? ''
+    if (next === current) return
+    if (!next && current) {
+      setPendingDelete(key)
+      return
+    }
+    const payload: Record<string, string> = { ...serverMap, [key]: next }
+    try {
+      await onPatch(payload)
+      flash(key)
+    } catch {
+      // Parent surfaces the error; keep the draft for retry.
+    }
+  }
+
+  const requestDelete = (key: string) => {
+    if (!(serverMap[key] ?? '').trim()) return
+    setPendingDelete(key)
+  }
+
+  const cancelDelete = () => {
+    const key = pendingDelete
+    if (key && serverMap[key]) {
+      setDrafts((prev) => ({ ...prev, [key]: serverMap[key] }))
+    }
+    setPendingDelete(null)
+  }
+
+  const confirmDelete = async () => {
+    const key = pendingDelete
+    if (!key) return
+    const payload: Record<string, string> = {}
+    for (const [k, v] of Object.entries(serverMap)) {
+      if (k === key) continue
+      const t = (v ?? '').trim()
+      if (t) payload[k] = t
+    }
+    try {
+      await onPatch(payload)
+      setDrafts((prev) => {
+        const { [key]: _, ...rest } = prev
+        return rest
+      })
+    } catch {
+      // Parent surfaces the error.
+    } finally {
+      setPendingDelete(null)
+    }
+  }
+
+  const handleNewKeyChange = (key: string) => {
+    if (!key) return
+    setNewKey(key)
+    shouldFocusNewValue.current = true
+  }
+
+  const handleNewBlur = async () => {
+    const value = newValue.trim()
+    if (!newKey || !value) return
+    const payload: Record<string, string> = { ...serverMap, [newKey]: value }
+    try {
+      await onPatch(payload)
+      flash(newKey)
+      setNewKey(null)
+      setNewValue('')
+      setSelectKey((k) => k + 1)
+    } catch {
+      // Parent surfaces the error; keep the draft for retry.
+    }
+  }
+
+  if (visibleKeys.length === 0 && unassignedKeys.length === 0) return null
+
+  return (
+    <Card className="p-6">
+      <h3 className="mb-4 text-primary">Identifiers</h3>
+
+      <div className="space-y-3">
+        {visibleKeys.map((key) => (
+          <div key={key} className="flex items-center gap-3">
+            <div className="w-[15%] flex-shrink-0 truncate text-sm text-secondary">
+              {toLabel(key)}
+            </div>
+            <div className="relative flex-1">
+              <Input
+                value={drafts[key] ?? ''}
+                onChange={(e) =>
+                  setDrafts((prev) => ({ ...prev, [key]: e.target.value }))
+                }
+                onBlur={() => handleBlur(key)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    e.currentTarget.blur()
+                  }
+                }}
+                placeholder={toLabel(key)}
+                className="pr-8 font-mono text-sm"
+              />
+              <SavedIndicator show={!!saved[key]} />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={`Remove ${toLabel(key)} identifier`}
+              className="h-8 w-8 flex-shrink-0 text-secondary hover:text-danger"
+              onClick={() => requestDelete(key)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+
+        {unassignedKeys.length > 0 && (
+          <div className="flex items-center gap-3 pt-2">
+            <Select
+              key={selectKey}
+              value={newKey ?? ''}
+              onValueChange={handleNewKeyChange}
+            >
+              <SelectTrigger className="w-[15%] flex-shrink-0 text-sm">
+                {newKey ? (
+                  <div className="flex min-w-0 items-center text-secondary">
+                    <span className="truncate">{toLabel(newKey)}</span>
+                  </div>
+                ) : (
+                  <SelectValue placeholder="Pick Identifier to Add" />
+                )}
+              </SelectTrigger>
+              <SelectContent>
+                {unassignedKeys.map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {toLabel(key)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              ref={newValueRef}
+              value={newValue}
+              onChange={(e) => setNewValue(e.target.value)}
+              onBlur={handleNewBlur}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  e.currentTarget.blur()
+                }
+              }}
+              placeholder={newKey ? toLabel(newKey) : 'identifier'}
+              disabled={!newKey}
+              className="flex-1 font-mono text-sm"
+            />
+            <div className="h-8 w-8 flex-shrink-0" aria-hidden />
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title={
+          pendingDelete
+            ? `Remove ${toLabel(pendingDelete)} identifier?`
+            : 'Remove identifier?'
+        }
+        description="This will clear the identifier value on the project."
+        confirmLabel="Remove"
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
+      />
+    </Card>
+  )
+}

--- a/src/components/EditIdentifiersCard.tsx
+++ b/src/components/EditIdentifiersCard.tsx
@@ -85,7 +85,13 @@ export function EditIdentifiersCard({
       setPendingDelete(key)
       return
     }
-    const payload: Record<string, string> = { ...serverMap, [key]: next }
+    // Merge the latest drafts so a blur that races with an in-flight PATCH
+    // does not revive stale server values for concurrently-edited fields.
+    const payload: Record<string, string> = {
+      ...serverMap,
+      ...drafts,
+      [key]: next,
+    }
     try {
       await onPatch(payload)
       flash(key)
@@ -138,7 +144,13 @@ export function EditIdentifiersCard({
   const handleNewBlur = async () => {
     const value = newValue.trim()
     if (!newKey || !value) return
-    const payload: Record<string, string> = { ...serverMap, [newKey]: value }
+    // Include the latest drafts so concurrent edits to existing identifiers
+    // aren't reverted to stale server values by this add.
+    const payload: Record<string, string> = {
+      ...serverMap,
+      ...drafts,
+      [newKey]: value,
+    }
     try {
       await onPatch(payload)
       flash(newKey)

--- a/src/components/EditLinksCard.tsx
+++ b/src/components/EditLinksCard.tsx
@@ -1,85 +1,257 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Trash2 } from 'lucide-react'
 import { getIcon } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Card } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { Input } from '@/components/ui/input'
+import { SavedIndicator } from '@/components/ui/saved-indicator'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useSavedFlash } from '@/hooks/useSavedFlash'
 import type { LinkDefinition } from '@/types'
 
 interface EditLinksCardProps {
   linkDefs: LinkDefinition[]
   links: Record<string, string>
-  isSaving: boolean
-  onSave: (links: Record<string, string>) => void
+  onPatch: (links: Record<string, string>) => Promise<void>
 }
 
 export function EditLinksCard({
   linkDefs,
   links,
-  isSaving,
-  onSave,
+  onPatch,
 }: EditLinksCardProps) {
-  const [urls, setUrls] = useState<Record<string, string>>({})
+  const [drafts, setDrafts] = useState<Record<string, string>>(links ?? {})
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null)
+  const [newSlug, setNewSlug] = useState<string | null>(null)
+  const [newUrl, setNewUrl] = useState('')
+  const newUrlRef = useRef<HTMLInputElement>(null)
+  const shouldFocusNewUrl = useRef(false)
+  const { saved, flash } = useSavedFlash()
+
+  const defBySlug = useMemo(() => {
+    const m = new Map<string, LinkDefinition>()
+    for (const d of linkDefs) m.set(d.slug, d)
+    return m
+  }, [linkDefs])
 
   useEffect(() => {
-    const initial: Record<string, string> = {}
-    for (const def of linkDefs) {
-      initial[def.slug] = links[def.slug] ?? ''
-    }
-    setUrls(initial)
-  }, [linkDefs, links])
+    setDrafts(links ?? {})
+  }, [links])
 
-  const handleSave = () => {
-    const result: Record<string, string> = {}
-    for (const [slug, url] of Object.entries(urls)) {
-      const trimmed = url.trim()
-      if (trimmed) result[slug] = trimmed
+  useEffect(() => {
+    if (shouldFocusNewUrl.current) {
+      newUrlRef.current?.focus()
+      shouldFocusNewUrl.current = false
     }
-    onSave(result)
+  })
+
+  const visibleSlugs = useMemo(() => {
+    return Object.keys(links || {})
+      .filter((slug) => defBySlug.has(slug))
+      .sort((a, b) =>
+        defBySlug.get(a)!.name.localeCompare(defBySlug.get(b)!.name),
+      )
+  }, [links, defBySlug])
+
+  const unassignedDefs = useMemo(() => {
+    const visible = new Set(visibleSlugs)
+    return linkDefs
+      .filter((d) => !visible.has(d.slug))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [linkDefs, visibleSlugs])
+
+  const newSlugDef = newSlug ? defBySlug.get(newSlug) : undefined
+  const NewSlugIcon = newSlugDef ? getIcon(newSlugDef.icon) : null
+
+  const handleBlur = async (slug: string) => {
+    const next = (drafts[slug] ?? '').trim()
+    const current = links[slug] ?? ''
+    if (next === current) return
+    if (!next && current) {
+      setPendingDelete(slug)
+      return
+    }
+    const newLinks: Record<string, string> = {}
+    for (const [s, v] of Object.entries({ ...links, [slug]: next })) {
+      const t = (v ?? '').trim()
+      if (t) newLinks[s] = t
+    }
+    try {
+      await onPatch(newLinks)
+      flash(slug)
+    } catch {
+      // Parent surfaces the error; keep the draft for retry.
+    }
   }
 
-  const sorted = useMemo(
-    () => [...linkDefs].sort((a, b) => a.name.localeCompare(b.name)),
-    [linkDefs],
-  )
+  const cancelDelete = () => {
+    const slug = pendingDelete
+    if (slug && links[slug]) {
+      setDrafts((prev) => ({ ...prev, [slug]: links[slug] }))
+    }
+    setPendingDelete(null)
+  }
+
+  const requestDelete = (slug: string) => {
+    if (!(links[slug] ?? '').trim()) return
+    setPendingDelete(slug)
+  }
+
+  const confirmDelete = async () => {
+    const slug = pendingDelete
+    if (!slug) return
+    const newLinks: Record<string, string> = {}
+    for (const [s, v] of Object.entries(links)) {
+      if (s === slug) continue
+      const t = (v ?? '').trim()
+      if (t) newLinks[s] = t
+    }
+    try {
+      await onPatch(newLinks)
+      setDrafts((prev) => {
+        const { [slug]: _, ...rest } = prev
+        return rest
+      })
+    } catch {
+      // Parent surfaces the error.
+    } finally {
+      setPendingDelete(null)
+    }
+  }
+
+  const handleNewSlugChange = (slug: string) => {
+    if (!slug) return
+    setNewSlug(slug)
+    shouldFocusNewUrl.current = true
+  }
+
+  const handleNewBlur = async () => {
+    const url = newUrl.trim()
+    if (!newSlug || !url) return
+    const newLinks: Record<string, string> = { ...links, [newSlug]: url }
+    try {
+      await onPatch(newLinks)
+      flash(newSlug)
+      setNewSlug(null)
+      setNewUrl('')
+    } catch {
+      // Parent surfaces the error; keep the draft for retry.
+    }
+  }
 
   return (
     <Card className="p-6">
       <h3 className="mb-4 text-primary">Links</h3>
 
       <div className="space-y-3">
-        {sorted.map((def) => {
+        {visibleSlugs.map((slug) => {
+          const def = defBySlug.get(slug)!
           const Icon = getIcon(def.icon)
           return (
-            <div key={def.slug} className="flex items-center gap-3">
+            <div key={slug} className="flex items-center gap-3">
               <div className="flex w-[15%] flex-shrink-0 items-center gap-2 text-secondary">
                 <Icon className="h-4 w-4 flex-shrink-0" />
                 <span className="truncate text-sm">{def.name}</span>
               </div>
-              <Input
-                value={urls[def.slug] ?? ''}
-                onChange={(e) =>
-                  setUrls((prev) => ({ ...prev, [def.slug]: e.target.value }))
-                }
-                disabled={isSaving}
-                placeholder={def.url_template || 'https://...'}
-                type="url"
-                className="flex-1 text-sm"
-              />
+              <div className="relative flex-1">
+                <Input
+                  value={drafts[slug] ?? ''}
+                  onChange={(e) =>
+                    setDrafts((prev) => ({ ...prev, [slug]: e.target.value }))
+                  }
+                  onBlur={() => handleBlur(slug)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault()
+                      e.currentTarget.blur()
+                    }
+                  }}
+                  placeholder={def.url_template || 'https://...'}
+                  type="url"
+                  className="pr-8 text-sm"
+                />
+                <SavedIndicator show={!!saved[slug]} />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove ${def.name} link`}
+                className="h-8 w-8 flex-shrink-0 text-secondary hover:text-danger"
+                onClick={() => requestDelete(slug)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
             </div>
           )
         })}
-      </div>
 
-      <div className="mt-4 flex justify-end">
-        <Button
-          size="sm"
-          className="bg-action text-action-foreground hover:bg-action-hover"
-          onClick={handleSave}
-          disabled={isSaving}
-        >
-          {isSaving ? 'Saving...' : 'Save'}
-        </Button>
+        {unassignedDefs.length > 0 && (
+          <div className="flex items-center gap-3 pt-2">
+            <Select value={newSlug ?? ''} onValueChange={handleNewSlugChange}>
+              <SelectTrigger className="w-[15%] flex-shrink-0 text-sm">
+                {newSlugDef && NewSlugIcon ? (
+                  <div className="flex min-w-0 items-center gap-2 text-secondary">
+                    <NewSlugIcon className="h-4 w-4 flex-shrink-0" />
+                    <span className="truncate">{newSlugDef.name}</span>
+                  </div>
+                ) : (
+                  <SelectValue placeholder="Pick Link Type to Add" />
+                )}
+              </SelectTrigger>
+              <SelectContent>
+                {unassignedDefs.map((def) => {
+                  const Icon = getIcon(def.icon)
+                  return (
+                    <SelectItem key={def.slug} value={def.slug}>
+                      <span className="flex items-center gap-2">
+                        <Icon className="h-4 w-4" />
+                        {def.name}
+                      </span>
+                    </SelectItem>
+                  )
+                })}
+              </SelectContent>
+            </Select>
+            <Input
+              ref={newUrlRef}
+              value={newUrl}
+              onChange={(e) => setNewUrl(e.target.value)}
+              onBlur={handleNewBlur}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  e.currentTarget.blur()
+                }
+              }}
+              placeholder={newSlugDef?.url_template || 'https://...'}
+              type="url"
+              disabled={!newSlug}
+              className="flex-1 text-sm"
+            />
+            <div className="h-8 w-8 flex-shrink-0" aria-hidden />
+          </div>
+        )}
       </div>
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title={
+          pendingDelete
+            ? `Remove ${defBySlug.get(pendingDelete)?.name ?? 'link'}?`
+            : 'Remove link?'
+        }
+        description="This will remove the link from the project."
+        confirmLabel="Remove"
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
+      />
     </Card>
   )
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -75,7 +75,7 @@ export function Navigation({
         id: 'operations',
         label: 'Operations Log',
         icon: Activity,
-        path: '/opslog',
+        path: '/operations-log',
       },
       { id: 'reports', label: 'Reports', icon: BarChart3, path: '/reports' },
     ]

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -141,6 +141,14 @@ export function OperationsLog({
   const [filters, setFilters] = useState<ScreenFilters>(() =>
     projectSlug ? { ...DEFAULT_FILTERS, range: 'all' } : DEFAULT_FILTERS,
   )
+  useEffect(() => {
+    if (!projectSlug) return
+    setFilters((prev) => ({
+      ...prev,
+      range: 'all',
+      project_slugs: [],
+    }))
+  }, [projectSlug])
   const [view, setView] = useState<OperationsLogView>('grouped')
   const [openId, setOpenId] = useState<string | undefined>(undefined)
   // Stable dispatcher — lets memoised row components compare props by

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -122,7 +122,19 @@ const DEFAULT_FILTERS: ScreenFilters = {
   project_slugs: [],
 }
 
-export function OperationsLog() {
+export interface OperationsLogProps {
+  projectSlug?: string
+  showSummary?: boolean
+  showHeader?: boolean
+  embedded?: boolean
+}
+
+export function OperationsLog({
+  projectSlug,
+  showSummary = true,
+  showHeader = true,
+  embedded = false,
+}: OperationsLogProps = {}) {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug || ''
 
@@ -187,8 +199,9 @@ export function OperationsLog() {
     () => ({
       performed_by: filters.performed_by,
       since: rangeToSince(filters.range),
+      project_slug: projectSlug,
     }),
-    [filters.performed_by, filters.range],
+    [filters.performed_by, filters.range, projectSlug],
   )
 
   const {
@@ -514,15 +527,17 @@ export function OperationsLog() {
   }
 
   return (
-    <div className="mx-auto max-w-[1400px] px-6 py-6">
+    <div className={cn(embedded ? '' : 'mx-auto max-w-[1400px] px-6 py-6')}>
       <div className="grid items-start gap-7">
         <main className="min-w-0">
-          <header className="mb-4 flex flex-wrap items-end justify-between gap-3">
-            <h1 className="flex items-center gap-2 text-h1 text-primary">
-              <LoadingIndicator loading={isPageLoading} />
-              Operations Log
-            </h1>
-          </header>
+          {showHeader && (
+            <header className="mb-4 flex flex-wrap items-end justify-between gap-3">
+              <h1 className="flex items-center gap-2 text-h1 text-primary">
+                <LoadingIndicator loading={isPageLoading} />
+                Operations Log
+              </h1>
+            </header>
+          )}
 
           <div
             inert={isPageLoading}
@@ -532,14 +547,16 @@ export function OperationsLog() {
               isPageLoading && 'cursor-wait opacity-50',
             )}
           >
-            <OperationsLogSummary
-              entries={visibleEntries}
-              environments={environments}
-              rangeLabel={RANGE_LABEL[filters.range]}
-              range={filters.range}
-              loading={isPageLoading}
-              serverMetrics={serverMetrics}
-            />
+            {showSummary && (
+              <OperationsLogSummary
+                entries={visibleEntries}
+                environments={environments}
+                rangeLabel={RANGE_LABEL[filters.range]}
+                range={filters.range}
+                loading={isPageLoading}
+                serverMetrics={serverMetrics}
+              />
+            )}
 
             <OperationsLogToolbar
               counts={counts}
@@ -561,6 +578,7 @@ export function OperationsLog() {
                 setFilters({ ...filters, project_slugs })
               }
               projectNames={projectNames}
+              hideProjectFilter={!!projectSlug}
             />
 
             {activeChips.length > 0 && (

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -138,7 +138,9 @@ export function OperationsLog({
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug || ''
 
-  const [filters, setFilters] = useState<ScreenFilters>(DEFAULT_FILTERS)
+  const [filters, setFilters] = useState<ScreenFilters>(() =>
+    projectSlug ? { ...DEFAULT_FILTERS, range: 'all' } : DEFAULT_FILTERS,
+  )
   const [view, setView] = useState<OperationsLogView>('grouped')
   const [openId, setOpenId] = useState<string | undefined>(undefined)
   // Stable dispatcher — lets memoised row components compare props by
@@ -579,6 +581,7 @@ export function OperationsLog({
               }
               projectNames={projectNames}
               hideProjectFilter={!!projectSlug}
+              hideTimeRange={!!projectSlug}
             />
 
             {activeChips.length > 0 && (

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -31,18 +31,19 @@ import { useEffect, useMemo, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { Link, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { ApiError } from '@/api/client'
 import { sortEnvironments } from '@/lib/utils'
 import {
   listLinkDefinitions,
+  listEnvironments,
   getProjectSchema,
   getProjectRelationships,
-  updateProject,
+  patchProject,
   deleteProject,
   listTeams,
   listProjectTypes,
-  listOperationsLog,
 } from '@/api/endpoints'
 import { OperationsLog } from '@/components/OperationsLog'
 import { buildRelationshipEdges } from '@/lib/relationship-edges'
@@ -62,7 +63,7 @@ import {
   type GraphProject,
 } from '@/components/ProjectsGraphCanvas'
 import { EditRelationshipsDialog } from '@/components/EditRelationshipsDialog'
-import { EditableKeyValueCard } from '@/components/EditableKeyValueCard'
+import { EditIdentifiersCard } from '@/components/EditIdentifiersCard'
 import { EditLinksCard } from '@/components/EditLinksCard'
 import { EditEnvironmentsCard } from '@/components/EditEnvironmentsCard'
 import type { Project, ProjectRelationship } from '@/types'
@@ -390,28 +391,13 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
     return fields.sort((a, b) => a.label.localeCompare(b.label))
   }, [projectSchema, project])
 
-  const { data: opsLogCountPage } = useQuery({
-    queryKey: ['operationsLog', 'count', orgSlug, project.slug],
-    queryFn: () =>
-      listOperationsLog({ limit: 1, filters: { project_slug: project.slug } }),
-    enabled: !!orgSlug && !!project.slug,
-    staleTime: 30_000,
-  })
-  const opsLogCount = opsLogCountPage?.metrics?.event_count
-
   const tabs: { id: TabType; label: string }[] = [
     { id: 'overview', label: 'Overview' },
     { id: 'configuration', label: 'Configuration' },
     { id: 'dependencies', label: 'Dependencies' },
     { id: 'logs', label: 'Logs' },
     { id: 'notes', label: 'Notes' },
-    {
-      id: 'operations-log',
-      label:
-        opsLogCount === undefined
-          ? 'Operations Log'
-          : `Operations Log (${opsLogCount})`,
-    },
+    { id: 'operations-log', label: 'Operations Log' },
     {
       id: 'relationships',
       label: (() => {
@@ -1236,6 +1222,7 @@ function SettingsTab({ project }: { project: Project }) {
   const orgSlug = selectedOrganization?.slug || ''
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const { patch } = useProjectPatch(orgSlug, project.id)
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
@@ -1254,27 +1241,6 @@ function SettingsTab({ project }: { project: Project }) {
       alert(`Failed to ${label}: ${detail}`)
     }
   }
-
-  const linksMutation = useMutation({
-    mutationFn: (links: Record<string, string>) =>
-      updateProject(orgSlug, project.id, { links }),
-    onSuccess: invalidateProject,
-    onError: mutationErrorHandler('save links'),
-  })
-
-  const identifiersMutation = useMutation({
-    mutationFn: (identifiers: Record<string, string>) =>
-      updateProject(orgSlug, project.id, { identifiers }),
-    onSuccess: invalidateProject,
-    onError: mutationErrorHandler('save identifiers'),
-  })
-
-  const envMutation = useMutation({
-    mutationFn: (environments: Record<string, Record<string, string>>) =>
-      updateProject(orgSlug, project.id, { environments }),
-    onSuccess: invalidateProject,
-    onError: mutationErrorHandler('save environments'),
-  })
 
   const deleteMutation = useMutation({
     mutationFn: () => deleteProject(orgSlug, project.id),
@@ -1296,6 +1262,12 @@ function SettingsTab({ project }: { project: Project }) {
     () => sortEnvironments(project.environments || []),
     [project.environments],
   )
+
+  const { data: availableEnvironments = [] } = useQuery({
+    queryKey: ['environments', orgSlug],
+    queryFn: () => listEnvironments(orgSlug),
+    enabled: !!orgSlug,
+  })
 
   return (
     <div className="space-y-6">
@@ -1321,27 +1293,36 @@ function SettingsTab({ project }: { project: Project }) {
         <EditLinksCard
           linkDefs={linkDefs}
           links={project.links || {}}
-          isSaving={linksMutation.isPending}
-          onSave={(entries) => linksMutation.mutate(entries)}
+          onPatch={(entries) => patch('/links', entries)}
         />
       )}
 
-      {sortedEnvironments.length > 0 && (
-        <EditEnvironmentsCard
-          environments={sortedEnvironments}
-          isSaving={envMutation.isPending}
-          onSave={(envData) => envMutation.mutate(envData)}
-        />
-      )}
+      <EditEnvironmentsCard
+        environments={sortedEnvironments}
+        availableEnvironments={availableEnvironments}
+        onPatch={async (envData) => {
+          try {
+            await patchProject(orgSlug, project.id, [
+              { op: 'replace', path: '/environments', value: envData },
+            ])
+          } catch (error) {
+            const detail =
+              error instanceof ApiError
+                ? (error.response as { data?: { detail?: string } } | undefined)
+                    ?.data?.detail || error.message
+                : error instanceof Error
+                  ? error.message
+                  : 'Failed to save'
+            toast.error(`Save failed: ${detail}`)
+            throw error
+          }
+          invalidateProject()
+        }}
+      />
 
-      <EditableKeyValueCard
-        title="Identifiers"
-        entries={project.identifiers || {}}
-        isSaving={identifiersMutation.isPending}
-        readOnlyKeys
-        showHeader={false}
-        valuePlaceholder="identifier"
-        onSave={(entries) => identifiersMutation.mutate(entries)}
+      <EditIdentifiersCard
+        identifiers={project.identifiers || {}}
+        onPatch={(entries) => patch('/identifiers', entries)}
       />
 
       <Card className={'border-amber-300'}>

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -391,10 +391,10 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
   }, [projectSchema, project])
 
   const { data: opsLogCountPage } = useQuery({
-    queryKey: ['operationsLog', 'count', project.slug],
+    queryKey: ['operationsLog', 'count', orgSlug, project.slug],
     queryFn: () =>
       listOperationsLog({ limit: 1, filters: { project_slug: project.slug } }),
-    enabled: !!project.slug,
+    enabled: !!orgSlug && !!project.slug,
     staleTime: 30_000,
   })
   const opsLogCount = opsLogCountPage?.metrics?.event_count

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -42,7 +42,9 @@ import {
   deleteProject,
   listTeams,
   listProjectTypes,
+  listOperationsLog,
 } from '@/api/endpoints'
+import { OperationsLog } from '@/components/OperationsLog'
 import { buildRelationshipEdges } from '@/lib/relationship-edges'
 import type {
   ProjectSchemaSection,
@@ -388,13 +390,28 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
     return fields.sort((a, b) => a.label.localeCompare(b.label))
   }, [projectSchema, project])
 
+  const { data: opsLogCountPage } = useQuery({
+    queryKey: ['operationsLog', 'count', project.slug],
+    queryFn: () =>
+      listOperationsLog({ limit: 1, filters: { project_slug: project.slug } }),
+    enabled: !!project.slug,
+    staleTime: 30_000,
+  })
+  const opsLogCount = opsLogCountPage?.metrics?.event_count
+
   const tabs: { id: TabType; label: string }[] = [
     { id: 'overview', label: 'Overview' },
     { id: 'configuration', label: 'Configuration' },
     { id: 'dependencies', label: 'Dependencies' },
     { id: 'logs', label: 'Logs' },
     { id: 'notes', label: 'Notes' },
-    { id: 'operations-log', label: 'Operations Log' },
+    {
+      id: 'operations-log',
+      label:
+        opsLogCount === undefined
+          ? 'Operations Log'
+          : `Operations Log (${opsLogCount})`,
+    },
     {
       id: 'relationships',
       label: (() => {
@@ -935,7 +952,12 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
           <PlaceholderTab name="Notes" />
         </TabsContent>
         <TabsContent value="operations-log">
-          <PlaceholderTab name="Operations Log" />
+          <OperationsLog
+            projectSlug={project.slug}
+            showSummary={false}
+            showHeader={false}
+            embedded
+          />
         </TabsContent>
         <TabsContent value="settings">
           <SettingsTab project={project} />

--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -61,6 +61,7 @@ interface ToolbarProps {
   view: OperationsLogView
   onView: (v: OperationsLogView) => void
   hideProjectFilter?: boolean
+  hideTimeRange?: boolean
 }
 
 function toggle<T>(arr: T[], value: T): T[] {
@@ -205,6 +206,7 @@ export function OperationsLogToolbar({
   view,
   onView,
   hideProjectFilter = false,
+  hideTimeRange = false,
 }: ToolbarProps) {
   const [projectQuery, setProjectQuery] = useState('')
 
@@ -266,29 +268,33 @@ export function OperationsLogToolbar({
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-2">
-      <div
-        role="group"
-        aria-label="Time range"
-        className="inline-flex items-center rounded-md border border-tertiary bg-secondary p-0.5"
-      >
-        {RANGES.map((r) => (
-          <button
-            key={r.key}
-            type="button"
-            onClick={() => onRange(r.key)}
-            className={cn(
-              'rounded px-2.5 py-1 text-xs font-medium transition-colors',
-              range === r.key
-                ? 'bg-primary text-primary shadow-sm'
-                : 'text-secondary hover:text-primary',
-            )}
+      {hideTimeRange ? null : (
+        <>
+          <div
+            role="group"
+            aria-label="Time range"
+            className="inline-flex items-center rounded-md border border-tertiary bg-secondary p-0.5"
           >
-            {r.label}
-          </button>
-        ))}
-      </div>
+            {RANGES.map((r) => (
+              <button
+                key={r.key}
+                type="button"
+                onClick={() => onRange(r.key)}
+                className={cn(
+                  'rounded px-2.5 py-1 text-xs font-medium transition-colors',
+                  range === r.key
+                    ? 'bg-primary text-primary shadow-sm'
+                    : 'text-secondary hover:text-primary',
+                )}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
 
-      <span className="mx-1 h-6 w-px bg-tertiary" aria-hidden />
+          <span className="mx-1 h-6 w-px bg-tertiary" aria-hidden />
+        </>
+      )}
 
       <FacetDropdown
         icon={<Filter className="h-3.5 w-3.5" />}

--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -60,6 +60,7 @@ interface ToolbarProps {
   projectNames: Map<string, string>
   view: OperationsLogView
   onView: (v: OperationsLogView) => void
+  hideProjectFilter?: boolean
 }
 
 function toggle<T>(arr: T[], value: T): T[] {
@@ -203,6 +204,7 @@ export function OperationsLogToolbar({
   projectNames,
   view,
   onView,
+  hideProjectFilter = false,
 }: ToolbarProps) {
   const [projectQuery, setProjectQuery] = useState('')
 
@@ -307,80 +309,85 @@ export function OperationsLogToolbar({
         contentClassName="min-w-[220px]"
       />
 
-      <DropdownMenu
-        onOpenChange={(open) => {
-          if (!open) setProjectQuery('')
-        }}
-      >
-        <DropdownMenuTrigger asChild>
-          <TriggerButton
-            icon={<Box className="h-3.5 w-3.5" />}
-            label="Project"
-            value={projectSlugs.length > 0 ? projectTriggerValue : undefined}
-            count={projectSlugs.length > 0 ? undefined : projectEntries.length}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="min-w-[260px] p-0">
-          <div className="relative border-b border-tertiary p-2">
-            <Search className="pointer-events-none absolute left-4 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
-            <Input
-              value={projectQuery}
-              onChange={(e) => setProjectQuery(e.target.value)}
-              placeholder="Filter projects…"
-              className="h-8 pl-7 text-sm"
-              autoFocus
+      {hideProjectFilter ? null : (
+        <DropdownMenu
+          onOpenChange={(open) => {
+            if (!open) setProjectQuery('')
+          }}
+        >
+          <DropdownMenuTrigger asChild>
+            <TriggerButton
+              icon={<Box className="h-3.5 w-3.5" />}
+              label="Project"
+              value={projectSlugs.length > 0 ? projectTriggerValue : undefined}
+              count={
+                projectSlugs.length > 0 ? undefined : projectEntries.length
+              }
             />
-          </div>
-          <div className="max-h-72 overflow-y-auto py-1">
-            <button
-              type="button"
-              onClick={() => onProjectSlugs([])}
-              className={cn(
-                'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
-                projectSlugs.length === 0 && 'bg-secondary text-primary',
-                projectSlugs.length > 0 && 'text-secondary hover:bg-secondary',
-              )}
-            >
-              <Check
-                className={cn(
-                  'h-3.5 w-3.5',
-                  projectSlugs.length > 0 && 'invisible',
-                )}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-[260px] p-0">
+            <div className="relative border-b border-tertiary p-2">
+              <Search className="pointer-events-none absolute left-4 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
+              <Input
+                value={projectQuery}
+                onChange={(e) => setProjectQuery(e.target.value)}
+                placeholder="Filter projects…"
+                className="h-8 pl-7 text-sm"
+                autoFocus
               />
-              All projects
-            </button>
-            {projectEntries.map(([slug, c]) => {
-              const checked = projectSlugs.includes(slug)
-              return (
-                <button
-                  key={slug}
-                  type="button"
-                  onClick={() => onProjectSlugs(toggle(projectSlugs, slug))}
+            </div>
+            <div className="max-h-72 overflow-y-auto py-1">
+              <button
+                type="button"
+                onClick={() => onProjectSlugs([])}
+                className={cn(
+                  'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
+                  projectSlugs.length === 0 && 'bg-secondary text-primary',
+                  projectSlugs.length > 0 &&
+                    'text-secondary hover:bg-secondary',
+                )}
+              >
+                <Check
                   className={cn(
-                    'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
-                    checked && 'bg-secondary text-primary',
-                    !checked && 'text-secondary hover:bg-secondary',
+                    'h-3.5 w-3.5',
+                    projectSlugs.length > 0 && 'invisible',
                   )}
-                  title={projectNames.get(slug) ?? slug}
-                >
-                  <Check
-                    className={cn('h-3.5 w-3.5', !checked && 'invisible')}
-                  />
-                  <span className="flex-1 truncate font-mono text-[13px]">
-                    {slug}
-                  </span>
-                  <span className="ml-3 text-xs text-tertiary">{c}</span>
-                </button>
-              )
-            })}
-            {projectEntries.length === 0 ? (
-              <div className="px-3 py-2 text-xs text-tertiary">
-                No projects match.
-              </div>
-            ) : null}
-          </div>
-        </DropdownMenuContent>
-      </DropdownMenu>
+                />
+                All projects
+              </button>
+              {projectEntries.map(([slug, c]) => {
+                const checked = projectSlugs.includes(slug)
+                return (
+                  <button
+                    key={slug}
+                    type="button"
+                    onClick={() => onProjectSlugs(toggle(projectSlugs, slug))}
+                    className={cn(
+                      'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors',
+                      checked && 'bg-secondary text-primary',
+                      !checked && 'text-secondary hover:bg-secondary',
+                    )}
+                    title={projectNames.get(slug) ?? slug}
+                  >
+                    <Check
+                      className={cn('h-3.5 w-3.5', !checked && 'invisible')}
+                    />
+                    <span className="flex-1 truncate font-mono text-[13px]">
+                      {slug}
+                    </span>
+                    <span className="ml-3 text-xs text-tertiary">{c}</span>
+                  </button>
+                )
+              })}
+              {projectEntries.length === 0 ? (
+                <div className="px-3 py-2 text-xs text-tertiary">
+                  No projects match.
+                </div>
+              ) : null}
+            </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
 
       <div
         role="group"

--- a/src/components/ui/saved-indicator.tsx
+++ b/src/components/ui/saved-indicator.tsx
@@ -1,0 +1,20 @@
+import { Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface SavedIndicatorProps {
+  show: boolean
+  className?: string
+}
+
+export function SavedIndicator({ show, className }: SavedIndicatorProps) {
+  return (
+    <Check
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-green-600 transition-opacity duration-500',
+        show ? 'opacity-100' : 'opacity-0',
+        className,
+      )}
+    />
+  )
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -11,7 +11,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+      'inline-flex h-10 w-full items-end justify-start gap-6 border-b border-muted-foreground text-muted-foreground',
       className,
     )}
     {...props}
@@ -26,10 +26,11 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all',
+      '-mb-px inline-flex items-center justify-center whitespace-nowrap border-b-2 border-transparent px-1 pb-2 pt-1 text-sm font-medium ring-offset-background transition-colors',
+      'hover:text-foreground',
       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       'disabled:pointer-events-none disabled:opacity-50',
-      'data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+      'data-[state=active]:border-amber-500 data-[state=active]:text-amber-600',
       className,
     )}
     {...props}
@@ -44,7 +45,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      'mt-0 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       className,
     )}
     {...props}

--- a/src/hooks/__tests__/useProjectPatch.test.tsx
+++ b/src/hooks/__tests__/useProjectPatch.test.tsx
@@ -40,9 +40,14 @@ describe('useProjectPatch', () => {
     // The hook invalidates the project query after a successful PATCH rather
     // than writing the server response into the cache (the PATCH and GET
     // bodies can differ in shape). Until the next GET completes, the cache
-    // holds the locally-applied optimistic value.
-    const updated = { ...baseProject, name: 'Beta' }
-    vi.spyOn(endpoints, 'patchProject').mockResolvedValue(updated as never)
+    // holds the locally-applied optimistic value. Use a server payload that
+    // intentionally differs from the optimistic value so this test would fail
+    // if the hook ever started writing the PATCH response back into cache.
+    const optimistic = { ...baseProject, name: 'Beta' }
+    const serverPayload = { ...baseProject, name: 'Server Beta' }
+    vi.spyOn(endpoints, 'patchProject').mockResolvedValue(
+      serverPayload as never,
+    )
 
     const { result } = renderHook(() => useProjectPatch('o', 'p1'), {
       wrapper: wrapper(qc),
@@ -55,7 +60,7 @@ describe('useProjectPatch', () => {
     expect(endpoints.patchProject).toHaveBeenCalledWith('o', 'p1', [
       { op: 'replace', path: '/name', value: 'Beta' },
     ])
-    expect(qc.getQueryData(['project', 'o', 'p1'])).toEqual(updated)
+    expect(qc.getQueryData(['project', 'o', 'p1'])).toEqual(optimistic)
   })
 
   it('rolls back on error and toasts', async () => {

--- a/src/hooks/__tests__/useProjectPatch.test.tsx
+++ b/src/hooks/__tests__/useProjectPatch.test.tsx
@@ -36,7 +36,11 @@ describe('useProjectPatch', () => {
     vi.clearAllMocks()
   })
 
-  it('applies optimistic update and sets returned project on success', async () => {
+  it('applies optimistic update and leaves it in cache on success', async () => {
+    // The hook invalidates the project query after a successful PATCH rather
+    // than writing the server response into the cache (the PATCH and GET
+    // bodies can differ in shape). Until the next GET completes, the cache
+    // holds the locally-applied optimistic value.
     const updated = { ...baseProject, name: 'Beta' }
     vi.spyOn(endpoints, 'patchProject').mockResolvedValue(updated as never)
 
@@ -92,7 +96,10 @@ describe('useProjectPatch', () => {
   })
 
   it('still sends the network PATCH when the optimistic apply fails', async () => {
-    // Nested paths are not supported by applyJsonPatch and will throw.
+    // Nested paths are not supported by applyJsonPatch and will throw, so the
+    // optimistic update is skipped. After the PATCH succeeds the hook
+    // invalidates the query; the cache retains its prior value until the next
+    // GET refetches, so it must NOT have been clobbered with a stale snapshot.
     const updated = { ...baseProject, name: 'Beta' }
     const spy = vi
       .spyOn(endpoints, 'patchProject')
@@ -109,7 +116,7 @@ describe('useProjectPatch', () => {
     expect(spy).toHaveBeenCalledWith('o', 'p1', [
       { op: 'replace', path: '/team/slug', value: 'new-team' },
     ])
-    expect(qc.getQueryData(['project', 'o', 'p1'])).toEqual(updated)
+    expect(qc.getQueryData(['project', 'o', 'p1'])).toEqual(baseProject)
   })
 
   it('does not roll back to stale snapshot when optimistic apply was skipped', async () => {

--- a/src/hooks/useProjectPatch.ts
+++ b/src/hooks/useProjectPatch.ts
@@ -51,8 +51,11 @@ export function useProjectPatch(
           }
         }
 
-        const result = await patchProject(orgSlug, projectId, [op])
-        qc.setQueryData(key, result)
+        await patchProject(orgSlug, projectId, [op])
+        // The server PATCH response may echo fields in a different shape than
+        // GET returns (e.g. environments as a map vs. an array). Invalidate
+        // so the next read comes from the canonical GET.
+        qc.invalidateQueries({ queryKey: key })
       } catch (error) {
         // Rollback optimistic update
         if (optimisticApplied && snapshot !== undefined) {

--- a/src/hooks/useSavedFlash.ts
+++ b/src/hooks/useSavedFlash.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface UseSavedFlashResult {
+  saved: Record<string, boolean>
+  flash: (key: string) => void
+}
+
+export function useSavedFlash(durationMs = 2000): UseSavedFlashResult {
+  const [saved, setSaved] = useState<Record<string, boolean>>({})
+  const timers = useRef<Record<string, number>>({})
+
+  useEffect(() => {
+    const handles = timers.current
+    return () => {
+      for (const id of Object.values(handles)) {
+        window.clearTimeout(id)
+      }
+    }
+  }, [])
+
+  const flash = useCallback(
+    (key: string) => {
+      setSaved((prev) => ({ ...prev, [key]: true }))
+      if (timers.current[key] !== undefined) {
+        window.clearTimeout(timers.current[key])
+      }
+      timers.current[key] = window.setTimeout(() => {
+        setSaved((prev) => ({ ...prev, [key]: false }))
+        delete timers.current[key]
+      }, durationMs)
+    },
+    [durationMs],
+  )
+
+  return { saved, flash }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -51,6 +51,7 @@ export function extractDynamicFields(
  * nullish treated as 0) and falling back to name.localeCompare for ties.
  */
 export function sortEnvironments(environments: Environment[]): Environment[] {
+  if (!Array.isArray(environments)) return []
   return [...environments].sort((a, b) => {
     const orderDiff = (a.sort_order ?? 0) - (b.sort_order ?? 0)
     return orderDiff !== 0 ? orderDiff : a.name.localeCompare(b.name)


### PR DESCRIPTION
## Summary

- Reworks the Project Detail **Operations Log** tab from a placeholder into the real Operations Log, scoped to the current project.
- Refactors `OperationsLog` to accept `projectSlug`, `showSummary`, `showHeader`, and `embedded` props so the same component powers both the standalone page and the embedded tab.
- When a `projectSlug` is set, the server filter `project_slug` is applied and the toolbar's Project dropdown is hidden.
- The tab label shows the total count as `Operations Log (N)`, sourced from `metrics.event_count` on a lightweight 1-row fetch.
- Renames the top-level route `/opslog` → `/operations-log` (and the nav link). `/opslog` now redirects to `/operations-log` so old links keep working.

## Test plan

- [ ] Navigate to a project's Operations Log tab and confirm the entries shown are all project-scoped.
- [ ] Confirm the Project filter dropdown is not rendered in the embedded toolbar.
- [ ] Confirm the tab label shows `Operations Log (N)` with a count that matches the number of entries returned.
- [ ] Confirm the metrics summary is absent on the tab, and the header is hidden (no `Operations Log` heading).
- [ ] Confirm `/operations-log` is the new URL for the standalone page, that the nav highlights it, and that `/opslog` redirects there.