### PR TITLE
Fix: redirect /admin to /admin/blueprints on mount

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Users,
   Shield,
@@ -81,6 +81,12 @@ export function Admin() {
     : 'blueprints'
   const [isCollapsed, setIsCollapsed] = useState(false)
   const { selectedOrganization } = useOrganization()
+
+  useEffect(() => {
+    if (section === undefined) {
+      navigate('/admin/blueprints', { replace: true })
+    }
+  }, [section, navigate])
 
   const orgName = selectedOrganization?.name || 'Organization'
 


### PR DESCRIPTION
## Summary
- Hard-navigating to `/admin` rendered the Blueprints section but left the URL as `/admin`, so `useAdminNav`'s `base` resolved to `/admin` and `goToEdit(slug)` produced `/admin/<slug>/edit` — which the router interpreted as `section=<slug>` and 404'd.
- Fix: `Admin.tsx` now redirects `/admin` → `/admin/blueprints` via `useNavigate({ replace: true })` on mount when `section` is undefined. The URL always carries a section segment; `useAdminNav` works without changes.

## Problem
Reported 2026-04-22: fresh `/admin` navigation rendered Blueprints but the URL stayed `/admin`. Clicking the first blueprint's edit action built `/admin/Project%3Aapis-facts/edit` instead of `/admin/blueprints/Project%3Aapis-facts/edit`, triggering a 404. Clicking any other sidebar item first updated the URL, after which Blueprints worked correctly.

## Solution
Redirect `/admin` → `/admin/blueprints` in `Admin.tsx` via `useEffect` + `useNavigate({ replace: true })` when `section` is undefined. Single source of truth for the default, visible in the address bar immediately. (Option 1 from the handoff doc.)

## Test plan
- [x] TypeScript / ESLint clean
- [ ] Hard-navigate to `/admin` → URL lands on `/admin/blueprints`
- [ ] Click edit on a blueprint → URL becomes `/admin/blueprints/<type>:<slug>/edit`
- [ ] Deep-link `/admin/environments` → sidebar shows Environments active
- [ ] Back-button from an edit page returns to `/admin/blueprints`