### PR TITLE
Refactor: extract useFormScaffold hook

### DIFF
--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input'
 import { Card, CardContent } from '@/components/ui/card'
 import { getRoles } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useFormScaffold } from '@/hooks/useFormScaffold'
 import type { ServiceAccount, ServiceAccountCreate } from '@/types'
 
 interface ServiceAccountFormProps {
@@ -51,10 +52,13 @@ export function ServiceAccountForm({
   })
 
   // Validation state
-  const [validationErrors, setValidationErrors] = useState<
-    Record<string, string>
-  >({})
-  const [touched, setTouched] = useState<Record<string, boolean>>({})
+  const {
+    validationErrors,
+    setValidationErrors,
+    touched,
+    setTouched,
+    handleFieldChange,
+  } = useFormScaffold()
 
   // Validation functions
   const validateSlug = (value: string): string => {
@@ -110,16 +114,6 @@ export function ServiceAccountForm({
     }
 
     onSave(data)
-  }
-
-  const handleFieldChange = (field: string) => {
-    setTouched({ ...touched, [field]: true })
-
-    if (validationErrors[field]) {
-      const newErrors = { ...validationErrors }
-      delete newErrors[field]
-      setValidationErrors(newErrors)
-    }
   }
 
   const handleSlugChange = (value: string) => {

--- a/src/hooks/useFormScaffold.ts
+++ b/src/hooks/useFormScaffold.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from 'react'
+
+// Shared validation/touched state used by admin *Form.tsx components.
+// Consumers own their validator functions and call setValidationErrors /
+// setTouched directly; this hook just removes the duplicated state + the
+// handleFieldChange helper that marks a field touched and clears its error.
+export interface FormScaffold {
+  validationErrors: Record<string, string>
+  setValidationErrors: React.Dispatch<
+    React.SetStateAction<Record<string, string>>
+  >
+  touched: Record<string, boolean>
+  setTouched: React.Dispatch<React.SetStateAction<Record<string, boolean>>>
+  handleFieldChange: (field: string) => void
+}
+
+export function useFormScaffold(): FormScaffold {
+  const [validationErrors, setValidationErrors] = useState<
+    Record<string, string>
+  >({})
+  const [touched, setTouched] = useState<Record<string, boolean>>({})
+
+  const handleFieldChange = useCallback((field: string) => {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+    setValidationErrors((prev) => {
+      if (!prev[field]) return prev
+      const next = { ...prev }
+      delete next[field]
+      return next
+    })
+  }, [])
+
+  return {
+    validationErrors,
+    setValidationErrors,
+    touched,
+    setTouched,
+    handleFieldChange,
+  }
+}


### PR DESCRIPTION
## Summary

First PR of section 2 (shared form primitives) from `docs/code-review-followups.md`. Extracts the duplicated validation scaffolding that appears character-for-character identical across eight admin `*Form.tsx` files into a narrow hook, and migrates `ServiceAccountForm` (smallest consumer) to validate the API shape. No behavior change.

## What's in this PR

- New `src/hooks/useFormScaffold.ts`. Owns `validationErrors`, `setValidationErrors`, `touched`, `setTouched`, and a stable `handleFieldChange(field)` helper that marks a field touched and clears its prior error.
- `ServiceAccountForm.tsx` — two `useState` calls + local `handleFieldChange` replaced with a single `useFormScaffold()` destructure. Every validator, the `validateForm` aggregator, `handleSave`, `handleSlugChange`, and every bit of JSX are unchanged.

## Design notes

The hook is deliberately narrow — it doesn't own the validator functions or a `validateForm` orchestrator. Consumers already encode their validators as closures over their own field state, so the hook just unifies the state + the one helper that was literally identical across files. Piling more into the hook would force consumers to either restructure their validators or reach around the hook, which defeats the purpose.

## What's not in this PR

Per the follow-ups doc, section 2 ships as three PRs:
1. **This PR** — `useFormScaffold` + ServiceAccountForm.
2. Next PR — `FormField` primitive + UserForm migration.
3. Third PR — `FormHeader` primitive + migrate remaining forms (RoleForm, WebhookForm, EnvironmentForm, ThirdPartyServiceForm, OAuth2ApplicationForm). `BlueprintForm` stays out of this work — its AJV-driven validation doesn't map onto the scaffold.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Smoke-test ServiceAccountForm: create + edit paths, confirm validation still marks fields touched and clears errors as you type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)