### PR TITLE
Refactor: mechanical code review follow-ups

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useEffect } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'sonner'
 import { BootstrapGate } from './components/BootstrapGate'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { OrganizationProvider } from './contexts/OrganizationContext'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { useAuth } from './hooks/useAuth'
@@ -97,69 +98,77 @@ function App() {
     <ThemeProvider>
       <Toaster richColors position="top-right" />
       <OrganizationProvider>
-        <Suspense fallback={<PageFallback />}>
-          <BootstrapGate fallback={<PageFallback />}>
-            <Routes>
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/auth/callback" element={<OAuthCallbackPage />} />
+        <ErrorBoundary>
+          <Suspense fallback={<PageFallback />}>
+            <BootstrapGate fallback={<PageFallback />}>
+              <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/auth/callback" element={<OAuthCallbackPage />} />
 
-              <Route
-                path="/dashboard"
-                element={
-                  <ProtectedRoute>
-                    <DashboardPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/projects"
-                element={
-                  <ProtectedRoute>
-                    <ProjectsPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/projects/:projectId/:tab?"
-                element={
-                  <ProtectedRoute>
-                    <ProjectDetailPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/operations-log"
-                element={
-                  <ProtectedRoute>
-                    <OperationsLogPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/settings/:tab?"
-                element={
-                  <ProtectedRoute>
-                    <SettingsPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/:section?/:slug?/:action?"
-                element={
-                  <AdminProtectedRoute>
-                    <AdminPage />
-                  </AdminProtectedRoute>
-                }
-              />
-              <Route
-                path="/opslog"
-                element={<Navigate to="/operations-log" replace />}
-              />
-              <Route path="/" element={<Navigate to="/dashboard" replace />} />
-              <Route path="*" element={<Navigate to="/dashboard" replace />} />
-            </Routes>
-          </BootstrapGate>
-        </Suspense>
+                <Route
+                  path="/dashboard"
+                  element={
+                    <ProtectedRoute>
+                      <DashboardPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/projects"
+                  element={
+                    <ProtectedRoute>
+                      <ProjectsPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/projects/:projectId/:tab?"
+                  element={
+                    <ProtectedRoute>
+                      <ProjectDetailPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/operations-log"
+                  element={
+                    <ProtectedRoute>
+                      <OperationsLogPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/settings/:tab?"
+                  element={
+                    <ProtectedRoute>
+                      <SettingsPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/:section?/:slug?/:action?"
+                  element={
+                    <AdminProtectedRoute>
+                      <AdminPage />
+                    </AdminProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/opslog"
+                  element={<Navigate to="/operations-log" replace />}
+                />
+                <Route
+                  path="/"
+                  element={<Navigate to="/dashboard" replace />}
+                />
+                <Route
+                  path="*"
+                  element={<Navigate to="/dashboard" replace />}
+                />
+              </Routes>
+            </BootstrapGate>
+          </Suspense>
+        </ErrorBoundary>
       </OrganizationProvider>
     </ThemeProvider>
   )

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -30,6 +30,7 @@ import { LinkDefinitionManagement } from './admin/LinkDefinitionManagement'
 import { WebhookManagement } from './admin/WebhookManagement'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useNavigate, useParams } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
 
 type AdminSection =
   | 'teams'
@@ -180,14 +181,15 @@ export function Admin() {
     const Icon = sectionDef.icon
     const isActive = currentSection === sectionDef.id
     return (
-      <button
+      <Button
         key={sectionDef.id}
+        variant="ghost"
         onClick={() => navigate(`/admin/${sectionDef.id}`)}
-        className={`flex w-full items-start gap-3 rounded-lg text-left transition-colors ${
+        className={`h-auto w-full items-start justify-start rounded-lg text-left transition-colors ${
           isCollapsed ? 'justify-center px-3 py-3' : 'px-4 py-3'
         } ${
           isActive
-            ? 'bg-amber-bg text-amber-text'
+            ? 'bg-amber-bg text-amber-text hover:bg-amber-bg hover:text-amber-text'
             : 'text-secondary hover:bg-secondary hover:text-primary'
         }`}
         title={isCollapsed ? sectionDef.label : undefined}
@@ -205,7 +207,7 @@ export function Admin() {
             )}
           </>
         )}
-      </button>
+      </Button>
     )
   }
 
@@ -223,9 +225,11 @@ export function Admin() {
             className={`absolute z-10 ${isCollapsed ? 'left-1/2 -translate-x-1/2' : 'right-2'}`}
             style={{ top: '22px' }}
           >
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={() => setIsCollapsed(!isCollapsed)}
-              className="rounded-lg p-2 text-secondary transition-colors hover:bg-secondary hover:text-primary"
+              className="h-auto w-auto rounded-lg p-2 text-secondary transition-colors hover:bg-secondary hover:text-primary"
               title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             >
               {isCollapsed ? (
@@ -233,7 +237,7 @@ export function Admin() {
               ) : (
                 <ChevronLeft className="h-5 w-5" />
               )}
-            </button>
+            </Button>
           </div>
 
           <nav

--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -22,6 +22,7 @@ import { getQueryKeysForResource } from '@/lib/queryKeys'
 import { SessionEntry } from './assistant/MessageBubble'
 import { ToolUseIndicator } from './assistant/ToolUseIndicator'
 import { ConversationHistory } from './assistant/ConversationHistory'
+import { Button } from '@/components/ui/button'
 
 function buildUserContext(
   user: {
@@ -342,38 +343,43 @@ export function CommandBar() {
             )}
           </div>
           <div className="flex items-center gap-1">
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={() => {
                 setInput('help')
                 inputRef.current?.focus()
               }}
               aria-label="Help"
               type="button"
-              className="rounded p-1 text-tertiary hover:bg-secondary hover:text-secondary"
+              className="h-auto w-auto rounded p-1 text-tertiary hover:bg-secondary hover:text-secondary"
             >
               <HelpCircle className="h-3.5 w-3.5" />
-            </button>
+            </Button>
             <ConversationHistory
               currentConversationId={currentConversationId}
               onSelectConversation={handleSelectConversation}
               onNewConversation={handleNewConversation}
             />
             {messages.length > 0 && (
-              <button
+              <Button
+                variant="ghost"
                 onClick={handleClearHistory}
-                className="rounded px-2 py-0.5 font-mono text-xs text-tertiary hover:bg-secondary hover:text-secondary"
+                className="h-auto rounded px-2 py-0.5 font-mono text-xs text-tertiary hover:bg-secondary hover:text-secondary"
               >
                 clear
-              </button>
+              </Button>
             )}
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={() => setExpanded(false)}
               aria-label="Close assistant"
               type="button"
-              className="rounded p-1 text-tertiary hover:bg-secondary hover:text-secondary"
+              className="h-auto w-auto rounded p-1 text-tertiary hover:bg-secondary hover:text-secondary"
             >
               <X className="h-3.5 w-3.5" />
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -418,11 +424,12 @@ export function CommandBar() {
       <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-card">
         {/* Tray Toggle */}
         <div className="flex justify-center">
-          <button
+          <Button
+            variant="ghost"
             onClick={() => setExpanded(!isExpanded)}
             aria-label={isExpanded ? 'Collapse assistant' : 'Expand assistant'}
             type="button"
-            className={`-mt-3 rounded-t-md border border-b-0 border-tertiary bg-card px-4 py-0.5 font-mono text-xs text-tertiary transition-all hover:text-secondary ${isExpanded ? 'shadow-lg' : ''}`}
+            className={`-mt-3 h-auto rounded-t-md border border-b-0 border-tertiary bg-card px-4 py-0.5 font-mono text-xs text-tertiary transition-all hover:text-secondary ${isExpanded ? 'shadow-lg' : ''}`}
           >
             {isExpanded ? (
               <ChevronDown className="h-3 w-3" />
@@ -434,7 +441,7 @@ export function CommandBar() {
                 )}
               </div>
             )}
-          </button>
+          </Button>
         </div>
 
         {/* Input */}
@@ -455,12 +462,14 @@ export function CommandBar() {
               className="flex-1 bg-transparent text-sm text-primary outline-none placeholder:text-muted-foreground disabled:opacity-50"
             />
             {input.trim() && !isStreaming && (
-              <button
+              <Button
+                variant="ghost"
+                size="icon"
                 type="submit"
-                className="rounded p-1 text-tertiary transition-colors hover:text-secondary"
+                className="h-auto w-auto rounded p-1 text-tertiary transition-colors hover:text-secondary"
               >
                 <Send className="h-3.5 w-3.5" />
-              </button>
+              </Button>
             )}
           </div>
           <div className="flex items-center justify-between px-1 pt-1">

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -46,7 +46,9 @@ export class ErrorBoundary extends Component<
               <AlertCircle className="h-6 w-6 flex-shrink-0 text-danger" />
               <h1 className="text-lg font-semibold">Something went wrong</h1>
             </div>
-            <p className="mt-3 text-sm text-secondary">{error.message}</p>
+            <p className="mt-3 text-sm text-secondary">
+              An unexpected error occurred. Please try again.
+            </p>
             <div className="mt-6 flex flex-wrap gap-2">
               <Button onClick={this.reset}>Try again</Button>
               <Button

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback?: (error: Error, reset: () => void) => ReactNode
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[ErrorBoundary] Render error:', error, info)
+  }
+
+  reset = (): void => {
+    this.setState({ error: null })
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    if (error) {
+      if (this.props.fallback) {
+        return this.props.fallback(error, this.reset)
+      }
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-secondary p-4">
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="w-full max-w-md rounded-lg border bg-primary p-6 text-primary shadow-sm"
+          >
+            <div className="flex items-center gap-3">
+              <AlertCircle className="h-6 w-6 flex-shrink-0 text-danger" />
+              <h1 className="text-lg font-semibold">Something went wrong</h1>
+            </div>
+            <p className="mt-3 text-sm text-secondary">{error.message}</p>
+            <div className="mt-6 flex flex-wrap gap-2">
+              <Button onClick={this.reset}>Try again</Button>
+              <Button
+                variant="outline"
+                onClick={() => window.location.reload()}
+              >
+                Reload
+              </Button>
+            </div>
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -104,9 +104,10 @@ export function Navigation({
       <div className="flex h-16 items-center justify-between px-6">
         {/* Logo and Brand */}
         <div className="flex items-center gap-8">
-          <button
+          <Button
+            variant="ghost"
             onClick={() => navigate('/dashboard')}
-            className="flex items-center gap-2 rounded-lg px-2 py-1.5 transition-all hover:bg-secondary"
+            className="h-auto rounded-lg px-2 py-1.5 transition-all hover:bg-secondary"
           >
             <img
               src={isDarkMode ? logoDark : logoLight}
@@ -116,7 +117,7 @@ export function Navigation({
             <span className="text-primary" style={{ fontWeight: 800 }}>
               Imbi
             </span>
-          </button>
+          </Button>
 
           {/* Navigation Items */}
           <div className="hidden items-center gap-1 md:flex">
@@ -124,18 +125,19 @@ export function Navigation({
               const Icon = item.icon
               const isActive = activeView === item.id
               return (
-                <button
+                <Button
                   key={item.id}
+                  variant="ghost"
                   onClick={() => navigate(item.path)}
-                  className={`flex items-center gap-2 rounded-lg px-4 py-2 transition-colors ${
+                  className={`h-auto rounded-lg px-4 py-2 transition-colors ${
                     isActive
-                      ? 'bg-amber-bg text-amber-text'
+                      ? 'bg-amber-bg text-amber-text hover:bg-amber-bg hover:text-amber-text'
                       : 'text-secondary hover:bg-secondary hover:text-primary'
                   }`}
                 >
                   <Icon className="h-4 w-4" />
                   <span>{item.label}</span>
-                </button>
+                </Button>
               )
             })}
           </div>

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -172,7 +172,12 @@ export function NewProjectDialog({
         if (e.key === 'Escape') handleClose()
       }}
     >
-      <div className="fixed inset-0 bg-black/50" onClick={handleClose} />
+      <button
+        type="button"
+        aria-label="Close dialog"
+        className="fixed inset-0 bg-black/50"
+        onClick={handleClose}
+      />
       <div className="relative mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col rounded-lg bg-white shadow-xl">
         {/* Header */}
         <div className="border-b p-6">

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import { Activity, LoaderCircle, SearchX, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { LoadingState } from '@/components/ui/loading-state'
 import { cn } from '@/lib/utils'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useInfiniteOperationsLog } from '@/hooks/useInfiniteOperationsLog'
@@ -591,18 +592,20 @@ export function OperationsLog({
                   Filters
                 </span>
                 {activeChips.map((c) => (
-                  <button
+                  <Button
                     key={c.key}
                     type="button"
+                    variant="ghost"
                     onClick={c.clear}
-                    className="inline-flex h-6 items-center gap-1 rounded bg-secondary px-2 text-[12px] text-secondary hover:text-primary"
+                    className="h-6 rounded bg-secondary px-2 text-[12px] text-secondary hover:text-primary"
                   >
                     <span className="truncate">{c.label}</span>
                     <X className="h-3 w-3" />
-                  </button>
+                  </Button>
                 ))}
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() =>
                     setFilters({
                       range: filters.range,
@@ -612,10 +615,10 @@ export function OperationsLog({
                       project_slugs: [],
                     })
                   }
-                  className="ml-1 rounded px-2 py-0.5 text-[12px] text-tertiary hover:bg-secondary hover:text-primary"
+                  className="ml-1 h-auto rounded px-2 py-0.5 text-[12px] text-tertiary hover:bg-secondary hover:text-primary"
                 >
                   Clear all
-                </button>
+                </Button>
               </div>
             )}
 
@@ -648,11 +651,7 @@ export function OperationsLog({
               </div>
             )}
 
-            {isLoading && (
-              <div className="rounded-md border border-tertiary bg-primary px-4 py-16 text-center text-secondary">
-                Loading operations log…
-              </div>
-            )}
+            {isLoading && <LoadingState label="Loading operations log…" />}
 
             {!isLoading &&
               !isError &&

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1066,15 +1066,16 @@ function RelationshipsSidebar({
         <div className="flex items-center justify-between">
           <div className="flex flex-wrap gap-1.5">
             {(['all', 'uses', 'used-by'] as const).map((f) => (
-              <button
+              <Button
                 key={f}
                 type="button"
+                variant="ghost"
                 aria-pressed={filter === f}
                 onClick={() => onFilterChange(f)}
-                className={`${chipBase} ${filter === f ? chipSelected : chipUnselected}`}
+                className={`h-auto ${chipBase} ${filter === f ? chipSelected : chipUnselected}`}
               >
                 {f === 'all' ? 'All' : f === 'uses' ? 'Uses' : 'Used by'}
-              </button>
+              </Button>
             ))}
           </div>
           <Button variant="ghost" size="sm" onClick={onAdd}>

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -2,6 +2,14 @@ import { Search, Plus, Grid3x3, List, Network } from 'lucide-react'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { Card } from './ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './ui/table'
 import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -230,67 +238,67 @@ export function ProjectsView() {
       ) : (
         <Card className="overflow-hidden">
           <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="border-b border-tertiary bg-secondary">
-                <tr>
-                  <th
+            <Table>
+              <TableHeader className="border-b border-tertiary bg-secondary">
+                <TableRow>
+                  <TableHead
                     className={
                       'px-6 py-3 text-left text-sm font-medium text-secondary'
                     }
                   >
                     Project
-                  </th>
-                  <th
+                  </TableHead>
+                  <TableHead
                     className={
                       'px-6 py-3 text-left text-sm font-medium text-secondary'
                     }
                   >
                     Type
-                  </th>
-                  <th
+                  </TableHead>
+                  <TableHead
                     className={
                       'px-6 py-3 text-left text-sm font-medium text-secondary'
                     }
                   >
                     Team
-                  </th>
-                  <th
+                  </TableHead>
+                  <TableHead
                     className={
                       'px-6 py-3 text-left text-sm font-medium text-secondary'
                     }
                   >
                     Environments
-                  </th>
-                  <th
+                  </TableHead>
+                  <TableHead
                     className={
                       'px-6 py-3 text-left text-sm font-medium text-secondary'
                     }
                   >
                     Health
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-tertiary">
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody className="divide-y divide-tertiary">
                 {filteredProjects.map((project) => {
                   const health = getMockHealth(project.slug)
                   return (
-                    <tr
+                    <TableRow
                       key={`table-${project.id}`}
                       className="cursor-pointer transition-colors hover:bg-secondary"
                       onClick={() => handleProjectSelect(project.id)}
                     >
-                      <td className="px-6 py-4 font-medium text-primary">
+                      <TableCell className="px-6 py-4 font-medium text-primary">
                         {project.name}
-                      </td>
-                      <td className="px-6 py-4 text-secondary">
+                      </TableCell>
+                      <TableCell className="px-6 py-4 text-secondary">
                         {(project.project_types || [])
                           .map((pt) => pt.name)
                           .join(', ')}
-                      </td>
-                      <td className="px-6 py-4 text-secondary">
+                      </TableCell>
+                      <TableCell className="px-6 py-4 text-secondary">
                         {project.team.name}
-                      </td>
-                      <td className="px-6 py-4">
+                      </TableCell>
+                      <TableCell className="px-6 py-4">
                         {project.environments &&
                           project.environments.length > 0 && (
                             <div className="flex flex-wrap items-center gap-2">
@@ -306,8 +314,8 @@ export function ProjectsView() {
                               )}
                             </div>
                           )}
-                      </td>
-                      <td className="px-6 py-4">
+                      </TableCell>
+                      <TableCell className="px-6 py-4">
                         <div
                           className={`inline-flex h-10 w-10 items-center justify-center rounded-full ${getHealthColor(health)}`}
                         >
@@ -315,12 +323,12 @@ export function ProjectsView() {
                             {health}
                           </span>
                         </div>
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   )
                 })}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
         </Card>
       )}

--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -1,5 +1,6 @@
 import md5 from 'md5'
 import { Card } from './ui/card'
+import { Button } from './ui/button'
 import type { ActivityFeedEntry } from '@/types'
 
 interface RecentActivityProps {
@@ -103,24 +104,26 @@ export function RecentActivity({
 
             <div className="min-w-0 flex-1">
               <p className="text-sm leading-relaxed text-secondary">
-                <button
+                <Button
+                  variant="link"
                   onClick={() => onUserSelect?.(activity.display_name)}
-                  className="font-medium text-primary transition-colors hover:text-info"
+                  className="h-auto p-0 font-medium text-primary transition-colors hover:text-info"
                 >
                   {activity.display_name}
-                </button>{' '}
+                </Button>{' '}
                 {activity.type === 'OperationsLogEntry'
                   ? activity.change_type.toLowerCase()
                   : activity.what === 'updated facts'
                     ? 'updated facts for the'
                     : activity.what}{' '}
                 {activity.project_name && (
-                  <button
+                  <Button
+                    variant="link"
                     onClick={() => onProjectSelect?.(activity.project_name!)}
-                    className="hover:text-info/80 font-medium text-info transition-colors"
+                    className="hover:text-info/80 h-auto p-0 font-medium text-info transition-colors"
                   >
                     {activity.project_name}
-                  </button>
+                  </Button>
                 )}
                 {activity.type === 'OperationsLogEntry' &&
                   activity.environment && (
@@ -159,13 +162,14 @@ export function RecentActivity({
       {/* Load More Button */}
       {onLoadMore && (
         <div className="pt-4 text-center">
-          <button
+          <Button
+            variant="link"
             onClick={onLoadMore}
             disabled={isLoadingMore}
-            className="hover:text-info/80 text-sm text-info transition-colors disabled:opacity-50"
+            className="hover:text-info/80 h-auto p-0 text-sm text-info transition-colors disabled:opacity-50"
           >
             {isLoadingMore ? 'Loading more...' : 'Load more activity'}
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { CardTitle } from '@/components/ui/card'
+import { LoadingState } from '@/components/ui/loading-state'
 import { getBlueprint } from '@/api/endpoints'
 import { getTypeSwatch } from '../BlueprintManagement'
 import { LabelChip } from '@/components/ui/label-chip'
@@ -121,11 +122,7 @@ export function BlueprintDetail({
   })
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <div className="text-sm text-secondary">Loading blueprint...</div>
-      </div>
-    )
+    return <LoadingState label="Loading blueprint..." />
   }
 
   if (error || !blueprint) {

--- a/src/components/admin/roles/RoleDetail.tsx
+++ b/src/components/admin/roles/RoleDetail.tsx
@@ -18,7 +18,16 @@ import {
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Gravatar } from '@/components/ui/gravatar'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import {
   getRole,
   getAdminSettings,
@@ -49,6 +58,10 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
   const [activeTab, setActiveTab] = useState<DetailTab>('permissions')
   const [showAddPermission, setShowAddPermission] = useState(false)
   const [selectedPermission, setSelectedPermission] = useState('')
+  const [confirm, setConfirm] = useState<{
+    action: 'revoke'
+    permName: string
+  } | null>(null)
 
   // Fetch role with permissions
   const {
@@ -138,9 +151,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
   }
 
   const handleRevokePermission = (permName: string) => {
-    if (confirm(`Remove permission "${permName}" from this role?`)) {
-      revokeMutation.mutate(permName)
-    }
+    setConfirm({ action: 'revoke', permName })
   }
 
   // Group permissions by resource type
@@ -353,37 +364,40 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
           ) : (
             <Card className="overflow-hidden">
               <CardContent className="p-0">
-                <table className="w-full">
-                  <thead className="border-b border-tertiary bg-secondary">
-                    <tr>
-                      <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+                <Table>
+                  <TableHeader className="border-b border-tertiary bg-secondary">
+                    <TableRow>
+                      <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                         Permission
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+                      </TableHead>
+                      <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                         Description
-                      </th>
+                      </TableHead>
                       {!role.is_system && (
-                        <th className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
+                        <TableHead className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
                           Actions
-                        </th>
+                        </TableHead>
                       )}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-tertiary">
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody className="divide-y divide-tertiary">
                     {(role.permissions || [])
                       .sort((a, b) => a.name.localeCompare(b.name))
                       .map((perm) => (
-                        <tr key={perm.name} className="hover:bg-secondary">
-                          <td className="px-6 py-4 text-primary">
+                        <TableRow
+                          key={perm.name}
+                          className="hover:bg-secondary"
+                        >
+                          <TableCell className="px-6 py-4 text-primary">
                             <code className="rounded bg-secondary px-2 py-1 text-sm text-info">
                               {perm.name}
                             </code>
-                          </td>
-                          <td className="px-6 py-4 text-sm text-secondary">
+                          </TableCell>
+                          <TableCell className="px-6 py-4 text-sm text-secondary">
                             {perm.description || perm.action}
-                          </td>
+                          </TableCell>
                           {!role.is_system && (
-                            <td className="px-6 py-4 text-right">
+                            <TableCell className="px-6 py-4 text-right">
                               <TooltipProvider delayDuration={200}>
                                 <Tooltip>
                                   <TooltipTrigger asChild>
@@ -402,12 +416,12 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
                                   </TooltipContent>
                                 </Tooltip>
                               </TooltipProvider>
-                            </td>
+                            </TableCell>
                           )}
-                        </tr>
+                        </TableRow>
                       ))}
-                  </tbody>
-                </table>
+                  </TableBody>
+                </Table>
               </CardContent>
             </Card>
           )}
@@ -703,6 +717,23 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
           )}
         </div>
       )}
+      <ConfirmDialog
+        open={confirm?.action === 'revoke'}
+        title="Remove permission"
+        description={
+          confirm?.action === 'revoke'
+            ? `Remove permission "${confirm.permName}" from this role?`
+            : 'This action cannot be undone.'
+        }
+        confirmLabel="Remove"
+        onConfirm={() => {
+          if (confirm?.action === 'revoke') {
+            revokeMutation.mutate(confirm.permName)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
     </div>
   )
 }

--- a/src/components/admin/service-accounts/ServiceAccountDetail.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountDetail.tsx
@@ -27,6 +27,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import {
   listServiceAccountApiKeys,
@@ -88,6 +89,16 @@ export function ServiceAccountDetail({
   const [showAddOrg, setShowAddOrg] = useState(false)
   const [newOrgSlug, setNewOrgSlug] = useState('')
   const [newRoleSlug, setNewRoleSlug] = useState('')
+
+  // Confirm dialog state (covers 5 destructive actions)
+  const [confirm, setConfirm] = useState<
+    | { action: 'revoke-key'; keyId: string }
+    | { action: 'rotate-key'; keyId: string }
+    | { action: 'revoke-credential'; clientId: string }
+    | { action: 'rotate-credential'; clientId: string }
+    | { action: 'remove-org'; orgSlug: string; orgName: string }
+    | null
+  >(null)
 
   const {
     data: availableRoles = [],
@@ -325,23 +336,11 @@ export function ServiceAccountDetail({
   }
 
   const handleRevokeKey = (keyId: string) => {
-    if (
-      confirm(
-        'Are you sure you want to revoke this API key? This action cannot be undone.',
-      )
-    ) {
-      revokeKeyMutation.mutate(keyId)
-    }
+    setConfirm({ action: 'revoke-key', keyId })
   }
 
   const handleRotateKey = (keyId: string) => {
-    if (
-      confirm(
-        'Are you sure you want to rotate this API key? The old key will stop working immediately.',
-      )
-    ) {
-      rotateKeyMutation.mutate(keyId)
-    }
+    setConfirm({ action: 'rotate-key', keyId })
   }
 
   const handleCreateCredential = () => {
@@ -370,23 +369,11 @@ export function ServiceAccountDetail({
   }
 
   const handleRevokeCredential = (clientId: string) => {
-    if (
-      confirm(
-        'Are you sure you want to revoke this credential? This action cannot be undone.',
-      )
-    ) {
-      revokeCredentialMutation.mutate(clientId)
-    }
+    setConfirm({ action: 'revoke-credential', clientId })
   }
 
   const handleRotateCredential = (clientId: string) => {
-    if (
-      confirm(
-        'Are you sure you want to rotate this credential? The old secret will stop working immediately.',
-      )
-    ) {
-      rotateCredentialMutation.mutate(clientId)
-    }
+    setConfirm({ action: 'rotate-credential', clientId })
   }
 
   const truncateClientId = (clientId: string) => {
@@ -588,17 +575,13 @@ export function ServiceAccountDetail({
                             <button
                               type="button"
                               aria-label={`Remove from ${membership.organization_name}`}
-                              onClick={() => {
-                                if (
-                                  confirm(
-                                    `Remove ${account.display_name} from ${membership.organization_name}?`,
-                                  )
-                                ) {
-                                  removeOrgMutation.mutate(
-                                    membership.organization_slug,
-                                  )
-                                }
-                              }}
+                              onClick={() =>
+                                setConfirm({
+                                  action: 'remove-org',
+                                  orgSlug: membership.organization_slug,
+                                  orgName: membership.organization_name,
+                                })
+                              }
                               disabled={removeOrgMutation.isPending}
                               className="rounded p-1.5 text-danger hover:bg-secondary"
                             >
@@ -1183,6 +1166,75 @@ export function ServiceAccountDetail({
           </div>
         </CardContent>
       </Card>
+      <ConfirmDialog
+        open={confirm?.action === 'revoke-key'}
+        title="Revoke API key"
+        description="Are you sure you want to revoke this API key? This action cannot be undone."
+        confirmLabel="Revoke"
+        onConfirm={() => {
+          if (confirm?.action === 'revoke-key') {
+            revokeKeyMutation.mutate(confirm.keyId)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+      <ConfirmDialog
+        open={confirm?.action === 'rotate-key'}
+        title="Rotate API key"
+        description="Are you sure you want to rotate this API key? The old key will stop working immediately."
+        confirmLabel="Rotate"
+        onConfirm={() => {
+          if (confirm?.action === 'rotate-key') {
+            rotateKeyMutation.mutate(confirm.keyId)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+      <ConfirmDialog
+        open={confirm?.action === 'revoke-credential'}
+        title="Revoke credential"
+        description="Are you sure you want to revoke this credential? This action cannot be undone."
+        confirmLabel="Revoke"
+        onConfirm={() => {
+          if (confirm?.action === 'revoke-credential') {
+            revokeCredentialMutation.mutate(confirm.clientId)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+      <ConfirmDialog
+        open={confirm?.action === 'rotate-credential'}
+        title="Rotate credential"
+        description="Are you sure you want to rotate this credential? The old secret will stop working immediately."
+        confirmLabel="Rotate"
+        onConfirm={() => {
+          if (confirm?.action === 'rotate-credential') {
+            rotateCredentialMutation.mutate(confirm.clientId)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+      <ConfirmDialog
+        open={confirm?.action === 'remove-org'}
+        title="Remove from organization"
+        description={
+          confirm?.action === 'remove-org'
+            ? `Remove ${account.display_name} from ${confirm.orgName}?`
+            : 'This action cannot be undone.'
+        }
+        confirmLabel="Remove"
+        onConfirm={() => {
+          if (confirm?.action === 'remove-org') {
+            removeOrgMutation.mutate(confirm.orgSlug)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
     </div>
   )
 }

--- a/src/components/admin/teams/TeamDetail.tsx
+++ b/src/components/admin/teams/TeamDetail.tsx
@@ -15,8 +15,17 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Gravatar } from '@/components/ui/gravatar'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import {
   getTeamMembers,
   addTeamMember,
@@ -44,6 +53,10 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
   const queryClient = useQueryClient()
   const [showAddMember, setShowAddMember] = useState(false)
   const [newMemberEmail, setNewMemberEmail] = useState('')
+  const [confirm, setConfirm] = useState<{
+    action: 'remove'
+    email: string
+  } | null>(null)
 
   const {
     data: members = [],
@@ -94,9 +107,7 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
   }
 
   const handleRemoveMember = (email: string) => {
-    if (confirm('Remove this member from the team?')) {
-      removeMemberMutation.mutate(email)
-    }
+    setConfirm({ action: 'remove', email })
   }
 
   return (
@@ -234,27 +245,27 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
               No members in this team yet. Click "Add Member" to get started.
             </div>
           ) : (
-            <table className="w-full">
-              <thead className="border-b border-tertiary bg-secondary">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
+            <Table>
+              <TableHeader className="border-b border-tertiary bg-secondary">
+                <TableRow>
+                  <TableHead className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
                     Member
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
+                  </TableHead>
+                  <TableHead className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
                     Email
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
+                  </TableHead>
+                  <TableHead className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-tertiary">
                     Status
-                  </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-tertiary">
+                  </TableHead>
+                  <TableHead className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-tertiary">
                     Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-tertiary">
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody className="divide-y divide-tertiary">
                 {members.map((member) => (
-                  <tr key={member.email} className="hover:bg-secondary">
-                    <td className="px-6 py-4">
+                  <TableRow key={member.email} className="hover:bg-secondary">
+                    <TableCell className="px-6 py-4">
                       <div className="flex items-center gap-3">
                         <Gravatar
                           email={member.email}
@@ -266,16 +277,16 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
                           {member.display_name}
                         </div>
                       </div>
-                    </td>
-                    <td className="px-6 py-4 text-sm text-secondary">
+                    </TableCell>
+                    <TableCell className="px-6 py-4 text-sm text-secondary">
                       {member.email}
-                    </td>
-                    <td className="px-6 py-4">
+                    </TableCell>
+                    <TableCell className="px-6 py-4">
                       <Badge variant={member.is_active ? 'success' : 'neutral'}>
                         {member.is_active ? 'Active' : 'Inactive'}
                       </Badge>
-                    </td>
-                    <td className="px-6 py-4 text-right">
+                    </TableCell>
+                    <TableCell className="px-6 py-4 text-right">
                       <TooltipProvider delayDuration={200}>
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -295,14 +306,27 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
                           </TooltipContent>
                         </Tooltip>
                       </TooltipProvider>
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ))}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           )}
         </CardContent>
       </Card>
+      <ConfirmDialog
+        open={confirm?.action === 'remove'}
+        title="Remove team member"
+        description="Remove this member from the team?"
+        confirmLabel="Remove"
+        onConfirm={() => {
+          if (confirm?.action === 'remove') {
+            removeMemberMutation.mutate(confirm.email)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
     </div>
   )
 }

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -4,6 +4,15 @@ import { toast } from 'sonner'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { Plus, Trash2, Key, AlertCircle, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import {
   listServiceApplications,
   deleteServiceApplication,
@@ -42,6 +51,11 @@ export function OAuth2ApplicationList({
   const queryClient = useQueryClient()
   const [viewMode, setViewModeInternal] = useState<ViewMode>('list')
   const [editingApp, setEditingApp] = useState<ServiceApplication | null>(null)
+  const [confirm, setConfirm] = useState<{
+    action: 'delete'
+    appSlug: string
+    appName: string
+  } | null>(null)
 
   const setViewMode = (mode: ViewMode) => {
     setViewModeInternal(mode)
@@ -101,9 +115,7 @@ export function OAuth2ApplicationList({
   })
 
   const handleDelete = (app: ServiceApplication) => {
-    if (confirm(`Delete application "${app.name}"? This cannot be undone.`)) {
-      deleteMutation.mutate(app.slug)
-    }
+    setConfirm({ action: 'delete', appSlug: app.slug, appName: app.name })
   }
 
   const handleSave = (
@@ -211,31 +223,31 @@ export function OAuth2ApplicationList({
         </div>
       ) : (
         <div className="overflow-hidden rounded-lg border border-border bg-card">
-          <table className="w-full">
-            <thead className="border-b border-tertiary bg-secondary">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+          <Table>
+            <TableHeader className="border-b border-tertiary bg-secondary">
+              <TableRow>
+                <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Application
-                </th>
-                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+                </TableHead>
+                <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Type
-                </th>
-                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+                </TableHead>
+                <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Client ID
-                </th>
-                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+                </TableHead>
+                <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Status
-                </th>
-                <th className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
+                </TableHead>
+                <TableHead className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
                   Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-tertiary">
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody className="divide-y divide-tertiary">
               {applications.map((app) => {
                 const statusVariant = statusBadgeVariant(app.status)
                 return (
-                  <tr
+                  <TableRow
                     key={app.slug}
                     className="hover:bg-secondary/50 cursor-pointer"
                     onClick={() => {
@@ -243,22 +255,22 @@ export function OAuth2ApplicationList({
                       setViewMode('edit')
                     }}
                   >
-                    <td className="px-6 py-4">
+                    <TableCell className="px-6 py-4">
                       <div className="font-medium text-primary">{app.name}</div>
                       <div className="text-sm text-tertiary">{app.slug}</div>
-                    </td>
-                    <td className="px-6 py-4">
+                    </TableCell>
+                    <TableCell className="px-6 py-4">
                       <code className="rounded bg-secondary px-2 py-1 text-xs text-primary">
                         {app.app_type}
                       </code>
-                    </td>
-                    <td className="px-6 py-4 font-mono text-sm text-secondary">
+                    </TableCell>
+                    <TableCell className="px-6 py-4 font-mono text-sm text-secondary">
                       {app.client_id}
-                    </td>
-                    <td className="px-6 py-4">
+                    </TableCell>
+                    <TableCell className="px-6 py-4">
                       <Badge variant={statusVariant}>{app.status}</Badge>
-                    </td>
-                    <td
+                    </TableCell>
+                    <TableCell
                       className="px-6 py-4 text-right"
                       onClick={(e) => e.stopPropagation()}
                       onKeyDown={(e) => e.stopPropagation()}
@@ -295,14 +307,31 @@ export function OAuth2ApplicationList({
                           <Trash2 className="h-4 w-4" />
                         </Button>
                       </div>
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 )
               })}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </div>
       )}
+      <ConfirmDialog
+        open={confirm?.action === 'delete'}
+        title="Delete application"
+        description={
+          confirm?.action === 'delete'
+            ? `Delete application "${confirm.appName}"? This cannot be undone.`
+            : 'This action cannot be undone.'
+        }
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (confirm?.action === 'delete') {
+            deleteMutation.mutate(confirm.appSlug)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
     </div>
   )
 }

--- a/src/components/admin/third-party-services/ServiceWebhookList.tsx
+++ b/src/components/admin/third-party-services/ServiceWebhookList.tsx
@@ -5,6 +5,15 @@ import { extractApiErrorDetail } from '@/lib/apiError'
 import { Plus, Search, Trash2, Webhook, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import { WebhookForm } from '../webhooks/WebhookForm'
 import { WebhookDetail } from '../webhooks/WebhookDetail'
 import {
@@ -31,6 +40,11 @@ export function ServiceWebhookList({
   const [viewMode, _setViewMode] = useState<ViewMode>('list')
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [confirm, setConfirm] = useState<{
+    action: 'delete'
+    slug: string
+    name: string
+  } | null>(null)
 
   const setViewMode = useCallback(
     (mode: ViewMode) => {
@@ -113,11 +127,8 @@ export function ServiceWebhookList({
 
   const handleDelete = (slug: string) => {
     const wh = webhooks.find((w) => w.slug === slug)
-    if (
-      wh &&
-      confirm(`Delete webhook "${wh.name}"? This action cannot be undone.`)
-    ) {
-      deleteMutation.mutate(slug)
+    if (wh) {
+      setConfirm({ action: 'delete', slug, name: wh.name })
     }
   }
 
@@ -242,26 +253,26 @@ export function ServiceWebhookList({
         </div>
       ) : (
         <div className="overflow-hidden rounded-lg border border-border bg-card">
-          <table className="w-full">
-            <thead className="border-b border-tertiary">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+          <Table>
+            <TableHeader className="border-b border-tertiary">
+              <TableRow>
+                <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Webhook
-                </th>
-                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+                </TableHead>
+                <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Path
-                </th>
-                <th className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
+                </TableHead>
+                <TableHead className="px-6 py-3 text-left text-xs uppercase tracking-wider text-tertiary">
                   Rules
-                </th>
-                <th className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
+                </TableHead>
+                <TableHead className="px-6 py-3 text-right text-xs uppercase tracking-wider text-tertiary">
                   Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-tertiary">
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody className="divide-y divide-tertiary">
               {filteredWebhooks.map((wh) => (
-                <tr
+                <TableRow
                   key={wh.slug}
                   onClick={() => {
                     setSelectedSlug(wh.slug)
@@ -279,7 +290,7 @@ export function ServiceWebhookList({
                   aria-label={`View webhook ${wh.name}`}
                   className="hover:bg-secondary/50 cursor-pointer"
                 >
-                  <td className="px-6 py-4">
+                  <TableCell className="px-6 py-4">
                     <div className="flex items-center gap-3">
                       <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-900/30">
                         <Webhook
@@ -301,16 +312,16 @@ export function ServiceWebhookList({
                         )}
                       </div>
                     </div>
-                  </td>
-                  <td className="px-6 py-4">
+                  </TableCell>
+                  <TableCell className="px-6 py-4">
                     <code className="rounded bg-secondary px-2 py-1 text-xs text-primary">
                       {wh.notification_path}
                     </code>
-                  </td>
-                  <td className="px-6 py-4 text-sm text-secondary">
+                  </TableCell>
+                  <TableCell className="px-6 py-4 text-sm text-secondary">
                     {wh.rules.length}
-                  </td>
-                  <td
+                  </TableCell>
+                  <TableCell
                     className="px-6 py-4 text-right"
                     onClick={(e) => e.stopPropagation()}
                     onKeyDown={(e) => e.stopPropagation()}
@@ -327,13 +338,30 @@ export function ServiceWebhookList({
                         <Trash2 className="h-4 w-4" />
                       </Button>
                     </div>
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </div>
       )}
+      <ConfirmDialog
+        open={confirm?.action === 'delete'}
+        title="Delete webhook"
+        description={
+          confirm?.action === 'delete'
+            ? `Delete webhook "${confirm.name}"? This action cannot be undone.`
+            : 'This action cannot be undone.'
+        }
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (confirm?.action === 'delete') {
+            deleteMutation.mutate(confirm.slug)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
     </div>
   )
 }

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
   getRoles,
@@ -45,6 +46,11 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
   const [showAddOrg, setShowAddOrg] = useState(false)
   const [newOrgSlug, setNewOrgSlug] = useState('')
   const [newRoleSlug, setNewRoleSlug] = useState('')
+  const [confirm, setConfirm] = useState<{
+    action: 'remove-org'
+    orgSlug: string
+    orgName: string
+  } | null>(null)
 
   const { data: availableRoles = [] } = useQuery({
     queryKey: ['roles'],
@@ -358,17 +364,13 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <button
-                            onClick={() => {
-                              if (
-                                confirm(
-                                  `Remove ${user.display_name} from ${membership.organization_name}?`,
-                                )
-                              ) {
-                                removeOrgMutation.mutate(
-                                  membership.organization_slug,
-                                )
-                              }
-                            }}
+                            onClick={() =>
+                              setConfirm({
+                                action: 'remove-org',
+                                orgSlug: membership.organization_slug,
+                                orgName: membership.organization_name,
+                              })
+                            }
                             disabled={removeOrgMutation.isPending}
                             className="rounded p-1.5 text-danger hover:bg-secondary"
                           >
@@ -410,6 +412,23 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
           </div>
         </CardContent>
       </Card>
+      <ConfirmDialog
+        open={confirm?.action === 'remove-org'}
+        title="Remove from organization"
+        description={
+          confirm?.action === 'remove-org'
+            ? `Remove ${user.display_name} from ${confirm.orgName}?`
+            : 'This action cannot be undone.'
+        }
+        confirmLabel="Remove"
+        onConfirm={() => {
+          if (confirm?.action === 'remove-org') {
+            removeOrgMutation.mutate(confirm.orgSlug)
+          }
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
     </div>
   )
 }

--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -2,6 +2,14 @@ import { ArrowLeft, Edit2, Webhook } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EntityIcon } from '@/components/ui/entity-icon'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import type { Webhook as WebhookType } from '@/types'
 
 interface WebhookDetailProps {
@@ -109,40 +117,40 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
             </div>
           ) : (
             <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead className="border-b border-tertiary">
-                  <tr>
-                    <th className="w-12 px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
+              <Table>
+                <TableHeader className="border-b border-tertiary">
+                  <TableRow>
+                    <TableHead className="w-12 px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
                       #
-                    </th>
-                    <th className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
+                    </TableHead>
+                    <TableHead className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
                       Filter Expression
-                    </th>
-                    <th className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
+                    </TableHead>
+                    <TableHead className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
                       Handler
-                    </th>
-                    <th className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
+                    </TableHead>
+                    <TableHead className="px-4 py-2 text-left text-xs uppercase tracking-wider text-tertiary">
                       Config
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-tertiary">
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody className="divide-y divide-tertiary">
                   {webhook.rules.map((rule, index) => (
-                    <tr key={index}>
-                      <td className="px-4 py-3 text-sm text-tertiary">
+                    <TableRow key={index}>
+                      <TableCell className="px-4 py-3 text-sm text-tertiary">
                         {index + 1}
-                      </td>
-                      <td className="px-4 py-3">
+                      </TableCell>
+                      <TableCell className="px-4 py-3">
                         <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                           {rule.filter_expression}
                         </code>
-                      </td>
-                      <td className="px-4 py-3">
+                      </TableCell>
+                      <TableCell className="px-4 py-3">
                         <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                           {rule.handler}
                         </code>
-                      </td>
-                      <td className="px-4 py-3">
+                      </TableCell>
+                      <TableCell className="px-4 py-3">
                         {rule.handler_config &&
                         (Array.isArray(rule.handler_config)
                           ? rule.handler_config.length > 0
@@ -153,11 +161,11 @@ export function WebhookDetail({ webhook, onEdit, onBack }: WebhookDetailProps) {
                         ) : (
                           <span className="text-tertiary">--</span>
                         )}
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   ))}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
             </div>
           )}
         </CardContent>

--- a/src/components/assistant/ConversationHistory.tsx
+++ b/src/components/assistant/ConversationHistory.tsx
@@ -7,6 +7,7 @@ import {
   updateConversation,
 } from '@/api/assistant'
 import type { Conversation } from '@/types/assistant'
+import { Button } from '@/components/ui/button'
 
 interface ConversationHistoryProps {
   currentConversationId: string | null
@@ -56,29 +57,31 @@ export function ConversationHistory({
 
   if (!showHistory) {
     return (
-      <button
+      <Button
+        variant="ghost"
         onClick={() => setShowHistory(true)}
-        className="flex items-center gap-1 rounded px-2 py-1 text-xs text-secondary hover:bg-secondary hover:text-primary"
+        className="h-auto gap-1 rounded px-2 py-1 text-xs text-secondary hover:bg-secondary hover:text-primary"
       >
         <MessageSquare className="h-3 w-3" />
         History
-      </button>
+      </Button>
     )
   }
 
   return (
     <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-lg border border-border bg-card shadow-lg">
       <div className="p-2">
-        <button
+        <Button
+          variant="ghost"
           onClick={() => {
             onNewConversation()
             setShowHistory(false)
           }}
-          className="flex w-full items-center gap-2 rounded px-3 py-2 text-sm text-secondary hover:bg-secondary"
+          className="h-auto w-full justify-start rounded px-3 py-2 text-sm text-secondary hover:bg-secondary"
         >
           <Plus className="h-4 w-4" />
           New Conversation
-        </button>
+        </Button>
         {conversations.map((conv: Conversation) => (
           <div
             key={conv.id}
@@ -103,31 +106,36 @@ export function ConversationHistory({
           >
             <span className="flex-1 truncate">{conv.title ?? 'Untitled'}</span>
             <div className="ml-2 flex items-center gap-1">
-              <button
+              <Button
+                variant="ghost"
+                size="icon"
                 onClick={(e) => handleArchive(e, conv.id)}
                 aria-label={`Archive ${conv.title ?? 'conversation'}`}
-                className="rounded p-1 hover:bg-secondary"
+                className="h-auto w-auto rounded p-1 hover:bg-secondary"
               >
                 <Archive className="h-3 w-3" />
-              </button>
-              <button
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
                 onClick={(e) => handleDelete(e, conv.id)}
                 aria-label={`Delete ${conv.title ?? 'conversation'}`}
-                className="rounded p-1 text-danger hover:bg-secondary"
+                className="h-auto w-auto rounded p-1 text-danger hover:bg-secondary"
               >
                 <Trash2 className="h-3 w-3" />
-              </button>
+              </Button>
             </div>
           </div>
         ))}
       </div>
       <div className="border-t border-tertiary p-1">
-        <button
+        <Button
+          variant="ghost"
           onClick={() => setShowHistory(false)}
-          className="w-full rounded px-3 py-1 text-xs text-tertiary hover:text-secondary"
+          className="h-auto w-full rounded px-3 py-1 text-xs text-tertiary hover:text-secondary"
         >
           Close
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -158,8 +158,9 @@ export function AdminTable<T>({
                 const parts = blockedBy.map((b, i) => (
                   <span key={i}>
                     {b.href ? (
-                      <button
-                        className="font-medium text-primary underline underline-offset-2 hover:opacity-80"
+                      <Button
+                        variant="link"
+                        className="h-auto p-0 font-medium text-primary underline underline-offset-2 hover:opacity-80"
                         onClick={() => {
                           setBlockedTarget(null)
                           navigate(b.href!)
@@ -167,7 +168,7 @@ export function AdminTable<T>({
                       >
                         {b.count} {b.label}
                         {b.count !== 1 ? 's' : ''}
-                      </button>
+                      </Button>
                     ) : (
                       <span className="font-medium">
                         {b.count} {b.label}

--- a/src/components/ui/dynamic-fields.tsx
+++ b/src/components/ui/dynamic-fields.tsx
@@ -12,6 +12,11 @@ import {
 } from '@/components/ui/select'
 import type { DynamicFieldSchema, DynamicSchema } from '@/api/endpoints'
 
+// Radix SelectItem rejects empty-string values, so use a sentinel to represent
+// an unset non-required enum field (preserves the clear-via-placeholder
+// behaviour of the native <select> this component replaced).
+const UNSET_VALUE = '__unset__'
+
 const ajv = new Ajv({ allErrors: true })
 addFormats(ajv)
 
@@ -90,8 +95,10 @@ export function DynamicFormFields({
                 {isRequired && <span className="text-red-500"> *</span>}
               </label>
               <Select
-                value={value}
-                onValueChange={(v) => onChange(key, v || undefined)}
+                value={value || (!isRequired ? UNSET_VALUE : '')}
+                onValueChange={(v) =>
+                  onChange(key, v === UNSET_VALUE ? undefined : v)
+                }
                 disabled={isLoading}
               >
                 <SelectTrigger className={fieldError ? 'border-red-500' : ''}>
@@ -100,6 +107,9 @@ export function DynamicFormFields({
                   />
                 </SelectTrigger>
                 <SelectContent>
+                  {!isRequired && (
+                    <SelectItem value={UNSET_VALUE}>None</SelectItem>
+                  )}
                   {field.enum.map((opt) => (
                     <SelectItem key={opt} value={opt}>
                       {opt}

--- a/src/components/ui/dynamic-fields.tsx
+++ b/src/components/ui/dynamic-fields.tsx
@@ -3,6 +3,13 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 import { AlertCircle } from 'lucide-react'
 import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import type { DynamicFieldSchema, DynamicSchema } from '@/api/endpoints'
 
 const ajv = new Ajv({ allErrors: true })
@@ -82,19 +89,24 @@ export function DynamicFormFields({
                 {label}
                 {isRequired && <span className="text-red-500"> *</span>}
               </label>
-              <select
+              <Select
                 value={value}
-                onChange={(e) => onChange(key, e.target.value || undefined)}
+                onValueChange={(v) => onChange(key, v || undefined)}
                 disabled={isLoading}
-                className={`w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground ${fieldError ? 'border-red-500' : ''}`}
               >
-                <option value="">Select {label.toLowerCase()}...</option>
-                {field.enum.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger className={fieldError ? 'border-red-500' : ''}>
+                  <SelectValue
+                    placeholder={`Select ${label.toLowerCase()}...`}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {field.enum.map((opt) => (
+                    <SelectItem key={opt} value={opt}>
+                      {opt}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {field.description && (
                 <p className="mt-1 text-xs text-tertiary">
                   {field.description}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -57,7 +57,7 @@ export function useAuth(): UseAuthReturn {
     },
     enabled: !!accessToken && !isTokenExpired(),
     retry: false,
-    staleTime: Infinity,
+    staleTime: 5 * 60 * 1000,
   })
 
   const loginMutation = useMutation({


### PR DESCRIPTION
## Summary

Addresses the mechanical-fix portion of the April 2026 code review follow-ups (sections 1a, 1b, 1c, 1d, 1e, 4c, 4g from `docs/code-review-followups.md`). Every change is behavior-preserving except where explicitly noted (ErrorBoundary adds a new surface, staleTime tightens auth-cache freshness).

## Changes

**Primitive adoption (section 1):**
- `window.confirm()` → `ConfirmDialog` across 7 admin detail files (ServiceWebhookList, OAuth2ApplicationList, RoleDetail, TeamDetail, ServiceAccountDetail, UserDetail). `ServiceAccountDetail` collapses 5 confirm sites into one `useState` with a discriminated union for the action.
- Raw `<button>` → `ui/button` in CommandBar, Admin, Navigation, ConversationHistory, RecentActivity, admin-table, OperationsLog, ProjectDetail. Compact sizes preserved via `h-auto`/`w-auto` overrides where base variants would change sizing.
- Raw `<table>` → `ui/table` primitives in ServiceWebhookList, OAuth2ApplicationList, RoleDetail, TeamDetail, WebhookDetail, ProjectsView.
- Raw `<select>` → `ui/select` in `dynamic-fields.tsx`.
- `ui/loading-state` adopted in OperationsLog and BlueprintDetail.
- `NewProjectDialog` backdrop changed from `<div onClick>` to `<button type="button" aria-label="Close dialog">` — keyboard a11y fix.

**Data layer (section 4):**
- New `ErrorBoundary` class component at `src/components/ErrorBoundary.tsx`, wired in `App.tsx` *outside* Suspense so chunk-load failures are caught. Default fallback offers "Try again" (resets error state) and "Reload" (window.location.reload).
- `useAuth.ts` currentUser `staleTime` dropped from `Infinity` to `5 * 60 * 1000`. Server-side permission changes now propagate without a page reload.

## Not in this PR

Skipped the deeper items from the follow-ups doc — they each warrant separate PRs:
- Section 2 (shared form primitives) — touches 8 large forms; needs its own review.
- Section 3 (monolith decomposition) — the doc explicitly says don't interleave.
- Sections 4a, 4b, 4d, 4f, 4h (withAuthRetry, OpenAPI codegen, AbortController, org-scoped query keys, mutation error UX) — each is a behavioral change worth reviewing independently.
- Section 4e (doc/code auth alignment) — `src/CLAUDE.md` referenced in the follow-up doc doesn't exist; not actionable as-is.
- Section 5 (EditableKeyValueMap vs key-value-editor) — needs a canonical-choice decision first.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean (only pre-existing icon-library chunk size warnings).
- [ ] Smoke-test admin delete flows (services, OAuth apps, roles, teams, service accounts, users) — each now shows `ConfirmDialog` instead of native confirm.
- [ ] Smoke-test NewProjectDialog backdrop-close and Escape.
- [ ] Verify ErrorBoundary shows the themed fallback when a route throws (e.g. temporarily `throw new Error` inside a page component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)