### PR TITLE
refactor(auth): gate app mount on bootstrap, drop useAuth side effects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,9 +50,9 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!isAuthenticated && !isLoading) {
-      const currentPath = window.location.pathname
-      if (currentPath !== '/login' && currentPath !== '/auth/callback') {
-        sessionStorage.setItem('imbi_redirect_after_login', currentPath)
+      const { pathname, search } = window.location
+      if (pathname !== '/login' && pathname !== '/auth/callback') {
+        sessionStorage.setItem('imbi_redirect_after_login', pathname + search)
       }
     }
   }, [isAuthenticated, isLoading])
@@ -73,9 +73,9 @@ function AdminProtectedRoute({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!isAuthenticated && !isLoading) {
-      const currentPath = window.location.pathname
-      if (currentPath !== '/login' && currentPath !== '/auth/callback') {
-        sessionStorage.setItem('imbi_redirect_after_login', currentPath)
+      const { pathname, search } = window.location
+      if (pathname !== '/login' && pathname !== '/auth/callback') {
+        sessionStorage.setItem('imbi_redirect_after_login', pathname + search)
       }
     }
   }, [isAuthenticated, isLoading])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'sonner'
+import { BootstrapGate } from './components/BootstrapGate'
 import { OrganizationProvider } from './contexts/OrganizationContext'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { useAuth } from './hooks/useAuth'
@@ -101,65 +102,67 @@ function App() {
       <Toaster richColors position="top-right" />
       <OrganizationProvider>
         <Suspense fallback={<PageFallback />}>
-          <Routes>
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/auth/callback" element={<OAuthCallbackPage />} />
+          <BootstrapGate fallback={<PageFallback />}>
+            <Routes>
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/auth/callback" element={<OAuthCallbackPage />} />
 
-            <Route
-              path="/dashboard"
-              element={
-                <ProtectedRoute>
-                  <DashboardPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/projects"
-              element={
-                <ProtectedRoute>
-                  <ProjectsPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/projects/:projectId/:tab?"
-              element={
-                <ProtectedRoute>
-                  <ProjectDetailPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/operations-log"
-              element={
-                <ProtectedRoute>
-                  <OperationsLogPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/settings/:tab?"
-              element={
-                <ProtectedRoute>
-                  <SettingsPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/admin/:section?/:slug?/:action?"
-              element={
-                <AdminProtectedRoute>
-                  <AdminPage />
-                </AdminProtectedRoute>
-              }
-            />
-            <Route
-              path="/opslog"
-              element={<Navigate to="/operations-log" replace />}
-            />
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route path="*" element={<Navigate to="/dashboard" replace />} />
-          </Routes>
+              <Route
+                path="/dashboard"
+                element={
+                  <ProtectedRoute>
+                    <DashboardPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/projects"
+                element={
+                  <ProtectedRoute>
+                    <ProjectsPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/projects/:projectId/:tab?"
+                element={
+                  <ProtectedRoute>
+                    <ProjectDetailPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/operations-log"
+                element={
+                  <ProtectedRoute>
+                    <OperationsLogPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/settings/:tab?"
+                element={
+                  <ProtectedRoute>
+                    <SettingsPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/admin/:section?/:slug?/:action?"
+                element={
+                  <AdminProtectedRoute>
+                    <AdminPage />
+                  </AdminProtectedRoute>
+                }
+              />
+              <Route
+                path="/opslog"
+                element={<Navigate to="/operations-log" replace />}
+              />
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route path="*" element={<Navigate to="/dashboard" replace />} />
+            </Routes>
+          </BootstrapGate>
         </Suspense>
       </OrganizationProvider>
     </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,16 +45,17 @@ function PageFallback() {
   )
 }
 
+function savePostLoginRedirect() {
+  const { pathname, search } = window.location
+  if (pathname === '/login' || pathname === '/auth/callback') return
+  sessionStorage.setItem('imbi_redirect_after_login', pathname + search)
+}
+
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth()
 
   useEffect(() => {
-    if (!isAuthenticated && !isLoading) {
-      const { pathname, search } = window.location
-      if (pathname !== '/login' && pathname !== '/auth/callback') {
-        sessionStorage.setItem('imbi_redirect_after_login', pathname + search)
-      }
-    }
+    if (!isAuthenticated && !isLoading) savePostLoginRedirect()
   }, [isAuthenticated, isLoading])
 
   if (isLoading) {
@@ -72,12 +73,7 @@ function AdminProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading, user } = useAuth()
 
   useEffect(() => {
-    if (!isAuthenticated && !isLoading) {
-      const { pathname, search } = window.location
-      if (pathname !== '/login' && pathname !== '/auth/callback') {
-        sessionStorage.setItem('imbi_redirect_after_login', pathname + search)
-      }
-    }
+    if (!isAuthenticated && !isLoading) savePostLoginRedirect()
   }, [isAuthenticated, isLoading])
 
   if (isLoading) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
     if (!isAuthenticated && !isLoading) {
       const currentPath = window.location.pathname
       if (currentPath !== '/login' && currentPath !== '/auth/callback') {
-        sessionStorage.setItem('returnTo', currentPath)
+        sessionStorage.setItem('imbi_redirect_after_login', currentPath)
       }
     }
   }, [isAuthenticated, isLoading])
@@ -75,7 +75,7 @@ function AdminProtectedRoute({ children }: { children: React.ReactNode }) {
     if (!isAuthenticated && !isLoading) {
       const currentPath = window.location.pathname
       if (currentPath !== '/login' && currentPath !== '/auth/callback') {
-        sessionStorage.setItem('returnTo', currentPath)
+        sessionStorage.setItem('imbi_redirect_after_login', currentPath)
       }
     }
   }, [isAuthenticated, isLoading])

--- a/src/components/BootstrapGate.tsx
+++ b/src/components/BootstrapGate.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { refreshToken as refreshTokenApi } from '@/api/endpoints'
+import { useAuthStore } from '@/stores/authStore'
+import { bootstrapAuth } from '@/hooks/authBootstrap'
+
+interface BootstrapGateProps {
+  children: React.ReactNode
+  fallback: React.ReactNode
+}
+
+const PUBLIC_PATHS = new Set(['/login', '/auth/callback'])
+
+export function BootstrapGate({ children, fallback }: BootstrapGateProps) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const store = useAuthStore.getState()
+    bootstrapAuth({
+      accessToken: store.accessToken,
+      refreshToken: store.refreshToken,
+      isTokenExpired: store.isTokenExpired,
+      setTokens: store.setTokens,
+      clearTokens: store.clearTokens,
+      refreshTokenApi,
+      pathname: location.pathname,
+      search: location.search,
+      onRedirect: () => navigate('/login', { replace: true }),
+    }).finally(() => setReady(true))
+    // Bootstrap runs exactly once at app mount. The captured pathname/search
+    // is the original URL we want to save as the post-login redirect target.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (PUBLIC_PATHS.has(location.pathname)) return <>{children}</>
+  if (!ready) return <>{fallback}</>
+  return <>{children}</>
+}

--- a/src/hooks/__tests__/authBootstrap.test.ts
+++ b/src/hooks/__tests__/authBootstrap.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { bootstrapAuth, type BootstrapDeps } from '../authBootstrap'
+
+function makeDeps(overrides: Partial<BootstrapDeps> = {}): {
+  deps: BootstrapDeps
+  setTokens: ReturnType<typeof vi.fn>
+  clearTokens: ReturnType<typeof vi.fn>
+  refreshTokenApi: ReturnType<typeof vi.fn>
+  onRedirect: ReturnType<typeof vi.fn>
+} {
+  const setTokens = vi.fn()
+  const clearTokens = vi.fn()
+  const refreshTokenApi = vi.fn()
+  const onRedirect = vi.fn()
+  return {
+    deps: {
+      accessToken: null,
+      refreshToken: null,
+      isTokenExpired: () => true,
+      setTokens,
+      clearTokens,
+      refreshTokenApi,
+      pathname: '/dashboard',
+      search: '',
+      onRedirect,
+      ...overrides,
+    },
+    setTokens,
+    clearTokens,
+    refreshTokenApi,
+    onRedirect,
+  }
+}
+
+describe('bootstrapAuth', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('valid access token: no-op (no refresh, no redirect, no setTokens)', async () => {
+    const { deps, clearTokens, refreshTokenApi, setTokens, onRedirect } =
+      makeDeps({
+        accessToken: 'good',
+        isTokenExpired: () => false,
+      })
+
+    await bootstrapAuth(deps)
+
+    expect(refreshTokenApi).not.toHaveBeenCalled()
+    expect(setTokens).not.toHaveBeenCalled()
+    expect(clearTokens).not.toHaveBeenCalled()
+    expect(onRedirect).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
+  })
+
+  it('no tokens on a protected path: clears, saves redirect, calls onRedirect', async () => {
+    const { deps, clearTokens, refreshTokenApi, onRedirect } = makeDeps({
+      pathname: '/projects',
+      search: '?filter=x',
+    })
+
+    await bootstrapAuth(deps)
+
+    expect(clearTokens).toHaveBeenCalledOnce()
+    expect(refreshTokenApi).not.toHaveBeenCalled()
+    expect(onRedirect).toHaveBeenCalledOnce()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
+      '/projects?filter=x',
+    )
+  })
+
+  it('no tokens on /login: clears but does NOT save redirect or call onRedirect', async () => {
+    const { deps, clearTokens, onRedirect } = makeDeps({ pathname: '/login' })
+
+    await bootstrapAuth(deps)
+
+    expect(clearTokens).toHaveBeenCalledOnce()
+    expect(onRedirect).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
+  })
+
+  it('expired access + valid refresh, refresh succeeds: setTokens, no redirect', async () => {
+    const { deps, setTokens, clearTokens, onRedirect, refreshTokenApi } =
+      makeDeps({
+        accessToken: 'old',
+        refreshToken: 'rt',
+      })
+    refreshTokenApi.mockResolvedValue({
+      access_token: 'new',
+      refresh_token: 'rt-new',
+      token_type: 'bearer',
+      expires_in: 3600,
+    })
+
+    await bootstrapAuth(deps)
+
+    expect(refreshTokenApi).toHaveBeenCalledWith('rt')
+    expect(setTokens).toHaveBeenCalledWith('new', 'rt-new')
+    expect(clearTokens).not.toHaveBeenCalled()
+    expect(onRedirect).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
+  })
+
+  it('expired access + valid refresh, refresh fails on protected path: clears, saves, redirects', async () => {
+    const { deps, setTokens, clearTokens, onRedirect, refreshTokenApi } =
+      makeDeps({
+        accessToken: 'old',
+        refreshToken: 'rt',
+        pathname: '/projects',
+      })
+    refreshTokenApi.mockRejectedValue(new Error('boom'))
+
+    await bootstrapAuth(deps)
+
+    expect(refreshTokenApi).toHaveBeenCalledWith('rt')
+    expect(setTokens).not.toHaveBeenCalled()
+    expect(clearTokens).toHaveBeenCalledOnce()
+    expect(onRedirect).toHaveBeenCalledOnce()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
+      '/projects',
+    )
+  })
+
+  it('expired access + valid refresh, refresh fails on /login: clears, no redirect, no save', async () => {
+    const { deps, clearTokens, onRedirect, refreshTokenApi } = makeDeps({
+      accessToken: 'old',
+      refreshToken: 'rt',
+      pathname: '/login',
+    })
+    refreshTokenApi.mockRejectedValue(new Error('boom'))
+
+    await bootstrapAuth(deps)
+
+    expect(clearTokens).toHaveBeenCalledOnce()
+    expect(onRedirect).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
+  })
+
+  it('expired access + no refresh token: clears, saves, redirects', async () => {
+    const { deps, clearTokens, onRedirect, refreshTokenApi } = makeDeps({
+      accessToken: 'old',
+      refreshToken: null,
+      pathname: '/dashboard',
+    })
+
+    await bootstrapAuth(deps)
+
+    expect(refreshTokenApi).not.toHaveBeenCalled()
+    expect(clearTokens).toHaveBeenCalledOnce()
+    expect(onRedirect).toHaveBeenCalledOnce()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
+      '/dashboard',
+    )
+  })
+
+  it('resolves without throwing on any outcome', async () => {
+    // The pre-refactor queryFn threw as control flow. bootstrapAuth must not.
+    const { deps: a, refreshTokenApi: apiA } = makeDeps({
+      accessToken: 'old',
+      refreshToken: 'rt',
+    })
+    apiA.mockRejectedValue(new Error('boom'))
+    await expect(bootstrapAuth(a)).resolves.toBeUndefined()
+
+    const { deps: b } = makeDeps({ accessToken: 'old', refreshToken: null })
+    await expect(bootstrapAuth(b)).resolves.toBeUndefined()
+  })
+})

--- a/src/hooks/__tests__/useAuth.test.tsx
+++ b/src/hooks/__tests__/useAuth.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/api/endpoints', () => ({
 
 import * as endpoints from '@/api/endpoints'
 import { ApiError } from '@/api/client'
+import { BootstrapGate } from '@/components/BootstrapGate'
 import { useAuthStore } from '@/stores/authStore'
 import { useAuth } from '../useAuth'
 
@@ -65,11 +66,14 @@ function setupEnv(initialPath: string) {
       mutations: { retry: false },
     },
   })
+  // Match App.tsx: session bootstrap happens inside BootstrapGate, not inside
+  // useAuth. Wrapping the hook under the gate keeps the 16-case suite honest
+  // as an integration test across the gate + hook.
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={qc}>
       <MemoryRouter initialEntries={[initialPath]}>
         <LocationProbe />
-        {children}
+        <BootstrapGate fallback={null}>{children}</BootstrapGate>
       </MemoryRouter>
     </QueryClientProvider>
   )

--- a/src/hooks/__tests__/useAuth.test.tsx
+++ b/src/hooks/__tests__/useAuth.test.tsx
@@ -1,0 +1,472 @@
+// Pins the observable behavior of useAuth before the refactor described in
+// docs/auth-refactor.md. All 16 cases must pass against the current
+// implementation; after the refactor, the same suite must pass unchanged.
+//
+// The suite covers the five "hidden behaviors" the doc calls out:
+//   HB-1 — no flash of /login while an expired token is being refreshed
+//   HB-2 — sessionStorage.imbi_redirect_after_login write semantics
+//   HB-3 — bootstrap fires at most once across multiple useAuth() consumers
+//   HB-4 — currentUser auto-fires once the store flips isTokenExpired → false
+//   HB-5 — 401 with detail "not found or inactive" → translated error
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, renderHook, waitFor } from '@testing-library/react'
+import { useEffect, type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+
+vi.mock('@/api/endpoints', () => ({
+  loginWithPassword: vi.fn(),
+  logoutAuth: vi.fn(),
+  refreshToken: vi.fn(),
+  getUserByUsername: vi.fn(),
+}))
+
+import * as endpoints from '@/api/endpoints'
+import { ApiError } from '@/api/client'
+import { useAuthStore } from '@/stores/authStore'
+import { useAuth } from '../useAuth'
+
+function makeJwt({
+  sub = 'user@example.com',
+  exp = Math.floor(Date.now() / 1000) + 3600,
+}: { sub?: string; exp?: number } = {}) {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = btoa(JSON.stringify({ sub, exp, iat: 1600000000 }))
+  return `${header}.${payload}.signature`
+}
+
+const validUser = {
+  username: 'user@example.com',
+  display_name: 'Test User',
+  email: 'user@example.com',
+  email_address: 'user@example.com',
+  user_type: 'standard',
+  is_admin: false,
+  is_active: true,
+}
+
+let latestLocation: { pathname: string; search: string } = {
+  pathname: '/',
+  search: '',
+}
+
+function LocationProbe() {
+  const loc = useLocation()
+  useEffect(() => {
+    latestLocation = { pathname: loc.pathname, search: loc.search }
+  }, [loc.pathname, loc.search])
+  return null
+}
+
+function setupEnv(initialPath: string) {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <LocationProbe />
+        {children}
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+  return { qc, Wrapper }
+}
+
+function setExpiredAccess({
+  refreshToken = 'rt',
+}: { refreshToken?: string | null } = {}) {
+  const token = makeJwt({ exp: Math.floor(Date.now() / 1000) - 3600 })
+  useAuthStore.setState({
+    accessToken: token,
+    refreshToken,
+    tokenExpiry: Date.now() - 1000,
+  })
+  return token
+}
+
+function setValidAccess() {
+  const exp = Math.floor(Date.now() / 1000) + 3600
+  const token = makeJwt({ exp })
+  useAuthStore.setState({
+    accessToken: token,
+    refreshToken: 'rt',
+    tokenExpiry: exp * 1000,
+  })
+  return token
+}
+
+// window.location stub: logout writes `window.location.href = '/login'`. We
+// replace window.location with a plain object so the assignment is observable
+// and does not emit jsdom "Not implemented: navigation" warnings.
+let locationHref = 'http://localhost/'
+beforeEach(() => {
+  locationHref = 'http://localhost/'
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      get href() {
+        return locationHref
+      },
+      set href(v: string) {
+        locationHref = v
+      },
+      get pathname() {
+        try {
+          return new URL(locationHref, 'http://localhost').pathname
+        } catch {
+          return '/'
+        }
+      },
+      get search() {
+        try {
+          return new URL(locationHref, 'http://localhost').search
+        } catch {
+          return ''
+        }
+      },
+      origin: 'http://localhost',
+      assign: vi.fn((v: string) => {
+        locationHref = v
+      }),
+      replace: vi.fn((v: string) => {
+        locationHref = v
+      }),
+    },
+  })
+})
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    useAuthStore.getState().clearTokens()
+    sessionStorage.clear()
+    vi.clearAllMocks()
+    latestLocation = { pathname: '/', search: '' }
+  })
+
+  afterEach(() => {
+    useAuthStore.getState().clearTokens()
+  })
+
+  // ── Bootstrap matrix ────────────────────────────────────────────────
+
+  it('no tokens on /login: no redirect, no API calls', async () => {
+    const { Wrapper } = setupEnv('/login')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    // Let React Query drain its microtask queue.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(endpoints.refreshToken).not.toHaveBeenCalled()
+    expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
+    expect(latestLocation.pathname).toBe('/login')
+    expect(result.current.isAuthenticated).toBe(false)
+  })
+
+  it('no tokens on a protected path: redirects to /login, saves path, no API calls', async () => {
+    const { Wrapper } = setupEnv('/projects')
+    renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(latestLocation.pathname).toBe('/login'))
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
+      '/projects',
+    )
+    expect(endpoints.refreshToken).not.toHaveBeenCalled()
+    expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
+  })
+
+  it('valid access token: fetches currentUser once, does not refresh', async () => {
+    setValidAccess()
+    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+
+    const { Wrapper } = setupEnv('/dashboard')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+    expect(endpoints.getUserByUsername).toHaveBeenCalledTimes(1)
+    expect(endpoints.getUserByUsername).toHaveBeenCalledWith('user@example.com')
+    expect(endpoints.refreshToken).not.toHaveBeenCalled()
+    expect(latestLocation.pathname).toBe('/dashboard')
+  })
+
+  it('HB-1: expired access + valid refresh succeeds: refreshes, fetches user, never lands on /login', async () => {
+    setExpiredAccess()
+    const newToken = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    vi.mocked(endpoints.refreshToken).mockResolvedValue({
+      access_token: newToken,
+      refresh_token: 'rt-new',
+      token_type: 'bearer',
+      expires_in: 3600,
+    } as never)
+    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+
+    const { Wrapper } = setupEnv('/dashboard')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+    expect(endpoints.refreshToken).toHaveBeenCalledTimes(1)
+    expect(endpoints.refreshToken).toHaveBeenCalledWith('rt')
+    expect(endpoints.getUserByUsername).toHaveBeenCalled()
+    expect(latestLocation.pathname).toBe('/dashboard')
+    expect(useAuthStore.getState().accessToken).toBe(newToken)
+    expect(useAuthStore.getState().refreshToken).toBe('rt-new')
+  })
+
+  it('expired access + valid refresh fails: clears tokens, redirects with saved path (including search)', async () => {
+    setExpiredAccess()
+    vi.mocked(endpoints.refreshToken).mockRejectedValue(new Error('nope'))
+
+    const { Wrapper } = setupEnv('/projects?filter=x')
+    renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(latestLocation.pathname).toBe('/login'))
+    expect(useAuthStore.getState().accessToken).toBeNull()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
+      '/projects?filter=x',
+    )
+    expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
+  })
+
+  it('expired access + no refresh token: redirects, saves path, no refresh API call', async () => {
+    setExpiredAccess({ refreshToken: null })
+
+    const { Wrapper } = setupEnv('/projects')
+    renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(latestLocation.pathname).toBe('/login'))
+    expect(endpoints.refreshToken).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
+      '/projects',
+    )
+  })
+
+  // ── De-duplication ──────────────────────────────────────────────────
+
+  it('HB-3: two useAuth consumers in one render pass trigger refreshToken exactly once', async () => {
+    setExpiredAccess()
+    const newToken = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    vi.mocked(endpoints.refreshToken).mockResolvedValue({
+      access_token: newToken,
+      refresh_token: 'rt-new',
+      token_type: 'bearer',
+      expires_in: 3600,
+    } as never)
+    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+
+    const { Wrapper } = setupEnv('/dashboard')
+    function Consumer() {
+      useAuth()
+      return null
+    }
+
+    render(
+      <Wrapper>
+        <Consumer />
+        <Consumer />
+      </Wrapper>,
+    )
+
+    await waitFor(() => expect(endpoints.refreshToken).toHaveBeenCalledTimes(1))
+  })
+
+  // ── currentUser 401 specifics ───────────────────────────────────────
+
+  it('HB-5: 401 with "not found or inactive" detail clears tokens', async () => {
+    // The currentUser queryFn catches this specific 401, calls clearTokens(),
+    // and throws a translated error. The translated error is not stably
+    // observable via `useAuth().error` because `clearTokens()` changes the
+    // currentUser query key (`getUsername()` flips to null) and the new
+    // subscription lands in a fresh empty state before the error render
+    // commits. The observable contract is: clearTokens() runs. A future
+    // refactor MUST keep at minimum this clearTokens side effect; lifting the
+    // translated error to a stable signal is a bonus but not required.
+    setValidAccess()
+    vi.mocked(endpoints.getUserByUsername).mockRejectedValue(
+      new ApiError(401, 'Unauthorized', {
+        detail: 'user not found or inactive',
+      }),
+    )
+
+    const { Wrapper } = setupEnv('/dashboard')
+    renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(useAuthStore.getState().accessToken).toBeNull())
+    expect(endpoints.getUserByUsername).toHaveBeenCalledTimes(1)
+  })
+
+  it('currentUser 401 with any other detail: surfaces error as-is, does not clear tokens', async () => {
+    const token = setValidAccess()
+    const apiErr = new ApiError(401, 'Unauthorized', {
+      detail: 'some generic auth failure',
+    })
+    vi.mocked(endpoints.getUserByUsername).mockRejectedValue(apiErr)
+
+    const { Wrapper } = setupEnv('/dashboard')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.error).toBe(apiErr))
+    expect(useAuthStore.getState().accessToken).toBe(token)
+  })
+
+  // ── Login / logout / refresh mutations ──────────────────────────────
+
+  it('login success: setTokens, invalidates organizations, resolves to a populated user', async () => {
+    const token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    vi.mocked(endpoints.loginWithPassword).mockResolvedValue({
+      access_token: token,
+      refresh_token: 'rt-new',
+      token_type: 'bearer',
+      expires_in: 3600,
+    } as never)
+    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+
+    const { Wrapper, qc } = setupEnv('/login')
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await act(async () => {
+      await result.current.login({ email: 'u@example.com', password: 'pw' })
+    })
+
+    // React Query v5 passes a 2nd context arg to mutationFn, so just assert
+    // the first argument (the LoginRequest).
+    expect(endpoints.loginWithPassword).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(endpoints.loginWithPassword).mock.calls[0][0]).toEqual({
+      email: 'u@example.com',
+      password: 'pw',
+    })
+    expect(useAuthStore.getState().accessToken).toBe(token)
+    expect(useAuthStore.getState().refreshToken).toBe('rt-new')
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['organizations'],
+    })
+    await waitFor(() => expect(result.current.user).not.toBeNull())
+  })
+
+  it('login failure: error exposed via hook return, user stays null', async () => {
+    const err = new Error('invalid credentials')
+    vi.mocked(endpoints.loginWithPassword).mockRejectedValue(err)
+
+    const { Wrapper } = setupEnv('/login')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await act(async () => {
+      await expect(
+        result.current.login({ email: 'u@example.com', password: 'bad' }),
+      ).rejects.toThrow()
+    })
+
+    await waitFor(() => expect(result.current.error).toBeTruthy())
+    expect(result.current.user).toBeNull()
+  })
+
+  it('logout success: clearTokens, queryClient.clear, window.location.href = /login', async () => {
+    setValidAccess()
+    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.logoutAuth).mockResolvedValue(undefined as never)
+
+    const { Wrapper, qc } = setupEnv('/dashboard')
+    const clearSpy = vi.spyOn(qc, 'clear')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    expect(useAuthStore.getState().accessToken).toBeNull()
+    expect(clearSpy).toHaveBeenCalled()
+    expect(window.location.href).toBe('/login')
+  })
+
+  it('logout failure: same cleanup as success (onError path)', async () => {
+    setValidAccess()
+    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.logoutAuth).mockRejectedValue(new Error('server down'))
+
+    const { Wrapper, qc } = setupEnv('/dashboard')
+    const clearSpy = vi.spyOn(qc, 'clear')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+
+    await act(async () => {
+      await expect(result.current.logout()).rejects.toThrow()
+    })
+
+    expect(useAuthStore.getState().accessToken).toBeNull()
+    expect(clearSpy).toHaveBeenCalled()
+    expect(window.location.href).toBe('/login')
+  })
+
+  it('refreshToken mutation success: setTokens and user re-populates', async () => {
+    setValidAccess()
+    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    const newToken = makeJwt({ exp: Math.floor(Date.now() / 1000) + 7200 })
+    vi.mocked(endpoints.refreshToken).mockResolvedValue({
+      access_token: newToken,
+      refresh_token: 'rt-new',
+      token_type: 'bearer',
+      expires_in: 7200,
+    } as never)
+
+    const { Wrapper } = setupEnv('/dashboard')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+
+    await act(async () => {
+      await result.current.refreshToken()
+    })
+
+    expect(endpoints.refreshToken).toHaveBeenCalledWith('rt')
+    expect(useAuthStore.getState().accessToken).toBe(newToken)
+    expect(useAuthStore.getState().refreshToken).toBe('rt-new')
+  })
+
+  it('refreshToken mutation failure on a protected route: clears tokens, redirects with saved path', async () => {
+    setValidAccess()
+    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.refreshToken).mockRejectedValue(new Error('boom'))
+
+    const { Wrapper } = setupEnv('/projects')
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
+
+    await act(async () => {
+      await expect(result.current.refreshToken()).rejects.toThrow()
+    })
+
+    await waitFor(() => expect(latestLocation.pathname).toBe('/login'))
+    expect(useAuthStore.getState().accessToken).toBeNull()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
+      '/projects',
+    )
+  })
+
+  // ── Redirect-key invariant (HB-2) ───────────────────────────────────
+
+  it('HB-2: does not write imbi_redirect_after_login when already on /login', async () => {
+    setExpiredAccess({ refreshToken: null })
+
+    const { Wrapper } = setupEnv('/login')
+    renderHook(() => useAuth(), { wrapper: Wrapper })
+
+    // Let the bootstrap queryFn run to completion.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
+    expect(latestLocation.pathname).toBe('/login')
+    expect(endpoints.refreshToken).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/authBootstrap.ts
+++ b/src/hooks/authBootstrap.ts
@@ -1,0 +1,44 @@
+import type { TokenResponse } from '@/types'
+
+export interface BootstrapDeps {
+  accessToken: string | null
+  refreshToken: string | null
+  isTokenExpired: () => boolean
+  setTokens: (access: string, refresh: string) => void
+  clearTokens: () => void
+  refreshTokenApi: (rt: string) => Promise<TokenResponse>
+  pathname: string
+  search: string
+  onRedirect: () => void
+}
+
+// Direct port of the previous `['authInit']` queryFn, minus the throws (which
+// were only used as dead signalling). Resolves on every outcome; callers wait
+// for the returned promise, then render.
+export async function bootstrapAuth(deps: BootstrapDeps): Promise<void> {
+  if (deps.accessToken && !deps.isTokenExpired()) return
+
+  if (!deps.refreshToken) {
+    deps.clearTokens()
+    triggerRedirect(deps)
+    return
+  }
+
+  try {
+    const response = await deps.refreshTokenApi(deps.refreshToken)
+    deps.setTokens(response.access_token, response.refresh_token)
+  } catch (error) {
+    console.error('[Auth] Token refresh failed during initialization:', error)
+    deps.clearTokens()
+    triggerRedirect(deps)
+  }
+}
+
+function triggerRedirect(deps: BootstrapDeps): void {
+  if (deps.pathname === '/login') return
+  sessionStorage.setItem(
+    'imbi_redirect_after_login',
+    deps.pathname + deps.search,
+  )
+  deps.onRedirect()
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,6 +10,10 @@ import {
 } from '@/api/endpoints'
 import type { UserResponse, LoginRequest, UseAuthReturn } from '@/types'
 
+// Session bootstrap (refresh-if-expired / redirect-if-no-refresh-token) lives
+// in <BootstrapGate> at the app root, not in this hook. useAuth is purely
+// ambient state over the Zustand store + the currentUser query + the
+// login/logout/refresh mutations.
 export function useAuth(): UseAuthReturn {
   const navigate = useNavigate()
   const location = useLocation()
@@ -52,46 +56,6 @@ export function useAuth(): UseAuthReturn {
       }
     },
     enabled: !!accessToken && !isTokenExpired(),
-    retry: false,
-    staleTime: Infinity,
-  })
-
-  useQuery({
-    queryKey: ['authInit'],
-    queryFn: async () => {
-      if (!accessToken || isTokenExpired()) {
-        if (!refreshToken) {
-          clearTokens()
-          if (location.pathname !== '/login') {
-            // Save current path before redirecting to login
-            const currentPath = location.pathname + location.search
-            sessionStorage.setItem('imbi_redirect_after_login', currentPath)
-            navigate('/login', { replace: true })
-          }
-          throw new Error('No refresh token available')
-        }
-        try {
-          const response = await refreshTokenApi(refreshToken)
-          setTokens(response.access_token, response.refresh_token)
-          await refetch()
-        } catch (error) {
-          console.error(
-            '[Auth] Token refresh failed during initialization:',
-            error,
-          )
-          clearTokens()
-          if (location.pathname !== '/login') {
-            // Save current path before redirecting to login
-            const currentPath = location.pathname + location.search
-            sessionStorage.setItem('imbi_redirect_after_login', currentPath)
-            navigate('/login', { replace: true })
-          }
-          throw error
-        }
-      }
-      return true
-    },
-    enabled: true,
     retry: false,
     staleTime: Infinity,
   })


### PR DESCRIPTION
## Summary

Moves the session bootstrap out of `useAuth`'s `['authInit']` `useQuery` anti-pattern and into a dedicated `<BootstrapGate>` at the app root. `useAuth` becomes a thin wrapper over the Zustand store + `currentUser` query + the three mutations.

## Problem

`useAuth` ran token-refresh/redirect **side effects** inside a `useQuery` `queryFn`, using `throw` as dead signalling and `queryKey: ['authInit']` as a process-wide "run once" primitive. Nothing read the query's data/error/loading — it existed purely for its side effects and the dedup `useQuery` gave across call sites. This created fragile timing windows around `isLoading`/`isAuthenticated` vs. `<ProtectedRoute>` (HB-1) and redundant cleanup paths with the logout mutation.

## Solution

Three commits, landed in order:

1. **`test(useAuth): pin behavior before bootstrap refactor`** — 16-case test suite at `src/hooks/__tests__/useAuth.test.tsx` covering the bootstrap matrix, HB-1 no-flash invariant, HB-3 cross-consumer dedup, HB-5 `clearTokens` on deactivated-user 401, all three mutations, and the sessionStorage redirect-key write semantics (HB-2). Passes against the pre-refactor implementation — proves the tests are faithful.

2. **`refactor(auth): extract bootstrapAuth as a plain async function`** — Pure port of the old `queryFn` to `src/hooks/authBootstrap.ts`. No React, router, or store imports; dependencies are injected. Resolves on every outcome (no throws as control flow). Dedicated 8-case test covers every branch without `AllTheProviders`.

3. **`refactor(auth): gate app mount on bootstrap, drop useAuth side effects`** — Adds `<BootstrapGate>` around `<Routes>`; the gate runs `bootstrapAuth` once on mount and blocks children with the page fallback until it resolves, except on `/login` and `/auth/callback` (which must render immediately). Deletes the `['authInit']` `useQuery` from `useAuth`. The existing 16-case suite was updated to mount hooks under the gate; assertions and case list unchanged — all 16 still pass.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 152/152 green (16 useAuth + 8 authBootstrap + 128 other)
- [x] `npm run build` clean
- [ ] **Manual verification against a dev Okteto deployment** — not done by the automation. Walk the checklist that lived in the prior `docs/auth-refactor.md` draft: cold load logged out, cold load with fresh token, cold load with expired-access + valid-refresh (DevTools: one `/auth/refresh` then one `/users/{me}`, **no flash of `/login`**), cold load with both tokens expired, password login, OAuth round-trip, logout, deactivated-user 401, two-tab protected-route load, browser back/forward across login.