### PR TITLE
Style: collapse className JSX-expression literals to plain strings

### DIFF
--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -323,23 +323,19 @@ export function CommandBar() {
           onPointerDown={handleDragStart}
           onPointerMove={handleDragMove}
           onPointerUp={handleDragEnd}
-          className={`group flex h-1.5 cursor-ns-resize items-center justify-center transition-colors hover:bg-secondary`}
+          className="group flex h-1.5 cursor-ns-resize items-center justify-center transition-colors hover:bg-secondary"
         >
-          <div
-            className={`h-0.5 w-8 rounded-full bg-secondary transition-colors group-hover:bg-muted-foreground/40`}
-          />
+          <div className="h-0.5 w-8 rounded-full bg-secondary transition-colors group-hover:bg-muted-foreground/40" />
         </div>
         {/* Panel Header */}
-        <div
-          className={`flex items-center justify-between border-b border-border bg-secondary px-4 py-2`}
-        >
+        <div className="flex items-center justify-between border-b border-border bg-secondary px-4 py-2">
           <div className="flex items-center gap-2">
-            <Terminal className={`h-3.5 w-3.5 text-tertiary`} />
-            <span className={`font-mono text-xs text-tertiary`}>
+            <Terminal className="h-3.5 w-3.5 text-tertiary" />
+            <span className="font-mono text-xs text-tertiary">
               imbi-assistant
             </span>
             {messages.length > 0 && (
-              <span className={`font-mono text-xs text-tertiary`}>
+              <span className="font-mono text-xs text-tertiary">
                 ({Math.floor(messages.length / 2) || 1} exchange
                 {Math.floor(messages.length / 2) !== 1 ? 's' : ''})
               </span>
@@ -353,7 +349,7 @@ export function CommandBar() {
               }}
               aria-label="Help"
               type="button"
-              className={`rounded p-1 text-tertiary hover:bg-secondary hover:text-secondary`}
+              className="rounded p-1 text-tertiary hover:bg-secondary hover:text-secondary"
             >
               <HelpCircle className="h-3.5 w-3.5" />
             </button>
@@ -365,7 +361,7 @@ export function CommandBar() {
             {messages.length > 0 && (
               <button
                 onClick={handleClearHistory}
-                className={`rounded px-2 py-0.5 font-mono text-xs text-tertiary hover:bg-secondary hover:text-secondary`}
+                className="rounded px-2 py-0.5 font-mono text-xs text-tertiary hover:bg-secondary hover:text-secondary"
               >
                 clear
               </button>
@@ -374,7 +370,7 @@ export function CommandBar() {
               onClick={() => setExpanded(false)}
               aria-label="Close assistant"
               type="button"
-              className={`rounded p-1 text-tertiary hover:bg-secondary hover:text-secondary`}
+              className="rounded p-1 text-tertiary hover:bg-secondary hover:text-secondary"
             >
               <X className="h-3.5 w-3.5" />
             </button>
@@ -384,7 +380,7 @@ export function CommandBar() {
         {/* Session Output */}
         <div
           ref={scrollRef}
-          className={`space-y-3 overflow-y-auto bg-tertiary px-6 py-4`}
+          className="space-y-3 overflow-y-auto bg-tertiary px-6 py-4"
           style={{ height: 'calc(100% - 43px)' }}
         >
           {messages.length === 0 && !isStreaming ? (
@@ -407,7 +403,7 @@ export function CommandBar() {
                     <SessionEntry role="assistant" content={streamingContent} />
                   )}
                   {!streamingContent && !activeToolUse && (
-                    <div className={`pl-4 font-mono text-sm text-tertiary`}>
+                    <div className="pl-4 font-mono text-sm text-tertiary">
                       <span className="animate-pulse">...</span>
                     </div>
                   )}
@@ -419,9 +415,7 @@ export function CommandBar() {
       </div>
 
       {/* Command Input Bar */}
-      <div
-        className={`fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-card`}
-      >
+      <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-card">
         {/* Tray Toggle */}
         <div className="flex justify-center">
           <button
@@ -445,10 +439,8 @@ export function CommandBar() {
 
         {/* Input */}
         <form onSubmit={handleSubmit} className="px-3 pb-1.5 pt-2">
-          <div
-            className={`flex items-center gap-2 rounded-md border border-tertiary bg-tertiary px-3 py-2 text-sm transition-colors focus-within:border-secondary`}
-          >
-            <span className={`select-none text-sm text-tertiary`}>&gt;</span>
+          <div className="flex items-center gap-2 rounded-md border border-tertiary bg-tertiary px-3 py-2 text-sm transition-colors focus-within:border-secondary">
+            <span className="select-none text-sm text-tertiary">&gt;</span>
             <input
               ref={inputRef}
               type="text"
@@ -460,24 +452,22 @@ export function CommandBar() {
                   : "Search projects, ask about deployments, or type 'help'..."
               }
               disabled={isStreaming}
-              className={`flex-1 bg-transparent text-sm text-primary outline-none placeholder:text-muted-foreground disabled:opacity-50`}
+              className="flex-1 bg-transparent text-sm text-primary outline-none placeholder:text-muted-foreground disabled:opacity-50"
             />
             {input.trim() && !isStreaming && (
               <button
                 type="submit"
-                className={`rounded p-1 text-tertiary transition-colors hover:text-secondary`}
+                className="rounded p-1 text-tertiary transition-colors hover:text-secondary"
               >
                 <Send className="h-3.5 w-3.5" />
               </button>
             )}
           </div>
           <div className="flex items-center justify-between px-1 pt-1">
-            <span className={`text-[11px] text-secondary`}>
+            <span className="text-[11px] text-secondary">
               Press Enter to send
             </span>
-            <span
-              className={`flex items-center gap-1 text-[11px] text-secondary`}
-            >
+            <span className="flex items-center gap-1 text-[11px] text-secondary">
               <Sparkles className="h-3 w-3" />
               AI-powered
             </span>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -149,7 +149,7 @@ function SortableWidget({ id, children }: SortableWidgetProps) {
       <div
         {...attributes}
         {...listeners}
-        className={`bg-secondary/80 absolute left-2 top-2 z-20 cursor-grab rounded p-1 text-tertiary opacity-0 transition-opacity hover:text-primary active:cursor-grabbing group-hover:opacity-100`}
+        className="bg-secondary/80 absolute left-2 top-2 z-20 cursor-grab rounded p-1 text-tertiary opacity-0 transition-opacity hover:text-primary active:cursor-grabbing group-hover:opacity-100"
       >
         <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
           <path d="M8 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM8 12a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM8 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM14 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM14 12a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM14 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" />
@@ -295,9 +295,7 @@ export function Dashboard({
 
       {/* Widgets */}
       {selectedWidgets.length === 0 ? (
-        <div
-          className={`rounded-lg border border-border bg-card p-12 text-center`}
-        >
+        <div className="rounded-lg border border-border bg-card p-12 text-center">
           <div className="mb-4 text-6xl text-secondary">📊</div>
           <h3 className="mb-2 text-xl font-medium text-primary">
             No Widgets Selected

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1131,7 +1131,7 @@ function SidebarProjectRow({ rel }: { rel: ProjectRelationship }) {
     <li className="flex items-center gap-2 py-1">
       <Link
         to={`/projects/${rel.project.id}`}
-        className={`truncate text-sm text-warning hover:underline`}
+        className="truncate text-sm text-warning hover:underline"
       >
         {rel.project.name}
       </Link>
@@ -1297,7 +1297,7 @@ function SettingsTab({ project }: { project: Project }) {
                 onChange={(e) => setDeleteConfirmSlug(e.target.value)}
                 placeholder={project.slug}
                 disabled={deleteMutation.isPending}
-                className={''}
+                className=""
               />
               <div className="flex gap-2">
                 <Button

--- a/src/components/ProjectsGraphCanvas.tsx
+++ b/src/components/ProjectsGraphCanvas.tsx
@@ -256,9 +256,7 @@ export function ProjectsGraphCanvas({
         } `}
       >
         {/* Toolbar */}
-        <CardHeader
-          className={`flex-shrink-0 flex-row items-center gap-2 space-y-0 border-b border-tertiary px-4 py-3`}
-        >
+        <CardHeader className="flex-shrink-0 flex-row items-center gap-2 space-y-0 border-b border-tertiary px-4 py-3">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -385,9 +383,7 @@ export function ProjectsGraphCanvas({
           className={`relative p-0 ${isFullscreen ? 'flex-1' : 'min-h-[400px] flex-1'}`}
         >
           {isRendering && nodes.length > 0 && (
-            <div
-              className={`absolute inset-0 z-10 flex items-center justify-center bg-background/80`}
-            >
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/80">
               <div className="flex flex-col items-center gap-3">
                 <div className="h-8 w-8 animate-spin rounded-full border-2 border-current border-t-transparent opacity-50" />
                 <p className="text-sm text-tertiary">Rendering graph…</p>

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -125,9 +125,7 @@ export function ProjectsView() {
         <Card className="p-4">
           <div className="flex items-center gap-3">
             <div className="relative max-w-md flex-1">
-              <Search
-                className={`absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary`}
-              />
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary" />
               <Input
                 type="text"
                 placeholder="Search projects..."
@@ -137,9 +135,7 @@ export function ProjectsView() {
               />
             </div>
 
-            <div
-              className={`flex items-center rounded-lg border border-secondary`}
-            >
+            <div className="flex items-center rounded-lg border border-secondary">
               <Button
                 variant="ghost"
                 size="sm"
@@ -187,7 +183,7 @@ export function ProjectsView() {
               >
                 <div className="mb-3 flex items-start justify-between">
                   <div className="min-w-0 flex-1">
-                    <h3 className={`mb-1 truncate font-medium text-primary`}>
+                    <h3 className="mb-1 truncate font-medium text-primary">
                       {project.name}
                     </h3>
                     <p className="text-sm text-tertiary">
@@ -206,7 +202,7 @@ export function ProjectsView() {
                 </div>
 
                 {project.description && (
-                  <p className={`mb-3 line-clamp-2 text-sm text-secondary`}>
+                  <p className="mb-3 line-clamp-2 text-sm text-secondary">
                     {project.description}
                   </p>
                 )}
@@ -235,7 +231,7 @@ export function ProjectsView() {
         <Card className="overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className={`border-b border-tertiary bg-secondary`}>
+              <thead className="border-b border-tertiary bg-secondary">
                 <tr>
                   <th
                     className={
@@ -280,7 +276,7 @@ export function ProjectsView() {
                   return (
                     <tr
                       key={`table-${project.id}`}
-                      className={`cursor-pointer transition-colors hover:bg-secondary`}
+                      className="cursor-pointer transition-colors hover:bg-secondary"
                       onClick={() => handleProjectSelect(project.id)}
                     >
                       <td className="px-6 py-4 font-medium text-primary">

--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -92,7 +92,7 @@ export function RecentActivity({
       {activities.map((activity, index) => (
         <div
           key={index}
-          className={`border-b border-tertiary pb-4 last:border-0 last:pb-0`}
+          className="border-b border-tertiary pb-4 last:border-0 last:pb-0"
         >
           <div className="flex gap-3">
             <img
@@ -105,7 +105,7 @@ export function RecentActivity({
               <p className="text-sm leading-relaxed text-secondary">
                 <button
                   onClick={() => onUserSelect?.(activity.display_name)}
-                  className={`font-medium text-primary transition-colors hover:text-info`}
+                  className="font-medium text-primary transition-colors hover:text-info"
                 >
                   {activity.display_name}
                 </button>{' '}
@@ -117,7 +117,7 @@ export function RecentActivity({
                 {activity.project_name && (
                   <button
                     onClick={() => onProjectSelect?.(activity.project_name!)}
-                    className={`hover:text-info/80 font-medium text-info transition-colors`}
+                    className="hover:text-info/80 font-medium text-info transition-colors"
                   >
                     {activity.project_name}
                   </button>
@@ -162,7 +162,7 @@ export function RecentActivity({
           <button
             onClick={onLoadMore}
             disabled={isLoadingMore}
-            className={`hover:text-info/80 text-sm text-info transition-colors disabled:opacity-50`}
+            className="hover:text-info/80 text-sm text-info transition-colors disabled:opacity-50"
           >
             {isLoadingMore ? 'Loading more...' : 'Load more activity'}
           </button>

--- a/src/components/admin/OAuthManagement.tsx
+++ b/src/components/admin/OAuthManagement.tsx
@@ -40,9 +40,7 @@ export function OAuthManagement() {
 
   return (
     <div className="space-y-4">
-      <div
-        className="flex items-start gap-3 rounded-lg border border-info bg-info p-4"
-      >
+      <div className="flex items-start gap-3 rounded-lg border border-info bg-info p-4">
         <Power className="mt-0.5 h-5 w-5 flex-shrink-0 text-info" />
         <p className="text-sm text-info">
           OAuth providers are configured in the backend. Contact an
@@ -51,9 +49,7 @@ export function OAuthManagement() {
       </div>
 
       <div className="relative">
-        <Search
-          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary"
-        />
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary" />
         <Input
           placeholder="Search providers..."
           value={searchQuery}
@@ -87,9 +83,7 @@ export function OAuthManagement() {
                 {provider.enabled ? (
                   <CheckCircle className="h-5 w-5 flex-shrink-0 text-green-500" />
                 ) : (
-                  <AlertCircle
-                    className="h-5 w-5 flex-shrink-0 text-tertiary"
-                  />
+                  <AlertCircle className="h-5 w-5 flex-shrink-0 text-tertiary" />
                 )}
               </CardHeader>
               <CardContent>

--- a/src/components/admin/OAuthManagement.tsx
+++ b/src/components/admin/OAuthManagement.tsx
@@ -41,9 +41,9 @@ export function OAuthManagement() {
   return (
     <div className="space-y-4">
       <div
-        className={`flex items-start gap-3 rounded-lg border border-info bg-info p-4`}
+        className="flex items-start gap-3 rounded-lg border border-info bg-info p-4"
       >
-        <Power className={`mt-0.5 h-5 w-5 flex-shrink-0 text-info`} />
+        <Power className="mt-0.5 h-5 w-5 flex-shrink-0 text-info" />
         <p className="text-sm text-info">
           OAuth providers are configured in the backend. Contact an
           administrator to add or modify providers.
@@ -52,13 +52,13 @@ export function OAuthManagement() {
 
       <div className="relative">
         <Search
-          className={`absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary`}
+          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary"
         />
         <Input
           placeholder="Search providers..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className={`border-input bg-background pl-10 text-foreground placeholder:text-muted-foreground`}
+          className="border-input bg-background pl-10 text-foreground placeholder:text-muted-foreground"
         />
       </div>
 
@@ -88,7 +88,7 @@ export function OAuthManagement() {
                   <CheckCircle className="h-5 w-5 flex-shrink-0 text-green-500" />
                 ) : (
                   <AlertCircle
-                    className={`h-5 w-5 flex-shrink-0 text-tertiary`}
+                    className="h-5 w-5 flex-shrink-0 text-tertiary"
                   />
                 )}
               </CardHeader>

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -154,7 +154,7 @@ export function ServiceAccountManagement() {
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
-          className={`rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground`}
+          className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground"
         >
           <option value="all">All Status</option>
           <option value="active">Active</option>

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -190,9 +190,7 @@ export function TeamManagement() {
             cellAlign: 'left',
             render: (team) => (
               <div className="flex items-center gap-3">
-                <div
-                  className={`flex size-8 flex-shrink-0 items-center justify-center rounded-lg bg-info`}
-                >
+                <div className="flex size-8 flex-shrink-0 items-center justify-center rounded-lg bg-info">
                   {team.icon ? (
                     <EntityIcon
                       icon={team.icon}
@@ -219,7 +217,7 @@ export function TeamManagement() {
             headerAlign: 'center',
             cellAlign: 'center',
             render: (team) => (
-              <code className={`rounded bg-secondary px-2 py-1 text-primary`}>
+              <code className="rounded bg-secondary px-2 py-1 text-primary">
                 {team.slug}
               </code>
             ),

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -134,9 +134,7 @@ export function ThirdPartyServiceManagement() {
       cellAlign: 'left',
       render: (svc) => (
         <div className="flex items-center gap-3">
-          <div
-            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-purple-50 dark:bg-purple-900/30`}
-          >
+          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-purple-50 dark:bg-purple-900/30">
             {svc.icon ? (
               <EntityIcon
                 icon={svc.icon}

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -220,7 +220,7 @@ export function UserManagement() {
             aria-label="Filter users by type"
             value={userFilter}
             onChange={(e) => setUserFilter(e.target.value as UserFilter)}
-            className={`rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground`}
+            className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground"
           >
             <option value="all">All Types</option>
             <option value="users">Regular Users</option>
@@ -230,7 +230,7 @@ export function UserManagement() {
             aria-label="Filter users by status"
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
-            className={`rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground`}
+            className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground"
           >
             <option value="all">All Status</option>
             <option value="active">Active</option>

--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -130,9 +130,7 @@ export function BlueprintDetail({
 
   if (error || !blueprint) {
     return (
-      <div
-        className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-      >
+      <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
         <AlertCircle className="h-5 w-5 flex-shrink-0" />
         <div>
           <div className="font-medium">Failed to load blueprint</div>
@@ -203,11 +201,9 @@ export function BlueprintDetail({
       </div>
 
       {/* Blueprint info card */}
-      <div className={`rounded-lg border border-border bg-card`}>
+      <div className="rounded-lg border border-border bg-card">
         {/* Title row */}
-        <div
-          className={`flex items-start justify-between border-b border-tertiary px-6 py-5`}
-        >
+        <div className="flex items-start justify-between border-b border-tertiary px-6 py-5">
           <div className="flex items-center gap-3">
             <div className="rounded-lg bg-info p-2">
               <FileJson className="h-6 w-6 text-info" />
@@ -311,7 +307,7 @@ export function BlueprintDetail({
 
       {/* Conditional Filter detail */}
       {hasFilter && parsedFilter && (
-        <div className={`rounded-lg border border-border bg-card`}>
+        <div className="rounded-lg border border-border bg-card">
           <div className="border-b border-tertiary px-6 py-4">
             <div className="flex items-center gap-2">
               <Filter className="h-4 w-4 text-warning" />
@@ -373,7 +369,7 @@ export function BlueprintDetail({
       )}
 
       {/* Schema Properties */}
-      <div className={`rounded-lg border border-border bg-card`}>
+      <div className="rounded-lg border border-border bg-card">
         <div className="border-b border-tertiary px-6 py-4">
           <h3 className="text-sm font-medium text-primary">
             Schema Properties
@@ -393,9 +389,7 @@ export function BlueprintDetail({
                 <div key={prop.name} className="px-6 py-4">
                   <div className="flex items-center gap-3">
                     <IconComponent className="h-4 w-4 flex-shrink-0 text-tertiary" />
-                    <code
-                      className={`rounded bg-secondary px-2 py-1 text-sm font-medium text-info`}
-                    >
+                    <code className="rounded bg-secondary px-2 py-1 text-sm font-medium text-info">
                       {prop.name}
                     </code>
                     <Badge variant="secondary">
@@ -487,9 +481,7 @@ export function BlueprintDetail({
                       {prop.defaultValue !== undefined && (
                         <div className="flex items-center gap-1.5">
                           <span className="text-xs text-tertiary">Default</span>
-                          <code
-                            className={`rounded bg-secondary px-1.5 py-0.5 text-xs text-primary`}
-                          >
+                          <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
                             {prop.defaultValue}
                           </code>
                         </div>
@@ -497,9 +489,7 @@ export function BlueprintDetail({
                       {prop.minimum !== undefined && (
                         <div className="flex items-center gap-1.5">
                           <span className="text-xs text-tertiary">Min</span>
-                          <code
-                            className={`rounded bg-secondary px-1.5 py-0.5 text-xs text-primary`}
-                          >
+                          <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
                             {prop.minimum}
                           </code>
                         </div>
@@ -507,9 +497,7 @@ export function BlueprintDetail({
                       {prop.maximum !== undefined && (
                         <div className="flex items-center gap-1.5">
                           <span className="text-xs text-tertiary">Max</span>
-                          <code
-                            className={`rounded bg-secondary px-1.5 py-0.5 text-xs text-primary`}
-                          >
+                          <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
                             {prop.maximum}
                           </code>
                         </div>
@@ -519,9 +507,7 @@ export function BlueprintDetail({
                           <span className="text-xs text-tertiary">
                             Min length
                           </span>
-                          <code
-                            className={`rounded bg-secondary px-1.5 py-0.5 text-xs text-primary`}
-                          >
+                          <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
                             {prop.minLength}
                           </code>
                         </div>
@@ -531,9 +517,7 @@ export function BlueprintDetail({
                           <span className="text-xs text-tertiary">
                             Max length
                           </span>
-                          <code
-                            className={`rounded bg-secondary px-1.5 py-0.5 text-xs text-primary`}
-                          >
+                          <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
                             {prop.maxLength}
                           </code>
                         </div>
@@ -548,7 +532,7 @@ export function BlueprintDetail({
       </div>
 
       {/* Raw JSON Schema (collapsible) */}
-      <div className={`rounded-lg border border-border bg-card`}>
+      <div className="rounded-lg border border-border bg-card">
         <button
           onClick={() => setRawSchemaOpen(!rawSchemaOpen)}
           className={`flex w-full items-center gap-2 px-6 py-4 text-left hover:bg-secondary ${rawSchemaOpen ? 'border-b border-tertiary' : ''}`}
@@ -564,9 +548,7 @@ export function BlueprintDetail({
           </span>
         </button>
         {rawSchemaOpen && (
-          <pre
-            className={`overflow-x-auto px-6 py-4 font-mono text-sm leading-relaxed text-primary`}
-          >
+          <pre className="overflow-x-auto px-6 py-4 font-mono text-sm leading-relaxed text-primary">
             {raw}
           </pre>
         )}

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -627,9 +627,7 @@ export function BlueprintForm({
 
   if (isEditing && bpError) {
     return (
-      <div
-        className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-      >
+      <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
         <AlertCircle className="h-5 w-5 flex-shrink-0" />
         <div>
           <div className="font-medium">Failed to load blueprint</div>
@@ -677,7 +675,7 @@ export function BlueprintForm({
 
       {/* API Error Display */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
@@ -714,7 +712,7 @@ export function BlueprintForm({
       )}
 
       {/* Basic Information */}
-      <div className={`rounded-lg border border-border bg-card p-6`}>
+      <div className="rounded-lg border border-border bg-card p-6">
         <h3 className="mb-4 text-sm font-medium text-primary">
           Basic Information
         </h3>
@@ -738,7 +736,7 @@ export function BlueprintForm({
               }}
               disabled={isLoading}
               placeholder="e.g. AWS Metadata"
-              className={''}
+              className=""
             />
             {touched.name && validationErrors.name && (
               <p className="mt-1 text-sm text-red-600">
@@ -950,7 +948,7 @@ export function BlueprintForm({
               }}
               disabled={isLoading}
               placeholder="0"
-              className={''}
+              className=""
             />
             <p className="mt-1 text-xs text-tertiary">
               Higher priority blueprints are applied later and can override
@@ -969,7 +967,7 @@ export function BlueprintForm({
               disabled={isLoading}
               placeholder="Brief description of what this blueprint defines"
               rows={3}
-              className={`w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground`}
+              className="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
             />
           </div>
 
@@ -997,7 +995,7 @@ export function BlueprintForm({
       </div>
 
       {/* Conditional Filter */}
-      <div className={`rounded-lg border border-border bg-card p-6`}>
+      <div className="rounded-lg border border-border bg-card p-6">
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Filter className="h-4 w-4 text-tertiary" />
@@ -1141,10 +1139,10 @@ export function BlueprintForm({
       </div>
 
       {/* JSON Schema Editor */}
-      <div className={`rounded-lg border border-border bg-card p-6`}>
+      <div className="rounded-lg border border-border bg-card p-6">
         <div className="mb-4 flex items-center justify-between">
           <h3 className="text-sm font-medium text-primary">JSON Schema</h3>
-          <div className={`flex items-center rounded-lg border border-input`}>
+          <div className="flex items-center rounded-lg border border-input">
             <button
               onClick={() => handleEditorModeSwitch('visual')}
               className={`flex items-center gap-1.5 rounded-l-lg px-3 py-1.5 text-sm transition-colors ${
@@ -1172,9 +1170,7 @@ export function BlueprintForm({
 
         {/* Schema Error */}
         {(schemaError || (touched.schema && validationErrors.schema)) && (
-          <div
-            className={`mb-4 flex items-start gap-2 rounded-lg bg-danger p-3 text-danger`}
-          >
+          <div className="mb-4 flex items-start gap-2 rounded-lg bg-danger p-3 text-danger">
             <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <div className="text-xs">
               {schemaError || validationErrors.schema}
@@ -1198,7 +1194,7 @@ export function BlueprintForm({
                 return (
                   <div
                     key={prop.id}
-                    className={`rounded-lg border border-input bg-secondary`}
+                    className="rounded-lg border border-input bg-secondary"
                   >
                     {/* Property Row */}
                     <div className="flex items-center gap-3 p-3">
@@ -1273,7 +1269,7 @@ export function BlueprintForm({
                             type: e.target.value as SchemaProperty['type'],
                           })
                         }
-                        className={`w-28 rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground`}
+                        className="w-28 rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground"
                       >
                         {PROPERTY_TYPES.map((t) => (
                           <option key={t} value={t}>
@@ -1333,7 +1329,7 @@ export function BlueprintForm({
                                   : 'Expand advanced options'
                               }
                               onClick={() => toggleExpandProp(prop.id)}
-                              className={`rounded p-1.5 text-xs text-secondary hover:bg-secondary`}
+                              className="rounded p-1.5 text-xs text-secondary hover:bg-secondary"
                             >
                               {isExpanded ? (
                                 <ChevronUp className="h-3.5 w-3.5" />
@@ -1355,7 +1351,7 @@ export function BlueprintForm({
                               type="button"
                               aria-label="Remove property"
                               onClick={() => removeProperty(prop.id)}
-                              className={`rounded p-1.5 text-danger hover:bg-danger`}
+                              className="rounded p-1.5 text-danger hover:bg-danger"
                             >
                               <Trash2 className="h-3.5 w-3.5" />
                             </button>
@@ -1369,9 +1365,7 @@ export function BlueprintForm({
 
                     {/* Advanced Options */}
                     {isExpanded && (
-                      <div
-                        className={`space-y-3 border-t border-secondary px-3 pb-3 pt-2`}
-                      >
+                      <div className="space-y-3 border-t border-secondary px-3 pb-3 pt-2">
                         <div className="grid grid-cols-2 gap-3">
                           <div>
                             <label className="mb-1 block text-xs text-secondary">
@@ -1418,7 +1412,7 @@ export function BlueprintForm({
                                     format: e.target.value || undefined,
                                   })
                                 }
-                                className={`w-full rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground`}
+                                className="w-full rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground"
                               >
                                 {STRING_FORMATS.map((f) => (
                                   <option key={f} value={f}>
@@ -1685,7 +1679,7 @@ export function BlueprintForm({
                                               })
                                               commit(next)
                                             }}
-                                            className={`rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground`}
+                                            className="rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground"
                                           >
                                             {[
                                               'green',
@@ -1771,7 +1765,7 @@ export function BlueprintForm({
             onBlur={() => syncCodeToVisual(rawSchema)}
             rows={20}
             spellCheck={false}
-            className={`w-full resize-y rounded-md border border-input bg-secondary px-4 py-3 font-mono text-sm text-primary`}
+            className="w-full resize-y rounded-md border border-input bg-secondary px-4 py-3 font-mono text-sm text-primary"
           />
         )}
       </div>

--- a/src/components/admin/blueprints/ImportBlueprintDialog.tsx
+++ b/src/components/admin/blueprints/ImportBlueprintDialog.tsx
@@ -431,9 +431,7 @@ export function ImportBlueprintDialog({
 
           {/* Validation error display */}
           {error && (
-            <div
-              className={`flex items-start gap-2.5 rounded-lg border border-danger bg-danger px-3 py-2.5 text-danger`}
-            >
+            <div className="flex items-start gap-2.5 rounded-lg border border-danger bg-danger px-3 py-2.5 text-danger">
               <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
               <span className="text-sm">{error}</span>
             </div>
@@ -441,9 +439,7 @@ export function ImportBlueprintDialog({
 
           {/* API error display */}
           {apiError && !error && (
-            <div
-              className={`flex items-start gap-2.5 rounded-lg border border-danger bg-danger px-3 py-2.5 text-danger`}
-            >
+            <div className="flex items-start gap-2.5 rounded-lg border border-danger bg-danger px-3 py-2.5 text-danger">
               <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
               <div className="text-sm">
                 <div className="font-medium">Failed to import blueprint</div>
@@ -459,9 +455,7 @@ export function ImportBlueprintDialog({
 
           {/* Preview */}
           {parsedPreview && (
-            <div
-              className={`rounded-lg border border-input bg-secondary px-3 py-2.5`}
-            >
+            <div className="rounded-lg border border-input bg-secondary px-3 py-2.5">
               <div className="mb-1.5 text-xs font-medium text-tertiary">
                 Preview
               </div>

--- a/src/components/admin/environments/EnvironmentDetail.tsx
+++ b/src/components/admin/environments/EnvironmentDetail.tsx
@@ -69,9 +69,7 @@ export function EnvironmentDetail({
             <div>
               <div className="text-sm text-secondary">Slug</div>
               <div className="mt-1 text-primary">
-                <code
-                  className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                >
+                <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                   {environment.slug}
                 </code>
               </div>

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -185,9 +185,7 @@ export function EnvironmentForm({
                 ))}
               </select>
               {errors.organization && (
-                <div
-                  className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                >
+                <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                   <AlertCircle className="h-3 w-3" />
                   {errors.organization}
                 </div>
@@ -213,9 +211,7 @@ export function EnvironmentForm({
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                 />
                 {errors.name && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                  >
+                  <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                     <AlertCircle className="h-3 w-3" />
                     {errors.name}
                   </div>
@@ -239,9 +235,7 @@ export function EnvironmentForm({
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                   />
                   {errors.slug && (
-                    <div
-                      className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                    >
+                    <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                       <AlertCircle className="h-3 w-3" />
                       {errors.slug}
                     </div>
@@ -285,7 +279,7 @@ export function EnvironmentForm({
                 rows={3}
                 disabled={isLoading}
                 placeholder="Brief description of this environment"
-                className={`w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground`}
+                className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground"
               />
             </div>
 

--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -85,7 +85,7 @@ export function LinkDefinitionForm({
     <div className="space-y-6">
       {/* API Error */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
@@ -153,9 +153,7 @@ export function LinkDefinitionForm({
                 ))}
               </select>
               {errors.organization && (
-                <div
-                  className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                >
+                <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                   <AlertCircle className="h-3 w-3" />
                   {errors.organization}
                 </div>
@@ -181,9 +179,7 @@ export function LinkDefinitionForm({
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                 />
                 {errors.name && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                  >
+                  <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                     <AlertCircle className="h-3 w-3" />
                     {errors.name}
                   </div>
@@ -207,9 +203,7 @@ export function LinkDefinitionForm({
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                   />
                   {errors.slug && (
-                    <div
-                      className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                    >
+                    <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                       <AlertCircle className="h-3 w-3" />
                       {errors.slug}
                     </div>
@@ -232,7 +226,7 @@ export function LinkDefinitionForm({
                 rows={3}
                 disabled={isLoading}
                 placeholder="Brief description of this link definition"
-                className={`w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground`}
+                className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground"
               />
             </div>
 
@@ -281,7 +275,7 @@ export function LinkDefinitionForm({
                 onChange={(e) => setUrlTemplate(e.target.value)}
                 placeholder="e.g., https://github.com/{organization}/{project}"
                 disabled={isLoading}
-                className={''}
+                className=""
               />
               <p className="mt-1 text-xs text-tertiary">
                 URL template with placeholders in curly braces

--- a/src/components/admin/organizations/OrganizationDetail.tsx
+++ b/src/components/admin/organizations/OrganizationDetail.tsx
@@ -58,9 +58,7 @@ export function OrganizationDetail({
           <div className="grid grid-cols-2 gap-6 md:grid-cols-4">
             <div>
               <div className="mb-1 text-sm text-secondary">Slug</div>
-              <code
-                className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-              >
+              <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                 {organization.slug}
               </code>
             </div>

--- a/src/components/admin/organizations/OrganizationForm.tsx
+++ b/src/components/admin/organizations/OrganizationForm.tsx
@@ -105,7 +105,7 @@ export function OrganizationForm({
 
       {/* API Error */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
@@ -141,9 +141,7 @@ export function OrganizationForm({
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                 />
                 {errors.name && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                  >
+                  <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                     <AlertCircle className="h-3 w-3" />
                     {errors.name}
                   </div>
@@ -163,9 +161,7 @@ export function OrganizationForm({
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                   />
                   {errors.slug && (
-                    <div
-                      className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                    >
+                    <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                       <AlertCircle className="h-3 w-3" />
                       {errors.slug}
                     </div>
@@ -184,7 +180,7 @@ export function OrganizationForm({
                 rows={3}
                 disabled={isLoading}
                 placeholder="Brief description of the organization's purpose"
-                className={`w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground`}
+                className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground"
               />
             </div>
 

--- a/src/components/admin/project-types/ProjectTypeDetail.tsx
+++ b/src/components/admin/project-types/ProjectTypeDetail.tsx
@@ -76,9 +76,7 @@ export function ProjectTypeDetail({
             <div>
               <div className="text-sm text-secondary">Slug</div>
               <div className="mt-1 text-primary">
-                <code
-                  className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                >
+                <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                   {projectType.slug}
                 </code>
               </div>

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -144,7 +144,7 @@ export function ProjectTypeForm({
 
       {/* API Error */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
@@ -185,9 +185,7 @@ export function ProjectTypeForm({
                 ))}
               </select>
               {errors.organization && (
-                <div
-                  className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                >
+                <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                   <AlertCircle className="h-3 w-3" />
                   {errors.organization}
                 </div>
@@ -209,9 +207,7 @@ export function ProjectTypeForm({
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                 />
                 {errors.name && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                  >
+                  <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                     <AlertCircle className="h-3 w-3" />
                     {errors.name}
                   </div>
@@ -231,9 +227,7 @@ export function ProjectTypeForm({
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                   />
                   {errors.slug && (
-                    <div
-                      className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                    >
+                    <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                       <AlertCircle className="h-3 w-3" />
                       {errors.slug}
                     </div>
@@ -252,7 +246,7 @@ export function ProjectTypeForm({
                 rows={3}
                 disabled={isLoading}
                 placeholder="Brief description of this project type"
-                className={`w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground`}
+                className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground"
               />
             </div>
 

--- a/src/components/admin/roles/RoleDetail.tsx
+++ b/src/components/admin/roles/RoleDetail.tsx
@@ -163,9 +163,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
 
   if (error || !role) {
     return (
-      <div
-        className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-      >
+      <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
         <AlertCircle className="h-5 w-5 flex-shrink-0" />
         <div>
           <div className="font-medium">Failed to load role</div>
@@ -292,7 +290,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
         <div className="space-y-4">
           {/* Add Permission Section */}
           {!role.is_system && (
-            <div className={`rounded-lg border border-border bg-card p-4`}>
+            <div className="rounded-lg border border-border bg-card p-4">
               <div className="mb-3 flex items-center justify-between">
                 <h3 className="text-sm font-medium text-primary">
                   Assign Permission
@@ -310,7 +308,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
                   <select
                     value={selectedPermission}
                     onChange={(e) => setSelectedPermission(e.target.value)}
-                    className={`flex-1 rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground`}
+                    className="flex-1 rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground"
                   >
                     <option value="">Select a permission...</option>
                     {availablePermissions.map((perm) => (
@@ -331,9 +329,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
                 </div>
               )}
 
-              <div
-                className={`mt-3 flex items-start gap-2 rounded bg-info p-2 text-xs text-info`}
-              >
+              <div className="mt-3 flex items-start gap-2 rounded bg-info p-2 text-xs text-info">
                 <AlertCircle className="mt-0.5 h-3 w-3 flex-shrink-0" />
                 <span>
                   Permissions define what actions users with this role can
@@ -360,20 +356,14 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
                 <table className="w-full">
                   <thead className="border-b border-tertiary bg-secondary">
                     <tr>
-                      <th
-                        className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                      >
+                      <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                         Permission
                       </th>
-                      <th
-                        className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                      >
+                      <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                         Description
                       </th>
                       {!role.is_system && (
-                        <th
-                          className={`px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary`}
-                        >
+                        <th className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
                           Actions
                         </th>
                       )}
@@ -385,9 +375,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
                       .map((perm) => (
                         <tr key={perm.name} className="hover:bg-secondary">
                           <td className="px-6 py-4 text-primary">
-                            <code
-                              className={`rounded bg-secondary px-2 py-1 text-sm text-info`}
-                            >
+                            <code className="rounded bg-secondary px-2 py-1 text-sm text-info">
                               {perm.name}
                             </code>
                           </td>
@@ -404,7 +392,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
                                         handleRevokePermission(perm.name)
                                       }
                                       disabled={revokeMutation.isPending}
-                                      className={`rounded p-1.5 text-danger hover:bg-danger`}
+                                      className="rounded p-1.5 text-danger hover:bg-danger"
                                     >
                                       <Trash2 className="h-4 w-4" />
                                     </button>
@@ -430,10 +418,8 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
       {activeTab === 'users' && (
         <div className="space-y-4">
           {/* Info banner */}
-          <div
-            className={`flex items-start gap-3 rounded-lg border border-tertiary bg-card p-4 dark:border-border dark:bg-card`}
-          >
-            <Info className={`mt-0.5 h-5 w-5 flex-shrink-0 text-info`} />
+          <div className="flex items-start gap-3 rounded-lg border border-tertiary bg-card p-4 dark:border-border dark:bg-card">
+            <Info className="mt-0.5 h-5 w-5 flex-shrink-0 text-info" />
             <div className="text-sm text-info">
               Role assignments are managed via User Management. This list shows
               users directly assigned this role.
@@ -446,9 +432,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
               <div className="text-sm text-secondary">Loading users...</div>
             </div>
           ) : usersError ? (
-            <div
-              className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-            >
+            <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
               <AlertCircle className="h-5 w-5 flex-shrink-0" />
               <div>
                 <div className="font-medium">Failed to load users</div>
@@ -470,9 +454,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
           ) : (
             <Card className="overflow-hidden">
               <CardContent className="p-0">
-                <div
-                  className={`grid grid-cols-[1fr_auto_auto] gap-4 border-b border-border bg-secondary px-4 py-2.5 text-xs font-medium uppercase tracking-wider text-tertiary`}
-                >
+                <div className="grid grid-cols-[1fr_auto_auto] gap-4 border-b border-border bg-secondary px-4 py-2.5 text-xs font-medium uppercase tracking-wider text-tertiary">
                   <div>User</div>
                   <div>Status</div>
                   <div>Last Login</div>
@@ -530,10 +512,8 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
       {activeTab === 'service-accounts' && (
         <div className="space-y-4">
           {/* Info banner */}
-          <div
-            className={`flex items-start gap-3 rounded-lg border border-tertiary bg-card p-4 dark:border-border dark:bg-card`}
-          >
-            <Info className={`mt-0.5 h-5 w-5 flex-shrink-0 text-info`} />
+          <div className="flex items-start gap-3 rounded-lg border border-tertiary bg-card p-4 dark:border-border dark:bg-card">
+            <Info className="mt-0.5 h-5 w-5 flex-shrink-0 text-info" />
             <div className="text-sm text-info">
               Role assignments are managed via Service Account Management. This
               list shows service accounts assigned this role via organization
@@ -549,9 +529,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
               </div>
             </div>
           ) : saError ? (
-            <div
-              className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-            >
+            <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
               <AlertCircle className="h-5 w-5 flex-shrink-0" />
               <div>
                 <div className="font-medium">
@@ -576,9 +554,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
           ) : (
             <Card className="overflow-hidden">
               <CardContent className="p-0">
-                <div
-                  className={`grid grid-cols-[1fr_auto_auto] gap-4 border-b border-border bg-secondary px-4 py-2.5 text-xs font-medium uppercase tracking-wider text-tertiary`}
-                >
+                <div className="grid grid-cols-[1fr_auto_auto] gap-4 border-b border-border bg-secondary px-4 py-2.5 text-xs font-medium uppercase tracking-wider text-tertiary">
                   <div>Service Account</div>
                   <div>Status</div>
                   <div>Last Authenticated</div>
@@ -643,10 +619,8 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
       {activeTab === 'groups' && (
         <div className="space-y-4">
           {/* Info banner */}
-          <div
-            className={`flex items-start gap-3 rounded-lg border border-tertiary bg-card p-4 dark:border-border dark:bg-card`}
-          >
-            <Info className={`mt-0.5 h-5 w-5 flex-shrink-0 text-info`} />
+          <div className="flex items-start gap-3 rounded-lg border border-tertiary bg-card p-4 dark:border-border dark:bg-card">
+            <Info className="mt-0.5 h-5 w-5 flex-shrink-0 text-info" />
             <div className="text-sm text-info">
               Role assignments to teams are managed via Team Management. All
               members of a team inherit the team's roles.
@@ -659,9 +633,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
               <div className="text-sm text-secondary">Loading groups...</div>
             </div>
           ) : groupsError ? (
-            <div
-              className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-            >
+            <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
               <AlertCircle className="h-5 w-5 flex-shrink-0" />
               <div>
                 <div className="font-medium">Failed to load groups</div>
@@ -683,9 +655,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
           ) : (
             <Card className="overflow-hidden">
               <CardContent className="p-0">
-                <div
-                  className={`grid grid-cols-[1fr_1fr] gap-4 border-b border-border bg-secondary px-4 py-2.5 text-xs font-medium uppercase tracking-wider text-tertiary`}
-                >
+                <div className="grid grid-cols-[1fr_1fr] gap-4 border-b border-border bg-secondary px-4 py-2.5 text-xs font-medium uppercase tracking-wider text-tertiary">
                   <div>Group</div>
                   <div>Description</div>
                 </div>

--- a/src/components/admin/roles/RoleForm.tsx
+++ b/src/components/admin/roles/RoleForm.tsx
@@ -241,9 +241,7 @@ export function RoleForm({
 
   if (isEditing && roleError) {
     return (
-      <div
-        className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-      >
+      <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
         <AlertCircle className="h-5 w-5 flex-shrink-0" />
         <div>
           <div className="font-medium">Failed to load role</div>
@@ -298,9 +296,9 @@ export function RoleForm({
 
       {/* System Role Warning */}
       {isSystemRole && (
-        <div className={`rounded-lg border border-warning bg-warning p-4`}>
+        <div className="rounded-lg border border-warning bg-warning p-4">
           <div className="flex items-start gap-3">
-            <AlertTriangle className={`h-5 w-5 flex-shrink-0 text-warning`} />
+            <AlertTriangle className="h-5 w-5 flex-shrink-0 text-warning" />
             <div>
               <div className="font-medium text-warning">System Role</div>
               <div className="mt-1 text-sm text-warning">
@@ -314,9 +312,9 @@ export function RoleForm({
 
       {/* API Error Display */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
-            <AlertCircle className={`h-5 w-5 flex-shrink-0 text-danger`} />
+            <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
               <div className="font-medium text-danger">Failed to save role</div>
               <div className="mt-1 text-sm text-danger">
@@ -442,9 +440,7 @@ export function RoleForm({
           </div>
         </CardHeader>
         <CardContent>
-          <div
-            className={`mb-4 flex items-start gap-2 rounded-lg bg-info p-3 text-info`}
-          >
+          <div className="mb-4 flex items-start gap-2 rounded-lg bg-info p-3 text-info">
             <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <div className="text-xs">
               Select the permissions this role should have. Permissions are
@@ -480,7 +476,7 @@ export function RoleForm({
                 return (
                   <div
                     key={resource}
-                    className={`rounded-lg border border-input bg-secondary`}
+                    className="rounded-lg border border-input bg-secondary"
                   >
                     {/* Group Header */}
                     <div className="flex items-center gap-3 p-3">
@@ -493,7 +489,7 @@ export function RoleForm({
                             : 'Expand permissions group'
                         }
                         aria-expanded={isExpanded}
-                        className={`rounded p-0.5 hover:bg-secondary`}
+                        className="rounded p-0.5 hover:bg-secondary"
                       >
                         {isExpanded ? (
                           <ChevronDown className="h-4 w-4 text-secondary" />
@@ -517,7 +513,7 @@ export function RoleForm({
                         />
                         <label
                           htmlFor={`group-${resource}`}
-                          className={`flex-1 cursor-pointer select-none text-primary`}
+                          className="flex-1 cursor-pointer select-none text-primary"
                         >
                           {resourceLabel(resource)}
                         </label>
@@ -535,15 +531,13 @@ export function RoleForm({
 
                     {/* Group Permissions */}
                     {isExpanded && (
-                      <div
-                        className={`space-y-2 border-t border-secondary px-3 pb-3`}
-                      >
+                      <div className="space-y-2 border-t border-secondary px-3 pb-3">
                         {perms
                           .sort((a, b) => a.action.localeCompare(b.action))
                           .map((perm) => (
                             <div
                               key={perm.name}
-                              className={`flex items-start gap-3 rounded p-2.5 hover:bg-primary`}
+                              className="flex items-start gap-3 rounded p-2.5 hover:bg-primary"
                             >
                               <Checkbox
                                 id={perm.name}
@@ -559,9 +553,7 @@ export function RoleForm({
                                 className="flex-1 cursor-pointer select-none"
                               >
                                 <div className="text-sm text-primary">
-                                  <code
-                                    className={`rounded bg-secondary px-1.5 py-0.5 text-xs text-info`}
-                                  >
+                                  <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-info">
                                     {perm.action}
                                   </code>
                                 </div>

--- a/src/components/admin/service-accounts/ServiceAccountDetail.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountDetail.tsx
@@ -433,9 +433,7 @@ export function ServiceAccountDetail({
               <Power className="h-4 w-4" />
               {account.is_active ? 'Active' : 'Inactive'}
             </div>
-            <div
-              className={`flex items-center gap-2 rounded bg-purple-100 px-3 py-1.5 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400`}
-            >
+            <div className="flex items-center gap-2 rounded bg-purple-100 px-3 py-1.5 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
               Service Account
             </div>
           </div>
@@ -454,7 +452,7 @@ export function ServiceAccountDetail({
               onClick={() => setShowAddOrg(!showAddOrg)}
               variant="outline"
               size="sm"
-              className={''}
+              className=""
             >
               <Plus className="mr-2 h-4 w-4" />
               Add to Organization
@@ -464,9 +462,7 @@ export function ServiceAccountDetail({
         <CardContent>
           {/* Add to Organization Form */}
           {showAddOrg && (
-            <div
-              className={`mb-4 rounded-lg border border-input bg-secondary p-4`}
-            >
+            <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="mb-1.5 block text-sm text-secondary">
@@ -475,7 +471,7 @@ export function ServiceAccountDetail({
                   <select
                     value={newOrgSlug}
                     onChange={(e) => setNewOrgSlug(e.target.value)}
-                    className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground`}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
                   >
                     <option value="">Select...</option>
                     {availableOrgs.map((org) => (
@@ -497,7 +493,7 @@ export function ServiceAccountDetail({
                     <select
                       value={newRoleSlug}
                       onChange={(e) => setNewRoleSlug(e.target.value)}
-                      className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground`}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
                     >
                       <option value="">Select...</option>
                       {availableRoles.map((role) => (
@@ -547,7 +543,7 @@ export function ServiceAccountDetail({
                 (membership: OrgMembership) => (
                   <div
                     key={membership.organization_slug}
-                    className={`flex items-center justify-between rounded-lg border border-input bg-secondary p-3`}
+                    className="flex items-center justify-between rounded-lg border border-input bg-secondary p-3"
                   >
                     <div className="flex-1">
                       <div className="text-sm font-medium text-primary">
@@ -577,7 +573,7 @@ export function ServiceAccountDetail({
                           }
                           disabled={updateOrgRoleMutation.isPending}
                           aria-label={`Role for ${membership.organization_name}`}
-                          className={`rounded border border-input bg-background px-2 py-1 text-xs text-foreground`}
+                          className="rounded border border-input bg-background px-2 py-1 text-xs text-foreground"
                         >
                           {availableRoles.map((role) => (
                             <option key={role.slug} value={role.slug}>
@@ -604,7 +600,7 @@ export function ServiceAccountDetail({
                                 }
                               }}
                               disabled={removeOrgMutation.isPending}
-                              className={`rounded p-1.5 text-danger hover:bg-secondary`}
+                              className="rounded p-1.5 text-danger hover:bg-secondary"
                             >
                               <Trash2 className="h-4 w-4" />
                             </button>
@@ -643,7 +639,7 @@ export function ServiceAccountDetail({
             onClick={() => setShowCreateCredential(!showCreateCredential)}
             variant="outline"
             size="sm"
-            className={''}
+            className=""
           >
             <Plus className="mr-2 h-4 w-4" />
             Create Credential
@@ -652,9 +648,7 @@ export function ServiceAccountDetail({
         <CardContent>
           {/* Create Credential Form */}
           {showCreateCredential && (
-            <div
-              className={`mb-4 rounded-lg border border-input bg-secondary p-4`}
-            >
+            <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
               <div className="space-y-3">
                 <div>
                   <label className="mb-1.5 block text-sm text-secondary">
@@ -664,7 +658,7 @@ export function ServiceAccountDetail({
                     value={credentialName}
                     onChange={(e) => setCredentialName(e.target.value)}
                     placeholder="e.g., production-api"
-                    className={''}
+                    className=""
                   />
                 </div>
                 <div>
@@ -675,7 +669,7 @@ export function ServiceAccountDetail({
                     value={credentialDescription}
                     onChange={(e) => setCredentialDescription(e.target.value)}
                     placeholder="What is this credential used for?"
-                    className={''}
+                    className=""
                   />
                 </div>
                 <div>
@@ -689,7 +683,7 @@ export function ServiceAccountDetail({
                     value={credentialScopes}
                     onChange={(e) => setCredentialScopes(e.target.value)}
                     placeholder="e.g., read:projects, write:projects"
-                    className={''}
+                    className=""
                   />
                 </div>
                 <div>
@@ -705,7 +699,7 @@ export function ServiceAccountDetail({
                     value={credentialExpiresDays}
                     onChange={(e) => setCredentialExpiresDays(e.target.value)}
                     placeholder="e.g., 90"
-                    className={''}
+                    className=""
                   />
                 </div>
                 <div className="flex items-center gap-2 pt-2">
@@ -727,7 +721,7 @@ export function ServiceAccountDetail({
                       setShowCreateCredential(false)
                       resetCredentialForm()
                     }}
-                    className={''}
+                    className=""
                   >
                     Cancel
                   </Button>
@@ -738,9 +732,7 @@ export function ServiceAccountDetail({
 
           {/* Newly Created Credential Banner */}
           {newlyCreatedCredential && (
-            <div
-              className={`mb-4 rounded-lg border border-success bg-success p-4`}
-            >
+            <div className="mb-4 rounded-lg border border-success bg-success p-4">
               <div className="mb-2 font-medium text-success">
                 Client Credential Created - Copy the secret now, it will not be
                 shown again!
@@ -749,9 +741,7 @@ export function ServiceAccountDetail({
                 <div>
                   <span className="text-xs text-secondary">Client ID</span>
                   <div className="flex items-center gap-2">
-                    <code
-                      className={`flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success`}
-                    >
+                    <code className="flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success">
                       {newlyCreatedCredential.client_id}
                     </code>
                     <TooltipProvider delayDuration={200}>
@@ -785,9 +775,7 @@ export function ServiceAccountDetail({
                 <div>
                   <span className="text-xs text-secondary">Client Secret</span>
                   <div className="flex items-center gap-2">
-                    <code
-                      className={`flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success`}
-                    >
+                    <code className="flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success">
                       {newlyCreatedCredential.client_secret}
                     </code>
                     <TooltipProvider delayDuration={200}>
@@ -834,9 +822,7 @@ export function ServiceAccountDetail({
               Loading client credentials...
             </div>
           ) : credentialsError ? (
-            <div
-              className={`flex items-center gap-2 rounded-lg bg-danger p-3 text-danger`}
-            >
+            <div className="flex items-center gap-2 rounded-lg bg-danger p-3 text-danger">
               <AlertCircle className="h-4 w-4 flex-shrink-0" />
               <span className="text-sm">Failed to load client credentials</span>
             </div>
@@ -864,9 +850,7 @@ export function ServiceAccountDetail({
                       <span className="text-sm font-medium text-primary">
                         {cred.name}
                       </span>
-                      <code
-                        className={`rounded bg-secondary px-2 py-0.5 text-xs text-secondary`}
-                      >
+                      <code className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary">
                         {truncateClientId(cred.client_id)}
                       </code>
                       {cred.revoked && <Badge variant="danger">Revoked</Badge>}
@@ -896,7 +880,7 @@ export function ServiceAccountDetail({
                                 handleRotateCredential(cred.client_id)
                               }
                               disabled={rotateCredentialMutation.isPending}
-                              className={`rounded p-1.5 text-info hover:bg-secondary`}
+                              className="rounded p-1.5 text-info hover:bg-secondary"
                             >
                               <RotateCw className="h-4 w-4" />
                             </button>
@@ -916,7 +900,7 @@ export function ServiceAccountDetail({
                                 handleRevokeCredential(cred.client_id)
                               }
                               disabled={revokeCredentialMutation.isPending}
-                              className={`rounded p-1.5 text-danger hover:bg-secondary`}
+                              className="rounded p-1.5 text-danger hover:bg-secondary"
                             >
                               <Trash2 className="h-4 w-4" />
                             </button>
@@ -946,7 +930,7 @@ export function ServiceAccountDetail({
             onClick={() => setShowCreateKey(!showCreateKey)}
             variant="outline"
             size="sm"
-            className={''}
+            className=""
           >
             <Plus className="mr-2 h-4 w-4" />
             Create API Key
@@ -955,9 +939,7 @@ export function ServiceAccountDetail({
         <CardContent>
           {/* Create Key Form */}
           {showCreateKey && (
-            <div
-              className={`mb-4 rounded-lg border border-input bg-secondary p-4`}
-            >
+            <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
               <div className="flex items-end gap-3">
                 <div className="flex-1">
                   <label className="mb-1.5 block text-sm text-secondary">
@@ -968,7 +950,7 @@ export function ServiceAccountDetail({
                     value={newKeyName}
                     onChange={(e) => setNewKeyName(e.target.value)}
                     placeholder="e.g., production, staging"
-                    className={`w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground`}
+                    className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
                   />
                 </div>
                 <Button
@@ -993,16 +975,12 @@ export function ServiceAccountDetail({
 
           {/* Newly Created Key Banner */}
           {newlyCreatedKey && (
-            <div
-              className={`mb-4 rounded-lg border border-success bg-success p-4`}
-            >
+            <div className="mb-4 rounded-lg border border-success bg-success p-4">
               <div className="mb-2 font-medium text-success">
                 API Key Created - Copy it now, it will not be shown again!
               </div>
               <div className="flex items-center gap-2">
-                <code
-                  className={`flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success`}
-                >
+                <code className="flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success">
                   {newlyCreatedKey.key_secret}
                 </code>
                 <TooltipProvider delayDuration={200}>
@@ -1044,9 +1022,7 @@ export function ServiceAccountDetail({
               Loading API keys...
             </div>
           ) : keysError ? (
-            <div
-              className={`flex items-center gap-2 rounded-lg bg-danger p-3 text-danger`}
-            >
+            <div className="flex items-center gap-2 rounded-lg bg-danger p-3 text-danger">
               <AlertCircle className="h-4 w-4 flex-shrink-0" />
               <span className="text-sm">Failed to load API keys</span>
             </div>
@@ -1074,9 +1050,7 @@ export function ServiceAccountDetail({
                       <span className="text-sm font-medium text-primary">
                         {key.name}
                       </span>
-                      <code
-                        className={`rounded bg-secondary px-2 py-0.5 text-xs text-secondary`}
-                      >
+                      <code className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary">
                         {key.key_id.substring(0, 7)}...
                       </code>
                       {key.revoked && <Badge variant="danger">Revoked</Badge>}
@@ -1099,7 +1073,7 @@ export function ServiceAccountDetail({
                               aria-label={`Rotate API key ${key.name}`}
                               onClick={() => handleRotateKey(key.key_id)}
                               disabled={rotateKeyMutation.isPending}
-                              className={`rounded p-1.5 text-info hover:bg-secondary`}
+                              className="rounded p-1.5 text-info hover:bg-secondary"
                             >
                               <RotateCw className="h-4 w-4" />
                             </button>
@@ -1117,7 +1091,7 @@ export function ServiceAccountDetail({
                               aria-label={`Revoke API key ${key.name}`}
                               onClick={() => handleRevokeKey(key.key_id)}
                               disabled={revokeKeyMutation.isPending}
-                              className={`rounded p-1.5 text-danger hover:bg-secondary`}
+                              className="rounded p-1.5 text-danger hover:bg-secondary"
                             >
                               <Trash2 className="h-4 w-4" />
                             </button>

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -165,9 +165,9 @@ export function ServiceAccountForm({
 
       {/* API Error Display */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
-            <AlertCircle className={`h-5 w-5 flex-shrink-0 text-danger`} />
+            <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
               <div className="font-medium text-danger">
                 Failed to save service account
@@ -207,7 +207,7 @@ export function ServiceAccountForm({
                   }}
                   disabled={isLoading}
                   placeholder="my-service-account"
-                  className={''}
+                  className=""
                 />
                 <p className="mt-1 text-xs text-tertiary">
                   Lowercase letters, numbers, and hyphens only. Must start with
@@ -244,7 +244,7 @@ export function ServiceAccountForm({
                 }}
                 disabled={isLoading}
                 placeholder="CI/CD Pipeline"
-                className={''}
+                className=""
               />
               {touched.display_name && validationErrors.display_name && (
                 <p className="mt-1 text-sm text-red-600">
@@ -264,7 +264,7 @@ export function ServiceAccountForm({
                 disabled={isLoading}
                 placeholder="What does this service account do?"
                 rows={3}
-                className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
             </div>
           </div>
@@ -293,7 +293,7 @@ export function ServiceAccountForm({
                     handleFieldChange('organization_slug')
                   }}
                   disabled={isLoading}
-                  className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                   <option value="">Select an organization...</option>
                   {organizations.map((org) => (
@@ -329,7 +329,7 @@ export function ServiceAccountForm({
                       handleFieldChange('role_slug')
                     }}
                     disabled={isLoading}
-                    className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     <option value="">Select a role...</option>
                     {availableRoles.map((role) => (

--- a/src/components/admin/teams/TeamDetail.tsx
+++ b/src/components/admin/teams/TeamDetail.tsx
@@ -140,9 +140,7 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
             <div>
               <div className="text-sm text-secondary">Slug</div>
               <div className="mt-1 text-primary">
-                <code
-                  className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                >
+                <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                   {team.slug}
                 </code>
               </div>
@@ -168,9 +166,7 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
             <div className="flex items-center gap-2">
               <Users className="h-5 w-5 text-secondary" />
               <CardTitle>Team Members</CardTitle>
-              <span
-                className={`ml-2 rounded bg-secondary px-2 py-1 text-sm text-primary`}
-              >
+              <span className="ml-2 rounded bg-secondary px-2 py-1 text-sm text-primary">
                 {members.length}
               </span>
             </div>
@@ -185,14 +181,10 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
 
           {/* Add Member Panel */}
           {showAddMember && (
-            <div
-              className={`mt-4 rounded-lg border border-input bg-secondary p-4`}
-            >
+            <div className="mt-4 rounded-lg border border-input bg-secondary p-4">
               <div className="flex items-center gap-3">
                 <div className="relative flex-1">
-                  <Search
-                    className={`absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary`}
-                  />
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary" />
                   <Input
                     placeholder="Enter user email address..."
                     value={newMemberEmail}
@@ -212,9 +204,7 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
                 </Button>
               </div>
               {!!addMemberMutation.error && (
-                <div
-                  className={`mt-2 flex items-center gap-2 text-xs text-danger`}
-                >
+                <div className="mt-2 flex items-center gap-2 text-xs text-danger">
                   <AlertCircle className="h-3 w-3" />
                   {extractApiErrorDetail(
                     addMemberMutation.error,
@@ -247,24 +237,16 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
             <table className="w-full">
               <thead className="border-b border-tertiary bg-secondary">
                 <tr>
-                  <th
-                    className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary`}
-                  >
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
                     Member
                   </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary`}
-                  >
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
                     Email
                   </th>
-                  <th
-                    className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary`}
-                  >
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
                     Status
                   </th>
-                  <th
-                    className={`px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-tertiary`}
-                  >
+                  <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-tertiary">
                     Actions
                   </th>
                 </tr>
@@ -303,7 +285,7 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
                               disabled={removeMemberMutation.isPending}
                               aria-label={`Remove ${member.display_name} from team`}
                               title="Remove from team"
-                              className={`rounded p-1.5 text-danger hover:bg-danger`}
+                              className="rounded p-1.5 text-danger hover:bg-danger"
                             >
                               <X className="h-4 w-4" />
                             </button>

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -138,7 +138,7 @@ export function TeamForm({
 
       {/* API Error */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
@@ -177,9 +177,7 @@ export function TeamForm({
                 ))}
               </select>
               {errors.organization && (
-                <div
-                  className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                >
+                <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                   <AlertCircle className="h-3 w-3" />
                   {errors.organization}
                 </div>
@@ -201,9 +199,7 @@ export function TeamForm({
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                 />
                 {errors.name && (
-                  <div
-                    className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                  >
+                  <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                     <AlertCircle className="h-3 w-3" />
                     {errors.name}
                   </div>
@@ -223,9 +219,7 @@ export function TeamForm({
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                   />
                   {errors.slug && (
-                    <div
-                      className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                    >
+                    <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                       <AlertCircle className="h-3 w-3" />
                       {errors.slug}
                     </div>
@@ -244,7 +238,7 @@ export function TeamForm({
                 rows={3}
                 disabled={isLoading}
                 placeholder="Brief description of the team's purpose"
-                className={`w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground`}
+                className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground"
               />
             </div>
 

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -125,7 +125,7 @@ export function ApplicationSecretsPanel({
   const is403 = error && (error as ApiError)?.response?.status === 403
 
   return (
-    <div className={`rounded-lg border border-border bg-card p-6`}>
+    <div className="rounded-lg border border-border bg-card p-6">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Shield className="h-5 w-5 text-warning" />
@@ -163,18 +163,14 @@ export function ApplicationSecretsPanel({
       )}
 
       {revealed && is403 && (
-        <div
-          className={`flex items-center gap-3 rounded-lg border border-warning bg-warning p-4 text-warning`}
-        >
+        <div className="flex items-center gap-3 rounded-lg border border-warning bg-warning p-4 text-warning">
           <AlertCircle className="h-5 w-5 flex-shrink-0" />
           <div className="text-sm">Admin access required to view secrets.</div>
         </div>
       )}
 
       {revealed && error && !is403 && (
-        <div
-          className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-        >
+        <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
           <AlertCircle className="h-5 w-5 flex-shrink-0" />
           <div className="text-sm">
             {error instanceof Error ? error.message : 'Failed to load secrets'}
@@ -195,9 +191,7 @@ export function ApplicationSecretsPanel({
                   {FIELD_LABELS[field]}
                 </div>
                 <div className="flex items-center gap-2">
-                  <code
-                    className={`flex-1 break-all rounded bg-secondary px-3 py-2 font-mono text-sm text-primary`}
-                  >
+                  <code className="flex-1 break-all rounded bg-secondary px-3 py-2 font-mono text-sm text-primary">
                     {field === 'private_key' ? (
                       <pre className="whitespace-pre-wrap text-xs">{value}</pre>
                     ) : (
@@ -213,7 +207,7 @@ export function ApplicationSecretsPanel({
                             size="sm"
                             aria-label={`Copy ${FIELD_LABELS[field]}`}
                             onClick={() => handleCopy(field, value)}
-                            className={''}
+                            className=""
                           >
                             {copiedField === field ? (
                               <Check className="h-4 w-4 text-green-500" />
@@ -243,9 +237,7 @@ export function ApplicationSecretsPanel({
           </p>
 
           {updateMutation.error && (
-            <div
-              className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-3 text-danger`}
-            >
+            <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-3 text-danger">
               <AlertCircle className="h-4 w-4 flex-shrink-0" />
               <div className="text-sm">
                 {updateMutation.error instanceof Error
@@ -268,7 +260,7 @@ export function ApplicationSecretsPanel({
                   }
                   placeholder="Paste new value to update"
                   rows={4}
-                  className={`w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm text-foreground`}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm text-foreground"
                 />
               ) : (
                 <Input
@@ -278,7 +270,7 @@ export function ApplicationSecretsPanel({
                     setEditValues({ ...editValues, [field]: e.target.value })
                   }
                   placeholder="Paste new value to update"
-                  className={''}
+                  className=""
                 />
               )}
             </div>

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -163,9 +163,7 @@ export function OAuth2ApplicationForm({
 
       {/* Error display */}
       {(validationError || error) && (
-        <div
-          className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-        >
+        <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
           <AlertCircle className="h-5 w-5 flex-shrink-0" />
           <div className="text-sm">
             {validationError ||
@@ -175,7 +173,7 @@ export function OAuth2ApplicationForm({
       )}
 
       {/* Form */}
-      <div className={`space-y-4 rounded-lg border border-border bg-card p-6`}>
+      <div className="space-y-4 rounded-lg border border-border bg-card p-6">
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className={labelClass}>Name *</label>
@@ -225,7 +223,7 @@ export function OAuth2ApplicationForm({
               value={appType}
               onChange={(e) => setAppType(e.target.value)}
               disabled={isEdit}
-              className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground`}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
             >
               {APP_TYPES.map((t) => (
                 <option key={t.value} value={t.value}>
@@ -241,7 +239,7 @@ export function OAuth2ApplicationForm({
               onChange={(e) =>
                 setStatus(e.target.value as 'active' | 'inactive' | 'revoked')
               }
-              className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground`}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
             >
               <option value="active">Active</option>
               <option value="inactive">Inactive</option>
@@ -311,7 +309,7 @@ export function OAuth2ApplicationForm({
                   onChange={(e) => setPrivateKey(e.target.value)}
                   placeholder={'-----BEGIN RSA PRIVATE KEY-----\n...'}
                   rows={4}
-                  className={`w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm text-foreground`}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm text-foreground"
                 />
               </div>
             )}

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -167,9 +167,7 @@ export function OAuth2ApplicationList({
 
   if (error) {
     return (
-      <div
-        className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-      >
+      <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
         <AlertCircle className="h-5 w-5 flex-shrink-0" />
         <div>
           <div className="font-medium">Failed to load applications</div>
@@ -212,35 +210,23 @@ export function OAuth2ApplicationList({
           </div>
         </div>
       ) : (
-        <div
-          className={`overflow-hidden rounded-lg border border-border bg-card`}
-        >
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
           <table className="w-full">
             <thead className="border-b border-tertiary bg-secondary">
               <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Application
                 </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Type
                 </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Client ID
                 </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Status
                 </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
                   Actions
                 </th>
               </tr>
@@ -262,9 +248,7 @@ export function OAuth2ApplicationList({
                       <div className="text-sm text-tertiary">{app.slug}</div>
                     </td>
                     <td className="px-6 py-4">
-                      <code
-                        className={`rounded bg-secondary px-2 py-1 text-xs text-primary`}
-                      >
+                      <code className="rounded bg-secondary px-2 py-1 text-xs text-primary">
                         {app.app_type}
                       </code>
                     </td>
@@ -289,7 +273,7 @@ export function OAuth2ApplicationList({
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   aria-label={`Open ${app.name} application`}
-                                  className={`inline-flex items-center rounded p-1.5 text-info hover:bg-info`}
+                                  className="inline-flex items-center rounded p-1.5 text-info hover:bg-info"
                                 >
                                   <ExternalLink className="h-4 w-4" />
                                 </a>

--- a/src/components/admin/third-party-services/ServiceWebhookList.tsx
+++ b/src/components/admin/third-party-services/ServiceWebhookList.tsx
@@ -179,9 +179,7 @@ export function ServiceWebhookList({
 
   if (error) {
     return (
-      <div
-        className={`flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger`}
-      >
+      <div className="flex items-center gap-3 rounded-lg border border-danger bg-danger p-4 text-danger">
         <AlertCircle className="h-5 w-5 flex-shrink-0" />
         <div>
           <div className="font-medium">Failed to load webhooks</div>
@@ -204,9 +202,7 @@ export function ServiceWebhookList({
           </div>
           {webhooks.length > 0 && (
             <div className="relative max-w-xs">
-              <Search
-                className={`absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary`}
-              />
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary" />
               <Input
                 placeholder="Search webhooks..."
                 value={searchQuery}
@@ -245,30 +241,20 @@ export function ServiceWebhookList({
           </div>
         </div>
       ) : (
-        <div
-          className={`overflow-hidden rounded-lg border border-border bg-card`}
-        >
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
           <table className="w-full">
             <thead className="border-b border-tertiary">
               <tr>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Webhook
                 </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Path
                 </th>
-                <th
-                  className={`px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Rules
                 </th>
-                <th
-                  className={`px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary`}
-                >
+                <th className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
                   Actions
                 </th>
               </tr>
@@ -295,9 +281,7 @@ export function ServiceWebhookList({
                 >
                   <td className="px-6 py-4">
                     <div className="flex items-center gap-3">
-                      <div
-                        className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-900/30`}
-                      >
+                      <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-900/30">
                         <Webhook
                           className={
                             'h-4 w-4 text-indigo-600 dark:text-indigo-400'
@@ -319,9 +303,7 @@ export function ServiceWebhookList({
                     </div>
                   </td>
                   <td className="px-6 py-4">
-                    <code
-                      className={`rounded bg-secondary px-2 py-1 text-xs text-primary`}
-                    >
+                    <code className="rounded bg-secondary px-2 py-1 text-xs text-primary">
                       {wh.notification_path}
                     </code>
                   </td>

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -118,9 +118,7 @@ export function ThirdPartyServiceDetail({
                 <div>
                   <div className="text-sm text-secondary">Slug</div>
                   <div className="mt-1 text-primary">
-                    <code
-                      className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                    >
+                    <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                       {service.slug}
                     </code>
                   </div>
@@ -159,7 +157,7 @@ export function ThirdPartyServiceDetail({
                         href={service.service_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`hover:text-info/80 inline-flex items-center gap-1 text-sm text-info`}
+                        className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
                       >
                         {service.service_url}
                         <ExternalLink className="h-3 w-3" />
@@ -189,7 +187,7 @@ export function ThirdPartyServiceDetail({
                           href={String(url)}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className={`hover:text-info/80 inline-flex items-center gap-1 text-sm text-info`}
+                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
                         >
                           {String(url)}
                           <ExternalLink className="h-3 w-3" />
@@ -214,9 +212,7 @@ export function ThirdPartyServiceDetail({
                     <div key={label}>
                       <div className="text-sm text-secondary">{label}</div>
                       <div className="mt-1 text-primary">
-                        <code
-                          className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                        >
+                        <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                           {String(val)}
                         </code>
                       </div>

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -146,7 +146,7 @@ export function ThirdPartyServiceForm({
 
       {/* API Error */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
@@ -170,7 +170,7 @@ export function ThirdPartyServiceForm({
         className="space-y-6"
       >
         {/* Basic Information */}
-        <div className={`rounded-lg border border-border bg-card p-6`}>
+        <div className="rounded-lg border border-border bg-card p-6">
           <h3 className="mb-4 text-sm font-medium text-primary">
             Service Information
           </h3>
@@ -280,7 +280,7 @@ export function ThirdPartyServiceForm({
                   onChange={(e) => setCategory(e.target.value)}
                   placeholder="e.g., Payments, Analytics, Communications"
                   disabled={isLoading}
-                  className={''}
+                  className=""
                 />
               </div>
             </div>
@@ -338,7 +338,7 @@ export function ThirdPartyServiceForm({
                 rows={3}
                 disabled={isLoading}
                 placeholder="Brief description of this service and how it is used"
-                className={`w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground`}
+                className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground"
               />
             </div>
 
@@ -377,7 +377,7 @@ export function ThirdPartyServiceForm({
         </div>
 
         {/* Links */}
-        <div className={`rounded-lg border border-border bg-card p-6`}>
+        <div className="rounded-lg border border-border bg-card p-6">
           <h3 className="mb-4 text-sm font-medium text-primary">Links</h3>
           <p className="mb-4 text-sm text-secondary">
             Named links to documentation, API references, status pages, etc.
@@ -392,7 +392,7 @@ export function ThirdPartyServiceForm({
         </div>
 
         {/* Identifiers */}
-        <div className={`rounded-lg border border-border bg-card p-6`}>
+        <div className="rounded-lg border border-border bg-card p-6">
           <h3 className="mb-4 text-sm font-medium text-primary">Identifiers</h3>
           <p className="mb-4 text-sm text-secondary">
             External IDs such as account ID, org ID, or API key names.

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -163,17 +163,13 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
               {user.is_active ? 'Active' : 'Inactive'}
             </div>
             {user.is_admin && (
-              <div
-                className={`flex items-center gap-2 rounded bg-danger px-3 py-1.5 text-danger`}
-              >
+              <div className="flex items-center gap-2 rounded bg-danger px-3 py-1.5 text-danger">
                 <Shield className="h-4 w-4" />
                 Administrator
               </div>
             )}
             {user.is_service_account && (
-              <div
-                className={`flex items-center gap-2 rounded bg-purple-100 px-3 py-1.5 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400`}
-              >
+              <div className="flex items-center gap-2 rounded bg-purple-100 px-3 py-1.5 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
                 Service Account
               </div>
             )}
@@ -246,7 +242,7 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
               onClick={() => setShowAddOrg(!showAddOrg)}
               variant="outline"
               size="sm"
-              className={''}
+              className=""
             >
               <Plus className="mr-2 h-4 w-4" />
               Add to Organization
@@ -256,9 +252,7 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
         <CardContent>
           {/* Add to Organization Form */}
           {showAddOrg && (
-            <div
-              className={`mb-4 rounded-lg border border-input bg-secondary p-4`}
-            >
+            <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="mb-1.5 block text-sm text-secondary">
@@ -267,7 +261,7 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
                   <select
                     value={newOrgSlug}
                     onChange={(e) => setNewOrgSlug(e.target.value)}
-                    className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground`}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
                   >
                     <option value="">Select...</option>
                     {availableOrgs.map((org) => (
@@ -284,7 +278,7 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
                   <select
                     value={newRoleSlug}
                     onChange={(e) => setNewRoleSlug(e.target.value)}
-                    className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground`}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
                   >
                     <option value="">Select...</option>
                     {availableRoles.map((role) => (
@@ -332,7 +326,7 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
               {(user.organizations ?? []).map((membership: OrgMembership) => (
                 <div
                   key={membership.organization_slug}
-                  className={`flex items-center justify-between rounded-lg border border-input bg-secondary p-3`}
+                  className="flex items-center justify-between rounded-lg border border-input bg-secondary p-3"
                 >
                   <div className="flex-1">
                     <div className="text-sm font-medium text-primary">
@@ -352,7 +346,7 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
                         })
                       }
                       disabled={updateRoleMutation.isPending}
-                      className={`rounded border border-input bg-background px-2 py-1 text-xs text-foreground`}
+                      className="rounded border border-input bg-background px-2 py-1 text-xs text-foreground"
                     >
                       {availableRoles.map((role) => (
                         <option key={role.slug} value={role.slug}>
@@ -376,7 +370,7 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
                               }
                             }}
                             disabled={removeOrgMutation.isPending}
-                            className={`rounded p-1.5 text-danger hover:bg-secondary`}
+                            className="rounded p-1.5 text-danger hover:bg-secondary"
                           >
                             <Trash2 className="h-4 w-4" />
                           </button>

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -227,9 +227,9 @@ export function UserForm({
 
       {/* API Error Display */}
       {error && (
-        <div className={`rounded-lg border border-danger bg-danger p-4`}>
+        <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
-            <AlertCircle className={`h-5 w-5 flex-shrink-0 text-danger`} />
+            <AlertCircle className="h-5 w-5 flex-shrink-0 text-danger" />
             <div>
               <div className="font-medium text-danger">Failed to save user</div>
               <div className="mt-1 text-sm text-danger">
@@ -268,7 +268,7 @@ export function UserForm({
                   }}
                   disabled={isLoading}
                   placeholder="john.doe@company.com"
-                  className={''}
+                  className=""
                 />
                 {touched.email && validationErrors.email && (
                   <p className="mt-1 text-sm text-red-600">
@@ -301,7 +301,7 @@ export function UserForm({
                 }}
                 disabled={isLoading}
                 placeholder="John Doe"
-                className={''}
+                className=""
               />
               {touched.display_name && validationErrors.display_name && (
                 <p className="mt-1 text-sm text-red-600">
@@ -386,7 +386,7 @@ export function UserForm({
                       type="button"
                       onClick={() => setShowPassword(!showPassword)}
                       disabled={isLoading}
-                      className={`absolute right-3 top-1/2 -translate-y-1/2 text-tertiary hover:text-secondary`}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-tertiary hover:text-secondary"
                     >
                       {showPassword ? (
                         <EyeOff className="h-4 w-4" />
@@ -508,7 +508,7 @@ export function UserForm({
                     }}
                     disabled={isLoading}
                     placeholder="Re-enter password"
-                    className={''}
+                    className=""
                   />
                   {touched.confirmPassword &&
                     validationErrors.confirmPassword && (
@@ -653,7 +653,7 @@ export function UserForm({
                     handleFieldChange('organization_slug')
                   }}
                   disabled={isLoading}
-                  className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                   <option value="">Select an organization...</option>
                   {organizations.map((org) => (
@@ -685,7 +685,7 @@ export function UserForm({
                       handleFieldChange('role_slug')
                     }}
                     disabled={isLoading}
-                    className={`w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     <option value="">Select a role...</option>
                     {availableRoles.map((role) => (

--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -28,9 +28,7 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
                   className="h-8 w-8 rounded object-cover"
                 />
               ) : (
-                <div
-                  className={`flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-900/30`}
-                >
+                <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-900/30">
                   <Webhook className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
                 </div>
               )}
@@ -62,9 +60,7 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
             <div>
               <div className="text-sm text-secondary">Slug</div>
               <div className="mt-1">
-                <code
-                  className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                >
+                <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                   {webhook.slug}
                 </code>
               </div>
@@ -72,9 +68,7 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
             <div>
               <div className="text-sm text-secondary">Notification Path</div>
               <div className="mt-1">
-                <code
-                  className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                >
+                <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                   {webhook.notification_path}
                 </code>
               </div>
@@ -93,9 +87,7 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
                   Identifier Selector
                 </div>
                 <div className="mt-1">
-                  <code
-                    className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                  >
+                  <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                     {webhook.identifier_selector}
                   </code>
                 </div>
@@ -120,24 +112,16 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
               <table className="w-full">
                 <thead className="border-b border-tertiary">
                   <tr>
-                    <th
-                      className={`w-12 px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary`}
-                    >
+                    <th className="w-12 px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
                       #
                     </th>
-                    <th
-                      className={`px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary`}
-                    >
+                    <th className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
                       Filter Expression
                     </th>
-                    <th
-                      className={`px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary`}
-                    >
+                    <th className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
                       Handler
                     </th>
-                    <th
-                      className={`px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary`}
-                    >
+                    <th className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
                       Config
                     </th>
                   </tr>
@@ -149,16 +133,12 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
                         {index + 1}
                       </td>
                       <td className="px-4 py-3">
-                        <code
-                          className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                        >
+                        <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                           {rule.filter_expression}
                         </code>
                       </td>
                       <td className="px-4 py-3">
-                        <code
-                          className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                        >
+                        <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                           {rule.handler}
                         </code>
                       </td>
@@ -167,9 +147,7 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
                         (Array.isArray(rule.handler_config)
                           ? rule.handler_config.length > 0
                           : Object.keys(rule.handler_config).length > 0) ? (
-                          <code
-                            className={`rounded bg-secondary px-2 py-1 text-sm text-primary`}
-                          >
+                          <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                             {JSON.stringify(rule.handler_config)}
                           </code>
                         ) : (

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -335,7 +335,7 @@ export function WebhookForm({
                     isEditing ? '(unchanged)' : 'HMAC verification secret'
                   }
                   disabled={isLoading}
-                  className={''}
+                  className=""
                 />
               </div>
             </div>
@@ -350,7 +350,7 @@ export function WebhookForm({
                 rows={3}
                 disabled={isLoading}
                 placeholder="Brief description of this webhook"
-                className={`w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground`}
+                className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground"
               />
             </div>
 
@@ -484,7 +484,7 @@ export function WebhookForm({
                 {rules.map((rule, index) => (
                   <div
                     key={rule._clientId}
-                    className={`bg-secondary/50 rounded-lg border border-input p-4`}
+                    className="bg-secondary/50 rounded-lg border border-input p-4"
                   >
                     <div className="flex items-start gap-3">
                       {/* Order controls */}
@@ -520,9 +520,7 @@ export function WebhookForm({
                       </div>
 
                       {/* Rule number */}
-                      <div
-                        className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-medium text-secondary`}
-                      >
+                      <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-medium text-secondary">
                         {index + 1}
                       </div>
 
@@ -637,7 +635,7 @@ export function WebhookForm({
                         disabled={isLoading}
                         aria-label={`Delete rule ${index + 1}`}
                         title={`Delete rule ${index + 1}`}
-                        className={`rounded p-1.5 text-danger transition-colors hover:bg-danger`}
+                        className="rounded p-1.5 text-danger transition-colors hover:bg-danger"
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>

--- a/src/components/assistant/ConversationHistory.tsx
+++ b/src/components/assistant/ConversationHistory.tsx
@@ -58,7 +58,7 @@ export function ConversationHistory({
     return (
       <button
         onClick={() => setShowHistory(true)}
-        className={`flex items-center gap-1 rounded px-2 py-1 text-xs text-secondary hover:bg-secondary hover:text-primary`}
+        className="flex items-center gap-1 rounded px-2 py-1 text-xs text-secondary hover:bg-secondary hover:text-primary"
       >
         <MessageSquare className="h-3 w-3" />
         History
@@ -67,16 +67,14 @@ export function ConversationHistory({
   }
 
   return (
-    <div
-      className={`absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-lg border border-border bg-card shadow-lg`}
-    >
+    <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-lg border border-border bg-card shadow-lg">
       <div className="p-2">
         <button
           onClick={() => {
             onNewConversation()
             setShowHistory(false)
           }}
-          className={`flex w-full items-center gap-2 rounded px-3 py-2 text-sm text-secondary hover:bg-secondary`}
+          className="flex w-full items-center gap-2 rounded px-3 py-2 text-sm text-secondary hover:bg-secondary"
         >
           <Plus className="h-4 w-4" />
           New Conversation
@@ -108,14 +106,14 @@ export function ConversationHistory({
               <button
                 onClick={(e) => handleArchive(e, conv.id)}
                 aria-label={`Archive ${conv.title ?? 'conversation'}`}
-                className={`rounded p-1 hover:bg-secondary`}
+                className="rounded p-1 hover:bg-secondary"
               >
                 <Archive className="h-3 w-3" />
               </button>
               <button
                 onClick={(e) => handleDelete(e, conv.id)}
                 aria-label={`Delete ${conv.title ?? 'conversation'}`}
-                className={`rounded p-1 text-danger hover:bg-secondary`}
+                className="rounded p-1 text-danger hover:bg-secondary"
               >
                 <Trash2 className="h-3 w-3" />
               </button>
@@ -126,7 +124,7 @@ export function ConversationHistory({
       <div className="border-t border-tertiary p-1">
         <button
           onClick={() => setShowHistory(false)}
-          className={`w-full rounded px-3 py-1 text-xs text-tertiary hover:text-secondary`}
+          className="w-full rounded px-3 py-1 text-xs text-tertiary hover:text-secondary"
         >
           Close
         </button>

--- a/src/components/assistant/MessageBubble.tsx
+++ b/src/components/assistant/MessageBubble.tsx
@@ -9,15 +9,15 @@ interface SessionEntryProps {
 export function SessionEntry({ role, content }: SessionEntryProps) {
   if (role === 'user') {
     return (
-      <div className={`font-mono text-sm text-info`}>
-        <span className={`select-none text-tertiary`}>{'> '}</span>
+      <div className="font-mono text-sm text-info">
+        <span className="select-none text-tertiary">{'> '}</span>
         {content}
       </div>
     )
   }
 
   return (
-    <div className={`border-l-2 border-tertiary pl-4 text-sm text-primary`}>
+    <div className="border-l-2 border-tertiary pl-4 text-sm text-primary">
       <div className="prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
         <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
       </div>

--- a/src/components/assistant/ToolUseIndicator.tsx
+++ b/src/components/assistant/ToolUseIndicator.tsx
@@ -18,9 +18,7 @@ export function ToolUseIndicator({ toolName }: ToolUseIndicatorProps) {
   const friendlyName = TOOL_FRIENDLY_NAMES[toolName] ?? `Running ${toolName}`
 
   return (
-    <div
-      className={`text-warning/70 flex items-center gap-2 py-1 pl-4 font-mono text-xs`}
-    >
+    <div className="text-warning/70 flex items-center gap-2 py-1 pl-4 font-mono text-xs">
       <Loader2 className="h-3 w-3 animate-spin" />
       <span>{friendlyName}...</span>
     </div>

--- a/src/components/dashboard/WidgetSelector.tsx
+++ b/src/components/dashboard/WidgetSelector.tsx
@@ -48,12 +48,10 @@ export function WidgetSelector({
         role="dialog"
         aria-modal="true"
         aria-labelledby="widget-selector-title"
-        className={`max-h-[80vh] w-full max-w-2xl rounded-lg border border-border bg-card shadow-xl`}
+        className="max-h-[80vh] w-full max-w-2xl rounded-lg border border-border bg-card shadow-xl"
       >
         {/* Header */}
-        <div
-          className={`flex items-center justify-between border-b border-tertiary p-6`}
-        >
+        <div className="flex items-center justify-between border-b border-tertiary p-6">
           <div>
             <h2 id="widget-selector-title" className="text-xl text-primary">
               Customize Dashboard
@@ -66,7 +64,7 @@ export function WidgetSelector({
             onClick={onClose}
             aria-label="Close"
             type="button"
-            className={`rounded p-2 text-secondary hover:bg-secondary`}
+            className="rounded p-2 text-secondary hover:bg-secondary"
           >
             <X className="h-5 w-5" />
           </button>
@@ -76,9 +74,7 @@ export function WidgetSelector({
         <div className="max-h-[60vh] overflow-y-auto p-6">
           {Object.entries(groupedWidgets).map(([category, widgets]) => (
             <div key={category} className="mb-6 last:mb-0">
-              <h3
-                className={`mb-3 text-sm uppercase tracking-wider text-tertiary`}
-              >
+              <h3 className="mb-3 text-sm uppercase tracking-wider text-tertiary">
                 {categories[category as keyof typeof categories]}
               </h3>
               <div className="space-y-2">
@@ -143,9 +139,7 @@ export function WidgetSelector({
         </div>
 
         {/* Footer */}
-        <div
-          className={`flex items-center justify-between border-t border-tertiary p-6`}
-        >
+        <div className="flex items-center justify-between border-t border-tertiary p-6">
           <div className="text-sm text-secondary">
             {selectedWidgets.length} widget
             {selectedWidgets.length !== 1 ? 's' : ''} selected

--- a/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
@@ -88,12 +88,10 @@ export function MyPullRequestsWidget({
           return (
             <div
               key={pr.id}
-              className={`rounded-lg border border-input bg-background p-4 transition-colors hover:border-secondary`}
+              className="rounded-lg border border-input bg-background p-4 transition-colors hover:border-secondary"
             >
               <div className="flex items-start gap-3">
-                <GitPullRequest
-                  className={`mt-0.5 h-5 w-5 flex-shrink-0 text-tertiary`}
-                />
+                <GitPullRequest className="mt-0.5 h-5 w-5 flex-shrink-0 text-tertiary" />
                 <div className="min-w-0 flex-1">
                   <div className="mb-1 font-medium text-primary">
                     {pr.title}

--- a/src/components/dashboard/widgets/OutdatedComponentsWidget.tsx
+++ b/src/components/dashboard/widgets/OutdatedComponentsWidget.tsx
@@ -89,13 +89,11 @@ export function OutdatedComponentsWidget({
           return (
             <div
               key={item.projectId}
-              className={`rounded-lg border border-input bg-background p-4 transition-colors hover:border-secondary`}
+              className="rounded-lg border border-input bg-background p-4 transition-colors hover:border-secondary"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="flex min-w-0 flex-1 items-start gap-3">
-                  <Package
-                    className={`mt-0.5 h-5 w-5 flex-shrink-0 text-tertiary`}
-                  />
+                  <Package className="mt-0.5 h-5 w-5 flex-shrink-0 text-tertiary" />
                   <div className="min-w-0 flex-1">
                     <div className="mb-1 flex items-center gap-2">
                       <code className="text-sm font-medium text-primary">
@@ -109,14 +107,12 @@ export function OutdatedComponentsWidget({
                     <button
                       type="button"
                       onClick={() => onProjectSelect?.(item.projectId)}
-                      className={`mb-2 text-sm text-info hover:underline`}
+                      className="mb-2 text-sm text-info hover:underline"
                     >
                       {item.project}
                     </button>
 
-                    <div
-                      className={`flex items-center gap-3 text-xs text-secondary`}
-                    >
+                    <div className="flex items-center gap-3 text-xs text-secondary">
                       <span className="font-mono">
                         {item.currentVersion} → {item.latestVersion}
                       </span>
@@ -134,7 +130,7 @@ export function OutdatedComponentsWidget({
                 <button
                   type="button"
                   onClick={() => onProjectSelect?.(item.projectId)}
-                  className={`flex-shrink-0 rounded p-2 text-secondary transition-colors hover:bg-secondary hover:text-primary`}
+                  className="flex-shrink-0 rounded p-2 text-secondary transition-colors hover:bg-secondary hover:text-primary"
                   aria-label={`View update details for ${item.component}`}
                 >
                   <TrendingUp className="h-4 w-4" />
@@ -149,7 +145,7 @@ export function OutdatedComponentsWidget({
         <button
           type="button"
           onClick={() => onProjectSelect?.('outdated-components')}
-          className={`hover:text-info/80 flex items-center gap-1 text-sm text-info`}
+          className="hover:text-info/80 flex items-center gap-1 text-sm text-info"
         >
           View all outdated components
           <ExternalLink className="h-3 w-3" />

--- a/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
+++ b/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
@@ -97,21 +97,17 @@ export function RecentDeploymentsWidget({
               type="button"
               key={deployment.id}
               onClick={() => onProjectSelect?.(deployment.projectId)}
-              className={`w-full rounded-lg border border-input bg-background p-3 text-left transition-colors hover:border-secondary`}
+              className="w-full rounded-lg border border-input bg-background p-3 text-left transition-colors hover:border-secondary"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="flex min-w-0 flex-1 items-start gap-3">
-                  <Rocket
-                    className={`mt-0.5 h-5 w-5 flex-shrink-0 text-tertiary`}
-                  />
+                  <Rocket className="mt-0.5 h-5 w-5 flex-shrink-0 text-tertiary" />
                   <div className="min-w-0 flex-1">
                     <div className="mb-1 truncate font-medium text-primary">
                       {deployment.project}
                     </div>
                     <div className="mb-1 flex flex-wrap items-center gap-2">
-                      <code
-                        className={`rounded bg-secondary px-2 py-0.5 text-xs text-primary`}
-                      >
+                      <code className="rounded bg-secondary px-2 py-0.5 text-xs text-primary">
                         {deployment.version}
                       </code>
                       <Badge variant={env.variant} className="rounded-full">
@@ -130,9 +126,7 @@ export function RecentDeploymentsWidget({
                     </div>
                   </div>
                 </div>
-                <ChevronRight
-                  className={`h-4 w-4 flex-shrink-0 text-tertiary`}
-                />
+                <ChevronRight className="h-4 w-4 flex-shrink-0 text-tertiary" />
               </div>
             </button>
           )

--- a/src/components/dashboard/widgets/StatWidget.tsx
+++ b/src/components/dashboard/widgets/StatWidget.tsx
@@ -6,7 +6,7 @@ interface StatWidgetProps {
 
 export function StatWidget({ title, value, icon }: StatWidgetProps) {
   return (
-    <div className={`rounded-lg border border-border bg-card p-6`}>
+    <div className="rounded-lg border border-border bg-card p-6">
       <div className="flex items-center justify-between">
         <div>
           <p className="text-sm text-secondary">{title}</p>

--- a/src/components/dashboard/widgets/TeamActivityWidget.tsx
+++ b/src/components/dashboard/widgets/TeamActivityWidget.tsx
@@ -107,7 +107,7 @@ export function TeamActivityWidget({ onViewChange }: TeamActivityWidgetProps) {
                   handleTeamClick(team.name)
                 }
               }}
-              className={`cursor-pointer rounded-lg border border-input bg-background p-4 text-left transition-all hover:border-secondary hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
+              className="cursor-pointer rounded-lg border border-input bg-background p-4 text-left transition-all hover:border-secondary hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <div className="mb-3 flex items-start justify-between">
                 <div className="flex-1">

--- a/src/components/settings/SettingsAccount.tsx
+++ b/src/components/settings/SettingsAccount.tsx
@@ -76,7 +76,7 @@ export function SettingsAccount() {
         <div className="flex justify-end gap-3">
           <Button
             variant="outline"
-            className={''}
+            className=""
             style={{ borderWidth: '0.5px' }}
           >
             Cancel

--- a/src/components/settings/SettingsApiKeys.tsx
+++ b/src/components/settings/SettingsApiKeys.tsx
@@ -135,7 +135,7 @@ export function SettingsApiKeys() {
                     onClick={() =>
                       handleCopyKey(`ik_${apiKey.key_id}`, apiKey.key_id)
                     }
-                    className={''}
+                    className=""
                     style={{ borderWidth: '0.5px' }}
                   >
                     {copiedKeyId === apiKey.key_id ? '✓' : '⎘'}
@@ -221,7 +221,7 @@ export function SettingsApiKeys() {
                   onClick={() =>
                     handleCopyKey(createdKey.key_secret, 'created')
                   }
-                  className={''}
+                  className=""
                   style={{ borderWidth: '0.5px' }}
                 >
                   {copiedKeyId === 'created' ? '✓' : '⎘'}
@@ -260,7 +260,7 @@ export function SettingsApiKeys() {
                     setShowCreateDialog(false)
                     setCreateError(null)
                   }}
-                  className={''}
+                  className=""
                   style={{ borderWidth: '0.5px' }}
                 >
                   Cancel
@@ -296,7 +296,7 @@ export function SettingsApiKeys() {
             <Button
               variant="outline"
               onClick={() => setRevokingKeyId(null)}
-              className={''}
+              className=""
               style={{ borderWidth: '0.5px' }}
             >
               Cancel

--- a/src/components/settings/SettingsIntegrations.tsx
+++ b/src/components/settings/SettingsIntegrations.tsx
@@ -52,9 +52,7 @@ export function SettingsIntegrations() {
         >
           <div className="flex items-start justify-between">
             <div className="flex items-start gap-4">
-              <div
-                className={`flex h-12 w-12 items-center justify-center rounded-lg bg-secondary text-xl`}
-              >
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-secondary text-xl">
                 {integration.icon}
               </div>
               <div>
@@ -88,7 +86,7 @@ export function SettingsIntegrations() {
                   <Button
                     variant="outline"
                     size="sm"
-                    className={''}
+                    className=""
                     style={{ borderWidth: '0.5px' }}
                   >
                     Configure

--- a/src/components/settings/SettingsNotifications.tsx
+++ b/src/components/settings/SettingsNotifications.tsx
@@ -75,7 +75,7 @@ export function SettingsNotifications() {
         <div className="flex justify-end gap-3">
           <Button
             variant="outline"
-            className={''}
+            className=""
             style={{ borderWidth: '0.5px' }}
           >
             Reset to defaults

--- a/src/components/settings/SettingsSecurity.tsx
+++ b/src/components/settings/SettingsSecurity.tsx
@@ -75,7 +75,7 @@ export function SettingsSecurity() {
             </div>
             <Button
               variant="outline"
-              className={''}
+              className=""
               style={{ borderWidth: '0.5px' }}
             >
               View active sessions
@@ -95,7 +95,7 @@ export function SettingsSecurity() {
           </p>
           <Button
             variant="outline"
-            className={''}
+            className=""
             style={{ borderWidth: '0.5px' }}
           >
             View access logs

--- a/src/components/ui/dynamic-fields.tsx
+++ b/src/components/ui/dynamic-fields.tsx
@@ -101,9 +101,7 @@ export function DynamicFormFields({
                 </p>
               )}
               {fieldError && (
-                <div
-                  className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-                >
+                <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                   <AlertCircle className="h-3 w-3" />
                   {fieldError}
                 </div>
@@ -167,9 +165,7 @@ export function DynamicFormFields({
               <p className="mt-1 text-xs text-tertiary">{field.description}</p>
             )}
             {fieldError && (
-              <div
-                className={`mt-1 flex items-center gap-1 text-xs text-danger`}
-              >
+              <div className="mt-1 flex items-center gap-1 text-xs text-danger">
                 <AlertCircle className="h-3 w-3" />
                 {fieldError}
               </div>

--- a/src/components/ui/icon-picker.tsx
+++ b/src/components/ui/icon-picker.tsx
@@ -77,16 +77,14 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
     <div ref={containerRef} className="relative">
       {/* Current value display */}
       {value ? (
-        <div
-          className={`flex items-center gap-3 rounded-lg border border-input bg-background p-2.5`}
-        >
+        <div className="flex items-center gap-3 rounded-lg border border-input bg-background p-2.5">
           <button
             type="button"
             onClick={() => setOpen(!open)}
-            className={`flex flex-1 items-center gap-3 text-left text-sm text-primary`}
+            className="flex flex-1 items-center gap-3 text-left text-sm text-primary"
           >
             {SelectedIcon && <SelectedIcon className="h-5 w-5 flex-shrink-0" />}
-            <code className={`rounded bg-secondary px-1.5 py-0.5 text-xs`}>
+            <code className="rounded bg-secondary px-1.5 py-0.5 text-xs">
               {value}
             </code>
           </button>
@@ -96,7 +94,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
             size="sm"
             onClick={handleClear}
             aria-label="Remove icon"
-            className={`h-7 w-7 p-0 text-tertiary hover:text-danger`}
+            className="h-7 w-7 p-0 text-tertiary hover:text-danger"
           >
             <X className="h-3.5 w-3.5" />
           </Button>
@@ -105,7 +103,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
         <button
           type="button"
           onClick={() => setOpen(!open)}
-          className={`flex w-full items-center gap-2 rounded-lg border border-input bg-background px-3 py-2 text-sm text-tertiary hover:border-secondary`}
+          className="flex w-full items-center gap-2 rounded-lg border border-input bg-background px-3 py-2 text-sm text-tertiary hover:border-secondary"
         >
           <Search className="h-4 w-4" />
           Pick an icon...
@@ -114,9 +112,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
 
       {/* Dropdown */}
       {open && (
-        <div
-          className={`absolute z-50 mt-1 w-full rounded-lg border border-border bg-card shadow-lg`}
-        >
+        <div className="absolute z-50 mt-1 w-full rounded-lg border border-border bg-card shadow-lg">
           <div className="p-2">
             <div className="mb-2 flex flex-wrap gap-1">
               {sets.map((set) => (
@@ -137,9 +133,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
               ))}
             </div>
             <div className="relative">
-              <Search
-                className={`absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary`}
-              />
+              <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary" />
               <Input
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
@@ -151,7 +145,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
           </div>
           <div className="max-h-64 overflow-y-auto px-2 pb-2">
             {filtered.length === 0 ? (
-              <div className={`py-6 text-center text-sm text-tertiary`}>
+              <div className="py-6 text-center text-sm text-tertiary">
                 No icons found
               </div>
             ) : (
@@ -176,7 +170,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
                               : 'hover:bg-secondary'
                           }`}
                         >
-                          <Icon className={`h-5 w-5 text-secondary`} />
+                          <Icon className="h-5 w-5 text-secondary" />
                         </button>
                       </HoverCardTrigger>
                       <HoverCardContent className="w-auto p-4" side="top">
@@ -193,7 +187,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
               </div>
             )}
             {filtered.length === MAX_RESULTS && (
-              <p className={`mt-2 text-center text-xs text-tertiary`}>
+              <p className="mt-2 text-center text-xs text-tertiary">
                 Type to narrow results
               </p>
             )}

--- a/src/components/ui/icon-upload.tsx
+++ b/src/components/ui/icon-upload.tsx
@@ -97,9 +97,7 @@ export function IconUpload({
   return (
     <div className="space-y-3">
       {isImageUrl && value && (
-        <div
-          className={`inline-flex items-center gap-3 rounded-lg border border-input bg-secondary p-3`}
-        >
+        <div className="inline-flex items-center gap-3 rounded-lg border border-input bg-secondary p-3">
           <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-lg bg-white">
             <img
               src={getThumbnailSrc(value)}
@@ -156,9 +154,7 @@ export function IconUpload({
       )}
 
       {error && (
-        <div
-          className={`flex items-start gap-2 rounded-lg border border-danger bg-danger p-3 text-danger`}
-        >
+        <div className="flex items-start gap-2 rounded-lg border border-danger bg-danger p-3 text-danger">
           <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <div className="text-xs">{error}</div>
         </div>


### PR DESCRIPTION
## Summary

Mechanical codemod. Collapses two equivalent-but-noisy forms of `className` values into plain strings:

- `className={'foo'}` → `className="foo"` — 31 instances
- `` className={`foo`} `` (no interpolation) → `className="foo"` — 284 instances

Template literals with actual `${...}` interpolation are **preserved** — they're real uses of the expression form.

**No runtime change.** JSX treats the two forms as identical; this is pure formatting cleanup for consistency with the rest of the codebase (which overwhelmingly uses the string-literal form).

## Stats

54 files changed. The commit shows +315 / −609 because `prettier` auto-collapsed previously-multi-line `className={...}` expressions after the codemod turned them into short string attributes.

## Codemod commands (for reproducibility)

```sh
find src -name '*.tsx' -exec perl -i -pe \
  "s/className=\{'([^'\n]*)'\}/className=\"\$1\"/g" {} \;
find src -name '*.tsx' -exec perl -i -pe \
  's/className=\{\`([^\`\n\$]*)\`\}/className="$1"/g' {} \;
```

## Test plan

- [ ] `npm run lint` / `npx tsc --noEmit` / `npm run build` clean (verified locally)
- [ ] Spot-check a few files to confirm only `className=` formatting changed — no logic diff
- [ ] Visual smoke-test a handful of pages (Dashboard, Projects, a Project detail, one admin section) to confirm no missing classes

## Out of scope

- `useAuth` `authInit` `useQuery` anti-pattern — still deferred. Moving side effects out of the queryFn risks changing the `isLoading` / `isAuthenticated` timing window during token refresh on app start. Needs a dedicated session with an auth test harness (mocked Zustand store, mocked API client, Suspense timing) before it can be safely refactored.
- `src/lib/icon-sets/{tabler,phosphor}.ts` `import * as` blowing up the icons chunk — addressed separately in #173.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>