### PR TITLE
Perf: route-level code splitting + vendor chunking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,48 @@
+import { lazy, Suspense, useEffect } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'sonner'
-import { DashboardPage } from './pages/DashboardPage'
-import { ProjectsPage } from './pages/ProjectsPage'
-import { ProjectDetailPage } from './pages/ProjectDetailPage'
-import { OperationsLogPage } from './pages/OperationsLogPage'
-import { AdminPage } from './pages/AdminPage'
-import { SettingsPage } from './pages/SettingsPage'
-import { LoginPage } from './pages/LoginPage'
-import { OAuthCallbackPage } from './pages/OAuthCallbackPage'
 import { OrganizationProvider } from './contexts/OrganizationContext'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { useAuth } from './hooks/useAuth'
-import { useEffect } from 'react'
+
+const DashboardPage = lazy(() =>
+  import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })),
+)
+const ProjectsPage = lazy(() =>
+  import('./pages/ProjectsPage').then((m) => ({ default: m.ProjectsPage })),
+)
+const ProjectDetailPage = lazy(() =>
+  import('./pages/ProjectDetailPage').then((m) => ({
+    default: m.ProjectDetailPage,
+  })),
+)
+const OperationsLogPage = lazy(() =>
+  import('./pages/OperationsLogPage').then((m) => ({
+    default: m.OperationsLogPage,
+  })),
+)
+const AdminPage = lazy(() =>
+  import('./pages/AdminPage').then((m) => ({ default: m.AdminPage })),
+)
+const SettingsPage = lazy(() =>
+  import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage })),
+)
+const LoginPage = lazy(() =>
+  import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })),
+)
+const OAuthCallbackPage = lazy(() =>
+  import('./pages/OAuthCallbackPage').then((m) => ({
+    default: m.OAuthCallbackPage,
+  })),
+)
+
+function PageFallback() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-lg">Loading…</div>
+    </div>
+  )
+}
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth()
@@ -26,11 +57,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   }, [isAuthenticated, isLoading])
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="text-lg">Loading...</div>
-      </div>
-    )
+    return <PageFallback />
   }
 
   if (!isAuthenticated) {
@@ -53,18 +80,13 @@ function AdminProtectedRoute({ children }: { children: React.ReactNode }) {
   }, [isAuthenticated, isLoading])
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="text-lg">Loading...</div>
-      </div>
-    )
+    return <PageFallback />
   }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />
   }
 
-  // Check if user has admin privileges
   const isAdmin = user?.is_admin === true
   if (!isAdmin) {
     return <Navigate to="/dashboard" replace />
@@ -78,65 +100,67 @@ function App() {
     <ThemeProvider>
       <Toaster richColors position="top-right" />
       <OrganizationProvider>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/auth/callback" element={<OAuthCallbackPage />} />
+        <Suspense fallback={<PageFallback />}>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/auth/callback" element={<OAuthCallbackPage />} />
 
-          <Route
-            path="/dashboard"
-            element={
-              <ProtectedRoute>
-                <DashboardPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/projects"
-            element={
-              <ProtectedRoute>
-                <ProjectsPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/projects/:projectId/:tab?"
-            element={
-              <ProtectedRoute>
-                <ProjectDetailPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/operations-log"
-            element={
-              <ProtectedRoute>
-                <OperationsLogPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/settings/:tab?"
-            element={
-              <ProtectedRoute>
-                <SettingsPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/admin/:section?/:slug?/:action?"
-            element={
-              <AdminProtectedRoute>
-                <AdminPage />
-              </AdminProtectedRoute>
-            }
-          />
-          <Route
-            path="/opslog"
-            element={<Navigate to="/operations-log" replace />}
-          />
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
-        </Routes>
+            <Route
+              path="/dashboard"
+              element={
+                <ProtectedRoute>
+                  <DashboardPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/projects"
+              element={
+                <ProtectedRoute>
+                  <ProjectsPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/projects/:projectId/:tab?"
+              element={
+                <ProtectedRoute>
+                  <ProjectDetailPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/operations-log"
+              element={
+                <ProtectedRoute>
+                  <OperationsLogPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/settings/:tab?"
+              element={
+                <ProtectedRoute>
+                  <SettingsPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/:section?/:slug?/:action?"
+              element={
+                <AdminProtectedRoute>
+                  <AdminPage />
+                </AdminProtectedRoute>
+              }
+            />
+            <Route
+              path="/opslog"
+              element={<Navigate to="/operations-log" replace />}
+            />
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          </Routes>
+        </Suspense>
       </OrganizationProvider>
     </ThemeProvider>
   )

--- a/src/components/LazyProjectsGraphCanvas.tsx
+++ b/src/components/LazyProjectsGraphCanvas.tsx
@@ -1,0 +1,33 @@
+import { lazy, Suspense } from 'react'
+import type { ComponentProps } from 'react'
+import { Card } from '@/components/ui/card'
+import type { GraphProject } from '@/components/ProjectsGraphCanvas'
+
+export type { GraphProject }
+
+const ProjectsGraphCanvas = lazy(() =>
+  import('@/components/ProjectsGraphCanvas').then((m) => ({
+    default: m.ProjectsGraphCanvas,
+  })),
+)
+
+type ProjectsGraphCanvasProps = ComponentProps<typeof ProjectsGraphCanvas>
+
+function GraphFallback() {
+  return (
+    <Card className="flex items-center justify-center p-12">
+      <div className="flex flex-col items-center gap-3">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent opacity-50" />
+        <p className="text-sm text-tertiary">Loading graph…</p>
+      </div>
+    </Card>
+  )
+}
+
+export function LazyProjectsGraphCanvas(props: ProjectsGraphCanvasProps) {
+  return (
+    <Suspense fallback={<GraphFallback />}>
+      <ProjectsGraphCanvas {...props} />
+    </Suspense>
+  )
+}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -59,9 +59,9 @@ import { InlineSwitch } from '@/components/ui/inline-edit/InlineSwitch'
 import { InlineNumber } from '@/components/ui/inline-edit/InlineNumber'
 import { InlineDate } from '@/components/ui/inline-edit/InlineDate'
 import {
-  ProjectsGraphCanvas,
+  LazyProjectsGraphCanvas,
   type GraphProject,
-} from '@/components/ProjectsGraphCanvas'
+} from '@/components/LazyProjectsGraphCanvas'
 import { EditRelationshipsDialog } from '@/components/EditRelationshipsDialog'
 import { EditIdentifiersCard } from '@/components/EditIdentifiersCard'
 import { EditLinksCard } from '@/components/EditLinksCard'
@@ -1074,7 +1074,7 @@ function RelationshipsTab({
             onFilterChange={setFilter}
             onAdd={() => setEditDialogOpen(true)}
           />
-          <ProjectsGraphCanvas
+          <LazyProjectsGraphCanvas
             projects={projects}
             edges={edges}
             centerId={projectId}

--- a/src/components/ProjectGraphView.tsx
+++ b/src/components/ProjectGraphView.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useQueries } from '@tanstack/react-query'
 import { getProjectRelationships } from '@/api/endpoints'
-import { ProjectsGraphCanvas } from '@/components/ProjectsGraphCanvas'
+import { LazyProjectsGraphCanvas } from '@/components/LazyProjectsGraphCanvas'
 import { Card } from '@/components/ui/card'
 import {
   buildRelationshipEdges,
@@ -87,7 +87,7 @@ export function ProjectGraphView({ projects }: ProjectGraphViewProps) {
         height: 'calc(100vh - 280px - var(--assistant-height, 64px))',
       }}
     >
-      <ProjectsGraphCanvas projects={projects} edges={edges} />
+      <LazyProjectsGraphCanvas projects={projects} edges={edges} />
     </div>
   )
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,23 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          tanstack: ['@tanstack/react-query', '@tanstack/react-virtual'],
+          three: [
+            'reagraph',
+            '@react-three/fiber',
+            '@react-three/drei',
+            '@react-spring/three',
+            'three',
+          ],
+          charts: ['recharts'],
+          markdown: ['react-markdown', 'remark-gfm'],
+        },
+      },
+    },
   },
   esbuild: {
     drop: ['console'],


### PR DESCRIPTION
## Summary

Split the previous single 22.5 MB / 5.8 MB gzip main bundle into per-route chunks plus stable vendor groupings.

**Dashboard first-load: ~850 KB raw / ~170 KB gzip** (index + react-vendor + tanstack + DashboardPage) — **~34× raw / ~33× gzip reduction** vs. the prior single bundle.

### Route-level splitting

All 8 page components in `App.tsx` converted to `React.lazy()`:
- `DashboardPage`, `ProjectsPage`, `ProjectDetailPage`, `OperationsLogPage`, `AdminPage`, `SettingsPage`, `LoginPage`, `OAuthCallbackPage`
- `<Routes>` wrapped in `<Suspense>` with a shared `PageFallback` component

`ProjectsGraphCanvas` (reagraph + three.js, ~1.5 MB raw / 440 KB gzip) extracted to a `LazyProjectsGraphCanvas` wrapper; both call sites (`ProjectGraphView`, `ProjectDetail`) updated. Three.js now only loads when the relationships tab is opened.

### Manual vendor chunks (`vite.config.ts`)

- `react-vendor`: `react`, `react-dom`, `react-router-dom` (48 KB / 17 KB gz)
- `tanstack`: `@tanstack/react-query`, `@tanstack/react-virtual` (62 KB / 18 KB gz)
- `three`: `reagraph`, `@react-three/*`, `@react-spring/three`, `three` (1.5 MB / 440 KB gz, lazy)
- `charts`: `recharts`
- `markdown`: `react-markdown`, `remark-gfm` (157 KB / 47 KB gz, lazy)

### Resulting chunk layout

| Chunk | Raw | Gzip |
|---|---|---|
| `index` (app shell) | 666 KB | 112 KB |
| `react-vendor` | 49 KB | 17 KB |
| `tanstack` | 62 KB | 18 KB |
| `DashboardPage` | 75 KB | 24 KB |
| `ProjectsPage` | 17 KB | 5 KB |
| `ProjectDetailPage` | 146 KB | 43 KB |
| `AdminPage` | 457 KB | 114 KB |
| `SettingsPage` | 17 KB | 5 KB |
| `OperationsLog` | 35 KB | 10 KB |
| `three` (lazy) | 1,525 KB | 439 KB |
| `markdown` (lazy) | 157 KB | 47 KB |
| `icons` (lazy, project/admin only) | 18,995 KB | 4,944 KB |

### Known remaining issue

The 19 MB `icons` chunk is still the dominant weight when a user navigates to a project-detail or admin page. Root cause: `src/lib/icon-sets/{tabler,phosphor}.ts` use `import * as TablerIcons from '@tabler/icons-react'` / `import * as PhosphorIcons from '@phosphor-icons/react'`, which pull in the entire icon packs (thousands of components each). It's now isolated as its own lazy chunk, but fixing it requires refactoring the icon registry to resolve icons on-demand rather than pre-importing the full packs. Left for a follow-up.

## Test plan

- [ ] `npm run build` succeeds; `dist/assets/index-*.js` is well under 1 MB
- [ ] Navigate across all pages (dashboard → projects → project detail → admin → settings → ops log); each route transition shows the fallback briefly, then loads
- [ ] Open a project's Relationships tab — the graph loads (three.js chunk is fetched)
- [ ] Cold page loads on dashboard don't fetch the `icons-*.js` or `three-*.js` chunks
- [ ] 401 / login flow still works
- [ ] `npm run lint` / `npx tsc --noEmit` clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>