### PR TITLE
Refactor: memoize InlineField callbacks in ProjectDetail

### DIFF
--- a/src/components/ProjectAttributesSection.tsx
+++ b/src/components/ProjectAttributesSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { getIcon } from '@/lib/icons'
 import { resolveColor, resolveIcon } from '@/lib/ui-maps'
 import type { XUiMaps } from '@/lib/ui-maps'
@@ -29,29 +29,115 @@ interface ProjectAttributesSectionProps {
   pendingPath: string | null
 }
 
+interface AttributeField {
+  key: string
+  label: string
+  value: string | null
+  rawValue: unknown
+  title?: string
+  uiMaps: XUiMaps
+  def: ProjectSchemaSectionProperty
+}
+
+interface ProjectAttributeRowProps {
+  field: AttributeField
+  patch: (path: string, value: unknown) => Promise<void>
+  pending: boolean
+}
+
+const LABEL_CLASS = 'text-tertiary'
+const VALUE_CLASS = 'text-primary'
+const MUTED_CLASS = 'text-tertiary'
+const DIVIDER_CLASS = 'border-tertiary'
+
+const ProjectAttributeRow = memo(function ProjectAttributeRow({
+  field,
+  patch,
+  pending,
+}: ProjectAttributeRowProps) {
+  const {
+    key,
+    label: fieldLabel,
+    value: fieldValue,
+    rawValue,
+    title: fieldTitle,
+    uiMaps,
+    def,
+  } = field
+
+  const handleCommit = useCallback(
+    (v: unknown) => patch(`/${key}`, v),
+    [patch, key],
+  )
+
+  const mappedColor = resolveColor(uiMaps, rawValue)
+  const mappedIcon = resolveIcon(uiMaps, rawValue)
+  const FieldIcon = mappedIcon ? getIcon(mappedIcon) : null
+  const textColorClass = mappedColor
+    ? (COLOR_TEXT[mappedColor] ?? VALUE_CLASS)
+    : VALUE_CLASS
+  const editable = isFieldEditable(key, def)
+  const richDisplay =
+    fieldValue !== null ? (
+      <span className="flex items-center gap-1.5">
+        {FieldIcon && (
+          <FieldIcon
+            className={`h-3.5 w-3.5 flex-shrink-0 ${textColorClass}`}
+          />
+        )}
+        {fieldTitle ? (
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className={`text-sm ${textColorClass} cursor-help underline decoration-dotted`}
+                >
+                  {fieldValue}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{fieldTitle}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <span className={`text-sm ${textColorClass}`}>{fieldValue}</span>
+        )}
+      </span>
+    ) : null
+
+  return (
+    <div
+      className={`flex items-center justify-between border-b py-1.5 ${DIVIDER_CLASS} last:border-0`}
+    >
+      <span className={`text-sm ${LABEL_CLASS}`}>{fieldLabel}</span>
+      {editable ? (
+        <InlineField
+          def={def}
+          raw={rawValue}
+          onCommit={handleCommit}
+          pending={pending}
+          display={richDisplay}
+        />
+      ) : richDisplay !== null ? (
+        richDisplay
+      ) : (
+        <span className={`text-sm italic ${MUTED_CLASS}`}>Not set</span>
+      )}
+    </div>
+  )
+})
+
 export function ProjectAttributesSection({
   project,
   projectSchema,
   patch,
   pendingPath,
 }: ProjectAttributesSectionProps) {
-  const label = 'text-tertiary'
-  const value = 'text-primary'
-  const muted = 'text-tertiary'
-  const divider = 'border-tertiary'
-
-  const attributeFields = useMemo(() => {
+  const attributeFields = useMemo<AttributeField[]>(() => {
     if (!projectSchema) return []
     const seen = new Set<string>()
-    const fields: {
-      key: string
-      label: string
-      value: string | null
-      rawValue: unknown
-      title?: string
-      uiMaps: XUiMaps
-      def: ProjectSchemaSectionProperty
-    }[] = []
+    const fields: AttributeField[] = []
     for (const section of projectSchema.sections) {
       for (const [key, def] of Object.entries(section.properties)) {
         if (seen.has(key) || key === 'url') continue
@@ -85,76 +171,14 @@ export function ProjectAttributesSection({
 
   return (
     <>
-      {attributeFields.map(
-        ({
-          key,
-          label: fieldLabel,
-          value: fieldValue,
-          rawValue,
-          title: fieldTitle,
-          uiMaps,
-          def,
-        }) => {
-          const mappedColor = resolveColor(uiMaps, rawValue)
-          const mappedIcon = resolveIcon(uiMaps, rawValue)
-          const FieldIcon = mappedIcon ? getIcon(mappedIcon) : null
-          const textColorClass = mappedColor
-            ? (COLOR_TEXT[mappedColor] ?? value)
-            : value
-          const editable = isFieldEditable(key, def)
-          const richDisplay =
-            fieldValue !== null ? (
-              <span className="flex items-center gap-1.5">
-                {FieldIcon && (
-                  <FieldIcon
-                    className={`h-3.5 w-3.5 flex-shrink-0 ${textColorClass}`}
-                  />
-                )}
-                {fieldTitle ? (
-                  <TooltipProvider delayDuration={200}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span
-                          className={`text-sm ${textColorClass} cursor-help underline decoration-dotted`}
-                        >
-                          {fieldValue}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{fieldTitle}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                ) : (
-                  <span className={`text-sm ${textColorClass}`}>
-                    {fieldValue}
-                  </span>
-                )}
-              </span>
-            ) : null
-          return (
-            <div
-              key={key}
-              className={`flex items-center justify-between border-b py-1.5 ${divider} last:border-0`}
-            >
-              <span className={`text-sm ${label}`}>{fieldLabel}</span>
-              {editable ? (
-                <InlineField
-                  def={def}
-                  raw={rawValue}
-                  onCommit={(v) => patch(`/${key}`, v)}
-                  pending={pendingPath === `/${key}`}
-                  display={richDisplay}
-                />
-              ) : richDisplay !== null ? (
-                richDisplay
-              ) : (
-                <span className={`text-sm italic ${muted}`}>Not set</span>
-              )}
-            </div>
-          )
-        },
-      )}
+      {attributeFields.map((field) => (
+        <ProjectAttributeRow
+          key={field.key}
+          field={field}
+          patch={patch}
+          pending={pendingPath === `/${field.key}`}
+        />
+      ))}
     </>
   )
 }

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -22,7 +22,7 @@ import {
   TooltipContent,
   TooltipProvider,
 } from '@/components/ui/tooltip'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
@@ -227,6 +227,41 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
     [projectTypes],
   )
 
+  const label = 'text-tertiary'
+  const value = 'text-primary'
+  const muted = 'text-tertiary'
+  const divider = 'border-tertiary'
+
+  const handleCommitName = useCallback(
+    (v: string | null) => patch('/name', v ?? ''),
+    [patch],
+  )
+  const handleCommitDescription = useCallback(
+    (v: string | null) => patch('/description', v),
+    [patch],
+  )
+  const handleCommitTeamSlug = useCallback(
+    (v: string) => patch('/team_slug', v),
+    [patch],
+  )
+  const handleCommitSlug = useCallback(
+    (v: string | null) => patch('/slug', v ?? ''),
+    [patch],
+  )
+  const handleCommitProjectTypeSlugs = useCallback(
+    (v: string[]) => patch('/project_type_slugs', v),
+    [patch],
+  )
+
+  const renderNameValue = useCallback(
+    (v: string) => <span className={`text-[1.75rem] ${value}`}>{v}</span>,
+    [value],
+  )
+  const renderSlugValue = useCallback(
+    (v: string) => <span className={`font-mono text-sm ${value}`}>{v}</span>,
+    [value],
+  )
+
   const tabs: { id: TabType; label: string }[] = [
     { id: 'overview', label: 'Overview' },
     { id: 'configuration', label: 'Configuration' },
@@ -245,11 +280,6 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
     { id: 'settings', label: '' },
   ]
 
-  const label = 'text-tertiary'
-  const value = 'text-primary'
-  const muted = 'text-tertiary'
-  const divider = 'border-tertiary'
-
   return (
     <div className="mx-auto max-w-[1600px] px-6 py-8">
       {/* Project Header */}
@@ -259,12 +289,10 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
             <div className="-ml-[18px] mb-1 flex items-center gap-3">
               <InlineText
                 value={project.name}
-                onCommit={(v) => patch('/name', v ?? '')}
+                onCommit={handleCommitName}
                 pending={pendingPath === '/name'}
                 className="text-[1.75rem]"
-                renderValue={(v) => (
-                  <span className={`text-[1.75rem] ${value}`}>{v}</span>
-                )}
+                renderValue={renderNameValue}
               />
             </div>
           </div>
@@ -312,7 +340,7 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
         <div className="-ml-[18px] mt-3 text-secondary">
           <InlineTextarea
             value={project.description ?? null}
-            onCommit={(v) => patch('/description', v)}
+            onCommit={handleCommitDescription}
             pending={pendingPath === '/description'}
             placeholder="Add a description…"
             rows={2}
@@ -379,7 +407,7 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
                       <InlineSelect
                         value={project.team.slug}
                         options={teamOptions}
-                        onCommit={(v) => patch('/team_slug', v)}
+                        onCommit={handleCommitTeamSlug}
                         pending={pendingPath === '/team_slug'}
                       />
                     </div>
@@ -390,13 +418,9 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
                       <span className={`text-sm ${label}`}>Slug</span>
                       <InlineText
                         value={project.slug}
-                        onCommit={(v) => patch('/slug', v ?? '')}
+                        onCommit={handleCommitSlug}
                         pending={pendingPath === '/slug'}
-                        renderValue={(v) => (
-                          <span className={`font-mono text-sm ${value}`}>
-                            {v}
-                          </span>
-                        )}
+                        renderValue={renderSlugValue}
                       />
                     </div>
 
@@ -409,7 +433,7 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
                           (pt) => pt.slug,
                         )}
                         options={projectTypeOptions}
-                        onCommit={(v) => patch('/project_type_slugs', v)}
+                        onCommit={handleCommitProjectTypeSlugs}
                         pending={pendingPath === '/project_type_slugs'}
                       />
                     </div>


### PR DESCRIPTION
## Summary

- Wrap each inline `onCommit` callback in `ProjectDetail.tsx` in `useCallback` keyed on the stable `patch` reference.
- Extract the per-attribute row in `ProjectAttributesSection.tsx` into a `React.memo`-ed `ProjectAttributeRow` so its `onCommit` closure is stable and non-edited rows skip re-render when the parent or a sibling row changes.
- Pure refactor - no UI, no behavior, no new props. Addresses section 2a of `docs/follow-ups-round-2.md`.

## Problem

Every render of `ProjectDetail` previously rebuilt the inline `onCommit` arrow functions passed to `InlineText`, `InlineTextarea`, `InlineSelect`, and `InlineMultiSelect`, plus the `renderValue` closures for the name and slug. Likewise, `ProjectAttributesSection` rebuilt a fresh `(v) => patch(\`/${key}\`, v)` for every row on every parent render. Because those props change identity, downstream memoization has nothing to hold onto and the inline-field subtrees re-render whenever the parent re-renders - including while typing in a sibling field.

## Solution

- `ProjectDetail`: add `useCallback` wrappers for the five edit callbacks (`/name`, `/description`, `/team_slug`, `/slug`, `/project_type_slugs`) and the two `renderValue` helpers (`renderNameValue`, `renderSlugValue`), each depending only on `patch` (or the stable `value` color-class constant).
- `ProjectAttributesSection`: pull the row body into a `memo(function ProjectAttributeRow(...))` that receives `field`, `patch`, and a scalar `pending` boolean. The row's `handleCommit` is a `useCallback` keyed on `(patch, field.key)`, so editing one row does not produce fresh callbacks for the others. The parent's `useMemo` for `attributeFields` and the static class constants are unchanged in semantics.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] Smoke: edit a project name, description, team, slug, project types; confirm optimistic save + pending indicator still work.
- [ ] Smoke: edit a schema-defined attribute (e.g. an enum field) in the attributes section; confirm the row commits and neighboring rows don't flash.