### PR TITLE
Refactor: extract FormHeader + migrate remaining admin forms

### DIFF
--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Save, X, AlertCircle } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { AlertCircle } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent } from '@/components/ui/card'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { ColorPicker } from '@/components/ui/color-picker'
+import { FormHeader } from '@/components/admin/form-header'
 import {
   DynamicFormFields,
   validateDynamicFields,
@@ -83,8 +83,7 @@ export function EnvironmentForm({
     return Object.keys(newErrors).length === 0
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSave = () => {
     if (!validate()) return
 
     onSave(orgSlug, {
@@ -98,6 +97,11 @@ export function EnvironmentForm({
         : null,
       ...dynamicFormData,
     })
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    handleSave()
   }
 
   const handleNameChange = (value: string) => {
@@ -121,36 +125,19 @@ export function EnvironmentForm({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-base font-medium text-primary">
-            {isEditing ? 'Edit Environment' : 'Create New Environment'}
-          </h2>
-          <p className="mt-1 text-sm text-secondary">
-            {isEditing
-              ? 'Update environment information'
-              : 'Create a new environment'}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={onCancel} disabled={isLoading}>
-            <X className="mr-2 h-4 w-4" />
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={isLoading}
-            className="bg-action text-action-foreground hover:bg-action-hover"
-          >
-            <Save className="mr-2 h-4 w-4" />
-            {isLoading
-              ? 'Saving...'
-              : isEditing
-                ? 'Save Changes'
-                : 'Create Environment'}
-          </Button>
-        </div>
-      </div>
+      <FormHeader
+        title={isEditing ? 'Edit Environment' : 'Create New Environment'}
+        subtitle={
+          isEditing
+            ? 'Update environment information'
+            : 'Create a new environment'
+        }
+        isEditing={isEditing}
+        isLoading={isLoading}
+        onCancel={onCancel}
+        onSave={handleSave}
+        createLabel="Create Environment"
+      />
 
       {/* API Error */}
       {!!error && (

--- a/src/components/admin/form-header.tsx
+++ b/src/components/admin/form-header.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import { Save, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+// Header row shared by admin *Form.tsx components. Admin-scoped because the
+// save-button text flip (Save Changes vs Create X) is admin-specific.
+export interface FormHeaderProps {
+  title: string
+  subtitle?: React.ReactNode
+  isEditing: boolean
+  isLoading: boolean
+  onCancel: () => void
+  onSave: () => void
+  createLabel: string
+}
+
+export function FormHeader({
+  title,
+  subtitle,
+  isEditing,
+  isLoading,
+  onCancel,
+  onSave,
+  createLabel,
+}: FormHeaderProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <h2 className="text-base font-medium text-primary">{title}</h2>
+        {subtitle && <p className="mt-1 text-secondary">{subtitle}</p>}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={onCancel} disabled={isLoading}>
+          <X className="mr-2 h-4 w-4" />
+          Cancel
+        </Button>
+        <Button
+          onClick={onSave}
+          disabled={isLoading}
+          className="bg-action text-action-foreground hover:bg-action-hover"
+        >
+          <Save className="mr-2 h-4 w-4" />
+          {isLoading ? 'Saving...' : isEditing ? 'Save Changes' : createLabel}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/form-header.tsx
+++ b/src/components/admin/form-header.tsx
@@ -30,11 +30,17 @@ export function FormHeader({
         {subtitle && <p className="mt-1 text-secondary">{subtitle}</p>}
       </div>
       <div className="flex items-center gap-2">
-        <Button variant="outline" onClick={onCancel} disabled={isLoading}>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={isLoading}
+        >
           <X className="mr-2 h-4 w-4" />
           Cancel
         </Button>
         <Button
+          type="button"
           onClick={onSave}
           disabled={isLoading}
           className="bg-action text-action-foreground hover:bg-action-hover"

--- a/src/components/admin/roles/RoleForm.tsx
+++ b/src/components/admin/roles/RoleForm.tsx
@@ -12,6 +12,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { FormField } from '@/components/ui/form-field'
+import { useFormScaffold } from '@/hooks/useFormScaffold'
 import { getRole, getAdminSettings } from '@/api/endpoints'
 import type { RoleCreate, Permission } from '@/types'
 
@@ -96,10 +98,13 @@ export function RoleForm({
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
 
   // Validation
-  const [validationErrors, setValidationErrors] = useState<
-    Record<string, string>
-  >({})
-  const [touched, setTouched] = useState<Record<string, boolean>>({})
+  const {
+    validationErrors,
+    setValidationErrors,
+    touched,
+    setTouched,
+    handleFieldChange,
+  } = useFormScaffold()
 
   // Group available permissions by resource_type
   const groupedPermissions = useMemo(
@@ -183,15 +188,6 @@ export function RoleForm({
       priority,
     }
     onSave(roleData, Array.from(selectedPermissions))
-  }
-
-  const handleFieldChange = (field: string) => {
-    setTouched({ ...touched, [field]: true })
-    if (validationErrors[field]) {
-      const newErrors = { ...validationErrors }
-      delete newErrors[field]
-      setValidationErrors(newErrors)
-    }
   }
 
   const togglePermission = (permName: string) => {
@@ -333,29 +329,28 @@ export function RoleForm({
           <div className="grid grid-cols-2 gap-4">
             {/* Name */}
             <div className="col-span-2">
-              <label className="mb-1.5 block text-sm text-secondary">
-                Name <span className="text-red-500">*</span>
-              </label>
-              <Input
-                value={name}
-                onChange={(e) => handleNameChange(e.target.value)}
-                onBlur={() => {
-                  setTouched({ ...touched, name: true })
-                  const err = validateName(name)
-                  if (err)
-                    setValidationErrors({ ...validationErrors, name: err })
-                }}
-                disabled={isLoading || isSystemRole}
-                placeholder="e.g. Project Manager"
-                className={` ${
-                  isSystemRole ? 'cursor-not-allowed opacity-60' : ''
-                }`}
-              />
-              {touched.name && validationErrors.name && (
-                <p className="mt-1 text-sm text-red-600">
-                  {validationErrors.name}
-                </p>
-              )}
+              <FormField
+                label="Name"
+                required
+                touched={touched.name}
+                error={validationErrors.name}
+              >
+                <Input
+                  value={name}
+                  onChange={(e) => handleNameChange(e.target.value)}
+                  onBlur={() => {
+                    setTouched({ ...touched, name: true })
+                    const err = validateName(name)
+                    if (err)
+                      setValidationErrors({ ...validationErrors, name: err })
+                  }}
+                  disabled={isLoading || isSystemRole}
+                  placeholder="e.g. Project Manager"
+                  className={` ${
+                    isSystemRole ? 'cursor-not-allowed opacity-60' : ''
+                  }`}
+                />
+              </FormField>
             </div>
 
             {/* Slug */}

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Save, X, AlertCircle } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { AlertCircle } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent } from '@/components/ui/card'
+import { FormHeader } from '@/components/admin/form-header'
 import { getRoles } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
@@ -126,36 +126,19 @@ export function ServiceAccountForm({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-base font-medium text-primary">
-            {isEditing ? 'Edit Service Account' : 'Create Service Account'}
-          </h2>
-          <p className="mt-1 text-secondary">
-            {isEditing
-              ? `Editing ${account?.display_name}`
-              : 'Create an automated service account for API access'}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={onCancel} disabled={isLoading}>
-            <X className="mr-2 h-4 w-4" />
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSave}
-            disabled={isLoading}
-            className="bg-action text-action-foreground hover:bg-action-hover"
-          >
-            <Save className="mr-2 h-4 w-4" />
-            {isLoading
-              ? 'Saving...'
-              : isEditing
-                ? 'Save Changes'
-                : 'Create Service Account'}
-          </Button>
-        </div>
-      </div>
+      <FormHeader
+        title={isEditing ? 'Edit Service Account' : 'Create Service Account'}
+        subtitle={
+          isEditing
+            ? `Editing ${account?.display_name}`
+            : 'Create an automated service account for API access'
+        }
+        isEditing={isEditing}
+        isLoading={isLoading}
+        onCancel={onCancel}
+        onSave={handleSave}
+        createLabel="Create Service Account"
+      />
 
       {/* API Error Display */}
       {error && (

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { ArrowLeft, AlertCircle } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { AlertCircle } from 'lucide-react'
 import { Input } from '@/components/ui/input'
+import { FormHeader } from '@/components/admin/form-header'
 import { slugify } from '@/lib/utils'
 import type {
   ServiceApplication,
@@ -142,24 +142,14 @@ export function OAuth2ApplicationForm({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button variant="outline" onClick={onCancel}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back
-          </Button>
-          <h3 className="text-base font-medium text-primary">
-            {isEdit ? 'Edit Application' : 'New Application'}
-          </h3>
-        </div>
-        <Button
-          onClick={handleSubmit}
-          disabled={isLoading}
-          className="bg-action text-action-foreground hover:bg-action-hover"
-        >
-          {isLoading ? 'Saving...' : isEdit ? 'Update' : 'Create'}
-        </Button>
-      </div>
+      <FormHeader
+        title={isEdit ? 'Edit Application' : 'New Application'}
+        isEditing={isEdit}
+        isLoading={isLoading}
+        onCancel={onCancel}
+        onSave={handleSubmit}
+        createLabel="Create"
+      />
 
       {/* Error display */}
       {(validationError || error) && (

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Save, X, AlertCircle } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { AlertCircle } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { KeyValueEditor } from '@/components/ui/key-value-editor'
+import { FormHeader } from '@/components/admin/form-header'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { listTeams } from '@/api/endpoints'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
@@ -81,8 +81,7 @@ export function ThirdPartyServiceForm({
     return Object.keys(newErrors).length === 0
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSave = () => {
     if (!validate()) return
 
     onSave({
@@ -100,6 +99,11 @@ export function ThirdPartyServiceForm({
     })
   }
 
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    handleSave()
+  }
+
   const handleNameChange = (value: string) => {
     setName(value)
     if (!isEditing) {
@@ -112,37 +116,21 @@ export function ThirdPartyServiceForm({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-base font-medium text-primary">
-            {isEditing ? 'Edit Third-Party Service' : 'Add Third-Party Service'}
-          </h2>
-          <p className="mt-1 text-sm text-secondary">
-            {isEditing
-              ? 'Update service information'
-              : 'Register a new external SaaS or managed service'}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={onCancel} disabled={isLoading}>
-            <X className="mr-2 h-4 w-4" />
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            form="third-party-service-form"
-            disabled={isLoading}
-            className="bg-action text-action-foreground hover:bg-action-hover"
-          >
-            <Save className="mr-2 h-4 w-4" />
-            {isLoading
-              ? 'Saving...'
-              : isEditing
-                ? 'Save Changes'
-                : 'Create Service'}
-          </Button>
-        </div>
-      </div>
+      <FormHeader
+        title={
+          isEditing ? 'Edit Third-Party Service' : 'Add Third-Party Service'
+        }
+        subtitle={
+          isEditing
+            ? 'Update service information'
+            : 'Register a new external SaaS or managed service'
+        }
+        isEditing={isEditing}
+        isLoading={isLoading}
+        onCancel={onCancel}
+        onSave={handleSave}
+        createLabel="Create Service"
+      />
 
       {/* API Error */}
       {error && (

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
-  Save,
-  X,
   AlertTriangle,
   Eye,
   EyeOff,
@@ -10,9 +8,9 @@ import {
   X as XIcon,
   AlertCircle,
 } from 'lucide-react'
-import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
 import { FormField } from '@/components/ui/form-field'
+import { FormHeader } from '@/components/admin/form-header'
 import { Gravatar } from '../../ui/gravatar'
 import { Card, CardContent } from '../../ui/card'
 import { getRoles } from '@/api/endpoints'
@@ -188,36 +186,19 @@ export function UserForm({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-base font-medium text-primary">
-            {isEditing ? 'Edit User' : 'Create New User'}
-          </h2>
-          <p className="mt-1 text-secondary">
-            {isEditing
-              ? `Editing ${user?.display_name}`
-              : 'Add a new user account to the system'}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={onCancel} disabled={isLoading}>
-            <X className="mr-2 h-4 w-4" />
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSave}
-            disabled={isLoading}
-            className="bg-action text-action-foreground hover:bg-action-hover"
-          >
-            <Save className="mr-2 h-4 w-4" />
-            {isLoading
-              ? 'Saving...'
-              : isEditing
-                ? 'Save Changes'
-                : 'Create User'}
-          </Button>
-        </div>
-      </div>
+      <FormHeader
+        title={isEditing ? 'Edit User' : 'Create New User'}
+        subtitle={
+          isEditing
+            ? `Editing ${user?.display_name}`
+            : 'Add a new user account to the system'
+        }
+        isEditing={isEditing}
+        isLoading={isLoading}
+        onCancel={onCancel}
+        onSave={handleSave}
+        createLabel="Create User"
+      />
 
       {/* API Error Display */}
       {error && (

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -1,20 +1,13 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import {
-  Save,
-  X,
-  AlertCircle,
-  Plus,
-  Trash2,
-  ArrowUp,
-  ArrowDown,
-} from 'lucide-react'
+import { AlertCircle, Plus, Trash2, ArrowUp, ArrowDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { IconPicker } from '@/components/ui/icon-picker'
+import { FormHeader } from '@/components/admin/form-header'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { listThirdPartyServices } from '@/api/endpoints'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
@@ -112,8 +105,7 @@ export function WebhookForm({
     return Object.keys(newErrors).length === 0
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSave = () => {
     if (!validate()) return
 
     onSave({
@@ -131,6 +123,11 @@ export function WebhookForm({
         handler_config: r.handler_config,
       })),
     })
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    handleSave()
   }
 
   const handleNameChange = (value: string) => {
@@ -201,36 +198,19 @@ export function WebhookForm({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-base font-medium text-primary">
-            {isEditing ? 'Edit Webhook' : 'Add Webhook'}
-          </h2>
-          <p className="mt-1 text-sm text-secondary">
-            {isEditing
-              ? 'Update webhook configuration'
-              : 'Configure a new inbound webhook'}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={onCancel} disabled={isLoading}>
-            <X className="mr-2 h-4 w-4" />
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={isLoading}
-            className="bg-action text-action-foreground hover:bg-action-hover"
-          >
-            <Save className="mr-2 h-4 w-4" />
-            {isLoading
-              ? 'Saving...'
-              : isEditing
-                ? 'Save Changes'
-                : 'Create Webhook'}
-          </Button>
-        </div>
-      </div>
+      <FormHeader
+        title={isEditing ? 'Edit Webhook' : 'Add Webhook'}
+        subtitle={
+          isEditing
+            ? 'Update webhook configuration'
+            : 'Configure a new inbound webhook'
+        }
+        isEditing={isEditing}
+        isLoading={isLoading}
+        onCancel={onCancel}
+        onSave={handleSave}
+        createLabel="Create Webhook"
+      />
 
       {/* API Error */}
       {error && <ErrorBanner title="Failed to save webhook" error={error} />}


### PR DESCRIPTION
## Summary

Closes out section 2 (shared form primitives) from `docs/code-review-followups.md`. Adds the third primitive — `FormHeader` — and migrates the remaining admin `*Form.tsx` files to use the primitives landed in #178 and #179.

## What's in this PR

**New primitive:**
- `src/components/admin/form-header.tsx` — admin-scoped (the Save/Save Changes/Create X text flip is admin-specific per the follow-ups doc). Props: `title`, `subtitle`, `isEditing`, `isLoading`, `onCancel`, `onSave`, `createLabel`.

**Migrations:**
- `ServiceAccountForm`, `UserForm` — header replaced with `<FormHeader>`. These two already use `useFormScaffold` + `FormField` from #178 / #179.
- `WebhookForm`, `EnvironmentForm`, `ThirdPartyServiceForm`, `OAuth2ApplicationForm` — header replaced with `<FormHeader>`.
- `RoleForm` — header stays inline (see Behavior notes). Validation state migrated to `useFormScaffold`; the Name field migrated to `FormField`.

## Behavior notes

### OAuth2ApplicationForm — intentional UX unification
This form previously used a leading `Back` button with `ArrowLeft` and a trailing `Update`/`Create` button. After migration it matches every other admin form: trailing `Cancel` (X icon) and `Save Changes`/`Create`. That is visible to users but brings the form in line with the consistency goal of the primitive.

### Skips with rationale
- `RoleForm` **header** — kept inline. The Save button is conditionally rendered (`!isSystemRole`) and has an extra disable condition on `adminSettingsLoading || !!adminSettingsError`. Expressing these via FormHeader would require a `hideSave?` prop + `saveDisabled?` prop, which widens the primitive's surface beyond what the doc specified for this PR. One lone inline header is acceptable.
- `RoleForm` **Slug field** — kept inline. An auto-gen helper note needs to render **between** the Input and the error message. FormField's fixed order (label → children → description → error) can't express that without reordering description+error, which would break UserForm's current use.
- `WebhookForm`, `EnvironmentForm`, `ThirdPartyServiceForm` scaffold/FormField — these use a single `errors: Record<string, string>` map + an `AlertCircle`-decorated error block rendered once at form level, with no `touched` state. The pattern is genuinely different from the three forms the review called out as character-for-character identical (ServiceAccount/User/Role). Force-fitting `useFormScaffold` here would require a bigger behavior change than this PR's scope allows.
- `OAuth2ApplicationForm` scaffold/FormField — uses a single `validationError: string` state (one error at a time), not a per-field map. Not a fit for the hook.
- `BlueprintForm` — intentionally untouched per the follow-ups doc. Its AJV-driven validation is a separate decomposition in section 3.

## What's not in this PR

- Validation consistency (AJV vs ad-hoc regex) — separate PR after the scaffold work lands.
- `useDirtyState` hook — separate PR.
- BlueprintForm decomposition — section 3.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Smoke-test each migrated form: create + edit paths show correct title/subtitle; Save flips to Saving… while loading; Cancel closes correctly; disabled states during mutation are preserved.
- [ ] Smoke-test OAuth2ApplicationForm — confirm the UX unification reads as intended, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)