### PR TITLE
Refactor: surface errors on three silent mutations

### DIFF
--- a/src/components/assistant/ConversationHistory.tsx
+++ b/src/components/assistant/ConversationHistory.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { MessageSquare, Plus, Archive, Trash2 } from 'lucide-react'
 import {
   listConversations,
   deleteConversation,
   updateConversation,
 } from '@/api/assistant'
+import { extractApiErrorDetail } from '@/lib/apiError'
 import type { Conversation } from '@/types/assistant'
 import { Button } from '@/components/ui/button'
 
@@ -35,6 +37,11 @@ export function ConversationHistory({
       queryClient.invalidateQueries({
         queryKey: ['assistant', 'conversations'],
       }),
+    onError: (error: unknown) => {
+      toast.error(
+        `Failed to delete conversation: ${extractApiErrorDetail(error)}`,
+      )
+    },
   })
 
   const archiveMutation = useMutation({
@@ -43,6 +50,11 @@ export function ConversationHistory({
       queryClient.invalidateQueries({
         queryKey: ['assistant', 'conversations'],
       }),
+    onError: (error: unknown) => {
+      toast.error(
+        `Failed to archive conversation: ${extractApiErrorDetail(error)}`,
+      )
+    },
   })
 
   const handleDelete = (e: React.MouseEvent, id: string) => {

--- a/src/components/settings/SettingsApiKeys.tsx
+++ b/src/components/settings/SettingsApiKeys.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -53,6 +54,9 @@ export function SettingsApiKeys() {
     onSuccess: () => {
       setRevokingKeyId(null)
       queryClient.invalidateQueries({ queryKey: ['api-keys'] })
+    },
+    onError: (error: unknown) => {
+      toast.error(`Failed to revoke API key: ${extractApiErrorDetail(error)}`)
     },
   })
 


### PR DESCRIPTION
## Summary

Section 4h of `docs/code-review-followups.md` called out mutation-error UX inconsistency:
> Some mutations toast inline, some swallow errors, some render inline. Pick one pattern (likely `useAdminCrud`'s, since it's the richest) and migrate the rest.

I audited every `useMutation` in `src/` (outside `api-generated.ts` and `__tests__`). The picture: three **acceptable** error patterns are in active use, and only a handful of mutations are actual bugs (no `onError`, no inline `.error` render — failures silently disappear).

## Patterns in use (unchanged by this PR)

1. **Inline toast in `onError`** — admin detail pages (`UserDetail`, `TeamDetail`, `RoleDetail`, `ServiceAccountDetail` via `useServiceAccountMutations`, `ProjectSettingsTab`, `UserManagement.toggleActiveMutation`, webhook/service-application delete flows).
2. **Render inline via `mutation.error`** — form-embedded mutations (`NewProjectDialog.createMutation`, `EditRelationshipsDialog`, `ApplicationSecretsPanel.updateMutation`, OAuth2/Service-webhook list create/update flows, `icon-upload`).
3. **Centralized through `useAdminCrud`** — list-scoped admin entities.

All three are working correctly. Migrating cross-pattern would either force UX changes (inline banners turning into toasts and vice versa) or require a bigger hook rewrite. Keeping them as-is.

## Actual fix

Three mutations had **no `onError` AND no `.error` render** — silent failures:

- **`SettingsApiKeys.deleteMutation`** → revoke API key errors now `toast.error('Failed to revoke API key: …')`.
- **`ConversationHistory.deleteMutation`** → delete-conversation errors now `toast.error('Failed to delete conversation: …')`.
- **`ConversationHistory.archiveMutation`** → archive-conversation errors now `toast.error('Failed to archive conversation: …')`.

Each uses `extractApiErrorDetail` from `@/lib/apiError` to get the server message, matching the style used by the rest of the codebase.

## Intentionally untouched

- **`useAuth.ts`** (`loginMutation`, `logoutMutation`, `refreshTokenMutation`) — auth flow owns its own error presentation (login form renders errors inline; refresh is internal; logout failures tolerable).
- **`useIconWithCleanup.ts`** — background orphan-cleanup delete that runs when an icon is replaced; silent failure is by design.
- **`useAdminCrud.ts`** — already has the centralized pattern; untouched.
- **`useServiceAccountMutations.ts`** — all nine factory mutations already have toast handlers; verified.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Manual: force a 403 on API-key revoke (e.g. via browser devtools network throttle/fail), a delete on a conversation that no longer exists, and an archive on a conversation with an expired token; confirm a toast fires each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)