### PR TITLE
Refactor: extract withAuthRetry for 401 refresh/retry

### DIFF
--- a/src/api/assistant.ts
+++ b/src/api/assistant.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from '@/stores/authStore'
+import { withAuthRetry } from '@/api/client'
 import type {
   Conversation,
   ConversationWithMessages,
@@ -12,19 +12,17 @@ async function assistantFetch<T>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const token = useAuthStore.getState().accessToken
-  const response = await fetch(`${ASSISTANT_BASE_URL}${path}`, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...options.headers,
-    },
-  })
+  const response = await withAuthRetry(path, (token) =>
+    fetch(`${ASSISTANT_BASE_URL}${path}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...options.headers,
+      },
+    }),
+  )
   if (!response.ok) {
-    if (response.status === 401) {
-      window.location.assign('/login')
-    }
     throw new Error(`HTTP ${response.status}`)
   }
   if (response.status === 204) return undefined as T
@@ -89,24 +87,22 @@ export async function sendMessageSSE(
   handlers: SSEEventHandler,
   signal?: AbortSignal,
 ): Promise<void> {
-  const token = useAuthStore.getState().accessToken
-  const url = `${ASSISTANT_BASE_URL}/conversations/${conversationId}/messages`
+  const path = `/conversations/${conversationId}/messages`
+  const url = `${ASSISTANT_BASE_URL}${path}`
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify({ content }),
-    signal,
-  })
+  const response = await withAuthRetry(path, (token) =>
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ content }),
+      signal,
+    }),
+  )
 
   if (!response.ok) {
-    if (response.status === 401) {
-      window.location.assign('/login')
-      return
-    }
     const errorText = await response.text()
     handlers.onError?.(errorText || `HTTP ${response.status}`)
     return

--- a/src/api/assistant.ts
+++ b/src/api/assistant.ts
@@ -1,4 +1,4 @@
-import { withAuthRetry } from '@/api/client'
+import { ApiError, withAuthRetry } from '@/api/client'
 import type {
   Conversation,
   ConversationWithMessages,
@@ -23,7 +23,13 @@ async function assistantFetch<T>(
     }),
   )
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`)
+    let errorData: unknown
+    try {
+      errorData = await response.json()
+    } catch {
+      /* no body */
+    }
+    throw new ApiError(response.status, response.statusText, errorData)
   }
   if (response.status === 204) return undefined as T
   return response.json()

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -98,71 +98,83 @@ function buildUrl(url: string, params?: Record<string, unknown>): string {
   return fullUrl
 }
 
+async function resolveAuthToken(url: string): Promise<string | null> {
+  if (shouldSkipAuth(url)) return null
+  const authStore = useAuthStore.getState()
+  if (authStore.isTokenExpired()) {
+    try {
+      return await refreshAccessToken()
+    } catch (error) {
+      // Proactive refresh failed; tokens already cleared by
+      // refreshAccessToken. Redirect to login and surface the failure
+      // rather than sending an unauthenticated request and triggering a
+      // second refresh via the 401 handler.
+      redirectToLogin()
+      throw error instanceof ApiError
+        ? error
+        : new ApiError(401, 'Token refresh failed')
+    }
+  }
+  return authStore.accessToken
+}
+
+/**
+ * Runs `fetcher` with an auth token resolved for `url`, and on a 401 response
+ * performs one reactive refresh + retry. Handles the proactive-refresh check,
+ * the `refreshPromise` lock (via `refreshAccessToken`), and the terminal
+ * behavior when the refresh endpoint itself returns 401 (clear tokens +
+ * redirect to login). URLs matching SKIP_AUTH_PATHS are passed a `null` token
+ * and never retried.
+ */
+export async function withAuthRetry(
+  url: string,
+  fetcher: (token: string | null) => Promise<Response>,
+): Promise<Response> {
+  const token = await resolveAuthToken(url)
+  const response = await fetcher(token)
+
+  if (response.status !== 401) return response
+  if (shouldSkipAuth(url)) return response
+
+  if (url.includes('/auth/token/refresh')) {
+    console.error(
+      '[API] Refresh token request failed, clearing tokens and redirecting',
+    )
+    useAuthStore.getState().clearTokens()
+    redirectToLogin()
+    return response
+  }
+
+  try {
+    const newToken = await refreshAccessToken()
+    return await fetcher(newToken)
+  } catch (refreshError) {
+    console.error(
+      '[API] Token refresh failed, redirecting to login',
+      refreshError,
+    )
+    useAuthStore.getState().clearTokens()
+    redirectToLogin()
+    return response
+  }
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let errorData: unknown
+    try {
+      errorData = await response.json()
+    } catch {
+      /* no body */
+    }
+    throw new ApiError(response.status, response.statusText, errorData)
+  }
+
+  if (response.status === 204) return undefined as T
+  return (await response.json()) as T
+}
+
 class ApiClient {
-  private async resolveAuthToken(url: string): Promise<string | null> {
-    if (shouldSkipAuth(url)) return null
-    const authStore = useAuthStore.getState()
-    if (authStore.isTokenExpired()) {
-      try {
-        return await refreshAccessToken()
-      } catch (error) {
-        // Proactive refresh failed; tokens already cleared by
-        // refreshAccessToken. Redirect to login and surface the failure
-        // rather than sending an unauthenticated request and triggering a
-        // second refresh via the 401 handler.
-        redirectToLogin()
-        throw error instanceof ApiError
-          ? error
-          : new ApiError(401, 'Token refresh failed')
-      }
-    }
-    return authStore.accessToken
-  }
-
-  private async handleResponse<T>(
-    response: Response,
-    retryRequest: () => Promise<T>,
-    isRetry: boolean,
-    url: string,
-  ): Promise<T> {
-    if (!response.ok) {
-      let errorData: unknown
-      try {
-        errorData = await response.json()
-      } catch {
-        /* no body */
-      }
-
-      if (response.status === 401 && !isRetry) {
-        if (url.includes('/auth/token/refresh')) {
-          console.error(
-            '[API] Refresh token request failed, clearing tokens and redirecting',
-          )
-          useAuthStore.getState().clearTokens()
-          redirectToLogin()
-          throw new ApiError(response.status, response.statusText, errorData)
-        }
-        try {
-          await refreshAccessToken()
-          return await retryRequest()
-        } catch (refreshError) {
-          console.error(
-            '[API] Token refresh failed, redirecting to login',
-            refreshError,
-          )
-          useAuthStore.getState().clearTokens()
-          redirectToLogin()
-          throw new ApiError(response.status, response.statusText, errorData)
-        }
-      }
-
-      throw new ApiError(response.status, response.statusText, errorData)
-    }
-
-    if (response.status === 204) return undefined as T
-    return (await response.json()) as T
-  }
-
   private async request<T>(
     method: string,
     url: string,
@@ -170,41 +182,34 @@ class ApiClient {
       params?: Record<string, unknown>
       body?: unknown
       headers?: Record<string, string>
-      isRetry?: boolean
     } = {},
   ): Promise<T> {
-    const { params, body, headers: extraHeaders, isRetry = false } = options
-
+    const { params, body, headers: extraHeaders } = options
     const fullUrl = buildUrl(url, params)
 
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      ...extraHeaders,
-    }
+    const response = await withAuthRetry(url, (token) => {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...extraHeaders,
+      }
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`
+      }
 
-    const token = await this.resolveAuthToken(url)
-    if (token) {
-      headers['Authorization'] = `Bearer ${token}`
-    }
+      const init: RequestInit = {
+        method,
+        credentials: 'include',
+        headers,
+      }
 
-    const init: RequestInit = {
-      method,
-      credentials: 'include',
-      headers,
-    }
+      if (body !== undefined) {
+        init.body = JSON.stringify(body)
+      }
 
-    if (body !== undefined) {
-      init.body = JSON.stringify(body)
-    }
+      return fetch(fullUrl, init)
+    })
 
-    const response = await fetch(fullUrl, init)
-
-    return this.handleResponse<T>(
-      response,
-      () => this.request<T>(method, url, { ...options, isRetry: true }),
-      isRetry,
-      url,
-    )
+    return parseResponse<T>(response)
   }
 
   async get<T>(url: string, params?: Record<string, unknown>): Promise<T> {
@@ -227,52 +232,44 @@ class ApiClient {
     return this.request<T>('DELETE', url)
   }
 
-  async postFormData<T>(
-    url: string,
-    formData: FormData,
-    isRetry = false,
-  ): Promise<T> {
-    const headers: Record<string, string> = {}
-    const token = await this.resolveAuthToken(url)
-    if (token) {
-      headers['Authorization'] = `Bearer ${token}`
-    }
+  async postFormData<T>(url: string, formData: FormData): Promise<T> {
+    const response = await withAuthRetry(url, (token) => {
+      const headers: Record<string, string> = {}
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`
+      }
 
-    // Don't set Content-Type — browser sets it with boundary for FormData
-    const response = await fetch(`${API_BASE_URL}${url}`, {
-      method: 'POST',
-      credentials: 'include',
-      headers,
-      body: formData,
+      // Don't set Content-Type — browser sets it with boundary for FormData
+      return fetch(`${API_BASE_URL}${url}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers,
+        body: formData,
+      })
     })
 
-    return this.handleResponse<T>(
-      response,
-      () => this.postFormData<T>(url, formData, true),
-      isRetry,
-      url,
-    )
+    return parseResponse<T>(response)
   }
 
   async getWithHeaders<T>(
     url: string,
     params?: Record<string, unknown>,
-    isRetry = false,
   ): Promise<{ data: T; headers: Headers }> {
     const fullUrl = buildUrl(url, params)
 
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    }
-    const token = await this.resolveAuthToken(url)
-    if (token) {
-      headers['Authorization'] = `Bearer ${token}`
-    }
+    const response = await withAuthRetry(url, (token) => {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      }
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`
+      }
 
-    const response = await fetch(fullUrl, {
-      method: 'GET',
-      credentials: 'include',
-      headers,
+      return fetch(fullUrl, {
+        method: 'GET',
+        credentials: 'include',
+        headers,
+      })
     })
 
     if (!response.ok) {
@@ -282,30 +279,6 @@ class ApiClient {
       } catch {
         /* no body */
       }
-
-      if (response.status === 401 && !isRetry) {
-        if (url.includes('/auth/token/refresh')) {
-          console.error(
-            '[API] Refresh token request failed, clearing tokens and redirecting',
-          )
-          useAuthStore.getState().clearTokens()
-          redirectToLogin()
-          throw new ApiError(response.status, response.statusText, errorData)
-        }
-        try {
-          await refreshAccessToken()
-          return await this.getWithHeaders<T>(url, params, true)
-        } catch (refreshError) {
-          console.error(
-            '[API] Token refresh failed, redirecting to login',
-            refreshError,
-          )
-          useAuthStore.getState().clearTokens()
-          redirectToLogin()
-          throw new ApiError(response.status, response.statusText, errorData)
-        }
-      }
-
       throw new ApiError(response.status, response.statusText, errorData)
     }
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -136,15 +136,6 @@ export async function withAuthRetry(
   if (response.status !== 401) return response
   if (shouldSkipAuth(url)) return response
 
-  if (url.includes('/auth/token/refresh')) {
-    console.error(
-      '[API] Refresh token request failed, clearing tokens and redirecting',
-    )
-    useAuthStore.getState().clearTokens()
-    redirectToLogin()
-    return response
-  }
-
   try {
     const newToken = await refreshAccessToken()
     return await fetcher(newToken)

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -144,7 +144,7 @@ export async function withAuthRetry(
       '[API] Token refresh failed, redirecting to login',
       refreshError,
     )
-    useAuthStore.getState().clearTokens()
+    // refreshAccessToken clears tokens in its catch block before rethrowing.
     redirectToLogin()
     return response
   }


### PR DESCRIPTION
## Summary

Section 4a of `docs/code-review-followups.md`. Consolidates the 401 refresh-and-retry logic duplicated across `request()`, `postFormData()`, and `getWithHeaders()` in `src/api/client.ts`, and brings `src/api/assistant.ts` into the same retry loop so a mid-session 401 no longer loses user work.

## Before

- `handleResponse` handled 401 retry for `request()` + `postFormData()` by taking a `retryRequest` callback.
- `getWithHeaders()` duplicated the same refresh-and-retry block inline (:278-307).
- `assistant.ts`'s `assistantFetch` and the pre-stream fetch in `sendMessageSSE` redirected to `/login` on 401 with no retry — a routine token-expiry during a conversation threw the user back to the sign-in page.

## After

- New `export async function withAuthRetry(url, fetcher)` in `src/api/client.ts`. Resolves a token (proactive refresh via the existing `refreshPromise` lock), calls the fetcher, and on a 401 does one refresh+retry. Terminal cases (skip-auth URLs, refresh-endpoint 401, refresh failure) return the original response to the caller so the normal error path surfaces it; the login-redirect side-effect still fires.
- `resolveAuthToken` moved out of `ApiClient` to module scope since it didn't depend on `this`.
- `request`, `postFormData`, `getWithHeaders` each wrap their fetch in `withAuthRetry` and no longer plumb `isRetry`.
- `handleResponse` collapsed to a small `parseResponse<T>` helper (body parse + `ApiError` on non-ok, `undefined` on 204). `getWithHeaders` keeps its inline error parse since it returns `{data, headers}` on success.
- `assistant.ts`: `assistantFetch` and `sendMessageSSE` both use `withAuthRetry`. REST calls retry on 401; the SSE path retries only the initial pre-stream request (mid-stream 401 after a 200 header can't be replayed transparently).

## Behavior preservation

- Proactive refresh on expired token: unchanged.
- Reactive 401 retry: same semantics, single retry.
- `refreshPromise` lock preserved — `withAuthRetry` calls `refreshAccessToken()` rather than re-implementing refresh, so concurrent callers still share one inflight refresh.
- `/auth/token/refresh` 401 is terminal: clears tokens and redirects to login, does not loop.
- `getWithHeaders` still returns `{data, headers}`.
- `ApiClient` public surface unchanged (`get`/`post`/`put`/`patch`/`delete`/`postFormData`/`getWithHeaders`).

## Not in this PR

- `AbortController` plumbing — section 4d, next PR.
- OpenAPI-generated types — section 4b, separate PR.
- Org-scoped query keys — section 4f, incremental per-entity PRs.
- Mutation error UX unification — section 4h, incremental.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Manual: expire the access token, fire a query (via any admin page action); verify one transparent refresh-and-retry, user remains on the page.
- [ ] Manual: expire the access token, open an assistant conversation, send a message; verify the message posts after a transparent refresh rather than landing on `/login`.
- [ ] Manual: break the refresh token (e.g. clear it), fire a request; verify redirect to `/login` with the `imbi_redirect_after_login` sessionStorage entry set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)