### PR TITLE
Refactor: extract BlueprintUiMapEditor from BlueprintSchemaPropertyRow

### DIFF
--- a/src/components/admin/blueprints/BlueprintSchemaPropertyRow.tsx
+++ b/src/components/admin/blueprints/BlueprintSchemaPropertyRow.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronUp, Plus, Trash2, X } from 'lucide-react'
+import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/tooltip'
 import type { SchemaProperty } from '@/types'
 import { PROPERTY_TYPES, STRING_FORMATS } from './blueprint-schema-utils'
+import { BlueprintUiMapEditor } from './BlueprintUiMapEditor'
 
 interface BlueprintSchemaPropertyRowProps {
   prop: SchemaProperty
@@ -440,118 +441,25 @@ export function BlueprintSchemaPropertyRow({
                   [mapType]: Object.keys(map).length > 0 ? map : undefined,
                 })
               }
+              const setEntries = (next: [string, string][]) => {
+                setUiMapEntries({
+                  ...uiMapEntries,
+                  [stateKey]: next,
+                })
+              }
               return (
-                <div key={mapType}>
-                  <div className="mb-1 flex items-center justify-between">
-                    <label className="text-xs text-secondary">{mapLabel}</label>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setUiMapEntries({
-                          ...uiMapEntries,
-                          [stateKey]: [...entries, ['', defaultVal]],
-                        })
-                      }}
-                      className={
-                        'hover:text-info/80 flex items-center gap-1 text-xs text-info'
-                      }
-                    >
-                      <Plus className="h-3 w-3" />
-                      Add entry
-                    </button>
-                  </div>
-                  {entries.length === 0 ? (
-                    <p className="text-xs italic text-tertiary">
-                      No {mapLabel.toLowerCase()} entries
-                    </p>
-                  ) : (
-                    <div className="space-y-1.5">
-                      {entries.map(([eKey, eVal], idx) => (
-                        <div key={idx} className="flex items-center gap-1.5">
-                          <Input
-                            value={eKey}
-                            onChange={(e) => {
-                              const next = entries.map(
-                                (row, i): [string, string] =>
-                                  i === idx ? [e.target.value, row[1]] : row,
-                              )
-                              setUiMapEntries({
-                                ...uiMapEntries,
-                                [stateKey]: next,
-                              })
-                            }}
-                            onBlur={() => commit(entries)}
-                            placeholder={keyPh}
-                            className="flex-1 text-xs"
-                          />
-                          {isColor ? (
-                            <select
-                              value={eVal}
-                              onChange={(e) => {
-                                const next = entries.map(
-                                  (row, i): [string, string] =>
-                                    i === idx ? [row[0], e.target.value] : row,
-                                )
-                                setUiMapEntries({
-                                  ...uiMapEntries,
-                                  [stateKey]: next,
-                                })
-                                commit(next)
-                              }}
-                              className="rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground"
-                            >
-                              {[
-                                'green',
-                                'red',
-                                'amber',
-                                'yellow',
-                                'blue',
-                                'gray',
-                              ].map((c) => (
-                                <option key={c} value={c}>
-                                  {c}
-                                </option>
-                              ))}
-                            </select>
-                          ) : (
-                            <Input
-                              value={eVal}
-                              onChange={(e) => {
-                                const next = entries.map(
-                                  (row, i): [string, string] =>
-                                    i === idx ? [row[0], e.target.value] : row,
-                                )
-                                setUiMapEntries({
-                                  ...uiMapEntries,
-                                  [stateKey]: next,
-                                })
-                              }}
-                              onBlur={() => commit(entries)}
-                              placeholder={valPh}
-                              className="flex-1 text-xs"
-                            />
-                          )}
-                          <button
-                            type="button"
-                            onClick={() => {
-                              const next = entries.filter((_, i) => i !== idx)
-                              setUiMapEntries({
-                                ...uiMapEntries,
-                                [stateKey]: next,
-                              })
-                              commit(next)
-                            }}
-                            className={
-                              'flex-shrink-0 text-tertiary hover:text-danger'
-                            }
-                          >
-                            <X className="h-3.5 w-3.5" />
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                <BlueprintUiMapEditor
+                  key={mapType}
+                  mapType={mapType}
+                  label={mapLabel}
+                  keyPh={keyPh}
+                  valPh={valPh}
+                  defaultVal={defaultVal}
+                  isColor={isColor}
+                  entries={entries}
+                  setEntries={setEntries}
+                  commit={commit}
+                />
               )
             },
           )}

--- a/src/components/admin/blueprints/BlueprintUiMapEditor.tsx
+++ b/src/components/admin/blueprints/BlueprintUiMapEditor.tsx
@@ -1,0 +1,115 @@
+import { Plus, X } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+
+interface BlueprintUiMapEditorProps {
+  mapType: string
+  label: string
+  keyPh: string
+  valPh: string
+  defaultVal: string
+  isColor: boolean
+  entries: [string, string][]
+  setEntries: (next: [string, string][]) => void
+  commit: (next: [string, string][]) => void
+}
+
+export function BlueprintUiMapEditor({
+  mapType,
+  label: mapLabel,
+  keyPh,
+  valPh,
+  defaultVal,
+  isColor,
+  entries,
+  setEntries,
+  commit,
+}: BlueprintUiMapEditorProps) {
+  return (
+    <div key={mapType}>
+      <div className="mb-1 flex items-center justify-between">
+        <label className="text-xs text-secondary">{mapLabel}</label>
+        <button
+          type="button"
+          onClick={() => {
+            setEntries([...entries, ['', defaultVal]])
+          }}
+          className={
+            'hover:text-info/80 flex items-center gap-1 text-xs text-info'
+          }
+        >
+          <Plus className="h-3 w-3" />
+          Add entry
+        </button>
+      </div>
+      {entries.length === 0 ? (
+        <p className="text-xs italic text-tertiary">
+          No {mapLabel.toLowerCase()} entries
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {entries.map(([eKey, eVal], idx) => (
+            <div key={idx} className="flex items-center gap-1.5">
+              <Input
+                value={eKey}
+                onChange={(e) => {
+                  const next = entries.map((row, i): [string, string] =>
+                    i === idx ? [e.target.value, row[1]] : row,
+                  )
+                  setEntries(next)
+                }}
+                onBlur={() => commit(entries)}
+                placeholder={keyPh}
+                className="flex-1 text-xs"
+              />
+              {isColor ? (
+                <select
+                  value={eVal}
+                  onChange={(e) => {
+                    const next = entries.map((row, i): [string, string] =>
+                      i === idx ? [row[0], e.target.value] : row,
+                    )
+                    setEntries(next)
+                    commit(next)
+                  }}
+                  className="rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground"
+                >
+                  {['green', 'red', 'amber', 'yellow', 'blue', 'gray'].map(
+                    (c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ),
+                  )}
+                </select>
+              ) : (
+                <Input
+                  value={eVal}
+                  onChange={(e) => {
+                    const next = entries.map((row, i): [string, string] =>
+                      i === idx ? [row[0], e.target.value] : row,
+                    )
+                    setEntries(next)
+                  }}
+                  onBlur={() => commit(entries)}
+                  placeholder={valPh}
+                  className="flex-1 text-xs"
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  const next = entries.filter((_, i) => i !== idx)
+                  setEntries(next)
+                  commit(next)
+                }}
+                className={'flex-shrink-0 text-tertiary hover:text-danger'}
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Addresses section 2d (second extraction) of `docs/follow-ups-round-2.md`. The six near-identical `mapType`-parameterized UI-map editors (color / icon / colorRange / iconRange / colorAge / iconAge) now render through a single `BlueprintUiMapEditor` component.

- Pure structural extraction — no renames, no behavior change.
- Config array stays in the parent `.map()`; each iteration builds stateKey-aware `setEntries` and `commit` callbacks before passing them in.
- `setEntries` replaces the ad-hoc `setUiMapEntries({...uiMapEntries, [stateKey]: next})` pattern while preserving the identical semantics.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npx prettier --check`
- [x] `npm run build`
- [ ] Manual: advanced-options panel renders the six UI-map editors the same as before; add/edit/remove entries, color-select vs icon-text behavior, on-blur commits.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>