### PR TITLE
Refactor: decompose ServiceAccountDetail into sibling files

### DIFF
--- a/src/components/admin/service-accounts/ApiKeysSection.tsx
+++ b/src/components/admin/service-accounts/ApiKeysSection.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import type { UseMutationResult } from '@tanstack/react-query'
+import { Plus, Trash2, AlertCircle, RotateCw, Key } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { SecretBanner } from '@/components/ui/secret-banner'
+import { listServiceAccountApiKeys } from '@/api/endpoints'
+import type { ServiceAccount, ApiKey, ApiKeyCreated } from '@/types'
+
+interface ApiKeysSectionProps {
+  account: ServiceAccount
+  createApiKeyMutation: UseMutationResult<ApiKeyCreated, unknown, string>
+  revokeApiKeyMutation: UseMutationResult<unknown, unknown, string>
+  rotateApiKeyMutation: UseMutationResult<ApiKeyCreated, unknown, string>
+  newlyCreatedKey: ApiKeyCreated | null
+  onNewlyCreatedKeyChange: (key: ApiKeyCreated | null) => void
+  onConfirmRevoke: (keyId: string) => void
+  onConfirmRotate: (keyId: string) => void
+}
+
+const formatDate = (dateString?: string | null) => {
+  if (!dateString) return 'Never'
+  return new Date(dateString).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function ApiKeysSection({
+  account,
+  createApiKeyMutation,
+  revokeApiKeyMutation,
+  rotateApiKeyMutation,
+  newlyCreatedKey,
+  onNewlyCreatedKeyChange,
+  onConfirmRevoke,
+  onConfirmRotate,
+}: ApiKeysSectionProps) {
+  const [newKeyName, setNewKeyName] = useState('')
+  const [showCreateKey, setShowCreateKey] = useState(false)
+
+  useEffect(() => {
+    setNewKeyName('')
+    setShowCreateKey(false)
+  }, [account.slug])
+
+  const {
+    data: apiKeys = [],
+    isLoading: keysLoading,
+    error: keysError,
+  } = useQuery({
+    queryKey: ['serviceAccountApiKeys', account.slug],
+    queryFn: () => listServiceAccountApiKeys(account.slug),
+  })
+
+  const handleCreateKey = () => {
+    const name = newKeyName.trim() || 'default'
+    createApiKeyMutation.mutate(name, {
+      onSuccess: (created) => {
+        onNewlyCreatedKeyChange(created)
+        setShowCreateKey(false)
+        setNewKeyName('')
+      },
+    })
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div className="flex items-center gap-2">
+          <Key className="h-5 w-5 text-secondary" />
+          <CardTitle>API Keys</CardTitle>
+        </div>
+        <Button
+          onClick={() => setShowCreateKey(!showCreateKey)}
+          variant="outline"
+          size="sm"
+          className=""
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Create API Key
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {/* Create Key Form */}
+        {showCreateKey && (
+          <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
+            <div className="flex items-end gap-3">
+              <div className="flex-1">
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Key Name
+                </label>
+                <input
+                  type="text"
+                  value={newKeyName}
+                  onChange={(e) => setNewKeyName(e.target.value)}
+                  placeholder="e.g., production, staging"
+                  className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
+                />
+              </div>
+              <Button
+                onClick={handleCreateKey}
+                disabled={createApiKeyMutation.isPending}
+                className="bg-action text-action-foreground hover:bg-action-hover"
+              >
+                {createApiKeyMutation.isPending ? 'Creating...' : 'Create'}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowCreateKey(false)
+                  setNewKeyName('')
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Newly Created Key Banner */}
+        {newlyCreatedKey && (
+          <SecretBanner
+            title="API Key Created"
+            description="Copy it now, it will not be shown again!"
+            secrets={[
+              {
+                value: newlyCreatedKey.key_secret,
+                copyAriaLabel: 'Copy API key',
+              },
+            ]}
+            onDismiss={() => onNewlyCreatedKeyChange(null)}
+          />
+        )}
+
+        {/* Keys List */}
+        {keysLoading ? (
+          <div className="py-4 text-sm text-secondary">Loading API keys...</div>
+        ) : keysError ? (
+          <div className="flex items-center gap-2 rounded-lg bg-danger p-3 text-danger">
+            <AlertCircle className="h-4 w-4 flex-shrink-0" />
+            <span className="text-sm">Failed to load API keys</span>
+          </div>
+        ) : apiKeys.length === 0 ? (
+          <div className="py-8 text-center text-tertiary">
+            <Key className="mx-auto mb-2 h-8 w-8 text-tertiary" />
+            <div>No API keys created yet</div>
+            <div className="mt-1 text-sm">
+              Create an API key to enable programmatic access
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {apiKeys.map((key: ApiKey) => (
+              <div
+                key={key.key_id}
+                className={`flex items-center justify-between rounded-lg border p-3 ${
+                  key.revoked
+                    ? 'border-input bg-secondary opacity-50'
+                    : 'border-input bg-secondary'
+                }`}
+              >
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-primary">
+                      {key.name}
+                    </span>
+                    <code className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary">
+                      {key.key_id.substring(0, 7)}...
+                    </code>
+                    {key.revoked && <Badge variant="danger">Revoked</Badge>}
+                  </div>
+                  <div className="mt-1 text-xs text-tertiary">
+                    Created {formatDate(key.created_at)}
+                    {key.last_used &&
+                      ` | Last used ${formatDate(key.last_used)}`}
+                    {key.expires_at &&
+                      ` | Expires ${formatDate(key.expires_at)}`}
+                  </div>
+                </div>
+                {!key.revoked && (
+                  <div className="flex items-center gap-1">
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label={`Rotate API key ${key.name}`}
+                            onClick={() => onConfirmRotate(key.key_id)}
+                            disabled={rotateApiKeyMutation.isPending}
+                            className="rounded p-1.5 text-info hover:bg-secondary"
+                          >
+                            <RotateCw className="h-4 w-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Rotate API key</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label={`Revoke API key ${key.name}`}
+                            onClick={() => onConfirmRevoke(key.key_id)}
+                            disabled={revokeApiKeyMutation.isPending}
+                            className="rounded p-1.5 text-danger hover:bg-secondary"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Revoke API key</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/admin/service-accounts/ClientCredentialsSection.tsx
+++ b/src/components/admin/service-accounts/ClientCredentialsSection.tsx
@@ -1,0 +1,354 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import type { UseMutationResult } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { Plus, Trash2, AlertCircle, RotateCw, Shield } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { SecretBanner } from '@/components/ui/secret-banner'
+import { listClientCredentials } from '@/api/endpoints'
+import type {
+  ServiceAccount,
+  ClientCredential,
+  ClientCredentialCreate,
+  ClientCredentialCreated,
+} from '@/types'
+
+interface ClientCredentialsSectionProps {
+  account: ServiceAccount
+  createCredentialMutation: UseMutationResult<
+    ClientCredentialCreated,
+    unknown,
+    ClientCredentialCreate
+  >
+  revokeCredentialMutation: UseMutationResult<unknown, unknown, string>
+  rotateCredentialMutation: UseMutationResult<
+    ClientCredentialCreated,
+    unknown,
+    string
+  >
+  newlyCreatedCredential: ClientCredentialCreated | null
+  onNewlyCreatedCredentialChange: (
+    credential: ClientCredentialCreated | null,
+  ) => void
+  onConfirmRevoke: (clientId: string) => void
+  onConfirmRotate: (clientId: string) => void
+}
+
+const formatDate = (dateString?: string | null) => {
+  if (!dateString) return 'Never'
+  return new Date(dateString).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const truncateClientId = (clientId: string) => {
+  if (clientId.length <= 12) return clientId
+  return `${clientId.substring(0, 12)}...`
+}
+
+export function ClientCredentialsSection({
+  account,
+  createCredentialMutation,
+  revokeCredentialMutation,
+  rotateCredentialMutation,
+  newlyCreatedCredential,
+  onNewlyCreatedCredentialChange,
+  onConfirmRevoke,
+  onConfirmRotate,
+}: ClientCredentialsSectionProps) {
+  const [showCreateCredential, setShowCreateCredential] = useState(false)
+  const [credentialName, setCredentialName] = useState('')
+  const [credentialDescription, setCredentialDescription] = useState('')
+  const [credentialScopes, setCredentialScopes] = useState('')
+  const [credentialExpiresDays, setCredentialExpiresDays] = useState('')
+
+  useEffect(() => {
+    setShowCreateCredential(false)
+    setCredentialName('')
+    setCredentialDescription('')
+    setCredentialScopes('')
+    setCredentialExpiresDays('')
+  }, [account.slug])
+
+  const {
+    data: credentials = [],
+    isLoading: credentialsLoading,
+    error: credentialsError,
+  } = useQuery({
+    queryKey: ['clientCredentials', account.slug],
+    queryFn: () => listClientCredentials(account.slug),
+  })
+
+  const resetCredentialForm = () => {
+    setCredentialName('')
+    setCredentialDescription('')
+    setCredentialScopes('')
+    setCredentialExpiresDays('')
+  }
+
+  const handleCreateCredential = () => {
+    const scopes = credentialScopes
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+    const expiresInDays =
+      credentialExpiresDays.trim() === '' ? null : Number(credentialExpiresDays)
+
+    if (
+      expiresInDays !== null &&
+      (!Number.isInteger(expiresInDays) || expiresInDays < 1)
+    ) {
+      toast.error('Expiration must be a positive whole number of days.')
+      return
+    }
+
+    const data: ClientCredentialCreate = {
+      name: credentialName.trim(),
+      description: credentialDescription.trim() || null,
+      scopes: scopes.length > 0 ? scopes : undefined,
+      expires_in_days: expiresInDays,
+    }
+    createCredentialMutation.mutate(data, {
+      onSuccess: (created) => {
+        onNewlyCreatedCredentialChange(created)
+        setShowCreateCredential(false)
+        resetCredentialForm()
+      },
+    })
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div className="flex items-center gap-2">
+          <Shield className="h-5 w-5 text-secondary" />
+          <CardTitle>Client Credentials</CardTitle>
+        </div>
+        <Button
+          onClick={() => setShowCreateCredential(!showCreateCredential)}
+          variant="outline"
+          size="sm"
+          className=""
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Create Credential
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {/* Create Credential Form */}
+        {showCreateCredential && (
+          <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
+            <div className="space-y-3">
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Name <span className="text-red-500">*</span>
+                </label>
+                <Input
+                  value={credentialName}
+                  onChange={(e) => setCredentialName(e.target.value)}
+                  placeholder="e.g., production-api"
+                  className=""
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Description
+                </label>
+                <Input
+                  value={credentialDescription}
+                  onChange={(e) => setCredentialDescription(e.target.value)}
+                  placeholder="What is this credential used for?"
+                  className=""
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Scopes{' '}
+                  <span className="text-xs text-tertiary">
+                    (comma-separated)
+                  </span>
+                </label>
+                <Input
+                  value={credentialScopes}
+                  onChange={(e) => setCredentialScopes(e.target.value)}
+                  placeholder="e.g., read:projects, write:projects"
+                  className=""
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Expires in (days){' '}
+                  <span className="text-xs text-tertiary">
+                    (leave empty for no expiration)
+                  </span>
+                </label>
+                <Input
+                  type="number"
+                  min="1"
+                  value={credentialExpiresDays}
+                  onChange={(e) => setCredentialExpiresDays(e.target.value)}
+                  placeholder="e.g., 90"
+                  className=""
+                />
+              </div>
+              <div className="flex items-center gap-2 pt-2">
+                <Button
+                  onClick={handleCreateCredential}
+                  disabled={
+                    !credentialName.trim() || createCredentialMutation.isPending
+                  }
+                  className="bg-action text-action-foreground hover:bg-action-hover"
+                >
+                  {createCredentialMutation.isPending
+                    ? 'Creating...'
+                    : 'Create'}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setShowCreateCredential(false)
+                    resetCredentialForm()
+                  }}
+                  className=""
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Newly Created Credential Banner */}
+        {newlyCreatedCredential && (
+          <SecretBanner
+            title="Client Credential Created"
+            description="Copy the secret now, it will not be shown again!"
+            secrets={[
+              {
+                label: 'Client ID',
+                value: newlyCreatedCredential.client_id,
+                copyAriaLabel: 'Copy client ID',
+              },
+              {
+                label: 'Client Secret',
+                value: newlyCreatedCredential.client_secret,
+                copyAriaLabel: 'Copy client secret',
+              },
+            ]}
+            onDismiss={() => onNewlyCreatedCredentialChange(null)}
+          />
+        )}
+
+        {/* Credentials List */}
+        {credentialsLoading ? (
+          <div className="py-4 text-sm text-secondary">
+            Loading client credentials...
+          </div>
+        ) : credentialsError ? (
+          <div className="flex items-center gap-2 rounded-lg bg-danger p-3 text-danger">
+            <AlertCircle className="h-4 w-4 flex-shrink-0" />
+            <span className="text-sm">Failed to load client credentials</span>
+          </div>
+        ) : credentials.length === 0 ? (
+          <div className="py-8 text-center text-tertiary">
+            <Shield className="mx-auto mb-2 h-8 w-8 text-tertiary" />
+            <div>No client credentials created yet</div>
+            <div className="mt-1 text-sm">
+              Create a credential for OAuth2 client_credentials flow
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {credentials.map((cred: ClientCredential) => (
+              <div
+                key={cred.client_id}
+                className={`flex items-center justify-between rounded-lg border p-3 ${
+                  cred.revoked
+                    ? 'border-input bg-secondary opacity-50'
+                    : 'border-input bg-secondary'
+                }`}
+              >
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-primary">
+                      {cred.name}
+                    </span>
+                    <code className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary">
+                      {truncateClientId(cred.client_id)}
+                    </code>
+                    {cred.revoked && <Badge variant="danger">Revoked</Badge>}
+                    {cred.scopes.length > 0 && cred.scopes[0] !== '*' && (
+                      <span className="text-xs text-tertiary">
+                        {cred.scopes.join(', ')}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-xs text-tertiary">
+                    Created {formatDate(cred.created_at)}
+                    {cred.last_used &&
+                      ` | Last used ${formatDate(cred.last_used)}`}
+                    {cred.expires_at &&
+                      ` | Expires ${formatDate(cred.expires_at)}`}
+                  </div>
+                </div>
+                {!cred.revoked && (
+                  <div className="flex items-center gap-1">
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label={`Rotate credential ${cred.name}`}
+                            onClick={() => onConfirmRotate(cred.client_id)}
+                            disabled={rotateCredentialMutation.isPending}
+                            className="rounded p-1.5 text-info hover:bg-secondary"
+                          >
+                            <RotateCw className="h-4 w-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Rotate credential</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label={`Revoke credential ${cred.name}`}
+                            onClick={() => onConfirmRevoke(cred.client_id)}
+                            disabled={revokeCredentialMutation.isPending}
+                            className="rounded p-1.5 text-danger hover:bg-secondary"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Revoke credential</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/admin/service-accounts/OrgMembershipsCard.tsx
+++ b/src/components/admin/service-accounts/OrgMembershipsCard.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useState } from 'react'
+import type { UseMutationResult } from '@tanstack/react-query'
+import { Plus, Trash2, Building2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import type { ServiceAccount, OrgMembership, Role } from '@/types'
+
+interface OrgMembershipsCardProps {
+  account: ServiceAccount
+  availableRoles: Role[]
+  rolesLoading: boolean
+  rolesError: boolean
+  addOrgMutation: UseMutationResult<
+    unknown,
+    unknown,
+    { organization_slug: string; role_slug: string }
+  >
+  updateOrgRoleMutation: UseMutationResult<
+    unknown,
+    unknown,
+    { orgSlug: string; roleSlug: string }
+  >
+  removeOrgMutation: UseMutationResult<unknown, unknown, string>
+  onConfirmRemove: (orgSlug: string, orgName: string) => void
+}
+
+export function OrgMembershipsCard({
+  account,
+  availableRoles,
+  rolesLoading,
+  rolesError,
+  addOrgMutation,
+  updateOrgRoleMutation,
+  removeOrgMutation,
+  onConfirmRemove,
+}: OrgMembershipsCardProps) {
+  const { organizations: allOrgs } = useOrganization()
+  const [showAddOrg, setShowAddOrg] = useState(false)
+  const [newOrgSlug, setNewOrgSlug] = useState('')
+  const [newRoleSlug, setNewRoleSlug] = useState('')
+
+  useEffect(() => {
+    setShowAddOrg(false)
+    setNewOrgSlug('')
+    setNewRoleSlug('')
+  }, [account.slug])
+
+  const memberOrgSlugs = new Set(
+    (account.organizations ?? []).map((o) => o.organization_slug),
+  )
+  const availableOrgs = allOrgs.filter((o) => !memberOrgSlugs.has(o.slug))
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div className="flex items-center gap-2">
+          <Building2 className="h-5 w-5 text-secondary" />
+          <CardTitle>Organization Memberships</CardTitle>
+        </div>
+        {availableOrgs.length > 0 && (
+          <Button
+            onClick={() => setShowAddOrg(!showAddOrg)}
+            variant="outline"
+            size="sm"
+            className=""
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Add to Organization
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent>
+        {/* Add to Organization Form */}
+        {showAddOrg && (
+          <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Organization
+                </label>
+                <select
+                  value={newOrgSlug}
+                  onChange={(e) => setNewOrgSlug(e.target.value)}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+                >
+                  <option value="">Select...</option>
+                  {availableOrgs.map((org) => (
+                    <option key={org.slug} value={org.slug}>
+                      {org.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Role
+                </label>
+                {rolesLoading ? (
+                  <p className="text-sm text-secondary">Loading roles...</p>
+                ) : rolesError ? (
+                  <p className="text-sm text-danger">Failed to load roles</p>
+                ) : (
+                  <select
+                    value={newRoleSlug}
+                    onChange={(e) => setNewRoleSlug(e.target.value)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+                  >
+                    <option value="">Select...</option>
+                    {availableRoles.map((role) => (
+                      <option key={role.slug} value={role.slug}>
+                        {role.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            </div>
+            <div className="mt-3 flex items-center gap-2">
+              <Button
+                onClick={() =>
+                  addOrgMutation.mutate(
+                    {
+                      organization_slug: newOrgSlug,
+                      role_slug: newRoleSlug,
+                    },
+                    {
+                      onSuccess: () => {
+                        setShowAddOrg(false)
+                        setNewOrgSlug('')
+                        setNewRoleSlug('')
+                      },
+                    },
+                  )
+                }
+                disabled={
+                  !newOrgSlug || !newRoleSlug || addOrgMutation.isPending
+                }
+                className="bg-action text-action-foreground hover:bg-action-hover"
+                size="sm"
+              >
+                {addOrgMutation.isPending ? 'Adding...' : 'Add'}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setShowAddOrg(false)
+                  setNewOrgSlug('')
+                  setNewRoleSlug('')
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Memberships List */}
+        {(account.organizations ?? []).length > 0 ? (
+          <div className="space-y-2">
+            {(account.organizations ?? []).map((membership: OrgMembership) => (
+              <div
+                key={membership.organization_slug}
+                className="flex items-center justify-between rounded-lg border border-input bg-secondary p-3"
+              >
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-primary">
+                    {membership.organization_name}
+                  </div>
+                  <div className="text-xs text-tertiary">
+                    {membership.organization_slug}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {rolesLoading ? (
+                    <span className="text-xs text-secondary">
+                      Loading roles...
+                    </span>
+                  ) : rolesError ? (
+                    <span className="text-xs text-danger">
+                      Roles unavailable
+                    </span>
+                  ) : (
+                    <select
+                      value={membership.role}
+                      onChange={(e) =>
+                        updateOrgRoleMutation.mutate({
+                          orgSlug: membership.organization_slug,
+                          roleSlug: e.target.value,
+                        })
+                      }
+                      disabled={updateOrgRoleMutation.isPending}
+                      aria-label={`Role for ${membership.organization_name}`}
+                      className="rounded border border-input bg-background px-2 py-1 text-xs text-foreground"
+                    >
+                      {availableRoles.map((role) => (
+                        <option key={role.slug} value={role.slug}>
+                          {role.name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={`Remove from ${membership.organization_name}`}
+                          onClick={() =>
+                            onConfirmRemove(
+                              membership.organization_slug,
+                              membership.organization_name,
+                            )
+                          }
+                          disabled={removeOrgMutation.isPending}
+                          className="rounded p-1.5 text-danger hover:bg-secondary"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Remove from organization</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="py-8 text-center text-tertiary">
+            <Building2 className="mx-auto mb-2 h-8 w-8 text-tertiary" />
+            <div>Not a member of any organization</div>
+            <div className="mt-1 text-sm">
+              This service account has no permissions until added to an
+              organization
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/admin/service-accounts/ServiceAccountDetail.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountDetail.tsx
@@ -1,57 +1,18 @@
 import { useEffect, useState } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
-import { extractApiErrorDetail } from '@/lib/apiError'
-import {
-  ArrowLeft,
-  Edit2,
-  Power,
-  Clock,
-  Calendar,
-  Key,
-  Copy,
-  Plus,
-  Trash2,
-  AlertCircle,
-  RotateCw,
-  Shield,
-  Tag,
-  Building2,
-} from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { ArrowLeft, Edit2, Power, Clock, Calendar, Tag } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
-import { Input } from '@/components/ui/input'
-import {
-  listServiceAccountApiKeys,
-  createServiceAccountApiKey,
-  revokeServiceAccountApiKey,
-  rotateServiceAccountApiKey,
-  listClientCredentials,
-  createClientCredential,
-  revokeClientCredential,
-  rotateClientCredential,
-  addServiceAccountToOrg,
-  updateServiceAccountOrgRole,
-  removeServiceAccountFromOrg,
-  getRoles,
-} from '@/api/endpoints'
-import { useOrganization } from '@/contexts/OrganizationContext'
+import { getRoles } from '@/api/endpoints'
+import { OrgMembershipsCard } from './OrgMembershipsCard'
+import { ClientCredentialsSection } from './ClientCredentialsSection'
+import { ApiKeysSection } from './ApiKeysSection'
+import { useServiceAccountMutations } from './useServiceAccountMutations'
 import type {
   ServiceAccount,
-  ApiKey,
   ApiKeyCreated,
-  ClientCredential,
   ClientCredentialCreated,
-  ClientCredentialCreate,
-  OrgMembership,
 } from '@/types'
 
 interface ServiceAccountDetailProps {
@@ -60,45 +21,28 @@ interface ServiceAccountDetailProps {
   onBack: () => void
 }
 
+type ConfirmState =
+  | { action: 'revoke-key'; keyId: string }
+  | { action: 'rotate-key'; keyId: string }
+  | { action: 'revoke-credential'; clientId: string }
+  | { action: 'rotate-credential'; clientId: string }
+  | { action: 'remove-org'; orgSlug: string; orgName: string }
+  | null
+
 export function ServiceAccountDetail({
   account,
   onEdit,
   onBack,
 }: ServiceAccountDetailProps) {
-  const queryClient = useQueryClient()
+  const [confirm, setConfirm] = useState<ConfirmState>(null)
 
-  // API Keys state
-  const [newKeyName, setNewKeyName] = useState('')
-  const [showCreateKey, setShowCreateKey] = useState(false)
+  // Cross-boundary state: rotate confirmation lives in parent ConfirmDialog,
+  // but the resulting "newly created" banner renders inside the sub-section.
   const [newlyCreatedKey, setNewlyCreatedKey] = useState<ApiKeyCreated | null>(
     null,
   )
-  const [copiedId, setCopiedId] = useState<string | null>(null)
-
-  // Client Credentials state
-  const [showCreateCredential, setShowCreateCredential] = useState(false)
-  const [credentialName, setCredentialName] = useState('')
-  const [credentialDescription, setCredentialDescription] = useState('')
-  const [credentialScopes, setCredentialScopes] = useState('')
-  const [credentialExpiresDays, setCredentialExpiresDays] = useState('')
   const [newlyCreatedCredential, setNewlyCreatedCredential] =
     useState<ClientCredentialCreated | null>(null)
-
-  // Organization membership state
-  const { organizations: allOrgs } = useOrganization()
-  const [showAddOrg, setShowAddOrg] = useState(false)
-  const [newOrgSlug, setNewOrgSlug] = useState('')
-  const [newRoleSlug, setNewRoleSlug] = useState('')
-
-  // Confirm dialog state (covers 5 destructive actions)
-  const [confirm, setConfirm] = useState<
-    | { action: 'revoke-key'; keyId: string }
-    | { action: 'rotate-key'; keyId: string }
-    | { action: 'revoke-credential'; clientId: string }
-    | { action: 'rotate-credential'; clientId: string }
-    | { action: 'remove-org'; orgSlug: string; orgName: string }
-    | null
-  >(null)
 
   const {
     data: availableRoles = [],
@@ -109,205 +53,23 @@ export function ServiceAccountDetail({
     queryFn: getRoles,
   })
 
-  const memberOrgSlugs = new Set(
-    (account.organizations ?? []).map((o) => o.organization_slug),
-  )
-  const availableOrgs = allOrgs.filter((o) => !memberOrgSlugs.has(o.slug))
+  const {
+    addOrgMutation,
+    updateOrgRoleMutation,
+    removeOrgMutation,
+    createApiKeyMutation,
+    revokeApiKeyMutation,
+    rotateApiKeyMutation,
+    createCredentialMutation,
+    revokeCredentialMutation,
+    rotateCredentialMutation,
+  } = useServiceAccountMutations(account)
 
-  const addOrgMutation = useMutation({
-    mutationFn: (data: { organization_slug: string; role_slug: string }) =>
-      addServiceAccountToOrg(account.slug, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['serviceAccounts'] })
-      queryClient.invalidateQueries({
-        queryKey: ['serviceAccount', account.slug],
-      })
-      setShowAddOrg(false)
-      setNewOrgSlug('')
-      setNewRoleSlug('')
-    },
-    onError: (error: unknown) => {
-      toast.error(
-        `Failed to add to organization: ${extractApiErrorDetail(error)}`,
-      )
-    },
-  })
-
-  const updateOrgRoleMutation = useMutation({
-    mutationFn: ({
-      orgSlug,
-      roleSlug,
-    }: {
-      orgSlug: string
-      roleSlug: string
-    }) =>
-      updateServiceAccountOrgRole(account.slug, orgSlug, {
-        role_slug: roleSlug,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['serviceAccounts'] })
-      queryClient.invalidateQueries({
-        queryKey: ['serviceAccount', account.slug],
-      })
-    },
-    onError: (error: unknown) => {
-      toast.error(`Failed to update role: ${extractApiErrorDetail(error)}`)
-    },
-  })
-
-  const removeOrgMutation = useMutation({
-    mutationFn: (orgSlug: string) =>
-      removeServiceAccountFromOrg(account.slug, orgSlug),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['serviceAccounts'] })
-      queryClient.invalidateQueries({
-        queryKey: ['serviceAccount', account.slug],
-      })
-    },
-    onError: (error: unknown) => {
-      toast.error(
-        `Failed to remove from organization: ${extractApiErrorDetail(error)}`,
-      )
-    },
-  })
-
-  // Reset all sensitive/form state when the viewed account changes
+  // Reset cross-boundary state when the viewed account changes
   useEffect(() => {
-    setNewKeyName('')
-    setShowCreateKey(false)
     setNewlyCreatedKey(null)
-    setShowCreateCredential(false)
-    setCredentialName('')
-    setCredentialDescription('')
-    setCredentialScopes('')
-    setCredentialExpiresDays('')
     setNewlyCreatedCredential(null)
-    setCopiedId(null)
-    setShowAddOrg(false)
-    setNewOrgSlug('')
-    setNewRoleSlug('')
   }, [account.slug])
-
-  // Fetch API keys
-  const {
-    data: apiKeys = [],
-    isLoading: keysLoading,
-    error: keysError,
-  } = useQuery({
-    queryKey: ['serviceAccountApiKeys', account.slug],
-    queryFn: () => listServiceAccountApiKeys(account.slug),
-  })
-
-  // Fetch Client Credentials
-  const {
-    data: credentials = [],
-    isLoading: credentialsLoading,
-    error: credentialsError,
-  } = useQuery({
-    queryKey: ['clientCredentials', account.slug],
-    queryFn: () => listClientCredentials(account.slug),
-  })
-
-  // API Key mutations
-  const createKeyMutation = useMutation({
-    mutationFn: (name: string) =>
-      createServiceAccountApiKey(account.slug, { name }),
-    onSuccess: (data: ApiKeyCreated) => {
-      setNewlyCreatedKey(data)
-      setShowCreateKey(false)
-      setNewKeyName('')
-      queryClient.invalidateQueries({
-        queryKey: ['serviceAccountApiKeys', account.slug],
-      })
-    },
-    onError: (error: unknown) => {
-      toast.error(`Failed to create API key: ${extractApiErrorDetail(error)}`)
-    },
-  })
-
-  const revokeKeyMutation = useMutation({
-    mutationFn: (keyId: string) =>
-      revokeServiceAccountApiKey(account.slug, keyId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['serviceAccountApiKeys', account.slug],
-      })
-    },
-    onError: (error: unknown) => {
-      toast.error(`Failed to revoke API key: ${extractApiErrorDetail(error)}`)
-    },
-  })
-
-  const rotateKeyMutation = useMutation({
-    mutationFn: (keyId: string) =>
-      rotateServiceAccountApiKey(account.slug, keyId),
-    onSuccess: (data: ApiKeyCreated) => {
-      setNewlyCreatedKey(data)
-      queryClient.invalidateQueries({
-        queryKey: ['serviceAccountApiKeys', account.slug],
-      })
-    },
-    onError: (error: unknown) => {
-      toast.error(`Failed to rotate API key: ${extractApiErrorDetail(error)}`)
-    },
-  })
-
-  // Client Credential mutations
-  const createCredentialMutation = useMutation({
-    mutationFn: (data: ClientCredentialCreate) =>
-      createClientCredential(account.slug, data),
-    onSuccess: (data: ClientCredentialCreated) => {
-      setNewlyCreatedCredential(data)
-      setShowCreateCredential(false)
-      resetCredentialForm()
-      queryClient.invalidateQueries({
-        queryKey: ['clientCredentials', account.slug],
-      })
-    },
-    onError: (error: unknown) => {
-      toast.error(
-        `Failed to create credential: ${extractApiErrorDetail(error)}`,
-      )
-    },
-  })
-
-  const revokeCredentialMutation = useMutation({
-    mutationFn: (clientId: string) =>
-      revokeClientCredential(account.slug, clientId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['clientCredentials', account.slug],
-      })
-    },
-    onError: (error: unknown) => {
-      toast.error(
-        `Failed to revoke credential: ${extractApiErrorDetail(error)}`,
-      )
-    },
-  })
-
-  const rotateCredentialMutation = useMutation({
-    mutationFn: (clientId: string) =>
-      rotateClientCredential(account.slug, clientId),
-    onSuccess: (data: ClientCredentialCreated) => {
-      setNewlyCreatedCredential(data)
-      queryClient.invalidateQueries({
-        queryKey: ['clientCredentials', account.slug],
-      })
-    },
-    onError: (error: unknown) => {
-      toast.error(
-        `Failed to rotate credential: ${extractApiErrorDetail(error)}`,
-      )
-    },
-  })
-
-  const resetCredentialForm = () => {
-    setCredentialName('')
-    setCredentialDescription('')
-    setCredentialScopes('')
-    setCredentialExpiresDays('')
-  }
 
   const formatDate = (dateString?: string | null) => {
     if (!dateString) return 'Never'
@@ -318,67 +80,6 @@ export function ServiceAccountDetail({
       hour: '2-digit',
       minute: '2-digit',
     })
-  }
-
-  const copyToClipboard = async (text: string, id: string) => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopiedId(id)
-      setTimeout(() => setCopiedId(null), 2000)
-    } catch {
-      toast.error('Failed to copy to clipboard')
-    }
-  }
-
-  const handleCreateKey = () => {
-    const name = newKeyName.trim() || 'default'
-    createKeyMutation.mutate(name)
-  }
-
-  const handleRevokeKey = (keyId: string) => {
-    setConfirm({ action: 'revoke-key', keyId })
-  }
-
-  const handleRotateKey = (keyId: string) => {
-    setConfirm({ action: 'rotate-key', keyId })
-  }
-
-  const handleCreateCredential = () => {
-    const scopes = credentialScopes
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-    const expiresInDays =
-      credentialExpiresDays.trim() === '' ? null : Number(credentialExpiresDays)
-
-    if (
-      expiresInDays !== null &&
-      (!Number.isInteger(expiresInDays) || expiresInDays < 1)
-    ) {
-      toast.error('Expiration must be a positive whole number of days.')
-      return
-    }
-
-    const data: ClientCredentialCreate = {
-      name: credentialName.trim(),
-      description: credentialDescription.trim() || null,
-      scopes: scopes.length > 0 ? scopes : undefined,
-      expires_in_days: expiresInDays,
-    }
-    createCredentialMutation.mutate(data)
-  }
-
-  const handleRevokeCredential = (clientId: string) => {
-    setConfirm({ action: 'revoke-credential', clientId })
-  }
-
-  const handleRotateCredential = (clientId: string) => {
-    setConfirm({ action: 'rotate-credential', clientId })
-  }
-
-  const truncateClientId = (clientId: string) => {
-    if (clientId.length <= 12) return clientId
-    return `${clientId.substring(0, 12)}...`
   }
 
   return (
@@ -427,671 +128,44 @@ export function ServiceAccountDetail({
         </CardContent>
       </Card>
 
-      {/* Organization Memberships */}
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
-          <div className="flex items-center gap-2">
-            <Building2 className="h-5 w-5 text-secondary" />
-            <CardTitle>Organization Memberships</CardTitle>
-          </div>
-          {availableOrgs.length > 0 && (
-            <Button
-              onClick={() => setShowAddOrg(!showAddOrg)}
-              variant="outline"
-              size="sm"
-              className=""
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              Add to Organization
-            </Button>
-          )}
-        </CardHeader>
-        <CardContent>
-          {/* Add to Organization Form */}
-          {showAddOrg && (
-            <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Organization
-                  </label>
-                  <select
-                    value={newOrgSlug}
-                    onChange={(e) => setNewOrgSlug(e.target.value)}
-                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
-                  >
-                    <option value="">Select...</option>
-                    {availableOrgs.map((org) => (
-                      <option key={org.slug} value={org.slug}>
-                        {org.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div>
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Role
-                  </label>
-                  {rolesLoading ? (
-                    <p className="text-sm text-secondary">Loading roles...</p>
-                  ) : rolesError ? (
-                    <p className="text-sm text-danger">Failed to load roles</p>
-                  ) : (
-                    <select
-                      value={newRoleSlug}
-                      onChange={(e) => setNewRoleSlug(e.target.value)}
-                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
-                    >
-                      <option value="">Select...</option>
-                      {availableRoles.map((role) => (
-                        <option key={role.slug} value={role.slug}>
-                          {role.name}
-                        </option>
-                      ))}
-                    </select>
-                  )}
-                </div>
-              </div>
-              <div className="mt-3 flex items-center gap-2">
-                <Button
-                  onClick={() =>
-                    addOrgMutation.mutate({
-                      organization_slug: newOrgSlug,
-                      role_slug: newRoleSlug,
-                    })
-                  }
-                  disabled={
-                    !newOrgSlug || !newRoleSlug || addOrgMutation.isPending
-                  }
-                  className="bg-action text-action-foreground hover:bg-action-hover"
-                  size="sm"
-                >
-                  {addOrgMutation.isPending ? 'Adding...' : 'Add'}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    setShowAddOrg(false)
-                    setNewOrgSlug('')
-                    setNewRoleSlug('')
-                  }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          )}
+      <OrgMembershipsCard
+        account={account}
+        availableRoles={availableRoles}
+        rolesLoading={rolesLoading}
+        rolesError={rolesError}
+        addOrgMutation={addOrgMutation}
+        updateOrgRoleMutation={updateOrgRoleMutation}
+        removeOrgMutation={removeOrgMutation}
+        onConfirmRemove={(orgSlug, orgName) =>
+          setConfirm({ action: 'remove-org', orgSlug, orgName })
+        }
+      />
 
-          {/* Memberships List */}
-          {(account.organizations ?? []).length > 0 ? (
-            <div className="space-y-2">
-              {(account.organizations ?? []).map(
-                (membership: OrgMembership) => (
-                  <div
-                    key={membership.organization_slug}
-                    className="flex items-center justify-between rounded-lg border border-input bg-secondary p-3"
-                  >
-                    <div className="flex-1">
-                      <div className="text-sm font-medium text-primary">
-                        {membership.organization_name}
-                      </div>
-                      <div className="text-xs text-tertiary">
-                        {membership.organization_slug}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      {rolesLoading ? (
-                        <span className="text-xs text-secondary">
-                          Loading roles...
-                        </span>
-                      ) : rolesError ? (
-                        <span className="text-xs text-danger">
-                          Roles unavailable
-                        </span>
-                      ) : (
-                        <select
-                          value={membership.role}
-                          onChange={(e) =>
-                            updateOrgRoleMutation.mutate({
-                              orgSlug: membership.organization_slug,
-                              roleSlug: e.target.value,
-                            })
-                          }
-                          disabled={updateOrgRoleMutation.isPending}
-                          aria-label={`Role for ${membership.organization_name}`}
-                          className="rounded border border-input bg-background px-2 py-1 text-xs text-foreground"
-                        >
-                          {availableRoles.map((role) => (
-                            <option key={role.slug} value={role.slug}>
-                              {role.name}
-                            </option>
-                          ))}
-                        </select>
-                      )}
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label={`Remove from ${membership.organization_name}`}
-                              onClick={() =>
-                                setConfirm({
-                                  action: 'remove-org',
-                                  orgSlug: membership.organization_slug,
-                                  orgName: membership.organization_name,
-                                })
-                              }
-                              disabled={removeOrgMutation.isPending}
-                              className="rounded p-1.5 text-danger hover:bg-secondary"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Remove from organization</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </div>
-                  </div>
-                ),
-              )}
-            </div>
-          ) : (
-            <div className="py-8 text-center text-tertiary">
-              <Building2 className="mx-auto mb-2 h-8 w-8 text-tertiary" />
-              <div>Not a member of any organization</div>
-              <div className="mt-1 text-sm">
-                This service account has no permissions until added to an
-                organization
-              </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <ClientCredentialsSection
+        account={account}
+        createCredentialMutation={createCredentialMutation}
+        revokeCredentialMutation={revokeCredentialMutation}
+        rotateCredentialMutation={rotateCredentialMutation}
+        newlyCreatedCredential={newlyCreatedCredential}
+        onNewlyCreatedCredentialChange={setNewlyCreatedCredential}
+        onConfirmRevoke={(clientId) =>
+          setConfirm({ action: 'revoke-credential', clientId })
+        }
+        onConfirmRotate={(clientId) =>
+          setConfirm({ action: 'rotate-credential', clientId })
+        }
+      />
 
-      {/* Client Credentials */}
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
-          <div className="flex items-center gap-2">
-            <Shield className="h-5 w-5 text-secondary" />
-            <CardTitle>Client Credentials</CardTitle>
-          </div>
-          <Button
-            onClick={() => setShowCreateCredential(!showCreateCredential)}
-            variant="outline"
-            size="sm"
-            className=""
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            Create Credential
-          </Button>
-        </CardHeader>
-        <CardContent>
-          {/* Create Credential Form */}
-          {showCreateCredential && (
-            <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
-              <div className="space-y-3">
-                <div>
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Name <span className="text-red-500">*</span>
-                  </label>
-                  <Input
-                    value={credentialName}
-                    onChange={(e) => setCredentialName(e.target.value)}
-                    placeholder="e.g., production-api"
-                    className=""
-                  />
-                </div>
-                <div>
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Description
-                  </label>
-                  <Input
-                    value={credentialDescription}
-                    onChange={(e) => setCredentialDescription(e.target.value)}
-                    placeholder="What is this credential used for?"
-                    className=""
-                  />
-                </div>
-                <div>
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Scopes{' '}
-                    <span className="text-xs text-tertiary">
-                      (comma-separated)
-                    </span>
-                  </label>
-                  <Input
-                    value={credentialScopes}
-                    onChange={(e) => setCredentialScopes(e.target.value)}
-                    placeholder="e.g., read:projects, write:projects"
-                    className=""
-                  />
-                </div>
-                <div>
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Expires in (days){' '}
-                    <span className="text-xs text-tertiary">
-                      (leave empty for no expiration)
-                    </span>
-                  </label>
-                  <Input
-                    type="number"
-                    min="1"
-                    value={credentialExpiresDays}
-                    onChange={(e) => setCredentialExpiresDays(e.target.value)}
-                    placeholder="e.g., 90"
-                    className=""
-                  />
-                </div>
-                <div className="flex items-center gap-2 pt-2">
-                  <Button
-                    onClick={handleCreateCredential}
-                    disabled={
-                      !credentialName.trim() ||
-                      createCredentialMutation.isPending
-                    }
-                    className="bg-action text-action-foreground hover:bg-action-hover"
-                  >
-                    {createCredentialMutation.isPending
-                      ? 'Creating...'
-                      : 'Create'}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() => {
-                      setShowCreateCredential(false)
-                      resetCredentialForm()
-                    }}
-                    className=""
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Newly Created Credential Banner */}
-          {newlyCreatedCredential && (
-            <div className="mb-4 rounded-lg border border-success bg-success p-4">
-              <div className="mb-2 font-medium text-success">
-                Client Credential Created - Copy the secret now, it will not be
-                shown again!
-              </div>
-              <div className="space-y-2">
-                <div>
-                  <span className="text-xs text-secondary">Client ID</span>
-                  <div className="flex items-center gap-2">
-                    <code className="flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success">
-                      {newlyCreatedCredential.client_id}
-                    </code>
-                    <TooltipProvider delayDuration={200}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            aria-label="Copy client ID"
-                            onClick={() =>
-                              copyToClipboard(
-                                newlyCreatedCredential.client_id,
-                                'cred-id',
-                              )
-                            }
-                            className={`rounded-lg p-2 ${
-                              copiedId === 'cred-id'
-                                ? 'bg-green-600 text-white'
-                                : 'text-secondary hover:bg-secondary'
-                            }`}
-                          >
-                            <Copy className="h-4 w-4" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Copy to clipboard</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                </div>
-                <div>
-                  <span className="text-xs text-secondary">Client Secret</span>
-                  <div className="flex items-center gap-2">
-                    <code className="flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success">
-                      {newlyCreatedCredential.client_secret}
-                    </code>
-                    <TooltipProvider delayDuration={200}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            aria-label="Copy client secret"
-                            onClick={() =>
-                              copyToClipboard(
-                                newlyCreatedCredential.client_secret,
-                                'cred-secret',
-                              )
-                            }
-                            className={`rounded-lg p-2 ${
-                              copiedId === 'cred-secret'
-                                ? 'bg-green-600 text-white'
-                                : 'text-secondary hover:bg-secondary'
-                            }`}
-                          >
-                            <Copy className="h-4 w-4" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Copy to clipboard</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={() => setNewlyCreatedCredential(null)}
-                className="hover:text-success/80 mt-2 text-sm text-success"
-              >
-                Dismiss
-              </button>
-            </div>
-          )}
-
-          {/* Credentials List */}
-          {credentialsLoading ? (
-            <div className="py-4 text-sm text-secondary">
-              Loading client credentials...
-            </div>
-          ) : credentialsError ? (
-            <div className="flex items-center gap-2 rounded-lg bg-danger p-3 text-danger">
-              <AlertCircle className="h-4 w-4 flex-shrink-0" />
-              <span className="text-sm">Failed to load client credentials</span>
-            </div>
-          ) : credentials.length === 0 ? (
-            <div className="py-8 text-center text-tertiary">
-              <Shield className="mx-auto mb-2 h-8 w-8 text-tertiary" />
-              <div>No client credentials created yet</div>
-              <div className="mt-1 text-sm">
-                Create a credential for OAuth2 client_credentials flow
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {credentials.map((cred: ClientCredential) => (
-                <div
-                  key={cred.client_id}
-                  className={`flex items-center justify-between rounded-lg border p-3 ${
-                    cred.revoked
-                      ? 'border-input bg-secondary opacity-50'
-                      : 'border-input bg-secondary'
-                  }`}
-                >
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-primary">
-                        {cred.name}
-                      </span>
-                      <code className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary">
-                        {truncateClientId(cred.client_id)}
-                      </code>
-                      {cred.revoked && <Badge variant="danger">Revoked</Badge>}
-                      {cred.scopes.length > 0 && cred.scopes[0] !== '*' && (
-                        <span className="text-xs text-tertiary">
-                          {cred.scopes.join(', ')}
-                        </span>
-                      )}
-                    </div>
-                    <div className="mt-1 text-xs text-tertiary">
-                      Created {formatDate(cred.created_at)}
-                      {cred.last_used &&
-                        ` | Last used ${formatDate(cred.last_used)}`}
-                      {cred.expires_at &&
-                        ` | Expires ${formatDate(cred.expires_at)}`}
-                    </div>
-                  </div>
-                  {!cred.revoked && (
-                    <div className="flex items-center gap-1">
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label={`Rotate credential ${cred.name}`}
-                              onClick={() =>
-                                handleRotateCredential(cred.client_id)
-                              }
-                              disabled={rotateCredentialMutation.isPending}
-                              className="rounded p-1.5 text-info hover:bg-secondary"
-                            >
-                              <RotateCw className="h-4 w-4" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Rotate credential</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label={`Revoke credential ${cred.name}`}
-                              onClick={() =>
-                                handleRevokeCredential(cred.client_id)
-                              }
-                              disabled={revokeCredentialMutation.isPending}
-                              className="rounded p-1.5 text-danger hover:bg-secondary"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Revoke credential</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* API Keys */}
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
-          <div className="flex items-center gap-2">
-            <Key className="h-5 w-5 text-secondary" />
-            <CardTitle>API Keys</CardTitle>
-          </div>
-          <Button
-            onClick={() => setShowCreateKey(!showCreateKey)}
-            variant="outline"
-            size="sm"
-            className=""
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            Create API Key
-          </Button>
-        </CardHeader>
-        <CardContent>
-          {/* Create Key Form */}
-          {showCreateKey && (
-            <div className="mb-4 rounded-lg border border-input bg-secondary p-4">
-              <div className="flex items-end gap-3">
-                <div className="flex-1">
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Key Name
-                  </label>
-                  <input
-                    type="text"
-                    value={newKeyName}
-                    onChange={(e) => setNewKeyName(e.target.value)}
-                    placeholder="e.g., production, staging"
-                    className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
-                  />
-                </div>
-                <Button
-                  onClick={handleCreateKey}
-                  disabled={createKeyMutation.isPending}
-                  className="bg-action text-action-foreground hover:bg-action-hover"
-                >
-                  {createKeyMutation.isPending ? 'Creating...' : 'Create'}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setShowCreateKey(false)
-                    setNewKeyName('')
-                  }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {/* Newly Created Key Banner */}
-          {newlyCreatedKey && (
-            <div className="mb-4 rounded-lg border border-success bg-success p-4">
-              <div className="mb-2 font-medium text-success">
-                API Key Created - Copy it now, it will not be shown again!
-              </div>
-              <div className="flex items-center gap-2">
-                <code className="flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success">
-                  {newlyCreatedKey.key_secret}
-                </code>
-                <TooltipProvider delayDuration={200}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label="Copy API key"
-                        onClick={() =>
-                          copyToClipboard(newlyCreatedKey.key_secret, 'new-key')
-                        }
-                        className={`rounded-lg p-2 ${
-                          copiedId === 'new-key'
-                            ? 'bg-green-600 text-white'
-                            : 'text-secondary hover:bg-secondary'
-                        }`}
-                      >
-                        <Copy className="h-4 w-4" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Copy to clipboard</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-              <button
-                onClick={() => setNewlyCreatedKey(null)}
-                className="hover:text-success/80 mt-2 text-sm text-success"
-              >
-                Dismiss
-              </button>
-            </div>
-          )}
-
-          {/* Keys List */}
-          {keysLoading ? (
-            <div className="py-4 text-sm text-secondary">
-              Loading API keys...
-            </div>
-          ) : keysError ? (
-            <div className="flex items-center gap-2 rounded-lg bg-danger p-3 text-danger">
-              <AlertCircle className="h-4 w-4 flex-shrink-0" />
-              <span className="text-sm">Failed to load API keys</span>
-            </div>
-          ) : apiKeys.length === 0 ? (
-            <div className="py-8 text-center text-tertiary">
-              <Key className="mx-auto mb-2 h-8 w-8 text-tertiary" />
-              <div>No API keys created yet</div>
-              <div className="mt-1 text-sm">
-                Create an API key to enable programmatic access
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {apiKeys.map((key: ApiKey) => (
-                <div
-                  key={key.key_id}
-                  className={`flex items-center justify-between rounded-lg border p-3 ${
-                    key.revoked
-                      ? 'border-input bg-secondary opacity-50'
-                      : 'border-input bg-secondary'
-                  }`}
-                >
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-primary">
-                        {key.name}
-                      </span>
-                      <code className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary">
-                        {key.key_id.substring(0, 7)}...
-                      </code>
-                      {key.revoked && <Badge variant="danger">Revoked</Badge>}
-                    </div>
-                    <div className="mt-1 text-xs text-tertiary">
-                      Created {formatDate(key.created_at)}
-                      {key.last_used &&
-                        ` | Last used ${formatDate(key.last_used)}`}
-                      {key.expires_at &&
-                        ` | Expires ${formatDate(key.expires_at)}`}
-                    </div>
-                  </div>
-                  {!key.revoked && (
-                    <div className="flex items-center gap-1">
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label={`Rotate API key ${key.name}`}
-                              onClick={() => handleRotateKey(key.key_id)}
-                              disabled={rotateKeyMutation.isPending}
-                              className="rounded p-1.5 text-info hover:bg-secondary"
-                            >
-                              <RotateCw className="h-4 w-4" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Rotate API key</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label={`Revoke API key ${key.name}`}
-                              onClick={() => handleRevokeKey(key.key_id)}
-                              disabled={revokeKeyMutation.isPending}
-                              className="rounded p-1.5 text-danger hover:bg-secondary"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Revoke API key</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <ApiKeysSection
+        account={account}
+        createApiKeyMutation={createApiKeyMutation}
+        revokeApiKeyMutation={revokeApiKeyMutation}
+        rotateApiKeyMutation={rotateApiKeyMutation}
+        newlyCreatedKey={newlyCreatedKey}
+        onNewlyCreatedKeyChange={setNewlyCreatedKey}
+        onConfirmRevoke={(keyId) => setConfirm({ action: 'revoke-key', keyId })}
+        onConfirmRotate={(keyId) => setConfirm({ action: 'rotate-key', keyId })}
+      />
 
       {/* Basic Information */}
       <Card>
@@ -1173,7 +247,7 @@ export function ServiceAccountDetail({
         confirmLabel="Revoke"
         onConfirm={() => {
           if (confirm?.action === 'revoke-key') {
-            revokeKeyMutation.mutate(confirm.keyId)
+            revokeApiKeyMutation.mutate(confirm.keyId)
           }
           setConfirm(null)
         }}
@@ -1186,7 +260,9 @@ export function ServiceAccountDetail({
         confirmLabel="Rotate"
         onConfirm={() => {
           if (confirm?.action === 'rotate-key') {
-            rotateKeyMutation.mutate(confirm.keyId)
+            rotateApiKeyMutation.mutate(confirm.keyId, {
+              onSuccess: (data) => setNewlyCreatedKey(data),
+            })
           }
           setConfirm(null)
         }}
@@ -1212,7 +288,9 @@ export function ServiceAccountDetail({
         confirmLabel="Rotate"
         onConfirm={() => {
           if (confirm?.action === 'rotate-credential') {
-            rotateCredentialMutation.mutate(confirm.clientId)
+            rotateCredentialMutation.mutate(confirm.clientId, {
+              onSuccess: (data) => setNewlyCreatedCredential(data),
+            })
           }
           setConfirm(null)
         }}

--- a/src/components/admin/service-accounts/useServiceAccountMutations.ts
+++ b/src/components/admin/service-accounts/useServiceAccountMutations.ts
@@ -1,0 +1,169 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import {
+  createServiceAccountApiKey,
+  revokeServiceAccountApiKey,
+  rotateServiceAccountApiKey,
+  createClientCredential,
+  revokeClientCredential,
+  rotateClientCredential,
+  addServiceAccountToOrg,
+  updateServiceAccountOrgRole,
+  removeServiceAccountFromOrg,
+} from '@/api/endpoints'
+import type { ServiceAccount, ClientCredentialCreate } from '@/types'
+
+export function useServiceAccountMutations(account: ServiceAccount) {
+  const queryClient = useQueryClient()
+
+  const addOrgMutation = useMutation({
+    mutationFn: (data: { organization_slug: string; role_slug: string }) =>
+      addServiceAccountToOrg(account.slug, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['serviceAccounts'] })
+      queryClient.invalidateQueries({
+        queryKey: ['serviceAccount', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        `Failed to add to organization: ${extractApiErrorDetail(error)}`,
+      )
+    },
+  })
+
+  const updateOrgRoleMutation = useMutation({
+    mutationFn: ({
+      orgSlug,
+      roleSlug,
+    }: {
+      orgSlug: string
+      roleSlug: string
+    }) =>
+      updateServiceAccountOrgRole(account.slug, orgSlug, {
+        role_slug: roleSlug,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['serviceAccounts'] })
+      queryClient.invalidateQueries({
+        queryKey: ['serviceAccount', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(`Failed to update role: ${extractApiErrorDetail(error)}`)
+    },
+  })
+
+  const removeOrgMutation = useMutation({
+    mutationFn: (orgSlug: string) =>
+      removeServiceAccountFromOrg(account.slug, orgSlug),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['serviceAccounts'] })
+      queryClient.invalidateQueries({
+        queryKey: ['serviceAccount', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        `Failed to remove from organization: ${extractApiErrorDetail(error)}`,
+      )
+    },
+  })
+
+  const createApiKeyMutation = useMutation({
+    mutationFn: (name: string) =>
+      createServiceAccountApiKey(account.slug, { name }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['serviceAccountApiKeys', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(`Failed to create API key: ${extractApiErrorDetail(error)}`)
+    },
+  })
+
+  const revokeApiKeyMutation = useMutation({
+    mutationFn: (keyId: string) =>
+      revokeServiceAccountApiKey(account.slug, keyId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['serviceAccountApiKeys', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(`Failed to revoke API key: ${extractApiErrorDetail(error)}`)
+    },
+  })
+
+  const rotateApiKeyMutation = useMutation({
+    mutationFn: (keyId: string) =>
+      rotateServiceAccountApiKey(account.slug, keyId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['serviceAccountApiKeys', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(`Failed to rotate API key: ${extractApiErrorDetail(error)}`)
+    },
+  })
+
+  const createCredentialMutation = useMutation({
+    mutationFn: (data: ClientCredentialCreate) =>
+      createClientCredential(account.slug, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['clientCredentials', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        `Failed to create credential: ${extractApiErrorDetail(error)}`,
+      )
+    },
+  })
+
+  const revokeCredentialMutation = useMutation({
+    mutationFn: (clientId: string) =>
+      revokeClientCredential(account.slug, clientId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['clientCredentials', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        `Failed to revoke credential: ${extractApiErrorDetail(error)}`,
+      )
+    },
+  })
+
+  const rotateCredentialMutation = useMutation({
+    mutationFn: (clientId: string) =>
+      rotateClientCredential(account.slug, clientId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['clientCredentials', account.slug],
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        `Failed to rotate credential: ${extractApiErrorDetail(error)}`,
+      )
+    },
+  })
+
+  return {
+    addOrgMutation,
+    updateOrgRoleMutation,
+    removeOrgMutation,
+    createApiKeyMutation,
+    revokeApiKeyMutation,
+    rotateApiKeyMutation,
+    createCredentialMutation,
+    revokeCredentialMutation,
+    rotateCredentialMutation,
+  }
+}

--- a/src/components/ui/secret-banner.tsx
+++ b/src/components/ui/secret-banner.tsx
@@ -89,6 +89,7 @@ export function SecretBanner({
         })}
       </div>
       <button
+        type="button"
         onClick={onDismiss}
         className="hover:text-success/80 mt-2 text-sm text-success"
       >

--- a/src/components/ui/secret-banner.tsx
+++ b/src/components/ui/secret-banner.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { Copy } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+export interface SecretBannerSecret {
+  label?: string
+  value: string
+  monospace?: boolean
+  copyAriaLabel?: string
+}
+
+interface SecretBannerProps {
+  title: string
+  description?: string
+  secrets: SecretBannerSecret[]
+  onDismiss: () => void
+}
+
+export function SecretBanner({
+  title,
+  description,
+  secrets,
+  onDismiss,
+}: SecretBannerProps) {
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+
+  const copyToClipboard = async (text: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopiedField(id)
+      setTimeout(() => setCopiedField(null), 2000)
+    } catch {
+      toast.error('Failed to copy to clipboard')
+    }
+  }
+
+  const heading = description ? `${title} - ${description}` : title
+
+  return (
+    <div className="mb-4 rounded-lg border border-success bg-success p-4">
+      <div className="mb-2 font-medium text-success">{heading}</div>
+      <div className="space-y-2">
+        {secrets.map((secret, index) => {
+          const fieldId = secret.label ?? `secret-${index}`
+          const copyLabel =
+            secret.copyAriaLabel ??
+            (secret.label
+              ? `Copy ${secret.label.toLowerCase()}`
+              : 'Copy to clipboard')
+          return (
+            <div key={fieldId}>
+              {secret.label && (
+                <span className="text-xs text-secondary">{secret.label}</span>
+              )}
+              <div className="flex items-center gap-2">
+                <code className="flex-1 rounded border border-input bg-background px-3 py-2 text-sm text-success">
+                  {secret.value}
+                </code>
+                <TooltipProvider delayDuration={200}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={copyLabel}
+                        onClick={() => copyToClipboard(secret.value, fieldId)}
+                        className={`rounded-lg p-2 ${
+                          copiedField === fieldId
+                            ? 'bg-green-600 text-white'
+                            : 'text-secondary hover:bg-secondary'
+                        }`}
+                      >
+                        <Copy className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Copy to clipboard</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      <button
+        onClick={onDismiss}
+        className="hover:text-success/80 mt-2 text-sm text-success"
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}

--- a/src/components/ui/secret-banner.tsx
+++ b/src/components/ui/secret-banner.tsx
@@ -47,7 +47,7 @@ export function SecretBanner({
       <div className="mb-2 font-medium text-success">{heading}</div>
       <div className="space-y-2">
         {secrets.map((secret, index) => {
-          const fieldId = secret.label ?? `secret-${index}`
+          const fieldId = `${secret.label ?? 'secret'}-${index}`
           const copyLabel =
             secret.copyAriaLabel ??
             (secret.label


### PR DESCRIPTION
## Summary

Section 3b of `docs/code-review-followups.md` — decompose `ServiceAccountDetail.tsx`. Before this PR: **1240 LOC**, 13 useStates, 9 mutations, two near-duplicate "newly-created secret" banners, and three cards of render inline. After this PR: **329 LOC** in the parent plus five sibling files.

Pure extraction — no behavior change. Per the doc's rule for section 3:
> Each extraction should be **structurally identical** to the original (no behavior change). CodeRabbit and the user will review for regressions; bundle any fixes the extraction reveals as separate follow-up PRs.

## Extractions

- **`src/components/ui/secret-banner.tsx`** — generic `SecretBanner` with internal copy-to-clipboard state keyed by secret label. Replaces the two near-duplicate banners for new credentials + new API keys (consolidating both branches, with per-secret `copyAriaLabel` overrides so the announced text stays accurate).
- **`useServiceAccountMutations.ts`** — wraps all nine mutations (add / update-role / remove org membership; create / revoke / rotate credentials; create / revoke / rotate API keys) plus their `queryClient.invalidateQueries` calls and `extractApiErrorDetail`-based toast error handling. Per-call `onSuccess` stays with each caller so local form resets still fire.
- **`OrgMembershipsCard.tsx`** — org-membership UI. Owns its own `showAddOrg` / `newOrgSlug` / `newRoleSlug` state. Requests destructive confirms via an `onConfirmRemove` callback; the ConfirmDialog stays in the parent.
- **`ClientCredentialsSection.tsx`** — client-credentials UI. Owns its five local form fields (`name`, `description`, `scopes`, `expiresDays`, `showCreate*`). Uses `SecretBanner` for the newly-created state.
- **`ApiKeysSection.tsx`** — API-keys UI, structurally parallel to `ClientCredentialsSection`. Owns `newKeyName` + `showCreateKey` locally.

## State redistribution — deviation from the doc worth flagging

The follow-ups doc suggested "collapse 13 useStates into useReducer with a single dispatch." The extraction above naturally redistributes 10 of those 13 useStates to the three sub-components (each sub-component now owns the state only it reads). That removes the single-component concentration without introducing a reducer. I think it's a cleaner outcome and would flag it only if a reviewer prefers the original plan.

Parent retains three useStates that genuinely cross section boundaries:
- `confirm` — the discriminated-union state coordinating all five destructive ConfirmDialogs.
- `newlyCreatedKey` / `newlyCreatedCredential` — these two stay at the parent because the **rotate** ConfirmDialog lives at the parent (its `onConfirm` is what fires the rotate mutation), so the success handler that populates the banner has to set state the child can read. Create-flow banners still reset via per-call `onSuccess` in the child.

The five ConfirmDialogs remain in the parent, unchanged.

## What's not in this PR

- `useReducer` collapse — see above; redistribution makes it unnecessary.
- Any behavior change — this is pure extraction.
- Section 3c (`BlueprintForm`) — next PR.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Smoke-test ServiceAccountDetail: create + revoke + rotate an API key; create + revoke + rotate a client credential; add + update + remove org membership; verify copy-to-clipboard per secret; verify all five ConfirmDialogs fire and cancel cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)