### PR TITLE
Refactor: scope activityFeed + operationsLog query keys by org

### DIFF
--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -218,7 +218,7 @@ export function OperationsLog({
     isFetchingNextPage,
     fetchNextPage,
     refetch,
-  } = useInfiniteOperationsLog(apiFilters)
+  } = useInfiniteOperationsLog(orgSlug, apiFilters)
 
   const rawEntries: OperationsLogRecord[] = useMemo(
     () => data?.entries ?? [],

--- a/src/components/dashboard/widgets/RecentActivityWidget.tsx
+++ b/src/components/dashboard/widgets/RecentActivityWidget.tsx
@@ -1,5 +1,6 @@
 import { RecentActivity } from '../../RecentActivity'
 import { useInfiniteActivityFeed } from '@/hooks/useInfiniteActivityFeed'
+import { useOrganization } from '@/contexts/OrganizationContext'
 
 interface RecentActivityWidgetProps {
   onUserSelect?: (userName: string) => void
@@ -10,13 +11,15 @@ export function RecentActivityWidget({
   onUserSelect,
   onProjectSelect,
 }: RecentActivityWidgetProps) {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
   const {
     data: activityData,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
     isLoading,
-  } = useInfiniteActivityFeed()
+  } = useInfiniteActivityFeed(orgSlug)
 
   const activityFeed = activityData?.activities || []
 

--- a/src/hooks/useInfiniteActivityFeed.ts
+++ b/src/hooks/useInfiniteActivityFeed.ts
@@ -60,9 +60,9 @@ async function fetchActivityFeed({
   }
 }
 
-export function useInfiniteActivityFeed() {
+export function useInfiniteActivityFeed(orgSlug: string) {
   return useInfiniteQuery({
-    queryKey: ['activityFeed', 'infinite'],
+    queryKey: ['activityFeed', 'infinite', orgSlug],
     queryFn: fetchActivityFeed,
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.nextToken,

--- a/src/hooks/useInfiniteActivityFeed.ts
+++ b/src/hooks/useInfiniteActivityFeed.ts
@@ -63,6 +63,7 @@ async function fetchActivityFeed({
 export function useInfiniteActivityFeed(orgSlug: string) {
   return useInfiniteQuery({
     queryKey: ['activityFeed', 'infinite', orgSlug],
+    enabled: Boolean(orgSlug),
     queryFn: fetchActivityFeed,
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.nextToken,

--- a/src/hooks/useInfiniteOperationsLog.ts
+++ b/src/hooks/useInfiniteOperationsLog.ts
@@ -4,9 +4,12 @@ import type { OperationsLogFilters } from '@/types'
 
 const PAGE_SIZE = 200
 
-export function useInfiniteOperationsLog(filters: OperationsLogFilters) {
+export function useInfiniteOperationsLog(
+  orgSlug: string,
+  filters: OperationsLogFilters,
+) {
   return useInfiniteQuery({
-    queryKey: ['operationsLog', 'infinite', filters],
+    queryKey: ['operationsLog', 'infinite', orgSlug, filters],
     queryFn: ({ pageParam, signal }) =>
       listOperationsLog(
         {

--- a/src/hooks/useInfiniteOperationsLog.ts
+++ b/src/hooks/useInfiniteOperationsLog.ts
@@ -10,6 +10,7 @@ export function useInfiniteOperationsLog(
 ) {
   return useInfiniteQuery({
     queryKey: ['operationsLog', 'infinite', orgSlug, filters],
+    enabled: Boolean(orgSlug),
     queryFn: ({ pageParam, signal }) =>
       listOperationsLog(
         {


### PR DESCRIPTION
## Summary

Section 4f of `docs/code-review-followups.md`. Audited every `queryKey` in `src/`:
- Most entity queries (projects, environments, teams, project-types, third-party-services, service-applications, webhooks, link-definitions, project-schema, project-relationships) already include `orgSlug` as a key element.
- Two infinite-query hooks didn't: `useInfiniteActivityFeed` and `useInfiniteOperationsLog`. On org switch, the cached pages from the previous org were reused until a refetch.

This PR closes that gap. Other entities are already correctly scoped — no further changes needed for the current entity set.

## What changed

- **`src/hooks/useInfiniteActivityFeed.ts`** — `useInfiniteActivityFeed(orgSlug: string)`. Query key now `['activityFeed', 'infinite', orgSlug]`.
- **`src/hooks/useInfiniteOperationsLog.ts`** — `useInfiniteOperationsLog(orgSlug: string, filters)`. Query key now `['operationsLog', 'infinite', orgSlug, filters]`.
- **`src/components/dashboard/widgets/RecentActivityWidget.tsx`** — pulls `orgSlug` from `useOrganization()` and passes it through.
- **`src/components/OperationsLog.tsx`** — passes the existing `orgSlug` (already derived at :142) to the hook.

## Behavior change

On org switch, the infinite-paged activity feed and operations log now re-fetch for the new org instead of reusing the previous org's cached pages. Intended.

## Not in this PR

- Key-element-order normalization. The doc suggested `['org', orgSlug, 'entity']`; the codebase uses `['entity', orgSlug]`. That's cosmetic — same invalidation semantics — and a separate PR if it's wanted at all.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [ ] Manual: with two orgs available, switch between them on the dashboard and the operations log; confirm each view fetches fresh data instead of flashing the other org's content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)