### PR TITLE
Feat: add useDirtyState hook (ServiceAccountForm consumer)

### DIFF
--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -61,16 +61,17 @@ export function ServiceAccountForm({
     handleFieldChange,
   } = useFormScaffold()
 
-  // Warn on unsaved navigation. Snapshot the initial values once (per mount /
-  // per account prop change) and compare against current form state.
-  const initialFormData = {
+  // Warn on unsaved navigation. Snapshot the initial values once at mount so
+  // the baseline doesn't drift when `organizations` loads asynchronously (which
+  // would otherwise flip an untouched form into "dirty").
+  const [initialFormData] = useState(() => ({
     slug: account?.slug ?? '',
     display_name: account?.display_name ?? '',
     description: account?.description ?? '',
     is_active: account?.is_active ?? true,
     organization_slug: organizations.length === 1 ? organizations[0].slug : '',
     role_slug: '',
-  }
+  }))
   const currentFormData = {
     slug,
     display_name: displayName,

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { FormHeader } from '@/components/admin/form-header'
 import { getRoles } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useDirtyState } from '@/hooks/useDirtyState'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
 import type { ServiceAccount, ServiceAccountCreate } from '@/types'
 
@@ -59,6 +60,26 @@ export function ServiceAccountForm({
     setTouched,
     handleFieldChange,
   } = useFormScaffold()
+
+  // Warn on unsaved navigation. Snapshot the initial values once (per mount /
+  // per account prop change) and compare against current form state.
+  const initialFormData = {
+    slug: account?.slug ?? '',
+    display_name: account?.display_name ?? '',
+    description: account?.description ?? '',
+    is_active: account?.is_active ?? true,
+    organization_slug: organizations.length === 1 ? organizations[0].slug : '',
+    role_slug: '',
+  }
+  const currentFormData = {
+    slug,
+    display_name: displayName,
+    description,
+    is_active: isActive,
+    organization_slug: organizationSlug,
+    role_slug: roleSlug,
+  }
+  useDirtyState(initialFormData, currentFormData, { enabled: !isLoading })
 
   // Validation functions
   const validateSlug = (value: string): string => {

--- a/src/hooks/useDirtyState.ts
+++ b/src/hooks/useDirtyState.ts
@@ -12,7 +12,7 @@ function jsonEquals<T>(a: T, b: T): boolean {
  * anyway?" confirm would let a user cancel the redirect and remain on a
  * protected screen with no valid session. Auth redirects always win.
  */
-const DEFAULT_BYPASS_PREFIXES = ['/login', '/logout', '/auth/']
+const DEFAULT_BYPASS_PREFIXES = ['/login', '/auth/']
 
 function pathnameOf(url: string | URL | null | undefined): string | null {
   if (url == null) return null

--- a/src/hooks/useDirtyState.ts
+++ b/src/hooks/useDirtyState.ts
@@ -6,6 +6,37 @@ function jsonEquals<T>(a: T, b: T): boolean {
   return JSON.stringify(a) === JSON.stringify(b)
 }
 
+/**
+ * Destinations that MUST never be blocked by the unsaved-changes prompt. If
+ * the session expires and auth code does `navigate('/login')`, a "Leave
+ * anyway?" confirm would let a user cancel the redirect and remain on a
+ * protected screen with no valid session. Auth redirects always win.
+ */
+const DEFAULT_BYPASS_PREFIXES = ['/login', '/logout', '/auth/']
+
+function pathnameOf(url: string | URL | null | undefined): string | null {
+  if (url == null) return null
+  if (typeof url !== 'string') return url.pathname
+  // Relative path like "/login?error=x" — take up to the query/hash.
+  if (url.startsWith('/')) return url.split(/[?#]/, 1)[0]
+  // Absolute URL — parse via URL (resolves against current origin if needed).
+  try {
+    return new URL(url, window.location.origin).pathname
+  } catch {
+    return null
+  }
+}
+
+function matchesBypass(pathname: string | null, prefixes: string[]): boolean {
+  if (!pathname) return false
+  return prefixes.some(
+    (p) =>
+      pathname === p ||
+      pathname === p.replace(/\/$/, '') ||
+      pathname.startsWith(p.endsWith('/') ? p : p + '/'),
+  )
+}
+
 export interface UseDirtyStateOptions {
   /**
    * Message shown in the in-app `window.confirm` prompt.
@@ -20,6 +51,13 @@ export interface UseDirtyStateOptions {
    * Defaults to true.
    */
   enabled?: boolean
+  /**
+   * Pathname prefixes that bypass the confirm prompt. Defaults to auth paths
+   * (`/login`, `/logout`, `/auth/`) so an expired session can always
+   * redirect the user out. Matches both exact pathnames and any descendants
+   * (e.g. `/login` also matches `/login?error=x`).
+   */
+  bypassPrefixes?: string[]
 }
 
 /**
@@ -46,10 +84,13 @@ export function useDirtyState<T>(
   const enabled = options.enabled ?? true
   const isDirty = enabled && !jsonEquals(initialData, currentData)
   const message = options.message ?? 'You have unsaved changes. Leave anyway?'
+  const bypassPrefixes = options.bypassPrefixes ?? DEFAULT_BYPASS_PREFIXES
 
-  // Keep the latest message in a ref so effect deps stay stable.
+  // Keep the latest message and bypass list in refs so effect deps stay stable.
   const messageRef = useRef(message)
   messageRef.current = message
+  const bypassRef = useRef(bypassPrefixes)
+  bypassRef.current = bypassPrefixes
 
   useEffect(() => {
     if (!isDirty) return
@@ -64,13 +105,15 @@ export function useDirtyState<T>(
     const originalPushState = window.history.pushState
     const originalReplaceState = window.history.replaceState
 
+    const isBypassed = (url: string | URL | null | undefined): boolean =>
+      matchesBypass(pathnameOf(url), bypassRef.current)
     const confirmNavigation = (): boolean => window.confirm(messageRef.current)
 
     const patchedPushState: typeof window.history.pushState = function (
       this: History,
       ...args
     ) {
-      if (!confirmNavigation()) return
+      if (!isBypassed(args[2]) && !confirmNavigation()) return
       return originalPushState.apply(this, args)
     }
 
@@ -78,7 +121,7 @@ export function useDirtyState<T>(
       this: History,
       ...args
     ) {
-      if (!confirmNavigation()) return
+      if (!isBypassed(args[2]) && !confirmNavigation()) return
       return originalReplaceState.apply(this, args)
     }
 
@@ -92,7 +135,7 @@ export function useDirtyState<T>(
     const handlePopState = () => {
       const attemptedHref = window.location.href
       if (attemptedHref === lastHref) return
-      if (confirmNavigation()) {
+      if (isBypassed(attemptedHref) || confirmNavigation()) {
         lastHref = attemptedHref
         return
       }

--- a/src/hooks/useDirtyState.ts
+++ b/src/hooks/useDirtyState.ts
@@ -45,8 +45,7 @@ export function useDirtyState<T>(
 ): boolean {
   const enabled = options.enabled ?? true
   const isDirty = enabled && !jsonEquals(initialData, currentData)
-  const message =
-    options.message ?? 'You have unsaved changes. Leave anyway?'
+  const message = options.message ?? 'You have unsaved changes. Leave anyway?'
 
   // Keep the latest message in a ref so effect deps stay stable.
   const messageRef = useRef(message)
@@ -65,8 +64,7 @@ export function useDirtyState<T>(
     const originalPushState = window.history.pushState
     const originalReplaceState = window.history.replaceState
 
-    const confirmNavigation = (): boolean =>
-      window.confirm(messageRef.current)
+    const confirmNavigation = (): boolean => window.confirm(messageRef.current)
 
     const patchedPushState: typeof window.history.pushState = function (
       this: History,

--- a/src/hooks/useDirtyState.ts
+++ b/src/hooks/useDirtyState.ts
@@ -1,0 +1,115 @@
+import { useEffect, useRef } from 'react'
+
+// Diff two values via JSON.stringify. Good enough for form data (plain
+// objects/arrays of primitives). Avoids pulling in a deep-equality dep.
+function jsonEquals<T>(a: T, b: T): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+export interface UseDirtyStateOptions {
+  /**
+   * Message shown in the in-app `window.confirm` prompt.
+   * The browser native `beforeunload` prompt is not customizable; this only
+   * affects the in-app navigation prompt.
+   */
+  message?: string
+  /**
+   * When false, the hook reports not-dirty and registers no listeners even if
+   * the data differs. Useful to skip prompting during an in-flight save —
+   * pass `enabled={!isSaving}` so the post-save `navigate()` doesn't prompt.
+   * Defaults to true.
+   */
+  enabled?: boolean
+}
+
+/**
+ * Warns on unsaved-navigation while `initialData` differs from `currentData`.
+ *
+ * While dirty:
+ * - Registers a `beforeunload` listener so tab-close/refresh surfaces the
+ *   browser's native "Leave site?" prompt.
+ * - Intercepts in-app navigation (history pushState/replaceState/popstate) and
+ *   prompts via `window.confirm`. If the user cancels, the navigation is
+ *   rolled back.
+ *
+ * NOTE: The in-app blocker uses history-patching rather than React Router's
+ * `useBlocker` because the app mounts a `BrowserRouter` (not a data router);
+ * `useBlocker` throws outside a data router. When the app migrates to
+ * `createBrowserRouter` + `RouterProvider`, swap the history patch for
+ * `useBlocker`.
+ */
+export function useDirtyState<T>(
+  initialData: T,
+  currentData: T,
+  options: UseDirtyStateOptions = {},
+): boolean {
+  const enabled = options.enabled ?? true
+  const isDirty = enabled && !jsonEquals(initialData, currentData)
+  const message =
+    options.message ?? 'You have unsaved changes. Leave anyway?'
+
+  // Keep the latest message in a ref so effect deps stay stable.
+  const messageRef = useRef(message)
+  messageRef.current = message
+
+  useEffect(() => {
+    if (!isDirty) return
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      // Required for legacy Chrome compatibility.
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+
+    const originalPushState = window.history.pushState
+    const originalReplaceState = window.history.replaceState
+
+    const confirmNavigation = (): boolean =>
+      window.confirm(messageRef.current)
+
+    const patchedPushState: typeof window.history.pushState = function (
+      this: History,
+      ...args
+    ) {
+      if (!confirmNavigation()) return
+      return originalPushState.apply(this, args)
+    }
+
+    const patchedReplaceState: typeof window.history.replaceState = function (
+      this: History,
+      ...args
+    ) {
+      if (!confirmNavigation()) return
+      return originalReplaceState.apply(this, args)
+    }
+
+    window.history.pushState = patchedPushState
+    window.history.replaceState = patchedReplaceState
+
+    // Capture the URL at activation so we can roll back popstate (back/forward)
+    // if the user cancels.
+    let lastHref = window.location.href
+
+    const handlePopState = () => {
+      const attemptedHref = window.location.href
+      if (attemptedHref === lastHref) return
+      if (confirmNavigation()) {
+        lastHref = attemptedHref
+        return
+      }
+      // Roll back: push the previous URL back into history.
+      originalPushState.call(window.history, null, '', lastHref)
+    }
+    window.addEventListener('popstate', handlePopState)
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      window.removeEventListener('popstate', handlePopState)
+      window.history.pushState = originalPushState
+      window.history.replaceState = originalReplaceState
+    }
+  }, [isDirty])
+
+  return isDirty
+}


### PR DESCRIPTION
## Summary

Add a `useDirtyState(initialData, currentData)` hook that warns on unsaved navigation and wire it into `ServiceAccountForm` as the first consumer. Addresses section 2c of `docs/follow-ups-round-2.md`.

## Problem

None of the admin forms warn on unsaved navigation. Closing the tab, refreshing, or navigating in-app silently discards form edits.

## Solution

New hook `src/hooks/useDirtyState.ts`:

- Compares `initialData` vs `currentData` via `JSON.stringify` (good enough for plain form data; avoids a new dep).
- While dirty, registers a `beforeunload` listener so tab-close/refresh surfaces the browser's native "Leave site?" prompt.
- While dirty, patches `history.pushState` / `replaceState` and intercepts `popstate` to prompt via `window.confirm` on in-app navigation; back/forward pops are rolled back if the user cancels.
- Listeners/patches are torn down on unmount and when `isDirty` returns to false.
- `enabled` option lets consumers suppress the prompt during an in-flight save (e.g. `enabled: !isLoading`) so the post-save `navigate()` doesn't trigger a prompt.

### Why not `useBlocker`?

`react-router-dom` v7's `useBlocker` requires a data router (`createBrowserRouter` + `RouterProvider`) and throws under the `BrowserRouter` this app still mounts. The history-patch path is the "equivalent" called out in the task; swap once the app migrates to a data router.

### First consumer

`ServiceAccountForm` passes snapshots of initial vs current field values plus `enabled: !isLoading` (suppresses the prompt while a save is in flight).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] `npm test` all suites pass (152/152)
- [ ] Manual: edit a service account, try to refresh — native browser prompt fires.
- [ ] Manual: edit a service account, click Cancel — `window.confirm` fires; cancelling stays on form.
- [ ] Manual: successful save navigates away without a spurious prompt.