### PR TITLE
Docs: clarify EditableKeyValueMap vs KeyValueEditor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,13 @@ This is a complete rewrite of the Imbi UI using modern TypeScript and React.
 4. Use React Query hooks for data fetching
 5. Handle loading and error states
 
+## Component conventions
+
+### Key/value editors
+Two primitives, intentionally kept distinct — pick by save model, not by look:
+- **`EditableKeyValueMap`** (`@/components/ui/EditableKeyValueMap`): inline-edit on a detail page. Each row commits on blur with a `SavedIndicator`, deletes route through `ConfirmDialog`, and keys are picked from a pre-known set via `Select`. Pairs with the `useEditableKeyValueMap` hook. Used by `EditLinksCard`, `EditIdentifiersCard`.
+- **`KeyValueEditor`** (`@/components/ui/key-value-editor`): form-embedded editor with free-form keys, controlled via `value`/`onChange`, no per-row save. Used inside forms that submit the whole object at once (e.g. `ThirdPartyServiceForm`'s links and identifiers).
+
 ## Backend API
 - OpenAPI spec snapshot committed at `openapi.json` (repo root). Regenerate types after backend changes with `npm run codegen:fetch` (requires a running backend at `localhost:8000`) or `npm run codegen` (from the current snapshot). Generated types at `src/types/api-generated.ts`.
 - Session cookie auth (or Private-Token header)

--- a/src/components/ui/EditableKeyValueMap.tsx
+++ b/src/components/ui/EditableKeyValueMap.tsx
@@ -1,3 +1,10 @@
+// Inline-edit key/value card: keys are picked from a pre-known set (Select),
+// values commit on blur with a SavedIndicator, and deletes pass through a
+// ConfirmDialog. Use on detail pages where each row is independently saved
+// against the server (see EditLinksCard, EditIdentifiersCard).
+//
+// For form-embedded free-form key/value editing where the whole form is
+// submitted at once, use KeyValueEditor (./key-value-editor) instead.
 import type { ReactNode } from 'react'
 import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'

--- a/src/components/ui/key-value-editor.tsx
+++ b/src/components/ui/key-value-editor.tsx
@@ -1,3 +1,10 @@
+// Form-embedded key/value editor: free-form keys (user types them), controlled
+// via value/onChange, no per-row save. Use inside a form that submits the
+// whole object at once (see ThirdPartyServiceForm's links/identifiers state).
+//
+// For inline-edit on a detail page where each row is independently committed
+// against the server (with confirm dialog + saved indicator + Select from a
+// pre-known key set), use EditableKeyValueMap (./EditableKeyValueMap) instead.
 import { useState } from 'react'
 import { Plus, Trash2 } from 'lucide-react'
 import { Button } from './button'


### PR DESCRIPTION
## Summary

Section 5 of `docs/code-review-followups.md` called for auditing these two primitives and picking one as canonical:

> `src/components/ui/EditableKeyValueMap.tsx` is full-featured (confirm dialogs, SavedIndicator, a11y, ~203 LOC). `src/components/ui/key-value-editor.tsx` is a lighter inline variant (~100 LOC, no confirmation).
>
> Audit consumers of each, pick one as canonical, migrate the other's consumers, then delete the loser. Record the choice in `src/CLAUDE.md` so future sessions know which to use.

After reading both files end-to-end, they aren't near-duplicates — they solve different problems:

- **`EditableKeyValueMap`** wraps `useEditableKeyValueMap`, commits each row on blur against the server, routes deletes through `ConfirmDialog`, and picks keys from a pre-known set via `Select`. The right answer for inline-edit on a detail page. Consumers: `EditLinksCard`, `EditIdentifiersCard`.
- **`KeyValueEditor`** is a plain controlled component with free-form keys, no hook, no commit-on-blur, no confirm. The right answer for form-embedded editing where the whole form saves at once. Consumer: `ThirdPartyServiceForm`'s `links` / `identifiers` state.

Forcing consolidation would either (a) regress UX on inline-edit pages by dropping the `ConfirmDialog` and `SavedIndicator`, or (b) widen `EditableKeyValueMap`'s API with a "form mode" that mostly turns off its defining features.

## What changed

- Added 6-line header comments to each component explaining its intended use case and pointing at the other one.
- Added a new **"Component conventions" → "Key/value editors"** section to `CLAUDE.md` so future sessions pick the right primitive without re-deriving the design.

No runtime changes.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)