### PR TITLE
Refactor: extract InlineField + admin cleanups

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -51,13 +51,8 @@ import type {
   ProjectSchemaSection,
   ProjectSchemaSectionProperty,
 } from '@/api/endpoints'
-import {
-  isFieldEditable,
-  pickInlineComponent,
-} from '@/components/ui/inline-edit/field-policy'
-import { InlineSwitch } from '@/components/ui/inline-edit/InlineSwitch'
-import { InlineNumber } from '@/components/ui/inline-edit/InlineNumber'
-import { InlineDate } from '@/components/ui/inline-edit/InlineDate'
+import { isFieldEditable } from '@/components/ui/inline-edit/field-policy'
+import { InlineField } from '@/components/ui/inline-edit/InlineField'
 import {
   ProjectsGraphCanvas,
   type GraphProject,
@@ -428,71 +423,6 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
   const muted = 'text-tertiary'
   const divider = 'border-tertiary'
 
-  function renderInlineForField(
-    _key: string,
-    def: ProjectSchemaSectionProperty,
-    raw: unknown,
-    onCommit: (v: unknown) => Promise<void>,
-    pending: boolean,
-    display: React.ReactNode,
-  ): React.ReactNode {
-    const kind = pickInlineComponent(def)
-    switch (kind) {
-      case 'select':
-        return (
-          <InlineSelect
-            value={raw == null ? null : String(raw)}
-            options={(def.enum ?? []).map((v) => ({
-              value: String(v),
-              label: String(v),
-            }))}
-            onCommit={(v) => onCommit(v)}
-            pending={pending}
-            renderDisplay={display}
-          />
-        )
-      case 'switch':
-        return (
-          <InlineSwitch
-            value={raw === true || raw === 'true'}
-            onCommit={(v) => onCommit(v)}
-            pending={pending}
-          />
-        )
-      case 'number':
-        return (
-          <InlineNumber
-            value={raw == null || raw === '' ? null : Number(raw)}
-            integer={def.type === 'integer'}
-            min={def.minimum ?? undefined}
-            max={def.maximum ?? undefined}
-            onCommit={(v) => onCommit(v)}
-            pending={pending}
-            renderDisplay={display}
-          />
-        )
-      case 'date':
-        return (
-          <InlineDate
-            value={raw == null ? null : String(raw)}
-            mode={def.format === 'date-time' ? 'date-time' : 'date'}
-            onCommit={(v) => onCommit(v)}
-            pending={pending}
-            renderDisplay={display}
-          />
-        )
-      default:
-        return (
-          <InlineText
-            value={raw == null ? null : String(raw)}
-            onCommit={(v) => onCommit(v)}
-            pending={pending}
-            renderValue={display !== null ? () => display : undefined}
-          />
-        )
-    }
-  }
-
   return (
     <div className="mx-auto max-w-[1600px] px-6 py-8">
       {/* Project Header */}
@@ -742,14 +672,13 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
                               {fieldLabel}
                             </span>
                             {editable ? (
-                              renderInlineForField(
-                                key,
-                                def,
-                                rawValue,
-                                (v) => patch(`/${key}`, v),
-                                pendingPath === `/${key}`,
-                                richDisplay,
-                              )
+                              <InlineField
+                                def={def}
+                                raw={rawValue}
+                                onCommit={(v) => patch(`/${key}`, v)}
+                                pending={pendingPath === `/${key}`}
+                                display={richDisplay}
+                              />
                             ) : richDisplay !== null ? (
                               richDisplay
                             ) : (

--- a/src/components/admin/OAuthManagement.tsx
+++ b/src/components/admin/OAuthManagement.tsx
@@ -4,6 +4,8 @@ import { Search, Power, AlertCircle, CheckCircle } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { LoadingState } from '@/components/ui/loading-state'
+import { ErrorBanner } from '@/components/ui/error-banner'
 import { getAuthProviders } from '@/api/endpoints'
 import type { AuthProvider } from '@/types'
 
@@ -29,22 +31,11 @@ export function OAuthManagement() {
   })
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <div className="text-sm text-tertiary">Loading OAuth providers...</div>
-      </div>
-    )
+    return <LoadingState label="Loading OAuth providers..." />
   }
 
   if (error) {
-    return (
-      <div
-        className={`flex items-center gap-2 rounded-lg bg-danger p-4 text-danger`}
-      >
-        <AlertCircle className="h-5 w-5 flex-shrink-0" />
-        <span>Failed to load OAuth providers. Please try again later.</span>
-      </div>
-    )
+    return <ErrorBanner title="Failed to load OAuth providers" error={error} />
   }
 
   return (

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -7,6 +7,7 @@ import { AdminSection } from './AdminSection'
 import { ThirdPartyServiceForm } from './third-party-services/ThirdPartyServiceForm'
 import { ThirdPartyServiceDetail } from './third-party-services/ThirdPartyServiceDetail'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useAdminNav } from '@/hooks/useAdminNav'
 import { useAdminCrud } from '@/hooks/useAdminCrud'
 import {
   listThirdPartyServices,
@@ -18,20 +19,19 @@ import { statusBadgeVariant } from '@/lib/status-colors'
 import { Badge } from '@/components/ui/badge'
 import type { ThirdPartyService, ThirdPartyServiceCreate } from '@/types'
 
-type ViewMode = 'list' | 'create' | 'edit' | 'detail'
-
 export function ThirdPartyServiceManagement() {
   const { selectedOrganization } = useOrganization()
-  const [viewMode, setViewMode] = useState<ViewMode>('list')
-  const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
+  const {
+    viewMode,
+    slug: selectedSlug,
+    goToList,
+    goToCreate,
+    goToDetail,
+    goToEdit,
+  } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
 
   const orgSlug = selectedOrganization?.slug
-
-  const goToList = () => {
-    setViewMode('list')
-    setSelectedSlug(null)
-  }
 
   const {
     items: services,
@@ -104,16 +104,12 @@ export function ThirdPartyServiceManagement() {
     }
   }
 
-  const handleCancel = () => {
-    goToList()
-  }
-
   if (viewMode === 'create' || viewMode === 'edit') {
     return (
       <ThirdPartyServiceForm
         service={selectedService}
         onSave={handleSave}
-        onCancel={handleCancel}
+        onCancel={goToList}
         isLoading={createMutation.isPending || updateMutation.isPending}
         error={createMutation.error || updateMutation.error}
       />
@@ -124,11 +120,8 @@ export function ThirdPartyServiceManagement() {
     return (
       <ThirdPartyServiceDetail
         service={selectedService}
-        onEdit={() => {
-          setSelectedSlug(selectedService.slug)
-          setViewMode('edit')
-        }}
-        onBack={handleCancel}
+        onEdit={() => goToEdit(selectedService.slug)}
+        onBack={goToList}
       />
     )
   }
@@ -206,10 +199,7 @@ export function ThirdPartyServiceManagement() {
       search={searchQuery}
       onSearchChange={setSearchQuery}
       createLabel="New Service"
-      onCreate={() => {
-        setSelectedSlug(null)
-        setViewMode('create')
-      }}
+      onCreate={goToCreate}
       isLoading={isLoading}
       loadingLabel="Loading third-party services..."
       error={error}
@@ -263,10 +253,7 @@ export function ThirdPartyServiceManagement() {
         rows={filteredServices}
         getRowKey={(svc) => svc.slug}
         getDeleteLabel={(svc) => svc.name}
-        onRowClick={(svc) => {
-          setSelectedSlug(svc.slug)
-          setViewMode('detail')
-        }}
+        onRowClick={(svc) => goToDetail(svc.slug)}
         onDelete={(svc) => deleteMutation.mutate(svc.slug)}
         isDeleting={deleteMutation.isPending}
         emptyMessage={

--- a/src/components/ui/inline-edit/InlineField.tsx
+++ b/src/components/ui/inline-edit/InlineField.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from 'react'
+import type { ProjectSchemaSectionProperty } from '@/api/endpoints'
+import { pickInlineComponent } from '@/components/ui/inline-edit/field-policy'
+import { InlineText } from '@/components/ui/inline-edit/InlineText'
+import { InlineSelect } from '@/components/ui/inline-edit/InlineSelect'
+import { InlineSwitch } from '@/components/ui/inline-edit/InlineSwitch'
+import { InlineNumber } from '@/components/ui/inline-edit/InlineNumber'
+import { InlineDate } from '@/components/ui/inline-edit/InlineDate'
+
+interface InlineFieldProps {
+  def: ProjectSchemaSectionProperty
+  raw: unknown
+  onCommit: (value: unknown) => Promise<void>
+  pending: boolean
+  display: ReactNode
+}
+
+export function InlineField({
+  def,
+  raw,
+  onCommit,
+  pending,
+  display,
+}: InlineFieldProps) {
+  const kind = pickInlineComponent(def)
+  switch (kind) {
+    case 'select':
+      return (
+        <InlineSelect
+          value={raw == null ? null : String(raw)}
+          options={(def.enum ?? []).map((v) => ({
+            value: String(v),
+            label: String(v),
+          }))}
+          onCommit={onCommit}
+          pending={pending}
+          renderDisplay={display}
+        />
+      )
+    case 'switch':
+      return (
+        <InlineSwitch
+          value={raw === true || raw === 'true'}
+          onCommit={onCommit}
+          pending={pending}
+        />
+      )
+    case 'number':
+      return (
+        <InlineNumber
+          value={raw == null || raw === '' ? null : Number(raw)}
+          integer={def.type === 'integer'}
+          min={def.minimum ?? undefined}
+          max={def.maximum ?? undefined}
+          onCommit={onCommit}
+          pending={pending}
+          renderDisplay={display}
+        />
+      )
+    case 'date':
+      return (
+        <InlineDate
+          value={raw == null ? null : String(raw)}
+          mode={def.format === 'date-time' ? 'date-time' : 'date'}
+          onCommit={onCommit}
+          pending={pending}
+          renderDisplay={display}
+        />
+      )
+    default:
+      return (
+        <InlineText
+          value={raw == null ? null : String(raw)}
+          onCommit={onCommit}
+          pending={pending}
+          renderValue={display !== null ? () => display : undefined}
+        />
+      )
+  }
+}

--- a/src/components/ui/inline-edit/InlineField.tsx
+++ b/src/components/ui/inline-edit/InlineField.tsx
@@ -73,7 +73,7 @@ export function InlineField({
           value={raw == null ? null : String(raw)}
           onCommit={onCommit}
           pending={pending}
-          renderValue={display !== null ? () => display : undefined}
+          renderValue={display != null ? () => display : undefined}
         />
       )
   }


### PR DESCRIPTION
## Summary

Small follow-up cleanup batch from the code review. Three disjoint, low-risk changes:

1. **`InlineField` extraction.** `ProjectDetail.renderInlineForField` (63 LOC of switch-based inline-editor dispatch) moves to `src/components/ui/inline-edit/InlineField.tsx` where it lives alongside the other inline-edit primitives. `ProjectDetail` drops 4 now-unused imports (`InlineSwitch`, `InlineNumber`, `InlineDate`, `pickInlineComponent`) and replaces the call site with `<InlineField def={def} raw={rawValue} ... />`.

2. **`ThirdPartyServiceManagement` → `useAdminNav`.** Was the one admin page still using local `useState<ViewMode>`; all 10 siblings use `useAdminNav`. Now matches the pattern and the detail/edit/create views are deep-linkable via `/admin/third-party-services/{slug}` / `.../edit` / `.../new`.

3. **`OAuthManagement` primitives.** Inline `flex items-center justify-center ... Loading OAuth providers...` div → `<LoadingState label="Loading OAuth providers..." />`. Inline `<div ...><AlertCircle/>Failed to load ... Please try again later.</div>` → `<ErrorBanner title="Failed to load OAuth providers" error={error} />`. Error surface now shows the real API detail instead of the generic "Please try again later" string.

## Stats

+107 / -120 across 4 files (1 new file: `InlineField.tsx` at 81 LOC).

## Test plan

- [ ] `npm run lint` / `npx tsc --noEmit` / `npm run build` clean
- [ ] Project detail: inline editing of schema-defined fields still picks the right editor (select / switch / number / date / text)
- [ ] `/admin/third-party-services` → click a row deep-links to `/admin/third-party-services/{slug}`, edit button goes to `/admin/third-party-services/{slug}/edit`, create button goes to `/admin/third-party-services/new`
- [ ] `/admin/oauth` loading and error states render via the shared primitives

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>