### PR TITLE
Refactor: plumb AbortSignal through client + queryFns

### DIFF
--- a/src/api/assistant.ts
+++ b/src/api/assistant.ts
@@ -11,16 +11,21 @@ const ASSISTANT_BASE_URL = '/assistant'
 async function assistantFetch<T>(
   path: string,
   options: RequestInit = {},
+  signal?: AbortSignal,
 ): Promise<T> {
-  const response = await withAuthRetry(path, (token) =>
-    fetch(`${ASSISTANT_BASE_URL}${path}`, {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        ...options.headers,
-      },
-    }),
+  const response = await withAuthRetry(
+    path,
+    (token) =>
+      fetch(`${ASSISTANT_BASE_URL}${path}`, {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...options.headers,
+        },
+        signal: signal ?? options.signal,
+      }),
+    signal,
   )
   if (!response.ok) {
     let errorData: unknown
@@ -42,11 +47,14 @@ export const createConversation = (data?: CreateConversationRequest) =>
     body: JSON.stringify(data ?? {}),
   })
 
-export const listConversations = (params?: {
-  limit?: number
-  offset?: number
-  include_archived?: boolean
-}) => {
+export const listConversations = (
+  params?: {
+    limit?: number
+    offset?: number
+    include_archived?: boolean
+  },
+  signal?: AbortSignal,
+) => {
   const searchParams = params
     ? '?' +
       new URLSearchParams(
@@ -55,11 +63,15 @@ export const listConversations = (params?: {
           .map(([k, v]) => [k, String(v)]),
       ).toString()
     : ''
-  return assistantFetch<Conversation[]>(`/conversations${searchParams}`)
+  return assistantFetch<Conversation[]>(
+    `/conversations${searchParams}`,
+    {},
+    signal,
+  )
 }
 
-export const getConversation = (id: string) =>
-  assistantFetch<ConversationWithMessages>(`/conversations/${id}`)
+export const getConversation = (id: string, signal?: AbortSignal) =>
+  assistantFetch<ConversationWithMessages>(`/conversations/${id}`, {}, signal)
 
 export const deleteConversation = (id: string) =>
   assistantFetch<void>(`/conversations/${id}`, { method: 'DELETE' })

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -129,12 +129,14 @@ async function resolveAuthToken(url: string): Promise<string | null> {
 export async function withAuthRetry(
   url: string,
   fetcher: (token: string | null) => Promise<Response>,
+  signal?: AbortSignal,
 ): Promise<Response> {
   const token = await resolveAuthToken(url)
   const response = await fetcher(token)
 
   if (response.status !== 401) return response
   if (shouldSkipAuth(url)) return response
+  if (signal?.aborted) return response
 
   try {
     const newToken = await refreshAccessToken()
@@ -173,71 +175,94 @@ class ApiClient {
       params?: Record<string, unknown>
       body?: unknown
       headers?: Record<string, string>
+      signal?: AbortSignal
     } = {},
   ): Promise<T> {
-    const { params, body, headers: extraHeaders } = options
+    const { params, body, headers: extraHeaders, signal } = options
     const fullUrl = buildUrl(url, params)
 
-    const response = await withAuthRetry(url, (token) => {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        ...extraHeaders,
-      }
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`
-      }
+    const response = await withAuthRetry(
+      url,
+      (token) => {
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          ...extraHeaders,
+        }
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`
+        }
 
-      const init: RequestInit = {
-        method,
-        credentials: 'include',
-        headers,
-      }
+        const init: RequestInit = {
+          method,
+          credentials: 'include',
+          headers,
+          signal,
+        }
 
-      if (body !== undefined) {
-        init.body = JSON.stringify(body)
-      }
+        if (body !== undefined) {
+          init.body = JSON.stringify(body)
+        }
 
-      return fetch(fullUrl, init)
-    })
+        return fetch(fullUrl, init)
+      },
+      signal,
+    )
 
     return parseResponse<T>(response)
   }
 
-  async get<T>(url: string, params?: Record<string, unknown>): Promise<T> {
-    return this.request<T>('GET', url, { params })
+  async get<T>(
+    url: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    return this.request<T>('GET', url, { params, signal })
   }
 
-  async post<T>(url: string, data?: unknown): Promise<T> {
-    return this.request<T>('POST', url, { body: data })
+  async post<T>(url: string, data?: unknown, signal?: AbortSignal): Promise<T> {
+    return this.request<T>('POST', url, { body: data, signal })
   }
 
-  async put<T>(url: string, data?: unknown): Promise<T> {
-    return this.request<T>('PUT', url, { body: data })
+  async put<T>(url: string, data?: unknown, signal?: AbortSignal): Promise<T> {
+    return this.request<T>('PUT', url, { body: data, signal })
   }
 
-  async patch<T>(url: string, data?: unknown): Promise<T> {
-    return this.request<T>('PATCH', url, { body: data })
+  async patch<T>(
+    url: string,
+    data?: unknown,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    return this.request<T>('PATCH', url, { body: data, signal })
   }
 
-  async delete<T>(url: string): Promise<T> {
-    return this.request<T>('DELETE', url)
+  async delete<T>(url: string, signal?: AbortSignal): Promise<T> {
+    return this.request<T>('DELETE', url, { signal })
   }
 
-  async postFormData<T>(url: string, formData: FormData): Promise<T> {
-    const response = await withAuthRetry(url, (token) => {
-      const headers: Record<string, string> = {}
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`
-      }
+  async postFormData<T>(
+    url: string,
+    formData: FormData,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const response = await withAuthRetry(
+      url,
+      (token) => {
+        const headers: Record<string, string> = {}
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`
+        }
 
-      // Don't set Content-Type — browser sets it with boundary for FormData
-      return fetch(`${API_BASE_URL}${url}`, {
-        method: 'POST',
-        credentials: 'include',
-        headers,
-        body: formData,
-      })
-    })
+        // Don't set Content-Type — browser sets it with boundary for FormData
+        return fetch(`${API_BASE_URL}${url}`, {
+          method: 'POST',
+          credentials: 'include',
+          headers,
+          body: formData,
+          signal,
+        })
+      },
+      signal,
+    )
 
     return parseResponse<T>(response)
   }
@@ -245,23 +270,29 @@ class ApiClient {
   async getWithHeaders<T>(
     url: string,
     params?: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<{ data: T; headers: Headers }> {
     const fullUrl = buildUrl(url, params)
 
-    const response = await withAuthRetry(url, (token) => {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      }
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`
-      }
+    const response = await withAuthRetry(
+      url,
+      (token) => {
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+        }
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`
+        }
 
-      return fetch(fullUrl, {
-        method: 'GET',
-        credentials: 'include',
-        headers,
-      })
-    })
+        return fetch(fullUrl, {
+          method: 'GET',
+          credentials: 'include',
+          headers,
+          signal,
+        })
+      },
+      signal,
+    )
 
     if (!response.ok) {
       let errorData: unknown

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -66,12 +66,15 @@ import type {
 export type { PatchOperation }
 
 // Status/Health
-export const getStatus = () => apiClient.get<ApiStatus>('/status')
+export const getStatus = (signal?: AbortSignal) =>
+  apiClient.get<ApiStatus>('/status', undefined, signal)
 
 // User/Auth
-export const getAuthProviders = () =>
+export const getAuthProviders = (signal?: AbortSignal) =>
   apiClient.get<{ providers: AuthProvider[]; default_redirect: string }>(
     '/auth/providers',
+    undefined,
+    signal,
   )
 
 export const loginWithPassword = (credentials: LoginRequest) =>
@@ -84,24 +87,36 @@ export const refreshToken = (refreshToken: string) =>
 
 export const logoutAuth = () => apiClient.post<void>('/auth/logout', {})
 
-export const getUserByUsername = (username: string) =>
-  apiClient.get<UserResponse>(`/users/${username}`)
+export const getUserByUsername = (username: string, signal?: AbortSignal) =>
+  apiClient.get<UserResponse>(`/users/${username}`, undefined, signal)
 
 // Legacy endpoints (kept for backward compatibility)
-export const getCurrentUser = () => apiClient.get<User>('/ui/user')
+export const getCurrentUser = (signal?: AbortSignal) =>
+  apiClient.get<User>('/ui/user', undefined, signal)
 export const logout = () => apiClient.get<void>('/ui/logout')
 
 // Projects (org-scoped)
-export const getProjects = async (orgSlug: string): Promise<Project[]> => {
+export const getProjects = async (
+  orgSlug: string,
+  signal?: AbortSignal,
+): Promise<Project[]> => {
   const response = await apiClient.get<Project[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getProject = (orgSlug: string, projectId: string) =>
+export const getProject = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<Project>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
+    undefined,
+    signal,
   )
 
 export interface ProjectSchemaSectionProperty {
@@ -135,14 +150,26 @@ export interface ProjectSchemaResponse {
   sections: ProjectSchemaSection[]
 }
 
-export const getProjectSchema = (orgSlug: string, projectId: string) =>
+export const getProjectSchema = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<ProjectSchemaResponse>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/schema`,
+    undefined,
+    signal,
   )
 
-export const getProjectRelationships = (orgSlug: string, projectId: string) =>
+export const getProjectRelationships = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<ProjectRelationshipsResponse>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/relationships`,
+    undefined,
+    signal,
   )
 
 export const setProjectRelationships = (
@@ -193,16 +220,25 @@ export const deleteProject = (orgSlug: string, projectId: string) =>
 // Link Definitions (org-scoped)
 export const listLinkDefinitions = async (
   orgSlug: string,
+  signal?: AbortSignal,
 ): Promise<LinkDefinition[]> => {
   const response = await apiClient.get<LinkDefinition[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/link-definitions/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getLinkDefinition = (orgSlug: string, slug: string) =>
+export const getLinkDefinition = (
+  orgSlug: string,
+  slug: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<LinkDefinition>(
     `/organizations/${encodeURIComponent(orgSlug)}/link-definitions/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
   )
 
 export const createLinkDefinition = (
@@ -230,14 +266,18 @@ export const deleteLinkDefinition = (orgSlug: string, slug: string) =>
   )
 
 // Activity Feed
-export const getActivityFeed = async (params?: {
-  limit?: number
-  omit_user?: string
-  token?: string
-}): Promise<ActivityFeedEntry[]> => {
+export const getActivityFeed = async (
+  params?: {
+    limit?: number
+    omit_user?: string
+    token?: string
+  },
+  signal?: AbortSignal,
+): Promise<ActivityFeedEntry[]> => {
   const response = await apiClient.get<ActivityFeedEntry[]>(
     '/activity-feed',
     params,
+    signal,
   )
   // Activity feed returns array directly, not wrapped in { data: [] }
   return Array.isArray(response) ? response : []
@@ -277,11 +317,14 @@ function parseNextCursor(headers: Headers): string | undefined {
   }
 }
 
-export const listOperationsLog = async (params: {
-  limit?: number
-  cursor?: string
-  filters?: OperationsLogFilters
-}): Promise<OperationsLogPage> => {
+export const listOperationsLog = async (
+  params: {
+    limit?: number
+    cursor?: string
+    filters?: OperationsLogFilters
+  },
+  signal?: AbortSignal,
+): Promise<OperationsLogPage> => {
   const query: Record<string, unknown> = { limit: params.limit ?? 50 }
   if (params.cursor) query.cursor = params.cursor
   if (params.filters) {
@@ -293,6 +336,7 @@ export const listOperationsLog = async (params: {
     await apiClient.getWithHeaders<OperationsLogEnvelope>(
       '/operations-log/',
       query,
+      signal,
     )
   return {
     entries: Array.isArray(data?.data) ? data.data : [],
@@ -301,37 +345,58 @@ export const listOperationsLog = async (params: {
   }
 }
 
-export const getOperationsLogEntry = (entryId: string) =>
+export const getOperationsLogEntry = (entryId: string, signal?: AbortSignal) =>
   apiClient.get<OperationsLogRecord>(
     `/operations-log/${encodeURIComponent(entryId)}`,
+    undefined,
+    signal,
   )
 
 // Metadata
-export const getEnvironments = async (): Promise<Environment[]> => {
-  const response =
-    await apiClient.get<CollectionResponse<Environment>>('/environments')
+export const getEnvironments = async (
+  signal?: AbortSignal,
+): Promise<Environment[]> => {
+  const response = await apiClient.get<CollectionResponse<Environment>>(
+    '/environments',
+    undefined,
+    signal,
+  )
   return response.data
 }
 
-export const getProjectTypes = async (): Promise<ProjectType[]> => {
-  const response =
-    await apiClient.get<CollectionResponse<ProjectType>>('/project-types')
+export const getProjectTypes = async (
+  signal?: AbortSignal,
+): Promise<ProjectType[]> => {
+  const response = await apiClient.get<CollectionResponse<ProjectType>>(
+    '/project-types',
+    undefined,
+    signal,
+  )
   return response.data
 }
 
 // Admin - Environments
 export const listEnvironments = async (
   orgSlug: string,
+  signal?: AbortSignal,
 ): Promise<Environment[]> => {
   const response = await apiClient.get<Environment[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/environments/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getEnvironment = (orgSlug: string, slug: string) =>
+export const getEnvironment = (
+  orgSlug: string,
+  slug: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<Environment>(
     `/organizations/${encodeURIComponent(orgSlug)}/environments/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
   )
 
 export const createEnvironment = (orgSlug: string, env: EnvironmentCreate) =>
@@ -355,22 +420,31 @@ export const deleteEnvironment = (orgSlug: string, slug: string) =>
     `/organizations/${encodeURIComponent(orgSlug)}/environments/${encodeURIComponent(slug)}`,
   )
 
-export const getEnvironmentSchema = () =>
-  getDynamicSchema('EnvironmentRequest', ENVIRONMENT_BASE_FIELDS)
+export const getEnvironmentSchema = (signal?: AbortSignal) =>
+  getDynamicSchema('EnvironmentRequest', ENVIRONMENT_BASE_FIELDS, signal)
 
 // Admin - Project Types
 export const listProjectTypes = async (
   orgSlug: string,
+  signal?: AbortSignal,
 ): Promise<ProjectType[]> => {
   const response = await apiClient.get<ProjectType[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/project-types/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getProjectType = (orgSlug: string, slug: string) =>
+export const getProjectType = (
+  orgSlug: string,
+  slug: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<ProjectType>(
     `/organizations/${encodeURIComponent(orgSlug)}/project-types/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
   )
 
 export const createProjectType = (orgSlug: string, pt: ProjectTypeCreate) =>
@@ -394,21 +468,28 @@ export const deleteProjectType = (orgSlug: string, slug: string) =>
     `/organizations/${encodeURIComponent(orgSlug)}/project-types/${encodeURIComponent(slug)}`,
   )
 
-export const getProjectTypeSchema = () =>
-  getDynamicSchema('ProjectTypeRequest', PROJECT_TYPE_BASE_FIELDS)
+export const getProjectTypeSchema = (signal?: AbortSignal) =>
+  getDynamicSchema('ProjectTypeRequest', PROJECT_TYPE_BASE_FIELDS, signal)
 
 // Admin - User Management
-export const listAdminUsers = async (params?: {
-  is_active?: boolean
-  is_admin?: boolean
-}): Promise<AdminUser[]> => {
-  const response = await apiClient.get<AdminUser[]>('/users/', params)
+export const listAdminUsers = async (
+  params?: {
+    is_active?: boolean
+    is_admin?: boolean
+  },
+  signal?: AbortSignal,
+): Promise<AdminUser[]> => {
+  const response = await apiClient.get<AdminUser[]>('/users/', params, signal)
   // Users endpoint returns array directly, not wrapped in { data: [] }
   return Array.isArray(response) ? response : []
 }
 
-export const getAdminUser = (email: string) =>
-  apiClient.get<AdminUser>(`/users/${encodeURIComponent(email)}`)
+export const getAdminUser = (email: string, signal?: AbortSignal) =>
+  apiClient.get<AdminUser>(
+    `/users/${encodeURIComponent(email)}`,
+    undefined,
+    signal,
+  )
 
 export const createAdminUser = (user: AdminUserCreate) =>
   apiClient.post<AdminUser>('/users/', user)
@@ -441,13 +522,17 @@ export const removeUserFromOrg = (email: string, orgSlug: string) =>
   )
 
 // Admin - Roles Management
-export const getRoles = async (): Promise<Role[]> => {
-  const response = await apiClient.get<Role[]>('/roles/')
+export const getRoles = async (signal?: AbortSignal): Promise<Role[]> => {
+  const response = await apiClient.get<Role[]>('/roles/', undefined, signal)
   return Array.isArray(response) ? response : []
 }
 
-export const getRole = (slug: string) =>
-  apiClient.get<RoleDetail>(`/roles/${encodeURIComponent(slug)}`)
+export const getRole = (slug: string, signal?: AbortSignal) =>
+  apiClient.get<RoleDetail>(
+    `/roles/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
+  )
 
 export const createRole = (role: RoleCreate) =>
   apiClient.post<RoleDetail>('/roles/', role)
@@ -468,57 +553,83 @@ export const revokePermission = (slug: string, permissionName: string) =>
     `/roles/${encodeURIComponent(slug)}/permissions/${encodeURIComponent(permissionName)}`,
   )
 
-export const getRoleUsers = async (slug: string): Promise<RoleUser[]> => {
+export const getRoleUsers = async (
+  slug: string,
+  signal?: AbortSignal,
+): Promise<RoleUser[]> => {
   const response = await apiClient.get<RoleUser[]>(
     `/roles/${encodeURIComponent(slug)}/users`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
 export const getRoleServiceAccounts = async (
   slug: string,
+  signal?: AbortSignal,
 ): Promise<ServiceAccount[]> => {
   const response = await apiClient.get<ServiceAccount[]>(
     `/roles/${encodeURIComponent(slug)}/service-accounts`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
 export const getRoleGroups = async (
   slug: string,
+  signal?: AbortSignal,
 ): Promise<{ name: string; slug: string }[]> => {
   const response = await apiClient.get<{ name: string; slug: string }[]>(
     `/roles/${encodeURIComponent(slug)}/groups`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
 // Admin - Settings (reference data)
-export const getAdminSettings = () =>
-  apiClient.get<AdminSettings>('/admin/settings')
+export const getAdminSettings = (signal?: AbortSignal) =>
+  apiClient.get<AdminSettings>('/admin/settings', undefined, signal)
 
 // Admin - Blueprints
-export const listBlueprints = async (params?: {
-  enabled?: boolean
-}): Promise<Blueprint[]> => {
-  const response = await apiClient.get<Blueprint[]>('/blueprints/', params)
+export const listBlueprints = async (
+  params?: {
+    enabled?: boolean
+  },
+  signal?: AbortSignal,
+): Promise<Blueprint[]> => {
+  const response = await apiClient.get<Blueprint[]>(
+    '/blueprints/',
+    params,
+    signal,
+  )
   return Array.isArray(response) ? response : []
 }
 
 export const listBlueprintsByType = async (
   type: string,
   params?: { enabled?: boolean },
+  signal?: AbortSignal,
 ): Promise<Blueprint[]> => {
   const response = await apiClient.get<Blueprint[]>(
     `/blueprints/${encodeURIComponent(type)}`,
     params,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getBlueprint = (type: string, slug: string) =>
+export const getBlueprint = (
+  type: string,
+  slug: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<Blueprint>(
     `/blueprints/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
   )
 
 export const createBlueprint = (blueprint: BlueprintCreate) =>
@@ -540,13 +651,23 @@ export const deleteBlueprint = (type: string, slug: string) =>
   )
 
 // Admin - Organizations
-export const listOrganizations = async (): Promise<Organization[]> => {
-  const response = await apiClient.get<Organization[]>('/organizations/')
+export const listOrganizations = async (
+  signal?: AbortSignal,
+): Promise<Organization[]> => {
+  const response = await apiClient.get<Organization[]>(
+    '/organizations/',
+    undefined,
+    signal,
+  )
   return Array.isArray(response) ? response : []
 }
 
-export const getOrganization = (slug: string) =>
-  apiClient.get<Organization>(`/organizations/${encodeURIComponent(slug)}`)
+export const getOrganization = (slug: string, signal?: AbortSignal) =>
+  apiClient.get<Organization>(
+    `/organizations/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
+  )
 
 export const createOrganization = (org: OrganizationCreate) =>
   apiClient.post<Organization>('/organizations/', org)
@@ -611,8 +732,13 @@ interface OpenApiResponse {
 export const getDynamicSchema = async (
   schemaName: string,
   baseFields: string[],
+  signal?: AbortSignal,
 ): Promise<DynamicSchema | null> => {
-  const response = await apiClient.get<OpenApiResponse>('/openapi.json')
+  const response = await apiClient.get<OpenApiResponse>(
+    '/openapi.json',
+    undefined,
+    signal,
+  )
   const schema = response.components?.schemas?.[schemaName]
   if (!schema?.properties) return null
   const baseSet = new Set(baseFields)
@@ -632,20 +758,27 @@ export const getDynamicSchema = async (
   }
 }
 
-export const getTeamSchema = () =>
-  getDynamicSchema('TeamRequest', TEAM_BASE_FIELDS)
+export const getTeamSchema = (signal?: AbortSignal) =>
+  getDynamicSchema('TeamRequest', TEAM_BASE_FIELDS, signal)
 
 // Admin - Teams
-export const listTeams = async (orgSlug: string): Promise<Team[]> => {
+export const listTeams = async (
+  orgSlug: string,
+  signal?: AbortSignal,
+): Promise<Team[]> => {
   const response = await apiClient.get<Team[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/teams/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getTeam = (orgSlug: string, slug: string) =>
+export const getTeam = (orgSlug: string, slug: string, signal?: AbortSignal) =>
   apiClient.get<Team>(
     `/organizations/${encodeURIComponent(orgSlug)}/teams/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
   )
 
 export const createTeam = (orgSlug: string, team: TeamCreate) =>
@@ -668,9 +801,12 @@ export const deleteTeam = (orgSlug: string, slug: string) =>
 export const getTeamMembers = async (
   orgSlug: string,
   slug: string,
+  signal?: AbortSignal,
 ): Promise<TeamMember[]> => {
   const response = await apiClient.get<TeamMember[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/teams/${encodeURIComponent(slug)}/members`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
@@ -693,16 +829,25 @@ export const removeTeamMember = (
 // Admin - Third-Party Services
 export const listThirdPartyServices = async (
   orgSlug: string,
+  signal?: AbortSignal,
 ): Promise<ThirdPartyService[]> => {
   const response = await apiClient.get<ThirdPartyService[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getThirdPartyService = (orgSlug: string, slug: string) =>
+export const getThirdPartyService = (
+  orgSlug: string,
+  slug: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<ThirdPartyService>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
   )
 
 export const createThirdPartyService = (
@@ -733,9 +878,12 @@ export const deleteThirdPartyService = (orgSlug: string, slug: string) =>
 export const listServiceApplications = async (
   orgSlug: string,
   serviceSlug: string,
+  signal?: AbortSignal,
 ): Promise<ServiceApplication[]> => {
   const response = await apiClient.get<ServiceApplication[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/applications/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
@@ -744,9 +892,12 @@ export const getServiceApplication = (
   orgSlug: string,
   serviceSlug: string,
   appSlug: string,
+  signal?: AbortSignal,
 ) =>
   apiClient.get<ServiceApplication>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}`,
+    undefined,
+    signal,
   )
 
 export const createServiceApplication = (
@@ -784,9 +935,12 @@ export const getApplicationSecrets = (
   orgSlug: string,
   serviceSlug: string,
   appSlug: string,
+  signal?: AbortSignal,
 ) =>
   apiClient.get<ServiceApplicationSecrets>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}/secrets`,
+    undefined,
+    signal,
   )
 
 export const updateApplicationSecrets = (
@@ -821,8 +975,8 @@ export const deleteUpload = (id: string) =>
   apiClient.delete<void>(`/uploads/${encodeURIComponent(id)}`)
 
 // API Keys (routes use the authenticated user, no user prefix)
-export const listApiKeys = async (): Promise<ApiKey[]> => {
-  const response = await apiClient.get<ApiKey[]>('/api-keys')
+export const listApiKeys = async (signal?: AbortSignal): Promise<ApiKey[]> => {
+  const response = await apiClient.get<ApiKey[]>('/api-keys', undefined, signal)
   return Array.isArray(response) ? response : []
 }
 
@@ -833,11 +987,17 @@ export const deleteApiKey = (keyId: string) =>
   apiClient.delete<void>(`/api-keys/${encodeURIComponent(keyId)}`)
 
 // Service Accounts
-export const listServiceAccounts = (params?: { is_active?: boolean }) =>
-  apiClient.get<ServiceAccount[]>('/service-accounts', params)
+export const listServiceAccounts = (
+  params?: { is_active?: boolean },
+  signal?: AbortSignal,
+) => apiClient.get<ServiceAccount[]>('/service-accounts', params, signal)
 
-export const getServiceAccount = (slug: string) =>
-  apiClient.get<ServiceAccount>(`/service-accounts/${encodeURIComponent(slug)}`)
+export const getServiceAccount = (slug: string, signal?: AbortSignal) =>
+  apiClient.get<ServiceAccount>(
+    `/service-accounts/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
+  )
 
 export const createServiceAccount = (data: ServiceAccountCreate) =>
   apiClient.post<ServiceAccount>('/service-accounts', data)
@@ -879,9 +1039,11 @@ export const removeServiceAccountFromOrg = (slug: string, orgSlug: string) =>
   )
 
 // Service Account Client Credentials
-export const listClientCredentials = (slug: string) =>
+export const listClientCredentials = (slug: string, signal?: AbortSignal) =>
   apiClient.get<ClientCredential[]>(
     `/service-accounts/${encodeURIComponent(slug)}/client-credentials`,
+    undefined,
+    signal,
   )
 
 export const createClientCredential = (
@@ -904,9 +1066,11 @@ export const rotateClientCredential = (slug: string, clientId: string) =>
   )
 
 // Service Account API Keys
-export const listServiceAccountApiKeys = (slug: string) =>
+export const listServiceAccountApiKeys = (slug: string, signal?: AbortSignal) =>
   apiClient.get<ApiKey[]>(
     `/service-accounts/${encodeURIComponent(slug)}/api-keys`,
+    undefined,
+    signal,
   )
 
 export const createServiceAccountApiKey = (
@@ -934,16 +1098,27 @@ export const rotateServiceAccountApiKey = (slug: string, keyId: string) =>
   )
 
 // Admin - Webhooks
-export const listWebhooks = async (orgSlug: string): Promise<Webhook[]> => {
+export const listWebhooks = async (
+  orgSlug: string,
+  signal?: AbortSignal,
+): Promise<Webhook[]> => {
   const response = await apiClient.get<Webhook[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/webhooks/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getWebhook = (orgSlug: string, slug: string) =>
+export const getWebhook = (
+  orgSlug: string,
+  slug: string,
+  signal?: AbortSignal,
+) =>
   apiClient.get<Webhook>(
     `/organizations/${encodeURIComponent(orgSlug)}/webhooks/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
   )
 
 export const createWebhook = (orgSlug: string, data: WebhookCreate) =>
@@ -970,9 +1145,12 @@ export const deleteWebhook = (orgSlug: string, slug: string) =>
 export const listServiceWebhooks = async (
   orgSlug: string,
   serviceSlug: string,
+  signal?: AbortSignal,
 ): Promise<Webhook[]> => {
   const response = await apiClient.get<Webhook[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/webhooks/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }
@@ -981,9 +1159,12 @@ export const listServiceWebhooks = async (
 export const listProjectServices = async (
   orgSlug: string,
   projectSlug: string,
+  signal?: AbortSignal,
 ): Promise<ProjectService[]> => {
   const response = await apiClient.get<ProjectService[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectSlug)}/services/`,
+    undefined,
+    signal,
   )
   return Array.isArray(response) ? response : []
 }

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -4,13 +4,13 @@ import { useQuery } from '@tanstack/react-query'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type OpenApiSpec = Record<string, any>
 
-export const fetchOpenApiSpec = () =>
-  apiClient.get<OpenApiSpec>('/openapi.json')
+export const fetchOpenApiSpec = (signal?: AbortSignal) =>
+  apiClient.get<OpenApiSpec>('/openapi.json', undefined, signal)
 
 export function useOpenApiSpec() {
   return useQuery({
     queryKey: ['openapi-spec'],
-    queryFn: fetchOpenApiSpec,
+    queryFn: ({ signal }) => fetchOpenApiSpec(signal),
     staleTime: Infinity,
   })
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -195,7 +195,7 @@ export function Dashboard({
   // Fetch real data for stats
   const { data: projects } = useQuery({
     queryKey: ['projects', orgSlug],
-    queryFn: () => getProjects(orgSlug),
+    queryFn: ({ signal }) => getProjects(orgSlug, signal),
     enabled: !!orgSlug,
   })
 

--- a/src/components/EditRelationshipsDialog.tsx
+++ b/src/components/EditRelationshipsDialog.tsx
@@ -81,7 +81,7 @@ export function EditRelationshipsDialog({
     isError,
   } = useQuery({
     queryKey: ['projects', orgSlug],
-    queryFn: () => getProjects(orgSlug),
+    queryFn: ({ signal }) => getProjects(orgSlug, signal),
     enabled: !!orgSlug && isOpen,
   })
 

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -56,25 +56,25 @@ export function NewProjectDialog({
 
   const { data: teams = [] } = useQuery({
     queryKey: ['teams', orgSlug],
-    queryFn: () => listTeams(orgSlug),
+    queryFn: ({ signal }) => listTeams(orgSlug, signal),
     enabled: !!orgSlug && isOpen,
   })
 
   const { data: projectTypes = [] } = useQuery({
     queryKey: ['projectTypes', orgSlug],
-    queryFn: () => listProjectTypes(orgSlug),
+    queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
     enabled: !!orgSlug && isOpen,
   })
 
   const { data: environments = [] } = useQuery({
     queryKey: ['environments', orgSlug],
-    queryFn: () => listEnvironments(orgSlug),
+    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
     enabled: !!orgSlug && isOpen,
   })
 
   const { data: linkDefs = [] } = useQuery({
     queryKey: ['linkDefinitions', orgSlug],
-    queryFn: () => listLinkDefinitions(orgSlug),
+    queryFn: ({ signal }) => listLinkDefinitions(orgSlug, signal),
     enabled: !!orgSlug && isOpen,
   })
 

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -164,7 +164,7 @@ export function OperationsLog({
     refetch: refetchProjects,
   } = useQuery({
     queryKey: ['projects', orgSlug],
-    queryFn: () => getProjects(orgSlug),
+    queryFn: ({ signal }) => getProjects(orgSlug, signal),
     enabled: !!orgSlug,
   })
   const {
@@ -173,7 +173,7 @@ export function OperationsLog({
     refetch: refetchEnvironments,
   } = useQuery({
     queryKey: ['environments', orgSlug],
-    queryFn: () => listEnvironments(orgSlug),
+    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
     enabled: !!orgSlug,
   })
   const {
@@ -182,7 +182,7 @@ export function OperationsLog({
     refetch: refetchUsers,
   } = useQuery({
     queryKey: ['admin-users', 'active'],
-    queryFn: () => listAdminUsers({ is_active: true }),
+    queryFn: ({ signal }) => listAdminUsers({ is_active: true }, signal),
   })
   // Metadata queries back the filter dropdowns and the slug→name
   // lookups. When any of them fail we surface a non-blocking banner so

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -168,24 +168,24 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
 
   const { data: linkDefs = [] } = useQuery({
     queryKey: ['linkDefinitions', orgSlug],
-    queryFn: () => listLinkDefinitions(orgSlug),
+    queryFn: ({ signal }) => listLinkDefinitions(orgSlug, signal),
     enabled: !!orgSlug,
   })
 
   const { data: projectSchema } = useQuery({
     queryKey: ['projectSchema', orgSlug, project.id],
-    queryFn: () => getProjectSchema(orgSlug, project.id),
+    queryFn: ({ signal }) => getProjectSchema(orgSlug, project.id, signal),
     enabled: !!orgSlug,
   })
 
   const { data: teams = [] } = useQuery({
     queryKey: ['teams', orgSlug],
-    queryFn: () => listTeams(orgSlug),
+    queryFn: ({ signal }) => listTeams(orgSlug, signal),
     enabled: !!orgSlug,
   })
   const { data: projectTypes = [] } = useQuery({
     queryKey: ['projectTypes', orgSlug],
-    queryFn: () => listProjectTypes(orgSlug),
+    queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
     enabled: !!orgSlug,
   })
 

--- a/src/components/ProjectGraphView.tsx
+++ b/src/components/ProjectGraphView.tsx
@@ -22,7 +22,7 @@ export function ProjectGraphView({ projects }: ProjectGraphViewProps) {
       const orgSlug = p.team?.organization?.slug ?? ''
       return {
         queryKey: ['project-relationships', orgSlug, p.id],
-        queryFn: () => getProjectRelationships(orgSlug, p.id),
+        queryFn: ({ signal }) => getProjectRelationships(orgSlug, p.id, signal),
         enabled: Boolean(orgSlug && p.id),
       }
     }),

--- a/src/components/ProjectRelationshipsTab.tsx
+++ b/src/components/ProjectRelationshipsTab.tsx
@@ -25,7 +25,8 @@ export function ProjectRelationshipsTab({
 }) {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['project-relationships', orgSlug, projectId],
-    queryFn: () => getProjectRelationships(orgSlug, projectId),
+    queryFn: ({ signal }) =>
+      getProjectRelationships(orgSlug, projectId, signal),
   })
   const [filter, setFilter] = useState<RelFilter>('all')
   const [editDialogOpen, setEditDialogOpen] = useState(false)

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -57,7 +57,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
     isError: linkDefsError,
   } = useQuery({
     queryKey: ['linkDefinitions', orgSlug],
-    queryFn: () => listLinkDefinitions(orgSlug),
+    queryFn: ({ signal }) => listLinkDefinitions(orgSlug, signal),
     enabled: !!orgSlug,
   })
 
@@ -68,7 +68,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
 
   const { data: availableEnvironments = [] } = useQuery({
     queryKey: ['environments', orgSlug],
-    queryFn: () => listEnvironments(orgSlug),
+    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
     enabled: !!orgSlug,
   })
 

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -58,7 +58,7 @@ export function ProjectsView() {
 
   const { data: projects, isLoading } = useQuery({
     queryKey: ['projects', orgSlug],
-    queryFn: () => getProjects(orgSlug),
+    queryFn: ({ signal }) => getProjects(orgSlug, signal),
     enabled: !!orgSlug,
   })
 

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -129,7 +129,7 @@ export function BlueprintManagement() {
     BlueprintKey
   >({
     queryKey: ['blueprints'],
-    listFn: listBlueprints,
+    listFn: (signal) => listBlueprints(undefined, signal),
     createFn: (blueprint) => createBlueprint(blueprint),
     updateFn: ({ type, slug, blueprint }) =>
       updateBlueprint(type, slug, blueprint),

--- a/src/components/admin/EnvironmentManagement.tsx
+++ b/src/components/admin/EnvironmentManagement.tsx
@@ -45,7 +45,7 @@ export function EnvironmentManagement() {
     { orgSlug: string; slug: string }
   >({
     queryKey: ['environments', orgSlug],
-    listFn: orgSlug ? () => listEnvironments(orgSlug) : null,
+    listFn: orgSlug ? (signal) => listEnvironments(orgSlug, signal) : null,
     createFn: ({ orgSlug, env }) => createEnvironment(orgSlug, env),
     updateFn: ({ orgSlug, slug, env }) => updateEnvironment(orgSlug, slug, env),
     deleteFn: ({ orgSlug, slug }) => deleteEnvironment(orgSlug, slug),

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -42,7 +42,7 @@ export function LinkDefinitionManagement() {
     { orgSlug: string; slug: string }
   >({
     queryKey: ['linkDefinitions', orgSlug],
-    listFn: orgSlug ? () => listLinkDefinitions(orgSlug) : null,
+    listFn: orgSlug ? (signal) => listLinkDefinitions(orgSlug, signal) : null,
     createFn: ({ orgSlug, data }) => createLinkDefinition(orgSlug, data),
     updateFn: ({ orgSlug, slug, data }) =>
       updateLinkDefinition(orgSlug, slug, data),

--- a/src/components/admin/OAuthManagement.tsx
+++ b/src/components/admin/OAuthManagement.tsx
@@ -14,7 +14,7 @@ export function OAuthManagement() {
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['authProviders'],
-    queryFn: getAuthProviders,
+    queryFn: ({ signal }) => getAuthProviders(signal),
   })
 
   const providers = data?.providers || []

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -44,7 +44,7 @@ export function ProjectTypeManagement() {
     { orgSlug: string; slug: string }
   >({
     queryKey: ['projectTypes', orgSlug],
-    listFn: orgSlug ? () => listProjectTypes(orgSlug) : null,
+    listFn: orgSlug ? (signal) => listProjectTypes(orgSlug, signal) : null,
     createFn: ({ orgSlug, pt }) => createProjectType(orgSlug, pt),
     updateFn: ({ orgSlug, slug, pt }) => updateProjectType(orgSlug, slug, pt),
     deleteFn: ({ orgSlug, slug }) => deleteProjectType(orgSlug, slug),

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -48,7 +48,7 @@ export function ServiceAccountManagement() {
     string
   >({
     queryKey: ['serviceAccounts'],
-    listFn: listServiceAccounts,
+    listFn: (signal) => listServiceAccounts(undefined, signal),
     createFn: createServiceAccount,
     updateFn: ({ slug, data }) => updateServiceAccount(slug, data),
     deleteFn: deleteServiceAccount,
@@ -75,7 +75,7 @@ export function ServiceAccountManagement() {
   // Fetch full SA detail (with orgs) when viewing/editing a specific account
   const { data: selectedAccount = null } = useQuery({
     queryKey: ['serviceAccount', selectedAccountSlug],
-    queryFn: () => getServiceAccount(selectedAccountSlug!),
+    queryFn: ({ signal }) => getServiceAccount(selectedAccountSlug!, signal),
     enabled:
       !!selectedAccountSlug && (viewMode === 'detail' || viewMode === 'edit'),
   })

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -41,7 +41,7 @@ export function TeamManagement() {
     { orgSlug: string; slug: string }
   >({
     queryKey: ['teams', orgSlug],
-    listFn: orgSlug ? () => listTeams(orgSlug) : null,
+    listFn: orgSlug ? (signal) => listTeams(orgSlug, signal) : null,
     createFn: ({ orgSlug, team }) => createTeam(orgSlug, team),
     updateFn: ({ orgSlug, slug, team }) => updateTeam(orgSlug, slug, team),
     deleteFn: ({ orgSlug, slug }) => deleteTeam(orgSlug, slug),

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -47,7 +47,9 @@ export function ThirdPartyServiceManagement() {
     string
   >({
     queryKey: ['third-party-services', orgSlug],
-    listFn: orgSlug ? () => listThirdPartyServices(orgSlug) : null,
+    listFn: orgSlug
+      ? (signal) => listThirdPartyServices(orgSlug, signal)
+      : null,
     createFn: (svc) => {
       if (!orgSlug) throw new Error('No organization selected')
       return createThirdPartyService(orgSlug, svc)

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -52,7 +52,7 @@ export function UserManagement() {
     string
   >({
     queryKey: ['adminUsers'],
-    listFn: listAdminUsers,
+    listFn: (signal) => listAdminUsers(undefined, signal),
     createFn: createAdminUser,
     updateFn: ({ email, user }) => updateAdminUser(email, user),
     deleteFn: deleteAdminUser,
@@ -134,7 +134,7 @@ export function UserManagement() {
     error: selectedUserError,
   } = useQuery({
     queryKey: ['adminUser', selectedUserEmail],
-    queryFn: () => getAdminUser(selectedUserEmail!),
+    queryFn: ({ signal }) => getAdminUser(selectedUserEmail!, signal),
     enabled:
       !!selectedUserEmail && (viewMode === 'detail' || viewMode === 'edit'),
   })

--- a/src/components/admin/WebhookManagement.tsx
+++ b/src/components/admin/WebhookManagement.tsx
@@ -43,7 +43,7 @@ export function WebhookManagement() {
     string
   >({
     queryKey: ['webhooks', orgSlug],
-    listFn: orgSlug ? () => listWebhooks(orgSlug) : null,
+    listFn: orgSlug ? (signal) => listWebhooks(orgSlug, signal) : null,
     createFn: (data) => {
       if (!orgSlug) throw new Error('No organization selected')
       return createWebhook(orgSlug, data)

--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -118,7 +118,8 @@ export function BlueprintDetail({
     error,
   } = useQuery({
     queryKey: ['blueprint', blueprintKey.type, blueprintKey.slug],
-    queryFn: () => getBlueprint(blueprintKey.type, blueprintKey.slug),
+    queryFn: ({ signal }) =>
+      getBlueprint(blueprintKey.type, blueprintKey.slug, signal),
   })
 
   if (isLoading) {

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -53,7 +53,8 @@ export function BlueprintForm({
     error: bpError,
   } = useQuery({
     queryKey: ['blueprint', blueprintKey?.type, blueprintKey?.slug],
-    queryFn: () => getBlueprint(blueprintKey!.type, blueprintKey!.slug),
+    queryFn: ({ signal }) =>
+      getBlueprint(blueprintKey!.type, blueprintKey!.slug, signal),
     enabled: isEditing,
   })
 
@@ -67,7 +68,7 @@ export function BlueprintForm({
     isError: ptIsError,
   } = useQuery({
     queryKey: ['projectTypes', orgSlug],
-    queryFn: () => listProjectTypes(orgSlug!),
+    queryFn: ({ signal }) => listProjectTypes(orgSlug!, signal),
     enabled: !!orgSlug,
   })
 
@@ -77,7 +78,7 @@ export function BlueprintForm({
     isError: envIsError,
   } = useQuery({
     queryKey: ['environments', orgSlug],
-    queryFn: () => listEnvironments(orgSlug!),
+    queryFn: ({ signal }) => listEnvironments(orgSlug!, signal),
     enabled: !!orgSlug,
   })
 

--- a/src/components/admin/environments/EnvironmentDetail.tsx
+++ b/src/components/admin/environments/EnvironmentDetail.tsx
@@ -22,7 +22,7 @@ export function EnvironmentDetail({
 }: EnvironmentDetailProps) {
   const { data: envSchema } = useQuery({
     queryKey: ['environmentSchema'],
-    queryFn: getEnvironmentSchema,
+    queryFn: ({ signal }) => getEnvironmentSchema(signal),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -60,7 +60,7 @@ export function EnvironmentForm({
 
   const { data: envSchema } = useQuery({
     queryKey: ['environmentSchema'],
-    queryFn: getEnvironmentSchema,
+    queryFn: ({ signal }) => getEnvironmentSchema(signal),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/admin/project-types/ProjectTypeDetail.tsx
+++ b/src/components/admin/project-types/ProjectTypeDetail.tsx
@@ -22,7 +22,7 @@ export function ProjectTypeDetail({
 }: ProjectTypeDetailProps) {
   const { data: ptSchema } = useQuery({
     queryKey: ['projectTypeSchema'],
-    queryFn: getProjectTypeSchema,
+    queryFn: ({ signal }) => getProjectTypeSchema(signal),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -54,7 +54,7 @@ export function ProjectTypeForm({
 
   const { data: ptSchema } = useQuery({
     queryKey: ['projectTypeSchema'],
-    queryFn: getProjectTypeSchema,
+    queryFn: ({ signal }) => getProjectTypeSchema(signal),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/admin/roles/RoleDetail.tsx
+++ b/src/components/admin/roles/RoleDetail.tsx
@@ -70,13 +70,13 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
     error,
   } = useQuery({
     queryKey: ['role', slug],
-    queryFn: () => getRole(slug),
+    queryFn: ({ signal }) => getRole(slug, signal),
   })
 
   // Fetch admin settings for available permissions
   const { data: adminSettings } = useQuery({
     queryKey: ['adminSettings'],
-    queryFn: getAdminSettings,
+    queryFn: ({ signal }) => getAdminSettings(signal),
   })
 
   // Fetch users with this role
@@ -86,7 +86,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
     error: usersError,
   } = useQuery({
     queryKey: ['roleUsers', slug],
-    queryFn: () => getRoleUsers(slug),
+    queryFn: ({ signal }) => getRoleUsers(slug, signal),
     enabled: activeTab === 'users',
   })
 
@@ -97,7 +97,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
     error: saError,
   } = useQuery({
     queryKey: ['roleServiceAccounts', slug],
-    queryFn: () => getRoleServiceAccounts(slug),
+    queryFn: ({ signal }) => getRoleServiceAccounts(slug, signal),
     enabled: activeTab === 'service-accounts',
   })
 
@@ -108,7 +108,7 @@ export function RoleDetail({ slug, onEdit, onBack }: RoleDetailProps) {
     error: groupsError,
   } = useQuery({
     queryKey: ['roleGroups', slug],
-    queryFn: () => getRoleGroups(slug),
+    queryFn: ({ signal }) => getRoleGroups(slug, signal),
     enabled: activeTab === 'groups',
   })
 

--- a/src/components/admin/roles/RoleForm.tsx
+++ b/src/components/admin/roles/RoleForm.tsx
@@ -73,7 +73,7 @@ export function RoleForm({
     error: roleError,
   } = useQuery({
     queryKey: ['role', roleSlug],
-    queryFn: () => getRole(roleSlug!),
+    queryFn: ({ signal }) => getRole(roleSlug!, signal),
     enabled: isEditing,
   })
 
@@ -84,7 +84,7 @@ export function RoleForm({
     error: adminSettingsError,
   } = useQuery({
     queryKey: ['adminSettings'],
-    queryFn: getAdminSettings,
+    queryFn: ({ signal }) => getAdminSettings(signal),
   })
 
   const [name, setName] = useState('')

--- a/src/components/admin/service-accounts/ApiKeysSection.tsx
+++ b/src/components/admin/service-accounts/ApiKeysSection.tsx
@@ -61,7 +61,7 @@ export function ApiKeysSection({
     error: keysError,
   } = useQuery({
     queryKey: ['serviceAccountApiKeys', account.slug],
-    queryFn: () => listServiceAccountApiKeys(account.slug),
+    queryFn: ({ signal }) => listServiceAccountApiKeys(account.slug, signal),
   })
 
   const handleCreateKey = () => {

--- a/src/components/admin/service-accounts/ClientCredentialsSection.tsx
+++ b/src/components/admin/service-accounts/ClientCredentialsSection.tsx
@@ -89,7 +89,7 @@ export function ClientCredentialsSection({
     error: credentialsError,
   } = useQuery({
     queryKey: ['clientCredentials', account.slug],
-    queryFn: () => listClientCredentials(account.slug),
+    queryFn: ({ signal }) => listClientCredentials(account.slug, signal),
   })
 
   const resetCredentialForm = () => {

--- a/src/components/admin/service-accounts/ServiceAccountDetail.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountDetail.tsx
@@ -50,7 +50,7 @@ export function ServiceAccountDetail({
     isLoading: rolesLoading,
   } = useQuery({
     queryKey: ['roles'],
-    queryFn: getRoles,
+    queryFn: ({ signal }) => getRoles(signal),
   })
 
   const {

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -48,7 +48,7 @@ export function ServiceAccountForm({
     isError: rolesError,
   } = useQuery({
     queryKey: ['roles'],
-    queryFn: getRoles,
+    queryFn: ({ signal }) => getRoles(signal),
   })
 
   // Validation state

--- a/src/components/admin/teams/TeamDetail.tsx
+++ b/src/components/admin/teams/TeamDetail.tsx
@@ -64,12 +64,13 @@ export function TeamDetail({ team, onEdit, onBack }: TeamDetailProps) {
     error: membersError,
   } = useQuery({
     queryKey: ['teamMembers', team.organization.slug, team.slug],
-    queryFn: () => getTeamMembers(team.organization.slug, team.slug),
+    queryFn: ({ signal }) =>
+      getTeamMembers(team.organization.slug, team.slug, signal),
   })
 
   const { data: teamSchema } = useQuery({
     queryKey: ['teamSchema'],
-    queryFn: getTeamSchema,
+    queryFn: ({ signal }) => getTeamSchema(signal),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -50,7 +50,7 @@ export function TeamForm({
 
   const { data: teamSchema } = useQuery({
     queryKey: ['teamSchema'],
-    queryFn: getTeamSchema,
+    queryFn: ({ signal }) => getTeamSchema(signal),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -65,7 +65,8 @@ export function ApplicationSecretsPanel({
     refetch,
   } = useQuery({
     queryKey: ['application-secrets', orgSlug, serviceSlug, appSlug],
-    queryFn: () => getApplicationSecrets(orgSlug, serviceSlug, appSlug),
+    queryFn: ({ signal }) =>
+      getApplicationSecrets(orgSlug, serviceSlug, appSlug, signal),
     enabled: revealed,
     retry: false,
   })

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -68,7 +68,8 @@ export function OAuth2ApplicationList({
     error,
   } = useQuery({
     queryKey: ['service-applications', orgSlug, serviceSlug],
-    queryFn: () => listServiceApplications(orgSlug, serviceSlug),
+    queryFn: ({ signal }) =>
+      listServiceApplications(orgSlug, serviceSlug, signal),
   })
 
   const createMutation = useMutation({

--- a/src/components/admin/third-party-services/ServiceWebhookList.tsx
+++ b/src/components/admin/third-party-services/ServiceWebhookList.tsx
@@ -60,7 +60,7 @@ export function ServiceWebhookList({
     error,
   } = useQuery({
     queryKey: ['service-webhooks', orgSlug, serviceSlug],
-    queryFn: () => listServiceWebhooks(orgSlug, serviceSlug),
+    queryFn: ({ signal }) => listServiceWebhooks(orgSlug, serviceSlug, signal),
   })
 
   const createMutation = useMutation({

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -58,7 +58,7 @@ export function ThirdPartyServiceForm({
 
   const { data: teams = [] } = useQuery({
     queryKey: ['teams', orgSlug],
-    queryFn: () => listTeams(orgSlug),
+    queryFn: ({ signal }) => listTeams(orgSlug, signal),
     enabled: !!orgSlug,
   })
 

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -54,7 +54,7 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
 
   const { data: availableRoles = [] } = useQuery({
     queryKey: ['roles'],
-    queryFn: getRoles,
+    queryFn: ({ signal }) => getRoles(signal),
   })
 
   const addOrgMutation = useMutation({

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -62,7 +62,7 @@ export function UserForm({
   // Fetch available roles
   const { data: availableRoles = [], isLoading: rolesLoading } = useQuery({
     queryKey: ['roles'],
-    queryFn: getRoles,
+    queryFn: ({ signal }) => getRoles(signal),
   })
 
   // Validation state

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -72,7 +72,7 @@ export function WebhookForm({
 
   const { data: services = [] } = useQuery({
     queryKey: ['third-party-services', orgSlug],
-    queryFn: () => listThirdPartyServices(orgSlug),
+    queryFn: ({ signal }) => listThirdPartyServices(orgSlug, signal),
     enabled: !!orgSlug,
   })
 

--- a/src/components/assistant/ConversationHistory.tsx
+++ b/src/components/assistant/ConversationHistory.tsx
@@ -25,7 +25,7 @@ export function ConversationHistory({
 
   const { data: conversations = [] } = useQuery({
     queryKey: ['assistant', 'conversations'],
-    queryFn: () => listConversations({ limit: 20 }),
+    queryFn: ({ signal }) => listConversations({ limit: 20 }, signal),
     enabled: showHistory,
   })
 

--- a/src/components/operations-log/OperationsLogEntryDetails.tsx
+++ b/src/components/operations-log/OperationsLogEntryDetails.tsx
@@ -51,7 +51,7 @@ function MetaChip({
 export function OperationsLogEntryDetails({ entry }: Props) {
   const { data } = useQuery({
     queryKey: ['operationsLog', 'entry', entry.id],
-    queryFn: () => getOperationsLogEntry(entry.id),
+    queryFn: ({ signal }) => getOperationsLogEntry(entry.id, signal),
     initialData: entry,
     staleTime: 30_000,
   })

--- a/src/components/settings/SettingsApiKeys.tsx
+++ b/src/components/settings/SettingsApiKeys.tsx
@@ -32,7 +32,7 @@ export function SettingsApiKeys() {
     error: listError,
   } = useQuery({
     queryKey: ['api-keys'],
-    queryFn: () => listApiKeys(),
+    queryFn: ({ signal }) => listApiKeys(signal),
   })
 
   const createMutation = useMutation({

--- a/src/contexts/OrganizationContext.tsx
+++ b/src/contexts/OrganizationContext.tsx
@@ -33,7 +33,7 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
 
   const { data: organizations = [], isLoading } = useQuery({
     queryKey: ['organizations'],
-    queryFn: listOrganizations,
+    queryFn: ({ signal }) => listOrganizations(signal),
     enabled: !!accessToken && !isTokenExpired(),
     retry: 1,
   })

--- a/src/hooks/__tests__/useAuth.test.tsx
+++ b/src/hooks/__tests__/useAuth.test.tsx
@@ -194,7 +194,10 @@ describe('useAuth', () => {
 
     await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
     expect(endpoints.getUserByUsername).toHaveBeenCalledTimes(1)
-    expect(endpoints.getUserByUsername).toHaveBeenCalledWith('user@example.com')
+    expect(endpoints.getUserByUsername).toHaveBeenCalledWith(
+      'user@example.com',
+      expect.any(AbortSignal),
+    )
     expect(endpoints.refreshToken).not.toHaveBeenCalled()
     expect(latestLocation.pathname).toBe('/dashboard')
   })

--- a/src/hooks/useAdminCrud.ts
+++ b/src/hooks/useAdminCrud.ts
@@ -9,7 +9,7 @@ interface AdminCrudConfig<TItem, TCreateInput, TUpdateInput, TDeleteInput> {
   /** React Query key for the list query. */
   queryKey: QueryKey
   /** Fetch the list. Return [] to disable via enabled=false. */
-  listFn: (() => Promise<TItem[]>) | null
+  listFn: ((signal?: AbortSignal) => Promise<TItem[]>) | null
   /** Create mutation handler. */
   createFn: (input: TCreateInput) => Promise<unknown>
   /** Update mutation handler. */
@@ -60,7 +60,8 @@ export function useAdminCrud<
 
   const listQuery = useQuery<TItem[]>({
     queryKey,
-    queryFn: listFn ?? (() => Promise.resolve([] as TItem[])),
+    queryFn: ({ signal }) =>
+      listFn ? listFn(signal) : Promise.resolve([] as TItem[]),
     enabled: !!listFn,
   })
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -34,13 +34,13 @@ export function useAuth(): UseAuthReturn {
     refetch,
   } = useQuery<UserResponse>({
     queryKey: ['currentUser', getUsername()],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const username = getUsername()
       if (!username) {
         throw new Error('No username found in token')
       }
       try {
-        return await getUserByUsername(username)
+        return await getUserByUsername(username, signal)
       } catch (error) {
         console.error('[Auth] Error fetching user:', error)
         if (error instanceof ApiError && error.status === 401) {

--- a/src/hooks/useInfiniteActivityFeed.ts
+++ b/src/hooks/useInfiniteActivityFeed.ts
@@ -52,6 +52,9 @@ async function fetchActivityFeed({
       nextToken,
     }
   } catch (error) {
+    if (signal?.aborted) {
+      throw error
+    }
     console.error('[API] Activity feed error:', error)
     return { data: [] }
   }

--- a/src/hooks/useInfiniteActivityFeed.ts
+++ b/src/hooks/useInfiniteActivityFeed.ts
@@ -22,8 +22,10 @@ function parseLinkHeader(headers: Headers): string | undefined {
 
 async function fetchActivityFeed({
   pageParam,
+  signal,
 }: {
   pageParam?: string
+  signal?: AbortSignal
 }): Promise<ActivityFeedResponse> {
   try {
     const params: Record<string, unknown> = { limit: 20 }
@@ -33,7 +35,7 @@ async function fetchActivityFeed({
 
     const { data, headers } = await apiClient.getWithHeaders<
       ActivityFeedEntry[]
-    >('/activity-feed', params)
+    >('/activity-feed', params, signal)
 
     const items = Array.isArray(data) ? data : []
     const nextToken = parseLinkHeader(headers)

--- a/src/hooks/useInfiniteOperationsLog.ts
+++ b/src/hooks/useInfiniteOperationsLog.ts
@@ -7,12 +7,15 @@ const PAGE_SIZE = 200
 export function useInfiniteOperationsLog(filters: OperationsLogFilters) {
   return useInfiniteQuery({
     queryKey: ['operationsLog', 'infinite', filters],
-    queryFn: ({ pageParam }) =>
-      listOperationsLog({
-        limit: PAGE_SIZE,
-        cursor: pageParam as string | undefined,
-        filters,
-      }),
+    queryFn: ({ pageParam, signal }) =>
+      listOperationsLog(
+        {
+          limit: PAGE_SIZE,
+          cursor: pageParam as string | undefined,
+          filters,
+        },
+        signal,
+      ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
       if (!lastPage.nextCursor) return undefined

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -30,7 +30,7 @@ export function LoginPage() {
 
   const { data: providersData, isLoading: providersLoading } = useQuery({
     queryKey: ['authProviders'],
-    queryFn: getAuthProviders,
+    queryFn: ({ signal }) => getAuthProviders(signal),
     staleTime: 10 * 60 * 1000,
     retry: false,
   })

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -19,7 +19,7 @@ export function ProjectDetailPage() {
     error,
   } = useQuery({
     queryKey: ['project', orgSlug, projectId],
-    queryFn: () => getProject(orgSlug, projectId!),
+    queryFn: ({ signal }) => getProject(orgSlug, projectId!, signal),
     enabled: !!orgSlug && !!projectId,
   })
 


### PR DESCRIPTION
## Summary

Section 4d of `docs/code-review-followups.md` — plumb `AbortSignal` through `src/api/client.ts`, the endpoint wrappers, and every `queryFn` call site. Before this PR React Query v5's per-query `signal` was silently dropped everywhere; a slow `/projects` request kept running after the user navigated away.

54 files touched; mechanical and behavior-preserving when no signal is supplied.

## What changed

**`src/api/client.ts`**
- `ApiClient.get` / `post` / `put` / `patch` / `delete` / `postFormData` / `getWithHeaders` each accept a trailing `signal?: AbortSignal`.
- Private `request()` forwards signal to both `withAuthRetry` and the inner `fetch(..)` init.
- `withAuthRetry(url, fetcher, signal?)` threads the signal into the initial fetch AND the reactive-refresh retry fetch, and short-circuits if the signal already aborted.

**`src/api/endpoints.ts`**
- Every read helper (`getX`, `listX`, `searchX`, `getXCount`, …) gains a trailing `signal?: AbortSignal`.
- Mutation helpers (`createX`, `updateX`, `deleteX`, `patchX`, `addX`, `removeX`, `rotateX`, …) are unchanged — `useMutation` doesn't produce a signal.

**`src/api/openapi.ts`**
- `fetchOpenApiSpec` accepts signal.

**`src/api/assistant.ts`**
- `assistantFetch` + read helpers (`listConversations`, `getConversation`) accept signal.
- `sendMessageSSE` already accepted signal; unchanged.

**QueryFn call sites (61 total)**
- Standard rewrite: `queryFn: () => fn(args)` → `queryFn: ({ signal }) => fn(args, signal)`.
- `useInfiniteOperationsLog` and `useInfiniteActivityFeed` destructure `{ pageParam, signal }`.
- `useAuth` passes signal into `getUserByUsername`.
- `useAdminCrud`: `listFn` type widened to `((signal?: AbortSignal) => Promise<TItem[]>) | null`; 12 callers updated. Wrappers around `listX(params, signal)` use `(signal) => listX(undefined, signal)`.

## Behavior preservation

- Every call site that passes no signal behaves exactly as before — the new parameter is optional and only kicks in when React Query (or a manual caller) fires `abort()`.
- No change to `mergeStateStatus` / queryKey / staleTime / cacheTime / any other React Query option.
- Mutations are deliberately untouched; they don't pair with `AbortSignal` in React Query's default flow.

## Not in this PR

- OpenAPI-generated types — section 4b, separate PR.
- Org-scoped query keys — section 4f, incremental per-entity PRs.
- Mutation error UX unification — section 4h, incremental.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Manual: navigate to a slow page, immediately click a different route before the fetch completes; verify the first query's request is aborted (DevTools Network panel shows "cancelled").

🤖 Generated with [Claude Code](https://claude.com/claude-code)