### PR TITLE
Perf: lazy-load icon sets via dynamic imports

### DIFF
--- a/src/components/EditLinksCard.tsx
+++ b/src/components/EditLinksCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { getIcon } from '@/lib/icons'
+import { getIcon, useIconRegistryVersion } from '@/lib/icons'
 import { EditableKeyValueMap } from '@/components/ui/EditableKeyValueMap'
 import { useEditableKeyValueMap } from '@/hooks/useEditableKeyValueMap'
 import type { LinkDefinition } from '@/types'
@@ -24,6 +24,8 @@ export function EditLinksCard({
   links,
   onPatch,
 }: EditLinksCardProps) {
+  useIconRegistryVersion()
+
   const serverMap = useMemo(() => links ?? {}, [links])
 
   const state = useEditableKeyValueMap<string>({

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -6,7 +6,7 @@ import {
   ArrowRight,
   Rocket,
 } from 'lucide-react'
-import { getIcon } from '@/lib/icons'
+import { getIcon, useIconRegistryVersion } from '@/lib/icons'
 import { resolveColor, resolveIcon } from '@/lib/ui-maps'
 import type { XUiMaps } from '@/lib/ui-maps'
 import { Button } from '@/components/ui/button'
@@ -324,6 +324,10 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
     enabled: !!orgSlug,
   })
 
+  // Bumps when an icon-set chunk finishes loading; include in useMemo deps
+  // where icons are resolved so they refresh once available.
+  const iconRegistryVersion = useIconRegistryVersion()
+
   const linkDefMap = useMemo(
     () => Object.fromEntries(linkDefs.map((ld) => [ld.slug, ld])),
     [linkDefs],
@@ -344,7 +348,8 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
           }
         })
         .filter((link): link is NonNullable<typeof link> => link !== null),
-    [project.links, linkDefMap],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [project.links, linkDefMap, iconRegistryVersion],
   )
 
   const teamOptions = useMemo(

--- a/src/components/ProjectsGraphCanvas.tsx
+++ b/src/components/ProjectsGraphCanvas.tsx
@@ -26,7 +26,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { getIconUrl } from '@/lib/icons'
+import { getIconUrl, useIconRegistryVersion } from '@/lib/icons'
 import {
   EDGE_COLOR_DEPENDS_ON,
   EDGE_COLOR_DEPENDED_UPON,
@@ -111,6 +111,9 @@ export function ProjectsGraphCanvas({
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [currentZoom, setCurrentZoom] = useState(100)
   const [isRendering, setIsRendering] = useState(true)
+  // Re-compute nodes when an icon set finishes its dynamic import so graph
+  // icons appear once the chunk arrives.
+  const iconRegistryVersion = useIconRegistryVersion()
 
   // Stable key that forces GraphCanvas to remount when layout or node set changes.
   const graphKey = useMemo(() => {
@@ -209,7 +212,8 @@ export function ProjectsGraphCanvas({
           data: p,
         }
       }),
-    [projects, centerId, nodeEdgeColor],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [projects, centerId, nodeEdgeColor, iconRegistryVersion],
   )
 
   const {

--- a/src/components/admin/project-types/ProjectTypeDetail.tsx
+++ b/src/components/admin/project-types/ProjectTypeDetail.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
 import { getProjectTypeSchema } from '@/api/endpoints'
 import { PROJECT_TYPE_BASE_FIELDS_SET } from '@/lib/constants'
-import { getIcon } from '@/lib/icons'
+import { useIcon } from '@/lib/icons'
 import { extractDynamicFields } from '@/lib/utils'
 import type { ProjectType } from '@/types'
 
@@ -25,6 +25,8 @@ export function ProjectTypeDetail({
     queryFn: getProjectTypeSchema,
     staleTime: 5 * 60 * 1000,
   })
+
+  const HeaderIcon = useIcon(projectType.icon ?? null, null)
 
   return (
     <div className="space-y-6">
@@ -48,12 +50,9 @@ export function ProjectTypeDetail({
                     alt=""
                     className="h-8 w-8 rounded object-cover"
                   />
-                ) : (
-                  (() => {
-                    const Icon = getIcon(projectType.icon, null)
-                    return Icon ? <Icon className="h-8 w-8" /> : null
-                  })()
-                ))}
+                ) : HeaderIcon ? (
+                  <HeaderIcon className="h-8 w-8" />
+                ) : null)}
               <CardTitle>{projectType.name}</CardTitle>
             </div>
             {projectType.description && (

--- a/src/components/ui/entity-icon.tsx
+++ b/src/components/ui/entity-icon.tsx
@@ -1,4 +1,4 @@
-import { getIcon } from '@/lib/icons'
+import { useIcon } from '@/lib/icons'
 
 interface EntityIconProps {
   icon: string
@@ -9,8 +9,11 @@ interface EntityIconProps {
  * Renders an icon from any supported source (Simple Icons, Lucide, AWS,
  * uploaded files, or absolute URLs). Use this instead of a raw <img> tag
  * when the icon value may be an identifier like "si-github" rather than a URL.
+ *
+ * Uses `useIcon` so the component re-renders when the owning icon set
+ * finishes its dynamic import.
  */
 export function EntityIcon({ icon, className }: EntityIconProps) {
-  const Icon = getIcon(icon)
+  const Icon = useIcon(icon)
   return <Icon className={className} />
 }

--- a/src/components/ui/icon-picker.tsx
+++ b/src/components/ui/icon-picker.tsx
@@ -7,7 +7,7 @@ import {
   HoverCardTrigger,
   HoverCardContent,
 } from '@/components/ui/hover-card'
-import { getIcon, iconRegistry } from '@/lib/icons'
+import { getIcon, iconRegistry, useIconRegistryVersion } from '@/lib/icons'
 import type { IconComponent } from '@/lib/icons'
 
 const MAX_RESULTS = 60
@@ -23,9 +23,26 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
   const [iconSet, setIconSet] = useState('lucide')
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const sets = iconRegistry.getSets()
-  const currentSet = sets.find((s) => s.id === iconSet)
-  const icons = useMemo(() => currentSet?.icons ?? [], [currentSet])
+  const version = useIconRegistryVersion()
+  // Metas are known up-front from loader registration; the set's actual
+  // icons arrive async once the chunk for `iconSet` has loaded.
+  const setMetas = useMemo(
+    () => iconRegistry.getSetMetas(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [version],
+  )
+  const currentSet = iconRegistry.getLoadedSet(iconSet)
+  const icons = useMemo(
+    () => currentSet?.icons ?? [],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentSet, version],
+  )
+
+  useEffect(() => {
+    if (open && !iconRegistry.isLoaded(iconSet)) {
+      void iconRegistry.loadSet(iconSet)
+    }
+  }, [open, iconSet])
 
   const filtered = useMemo(() => {
     if (!query.trim()) return icons.slice(0, MAX_RESULTS)
@@ -115,7 +132,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
         <div className="absolute z-50 mt-1 w-full rounded-lg border border-border bg-card shadow-lg">
           <div className="p-2">
             <div className="mb-2 flex flex-wrap gap-1">
-              {sets.map((set) => (
+              {setMetas.map((set) => (
                 <button
                   key={set.id}
                   type="button"
@@ -144,7 +161,11 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
             </div>
           </div>
           <div className="max-h-64 overflow-y-auto px-2 pb-2">
-            {filtered.length === 0 ? (
+            {!currentSet ? (
+              <div className="py-6 text-center text-sm text-tertiary">
+                Loading icons…
+              </div>
+            ) : filtered.length === 0 ? (
               <div className="py-6 text-center text-sm text-tertiary">
                 No icons found
               </div>

--- a/src/lib/__tests__/icon-sets.test.ts
+++ b/src/lib/__tests__/icon-sets.test.ts
@@ -1,11 +1,20 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll } from 'vitest'
 import { iconRegistry } from '@/lib/icon-registry'
-import '@/lib/icon-sets/lucide'
-import '@/lib/icon-sets/simple-icons'
-import '@/lib/icon-sets/phosphor'
-import '@/lib/icon-sets/tabler'
-import '@/lib/icon-sets/devicon'
-import '@/lib/icon-sets/aws'
+import { iconSet as lucideSet } from '@/lib/icon-sets/lucide'
+import { iconSet as simpleIconsSet } from '@/lib/icon-sets/simple-icons'
+import { iconSet as phosphorSet } from '@/lib/icon-sets/phosphor'
+import { iconSet as tablerSet } from '@/lib/icon-sets/tabler'
+import { iconSet as deviconSet } from '@/lib/icon-sets/devicon'
+import { iconSet as awsSet } from '@/lib/icon-sets/aws'
+
+beforeAll(() => {
+  iconRegistry.register(lucideSet)
+  iconRegistry.register(simpleIconsSet)
+  iconRegistry.register(phosphorSet)
+  iconRegistry.register(tablerSet)
+  iconRegistry.register(deviconSet)
+  iconRegistry.register(awsSet)
+})
 
 describe('Lucide icon set', () => {
   it('registers under id "lucide" with label "Lucide"', () => {

--- a/src/lib/icon-registry.ts
+++ b/src/lib/icon-registry.ts
@@ -20,6 +20,20 @@ export interface IconSetDefinition {
   resolveUrl: (value: string, color?: string) => string | null
 }
 
+export interface IconSetMeta {
+  id: string
+  label: string
+  description: string
+  valueFormat: string
+}
+
+export interface IconSetLoader {
+  meta: IconSetMeta
+  // Does this loader own `value`? Evaluated in insertion order; first match wins.
+  matches: (value: string) => boolean
+  load: () => Promise<IconSetDefinition>
+}
+
 export interface AgentIconManifest {
   sets: {
     id: string
@@ -31,13 +45,51 @@ export interface AgentIconManifest {
   }[]
 }
 
+type Listener = () => void
+
 export class IconRegistry {
+  private loaders: Map<string, IconSetLoader> = new Map()
   private sets: Map<string, IconSetDefinition> = new Map()
+  private loadPromises: Map<string, Promise<IconSetDefinition>> = new Map()
+  private cachedMetas: IconSetMeta[] | null = null
   private cachedSets: IconSetDefinition[] | null = null
+  private listeners: Set<Listener> = new Set()
+  private version = 0
+
+  registerLoader(loader: IconSetLoader): void {
+    this.loaders.set(loader.meta.id, loader)
+    this.cachedMetas = null
+    this.emit()
+  }
 
   register(set: IconSetDefinition): void {
     this.sets.set(set.id, set)
     this.cachedSets = null
+    this.cachedMetas = null
+    this.emit()
+  }
+
+  getSetMetas(): IconSetMeta[] {
+    if (!this.cachedMetas) {
+      const metas: IconSetMeta[] = []
+      const seen = new Set<string>()
+      for (const loader of this.loaders.values()) {
+        metas.push(loader.meta)
+        seen.add(loader.meta.id)
+      }
+      // Include directly-registered sets without a loader (e.g. test fixtures).
+      for (const set of this.sets.values()) {
+        if (seen.has(set.id)) continue
+        metas.push({
+          id: set.id,
+          label: set.label,
+          description: set.description,
+          valueFormat: set.valueFormat,
+        })
+      }
+      this.cachedMetas = metas.sort((a, b) => a.label.localeCompare(b.label))
+    }
+    return this.cachedMetas
   }
 
   getSets(): IconSetDefinition[] {
@@ -47,6 +99,43 @@ export class IconRegistry {
       )
     }
     return this.cachedSets
+  }
+
+  getLoadedSet(id: string): IconSetDefinition | null {
+    return this.sets.get(id) ?? null
+  }
+
+  isLoaded(id: string): boolean {
+    return this.sets.has(id)
+  }
+
+  loadSet(id: string): Promise<IconSetDefinition | null> {
+    const existing = this.sets.get(id)
+    if (existing) return Promise.resolve(existing)
+    const pending = this.loadPromises.get(id)
+    if (pending) return pending
+    const loader = this.loaders.get(id)
+    if (!loader) return Promise.resolve(null)
+    const promise = loader
+      .load()
+      .then((set) => {
+        this.register(set)
+        this.loadPromises.delete(id)
+        return set
+      })
+      .catch((err) => {
+        this.loadPromises.delete(id)
+        throw err
+      })
+    this.loadPromises.set(id, promise)
+    return promise
+  }
+
+  loadSetFor(value: string): Promise<IconSetDefinition | null> {
+    for (const loader of this.loaders.values()) {
+      if (loader.matches(value)) return this.loadSet(loader.meta.id)
+    }
+    return Promise.resolve(null)
   }
 
   resolve(value: string): IconComponent | null {
@@ -97,6 +186,22 @@ export class IconRegistry {
         count: set.icons.length,
       })),
     }
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  getVersion(): number {
+    return this.version
+  }
+
+  private emit(): void {
+    this.version++
+    for (const l of this.listeners) l()
   }
 }
 

--- a/src/lib/icon-sets/aws.ts
+++ b/src/lib/icon-sets/aws.ts
@@ -1,5 +1,8 @@
-import { iconRegistry } from '@/lib/icon-registry'
-import type { IconComponent, IconEntry } from '@/lib/icon-registry'
+import type {
+  IconComponent,
+  IconEntry,
+  IconSetDefinition,
+} from '@/lib/icon-registry'
 import { createImgComponent } from '@/lib/icon-sets/utils'
 
 const awsArchGlob = import.meta.glob<string>(
@@ -64,7 +67,7 @@ function resolveUrl(value: string): string | null {
   return resolveAwsUrl(value)
 }
 
-iconRegistry.register({
+export const iconSet: IconSetDefinition = {
   id: 'aws',
   label: 'AWS',
   description: 'Amazon Web Services architecture and resource icons',
@@ -72,4 +75,4 @@ iconRegistry.register({
   icons: AWS_ICONS,
   resolve,
   resolveUrl,
-})
+}

--- a/src/lib/icon-sets/devicon.ts
+++ b/src/lib/icon-sets/devicon.ts
@@ -1,6 +1,9 @@
 import { createElement } from 'react'
-import { iconRegistry } from '@/lib/icon-registry'
-import type { IconComponent, IconEntry } from '@/lib/icon-registry'
+import type {
+  IconComponent,
+  IconEntry,
+  IconSetDefinition,
+} from '@/lib/icon-registry'
 
 const deviconGlob = import.meta.glob<string>(
   '/node_modules/devicon/icons/**/*.svg',
@@ -69,7 +72,7 @@ function resolveUrl(value: string): string | null {
   return deviconIndex[value] ?? null
 }
 
-iconRegistry.register({
+export const iconSet: IconSetDefinition = {
   id: 'devicon',
   label: 'Devicon',
   description:
@@ -78,4 +81,4 @@ iconRegistry.register({
   icons: DEVICON_ICONS,
   resolve,
   resolveUrl,
-})
+}

--- a/src/lib/icon-sets/lucide.ts
+++ b/src/lib/icon-sets/lucide.ts
@@ -1,8 +1,11 @@
 import { icons as lucideIcons } from 'lucide-react'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { iconRegistry } from '@/lib/icon-registry'
-import type { IconComponent, IconEntry } from '@/lib/icon-registry'
+import type {
+  IconComponent,
+  IconEntry,
+  IconSetDefinition,
+} from '@/lib/icon-registry'
 import { toPascalCase, encodeSvgToDataUrl } from '@/lib/icon-sets/utils'
 
 export const LUCIDE_ICONS: IconEntry[] = Object.keys(lucideIcons)
@@ -36,7 +39,7 @@ function resolveUrl(value: string, color?: string): string | null {
   }
 }
 
-iconRegistry.register({
+export const iconSet: IconSetDefinition = {
   id: 'lucide',
   label: 'Lucide',
   description: 'General purpose outline icons for UI elements',
@@ -44,4 +47,4 @@ iconRegistry.register({
   icons: LUCIDE_ICONS,
   resolve,
   resolveUrl,
-})
+}

--- a/src/lib/icon-sets/phosphor.ts
+++ b/src/lib/icon-sets/phosphor.ts
@@ -1,8 +1,11 @@
 import * as PhosphorIcons from '@phosphor-icons/react'
 import { type ComponentType, createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { iconRegistry } from '@/lib/icon-registry'
-import type { IconComponent, IconEntry } from '@/lib/icon-registry'
+import type {
+  IconComponent,
+  IconEntry,
+  IconSetDefinition,
+} from '@/lib/icon-registry'
 import {
   toPascalCase,
   encodeSvgToDataUrl,
@@ -55,7 +58,7 @@ function resolveUrl(value: string, color?: string): string | null {
   }
 }
 
-iconRegistry.register({
+export const iconSet: IconSetDefinition = {
   id: 'phosphor',
   label: 'Phosphor',
   description:
@@ -64,4 +67,4 @@ iconRegistry.register({
   icons: PHOSPHOR_ICONS,
   resolve,
   resolveUrl,
-})
+}

--- a/src/lib/icon-sets/simple-icons.ts
+++ b/src/lib/icon-sets/simple-icons.ts
@@ -1,8 +1,11 @@
 import * as simpleIcons from '@icons-pack/react-simple-icons'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { iconRegistry } from '@/lib/icon-registry'
-import type { IconComponent, IconEntry } from '@/lib/icon-registry'
+import type {
+  IconComponent,
+  IconEntry,
+  IconSetDefinition,
+} from '@/lib/icon-registry'
 import { toPascalCase, encodeSvgToDataUrl } from '@/lib/icon-sets/utils'
 
 const siLookup = simpleIcons as Record<string, unknown>
@@ -40,7 +43,7 @@ function resolveUrl(value: string, color?: string): string | null {
   }
 }
 
-iconRegistry.register({
+export const iconSet: IconSetDefinition = {
   id: 'simple-icons',
   label: 'Simple Icons',
   description: 'Brand icons for popular services, frameworks, and tools',
@@ -48,4 +51,4 @@ iconRegistry.register({
   icons: SI_ICONS,
   resolve,
   resolveUrl,
-})
+}

--- a/src/lib/icon-sets/tabler.ts
+++ b/src/lib/icon-sets/tabler.ts
@@ -1,8 +1,11 @@
 import * as TablerIcons from '@tabler/icons-react'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { iconRegistry } from '@/lib/icon-registry'
-import type { IconComponent, IconEntry } from '@/lib/icon-registry'
+import type {
+  IconComponent,
+  IconEntry,
+  IconSetDefinition,
+} from '@/lib/icon-registry'
 import {
   toPascalCase,
   encodeSvgToDataUrl,
@@ -45,7 +48,7 @@ function resolveUrl(value: string, color?: string): string | null {
   }
 }
 
-iconRegistry.register({
+export const iconSet: IconSetDefinition = {
   id: 'tabler',
   label: 'Tabler',
   description: 'Clean open source SVG icons (outline and filled variants)',
@@ -53,4 +56,4 @@ iconRegistry.register({
   icons: TABLER_ICONS,
   resolve,
   resolveUrl,
-})
+}

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,34 +1,124 @@
+import { useSyncExternalStore } from 'react'
 import { ExternalLink } from 'lucide-react'
 import { iconRegistry } from '@/lib/icon-registry'
 import type { IconComponent } from '@/lib/icon-registry'
 import { createImgComponent } from '@/lib/icon-sets/utils'
 
-// Side-effect imports — each file self-registers with iconRegistry
-import '@/lib/icon-sets/lucide'
-import '@/lib/icon-sets/simple-icons'
-import '@/lib/icon-sets/aws'
-import '@/lib/icon-sets/devicon'
-import '@/lib/icon-sets/phosphor'
-import '@/lib/icon-sets/tabler'
+// ---------------------------------------------------------------------------
+// Loader registration
+//
+// Each loader's `load()` uses a dynamic import so Vite emits a separate chunk
+// per icon set. The heavy per-library deps (lucide-react, @phosphor-icons,
+// @tabler/icons-react, @icons-pack/react-simple-icons, devicon SVGs, aws SVGs)
+// are only downloaded when a consumer first asks for an icon from that set,
+// or when the IconPicker opens that set's tab.
+// ---------------------------------------------------------------------------
 
-// Re-exports for consumers
+iconRegistry.registerLoader({
+  meta: {
+    id: 'lucide',
+    label: 'Lucide',
+    description: 'General purpose outline icons for UI elements',
+    valueFormat: 'lucide-{name}',
+  },
+  matches: (v) => v.startsWith('lucide-'),
+  load: () => import('@/lib/icon-sets/lucide').then((m) => m.iconSet),
+})
+
+iconRegistry.registerLoader({
+  meta: {
+    id: 'simple-icons',
+    label: 'Simple Icons',
+    description: 'Brand icons for popular services, frameworks, and tools',
+    valueFormat: 'si-{name}',
+  },
+  matches: (v) => v.startsWith('si-'),
+  load: () => import('@/lib/icon-sets/simple-icons').then((m) => m.iconSet),
+})
+
+iconRegistry.registerLoader({
+  meta: {
+    id: 'phosphor',
+    label: 'Phosphor',
+    description:
+      'Flexible icon family for interfaces and diagrams (regular weight)',
+    valueFormat: 'phosphor-{name}',
+  },
+  matches: (v) => v.startsWith('phosphor-'),
+  load: () => import('@/lib/icon-sets/phosphor').then((m) => m.iconSet),
+})
+
+iconRegistry.registerLoader({
+  meta: {
+    id: 'tabler',
+    label: 'Tabler',
+    description: 'Clean open source SVG icons (outline and filled variants)',
+    valueFormat: 'tabler-{name}',
+  },
+  matches: (v) => v.startsWith('tabler-'),
+  load: () => import('@/lib/icon-sets/tabler').then((m) => m.iconSet),
+})
+
+iconRegistry.registerLoader({
+  meta: {
+    id: 'devicon',
+    label: 'Devicon',
+    description:
+      'Technology and programming language icons, multiple style variants',
+    valueFormat: 'devicon-{tech}-{variant}',
+  },
+  matches: (v) => v.startsWith('devicon-'),
+  load: () => import('@/lib/icon-sets/devicon').then((m) => m.iconSet),
+})
+
+// AWS values have no prefix, so this matcher is the fallback for any value
+// that doesn't belong to a prefixed set. Registered last so prefixed loaders
+// claim matching values first.
+iconRegistry.registerLoader({
+  meta: {
+    id: 'aws',
+    label: 'AWS',
+    description: 'Amazon Web Services architecture and resource icons',
+    valueFormat: '{service-name}',
+  },
+  matches: (v) =>
+    !v.startsWith('lucide-') &&
+    !v.startsWith('si-') &&
+    !v.startsWith('phosphor-') &&
+    !v.startsWith('tabler-') &&
+    !v.startsWith('devicon-'),
+  load: () => import('@/lib/icon-sets/aws').then((m) => m.iconSet),
+})
+
+// Re-exports
 export { iconRegistry } from '@/lib/icon-registry'
 export type { IconComponent } from '@/lib/icon-registry'
-export { AWS_ICONS } from '@/lib/icon-sets/aws'
 
 const MAX_ICON_CACHE_SIZE = 500
 const iconUrlCache = new Map<string, string | null>()
 
+const KNOWN_PREFIXES = [
+  'lucide-',
+  'si-',
+  'phosphor-',
+  'tabler-',
+  'devicon-',
+] as const
+
+function hasKnownPrefix(value: string): boolean {
+  for (const p of KNOWN_PREFIXES) if (value.startsWith(p)) return true
+  return false
+}
+
 // ---------------------------------------------------------------------------
-// Public API
+// Synchronous resolution
+//
+// `getIcon` / `getIconUrl` stay synchronous so existing call sites keep
+// working. If the owning set isn't loaded yet, they kick off a dynamic import
+// (fire-and-forget) and return a fallback / null for now. Components that
+// need to re-render when the set arrives should use the hooks below.
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve an icon name to a React component.
- *
- * Dispatches through the registry. Falls back to attempting a bare Lucide
- * name (no prefix) for backwards compatibility with legacy stored values.
- */
 export function getIcon(
   iconName: string | null | undefined,
   fallback: null,
@@ -54,20 +144,27 @@ export function getIcon(
     return createImgComponent(iconName)
   }
 
-  // Try registry (handles lucide-, si-, aws, devicon-, phosphor-, tabler-)
   const resolved = iconRegistry.resolve(iconName)
   if (resolved) return resolved
 
-  // Backward compat: bare Lucide name stored without prefix (e.g. "external-link")
-  const withPrefix = iconRegistry.resolve(`lucide-${iconName}`)
-  if (withPrefix) return withPrefix
+  // Legacy bare Lucide names (e.g. "external-link") — only works after
+  // the lucide set has loaded.
+  if (iconRegistry.isLoaded('lucide')) {
+    const withPrefix = iconRegistry.resolve(`lucide-${iconName}`)
+    if (withPrefix) return withPrefix
+  }
 
+  // Not loaded yet: trigger a load for the owning set. For unprefixed names
+  // also load lucide so the legacy bare-name fallback can resolve (AWS names
+  // are unprefixed too, so loadSetFor covers that side). Callers using
+  // useIcon() will re-render once the set lands.
+  void iconRegistry.loadSetFor(iconName)
+  if (!hasKnownPrefix(iconName) && !iconRegistry.isLoaded('lucide')) {
+    void iconRegistry.loadSet('lucide')
+  }
   return fb
 }
 
-/**
- * Resolve an icon name to a URL for use in reagraph GraphNode.icon.
- */
 export function getIconUrl(
   iconName: string | null | undefined,
   color?: string,
@@ -77,6 +174,12 @@ export function getIconUrl(
   const cached = iconUrlCache.get(cacheKey)
   if (cached !== undefined) return cached
   const result = computeIconUrl(iconName, color)
+  if (result === null) {
+    // Don't cache nulls while sets may still be loading; let the next call
+    // retry after the set arrives.
+    void iconRegistry.loadSetFor(iconName)
+    return null
+  }
   if (iconUrlCache.size >= MAX_ICON_CACHE_SIZE) {
     iconUrlCache.delete(iconUrlCache.keys().next().value!)
   }
@@ -93,4 +196,51 @@ function computeIconUrl(iconName: string, color?: string): string | null {
     return iconName
   }
   return iconRegistry.resolveUrl(iconName, color)
+}
+
+// ---------------------------------------------------------------------------
+// React hooks
+// ---------------------------------------------------------------------------
+
+function subscribe(listener: () => void): () => void {
+  return iconRegistry.subscribe(listener)
+}
+
+function getVersion(): number {
+  return iconRegistry.getVersion()
+}
+
+/**
+ * Subscribes to registry changes so the calling component re-renders when a
+ * new icon set finishes loading. Include the returned value in useMemo deps
+ * if you derive icons inside a memoized computation.
+ */
+export function useIconRegistryVersion(): number {
+  return useSyncExternalStore(subscribe, getVersion, getVersion)
+}
+
+export function useIcon(
+  iconName: string | null | undefined,
+  fallback: null,
+): IconComponent | null
+export function useIcon(
+  iconName: string | null | undefined,
+  fallback?: IconComponent,
+): IconComponent
+export function useIcon(
+  iconName: string | null | undefined,
+  fallback?: IconComponent | null,
+): IconComponent | null {
+  useIconRegistryVersion()
+  if (fallback === null) return getIcon(iconName, null)
+  if (fallback === undefined) return getIcon(iconName)
+  return getIcon(iconName, fallback)
+}
+
+export function useIconUrl(
+  iconName: string | null | undefined,
+  color?: string,
+): string | null {
+  useIconRegistryVersion()
+  return getIconUrl(iconName, color)
 }


### PR DESCRIPTION
## Summary

Icon sets (lucide, simple-icons, phosphor, tabler, devicon, aws) were
self-registering at startup, forcing every library into the initial bundle
regardless of use. Each is now behind a loader whose \`load()\` is a dynamic
import, so Vite emits a separate chunk per set and a chunk is only downloaded
when a consumer actually needs an icon it owns.

## Bundle impact

From \`vite build\` — these chunks leave the main bundle:

| Set | Raw | Gzipped |
|---|---|---|
| simple-icons | 5.7 MB | 2.1 MB |
| phosphor | 5.0 MB | 1.1 MB |
| tabler | 3.7 MB | 0.5 MB |
| devicon | 2.9 MB | 0.9 MB |
| aws | 1.4 MB | 0.3 MB |
| lucide (set) | 1.5 kB | 0.9 kB |

The registry + loader metadata (\`icons-*.js\`, 7 kB) stays in the eager path.
Dashboard and other icon-free routes now pull zero set modules.

## Design

**\`IconRegistry\`** gains:
- \`registerLoader(loader)\` — each loader has \`meta\`, \`matches(value)\`, and \`load(): Promise<IconSetDefinition>\`.
- \`loadSet(id)\` / \`loadSetFor(value)\` — idempotent; dedupes in-flight loads via a promise cache.
- \`subscribe(listener)\` / \`getVersion()\` — pub/sub for \`useSyncExternalStore\`.

**\`icons.ts\`** wires up the six loaders via dynamic imports:

\`\`\`ts
iconRegistry.registerLoader({
  meta: { id: 'lucide', ... },
  matches: (v) => v.startsWith('lucide-'),
  load: () => import('@/lib/icon-sets/lucide').then((m) => m.iconSet),
})
\`\`\`

AWS has no prefix and is registered last as the fallback matcher.

**Consumer API is a drop-in:**
- \`getIcon(name, fallback?)\` / \`getIconUrl(name, color?)\` stay synchronous. On a miss they fire-and-forget the owning set's load and return the fallback (or null) for now. The lucide fallback kickoff only fires for unprefixed names so prefixed icons don't drag lucide in alongside their own set.
- \`useIcon\` / \`useIconUrl\` / \`useIconRegistryVersion\` subscribe via \`useSyncExternalStore\` so components re-render once the set lands.

**Icon-set modules** no longer self-register — each exports \`iconSet: IconSetDefinition\` and is wired up by the single \`registerLoader\` call in \`icons.ts\`.

**Consumers updated:**
- \`EntityIcon\` → \`useIcon\`.
- \`IconPicker\` uses \`getSetMetas()\` for tabs and lazy-loads the selected tab's chunk on open; shows "Loading icons…" until the set lands.
- \`ProjectsGraphCanvas\`, \`ProjectDetail\`, \`EditLinksCard\` depend on \`useIconRegistryVersion()\` so icon-derived memos refresh when the chunk arrives.
- \`ProjectTypeDetail\` uses \`useIcon(name, null)\`.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [x] \`vitest\` — 152/152 pass (icon-sets test updated to register sets directly in \`beforeAll\`)
- [x] \`vite build\` — confirms each set is its own chunk
- [x] Manual: Dashboard route loads with zero icon-set modules fetched (verified in Chrome DevTools network panel)
- [x] Manual: \`/admin/project-types\` triggers on-demand loads for whichever sets the project-type data references; icons render correctly with no console errors and no fallback flashes