### PR TITLE
Refactor: convert admin PUT calls to PATCH with JSON Patch bodies

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -23,7 +23,6 @@ import type {
   UserResponse,
   AdminUser,
   AdminUserCreate,
-  AdminUserUpdate,
   AdminSettings,
   Role,
   RoleDetail,
@@ -40,15 +39,12 @@ import type {
   ThirdPartyServiceCreate,
   ServiceApplication,
   ServiceApplicationCreate,
-  ServiceApplicationUpdate,
   ServiceApplicationSecrets,
-  ServiceApplicationSecretsUpdate,
   Upload,
   ApiKey,
   ApiKeyCreated,
   ServiceAccount,
   ServiceAccountCreate,
-  ServiceAccountUpdate,
   ClientCredential,
   ClientCredentialCreated,
   ClientCredentialCreate,
@@ -192,16 +188,6 @@ export const createProject = (
     project,
   )
 
-export const updateProject = (
-  orgSlug: string,
-  projectId: string,
-  project: Partial<ProjectCreate>,
-) =>
-  apiClient.put<Project>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
-    project,
-  )
-
 export const patchProject = (
   orgSlug: string,
   projectId: string,
@@ -253,11 +239,11 @@ export const createLinkDefinition = (
 export const updateLinkDefinition = (
   orgSlug: string,
   slug: string,
-  data: Partial<LinkDefinitionCreate>,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<LinkDefinition>(
+  apiClient.patch<LinkDefinition>(
     `/organizations/${encodeURIComponent(orgSlug)}/link-definitions/${encodeURIComponent(slug)}`,
-    data,
+    operations,
   )
 
 export const deleteLinkDefinition = (orgSlug: string, slug: string) =>
@@ -408,11 +394,11 @@ export const createEnvironment = (orgSlug: string, env: EnvironmentCreate) =>
 export const updateEnvironment = (
   orgSlug: string,
   slug: string,
-  env: EnvironmentCreate,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<Environment>(
+  apiClient.patch<Environment>(
     `/organizations/${encodeURIComponent(orgSlug)}/environments/${encodeURIComponent(slug)}`,
-    env,
+    operations,
   )
 
 export const deleteEnvironment = (orgSlug: string, slug: string) =>
@@ -456,11 +442,11 @@ export const createProjectType = (orgSlug: string, pt: ProjectTypeCreate) =>
 export const updateProjectType = (
   orgSlug: string,
   slug: string,
-  pt: ProjectTypeCreate,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<ProjectType>(
+  apiClient.patch<ProjectType>(
     `/organizations/${encodeURIComponent(orgSlug)}/project-types/${encodeURIComponent(slug)}`,
-    pt,
+    operations,
   )
 
 export const deleteProjectType = (orgSlug: string, slug: string) =>
@@ -494,8 +480,8 @@ export const getAdminUser = (email: string, signal?: AbortSignal) =>
 export const createAdminUser = (user: AdminUserCreate) =>
   apiClient.post<AdminUser>('/users/', user)
 
-export const updateAdminUser = (email: string, user: AdminUserUpdate) =>
-  apiClient.put<AdminUser>(`/users/${encodeURIComponent(email)}`, user)
+export const updateAdminUser = (email: string, operations: PatchOperation[]) =>
+  apiClient.patch<AdminUser>(`/users/${encodeURIComponent(email)}`, operations)
 
 export const deleteAdminUser = (email: string) =>
   apiClient.delete<void>(`/users/${encodeURIComponent(email)}`)
@@ -509,11 +495,11 @@ export const addUserToOrg = (
 export const updateUserOrgRole = (
   email: string,
   orgSlug: string,
-  data: { role_slug: string },
+  operations: PatchOperation[],
 ) =>
-  apiClient.put(
+  apiClient.patch(
     `/users/${encodeURIComponent(email)}/organizations/${encodeURIComponent(orgSlug)}`,
-    data,
+    operations,
   )
 
 export const removeUserFromOrg = (email: string, orgSlug: string) =>
@@ -537,8 +523,8 @@ export const getRole = (slug: string, signal?: AbortSignal) =>
 export const createRole = (role: RoleCreate) =>
   apiClient.post<RoleDetail>('/roles/', role)
 
-export const updateRole = (slug: string, role: RoleCreate) =>
-  apiClient.put<RoleDetail>(`/roles/${encodeURIComponent(slug)}`, role)
+export const updateRole = (slug: string, operations: PatchOperation[]) =>
+  apiClient.patch<RoleDetail>(`/roles/${encodeURIComponent(slug)}`, operations)
 
 export const deleteRole = (slug: string) =>
   apiClient.delete<void>(`/roles/${encodeURIComponent(slug)}`)
@@ -638,11 +624,11 @@ export const createBlueprint = (blueprint: BlueprintCreate) =>
 export const updateBlueprint = (
   type: string,
   slug: string,
-  blueprint: BlueprintCreate,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<Blueprint>(
+  apiClient.patch<Blueprint>(
     `/blueprints/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`,
-    blueprint,
+    operations,
   )
 
 export const deleteBlueprint = (type: string, slug: string) =>
@@ -672,8 +658,14 @@ export const getOrganization = (slug: string, signal?: AbortSignal) =>
 export const createOrganization = (org: OrganizationCreate) =>
   apiClient.post<Organization>('/organizations/', org)
 
-export const updateOrganization = (slug: string, org: OrganizationCreate) =>
-  apiClient.put<Organization>(`/organizations/${encodeURIComponent(slug)}`, org)
+export const updateOrganization = (
+  slug: string,
+  operations: PatchOperation[],
+) =>
+  apiClient.patch<Organization>(
+    `/organizations/${encodeURIComponent(slug)}`,
+    operations,
+  )
 
 export const deleteOrganization = (slug: string) =>
   apiClient.delete<void>(`/organizations/${encodeURIComponent(slug)}`)
@@ -787,10 +779,14 @@ export const createTeam = (orgSlug: string, team: TeamCreate) =>
     team,
   )
 
-export const updateTeam = (orgSlug: string, slug: string, team: TeamCreate) =>
-  apiClient.put<Team>(
+export const updateTeam = (
+  orgSlug: string,
+  slug: string,
+  operations: PatchOperation[],
+) =>
+  apiClient.patch<Team>(
     `/organizations/${encodeURIComponent(orgSlug)}/teams/${encodeURIComponent(slug)}`,
-    team,
+    operations,
   )
 
 export const deleteTeam = (orgSlug: string, slug: string) =>
@@ -862,11 +858,11 @@ export const createThirdPartyService = (
 export const updateThirdPartyService = (
   orgSlug: string,
   slug: string,
-  svc: ThirdPartyServiceCreate,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<ThirdPartyService>(
+  apiClient.patch<ThirdPartyService>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(slug)}`,
-    svc,
+    operations,
   )
 
 export const deleteThirdPartyService = (orgSlug: string, slug: string) =>
@@ -914,11 +910,11 @@ export const updateServiceApplication = (
   orgSlug: string,
   serviceSlug: string,
   appSlug: string,
-  data: ServiceApplicationUpdate,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<ServiceApplication>(
+  apiClient.patch<ServiceApplication>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}`,
-    data,
+    operations,
   )
 
 export const deleteServiceApplication = (
@@ -947,11 +943,11 @@ export const updateApplicationSecrets = (
   orgSlug: string,
   serviceSlug: string,
   appSlug: string,
-  data: ServiceApplicationSecretsUpdate,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<ServiceApplicationSecrets>(
+  apiClient.patch<ServiceApplicationSecrets>(
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/applications/${encodeURIComponent(appSlug)}/secrets`,
-    data,
+    operations,
   )
 
 // Uploads
@@ -1004,11 +1000,11 @@ export const createServiceAccount = (data: ServiceAccountCreate) =>
 
 export const updateServiceAccount = (
   slug: string,
-  data: ServiceAccountUpdate,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<ServiceAccount>(
+  apiClient.patch<ServiceAccount>(
     `/service-accounts/${encodeURIComponent(slug)}`,
-    data,
+    operations,
   )
 
 export const deleteServiceAccount = (slug: string) =>
@@ -1026,11 +1022,11 @@ export const addServiceAccountToOrg = (
 export const updateServiceAccountOrgRole = (
   slug: string,
   orgSlug: string,
-  data: { role_slug: string },
+  operations: PatchOperation[],
 ) =>
-  apiClient.put(
+  apiClient.patch(
     `/service-accounts/${encodeURIComponent(slug)}/organizations/${encodeURIComponent(orgSlug)}`,
-    data,
+    operations,
   )
 
 export const removeServiceAccountFromOrg = (slug: string, orgSlug: string) =>
@@ -1130,11 +1126,11 @@ export const createWebhook = (orgSlug: string, data: WebhookCreate) =>
 export const updateWebhook = (
   orgSlug: string,
   slug: string,
-  data: WebhookCreate,
+  operations: PatchOperation[],
 ) =>
-  apiClient.put<Webhook>(
+  apiClient.patch<Webhook>(
     `/organizations/${encodeURIComponent(orgSlug)}/webhooks/${encodeURIComponent(slug)}`,
-    data,
+    operations,
   )
 
 export const deleteWebhook = (orgSlug: string, slug: string) =>

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -177,7 +177,9 @@ export function BlueprintManagement() {
       createMutation.mutate(data)
     } else if (selectedKey) {
       const existing = blueprints.find(
-        (bp) => bp.type === selectedKey.type && bp.slug === selectedKey.slug,
+        (bp) =>
+          blueprintPathType(bp) === selectedKey.type &&
+          bp.slug === selectedKey.slug,
       )
       if (!existing) return
       const operations = buildDiffPatch(

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -25,7 +25,8 @@ import {
   updateBlueprint,
 } from '@/api/endpoints'
 import { parseFilterFromBlueprint } from '@/lib/utils'
-import type { Blueprint, BlueprintCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type { Blueprint, BlueprintCreate, PatchOperation } from '@/types'
 
 interface BlueprintKey {
   type: string
@@ -125,14 +126,14 @@ export function BlueprintManagement() {
   } = useAdminCrud<
     Blueprint,
     BlueprintCreate,
-    { type: string; slug: string; blueprint: BlueprintCreate },
+    { type: string; slug: string; operations: PatchOperation[] },
     BlueprintKey
   >({
     queryKey: ['blueprints'],
     listFn: (signal) => listBlueprints(undefined, signal),
     createFn: (blueprint) => createBlueprint(blueprint),
-    updateFn: ({ type, slug, blueprint }) =>
-      updateBlueprint(type, slug, blueprint),
+    updateFn: ({ type, slug, operations }) =>
+      updateBlueprint(type, slug, operations),
     deleteFn: ({ type, slug }) => deleteBlueprint(type, slug),
     onMutationSuccess: goToList,
     // The backend auto-refreshes its OpenAPI schema cache on blueprint CRUD;
@@ -175,10 +176,23 @@ export function BlueprintManagement() {
     if (viewMode === 'create') {
       createMutation.mutate(data)
     } else if (selectedKey) {
+      const existing = blueprints.find(
+        (bp) => bp.type === selectedKey.type && bp.slug === selectedKey.slug,
+      )
+      if (!existing) return
+      const operations = buildDiffPatch(
+        existing as unknown as Record<string, unknown>,
+        data as unknown as Record<string, unknown>,
+        { fields: Object.keys(data) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
       updateMutation.mutate({
         type: selectedKey.type,
         slug: selectedKey.slug,
-        blueprint: data,
+        operations,
       })
     }
   }

--- a/src/components/admin/EnvironmentManagement.tsx
+++ b/src/components/admin/EnvironmentManagement.tsx
@@ -17,7 +17,8 @@ import {
   createEnvironment,
   updateEnvironment,
 } from '@/api/endpoints'
-import type { Environment, EnvironmentCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type { Environment, EnvironmentCreate, PatchOperation } from '@/types'
 
 export function EnvironmentManagement() {
   const { selectedOrganization } = useOrganization()
@@ -41,13 +42,14 @@ export function EnvironmentManagement() {
   } = useAdminCrud<
     Environment,
     { orgSlug: string; env: EnvironmentCreate },
-    { orgSlug: string; slug: string; env: EnvironmentCreate },
+    { orgSlug: string; slug: string; operations: PatchOperation[] },
     { orgSlug: string; slug: string }
   >({
     queryKey: ['environments', orgSlug],
     listFn: orgSlug ? (signal) => listEnvironments(orgSlug, signal) : null,
     createFn: ({ orgSlug, env }) => createEnvironment(orgSlug, env),
-    updateFn: ({ orgSlug, slug, env }) => updateEnvironment(orgSlug, slug, env),
+    updateFn: ({ orgSlug, slug, operations }) =>
+      updateEnvironment(orgSlug, slug, operations),
     deleteFn: ({ orgSlug, slug }) => deleteEnvironment(orgSlug, slug),
     onMutationSuccess: goToList,
     deleteErrorLabel: 'environment',
@@ -86,11 +88,20 @@ export function EnvironmentManagement() {
   const handleSave = (formOrgSlug: string, envData: EnvironmentCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate({ orgSlug: formOrgSlug, env: envData })
-    } else if (selectedEnvSlug) {
+    } else if (selectedEnvSlug && selectedEnvironment) {
+      const operations = buildDiffPatch(
+        selectedEnvironment as unknown as Record<string, unknown>,
+        envData as unknown as Record<string, unknown>,
+        { fields: Object.keys(envData) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
       updateMutation.mutate({
-        orgSlug: selectedEnvironment?.organization.slug || formOrgSlug,
+        orgSlug: selectedEnvironment.organization.slug || formOrgSlug,
         slug: selectedEnvSlug,
-        env: envData,
+        operations,
       })
     }
   }

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -14,7 +14,12 @@ import {
   createLinkDefinition,
   updateLinkDefinition,
 } from '@/api/endpoints'
-import type { LinkDefinition, LinkDefinitionCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type {
+  LinkDefinition,
+  LinkDefinitionCreate,
+  PatchOperation,
+} from '@/types'
 
 export function LinkDefinitionManagement() {
   const { selectedOrganization } = useOrganization()
@@ -38,14 +43,14 @@ export function LinkDefinitionManagement() {
   } = useAdminCrud<
     LinkDefinition,
     { orgSlug: string; data: LinkDefinitionCreate },
-    { orgSlug: string; slug: string; data: LinkDefinitionCreate },
+    { orgSlug: string; slug: string; operations: PatchOperation[] },
     { orgSlug: string; slug: string }
   >({
     queryKey: ['linkDefinitions', orgSlug],
     listFn: orgSlug ? (signal) => listLinkDefinitions(orgSlug, signal) : null,
     createFn: ({ orgSlug, data }) => createLinkDefinition(orgSlug, data),
-    updateFn: ({ orgSlug, slug, data }) =>
-      updateLinkDefinition(orgSlug, slug, data),
+    updateFn: ({ orgSlug, slug, operations }) =>
+      updateLinkDefinition(orgSlug, slug, operations),
     deleteFn: ({ orgSlug, slug }) => deleteLinkDefinition(orgSlug, slug),
     onMutationSuccess: goToList,
     deleteErrorLabel: 'link definition',
@@ -84,11 +89,20 @@ export function LinkDefinitionManagement() {
   const handleSave = (formOrgSlug: string, data: LinkDefinitionCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate({ orgSlug: formOrgSlug, data })
-    } else if (selectedSlug) {
+    } else if (selectedSlug && selectedLinkDefinition) {
+      const operations = buildDiffPatch(
+        selectedLinkDefinition as unknown as Record<string, unknown>,
+        data as unknown as Record<string, unknown>,
+        { fields: Object.keys(data) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
       updateMutation.mutate({
-        orgSlug: selectedLinkDefinition?.organization.slug || formOrgSlug,
+        orgSlug: selectedLinkDefinition.organization.slug || formOrgSlug,
         slug: selectedSlug,
-        data,
+        operations,
       })
     }
   }

--- a/src/components/admin/OrganizationManagement.tsx
+++ b/src/components/admin/OrganizationManagement.tsx
@@ -15,7 +15,8 @@ import {
   createOrganization,
   updateOrganization,
 } from '@/api/endpoints'
-import type { Organization, OrganizationCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type { Organization, OrganizationCreate, PatchOperation } from '@/types'
 
 export function OrganizationManagement() {
   const {
@@ -37,13 +38,13 @@ export function OrganizationManagement() {
   } = useAdminCrud<
     Organization,
     OrganizationCreate,
-    { slug: string; org: OrganizationCreate },
+    { slug: string; operations: PatchOperation[] },
     string
   >({
     queryKey: ['organizations'],
     listFn: listOrganizations,
     createFn: createOrganization,
-    updateFn: ({ slug, org }) => updateOrganization(slug, org),
+    updateFn: ({ slug, operations }) => updateOrganization(slug, operations),
     deleteFn: deleteOrganization,
     onMutationSuccess: goToList,
     deleteErrorLabel: 'organization',
@@ -87,8 +88,17 @@ export function OrganizationManagement() {
   const handleSave = (orgData: OrganizationCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate(orgData)
-    } else if (selectedOrgSlug) {
-      updateMutation.mutate({ slug: selectedOrgSlug, org: orgData })
+    } else if (selectedOrgSlug && selectedOrg) {
+      const operations = buildDiffPatch(
+        selectedOrg as unknown as Record<string, unknown>,
+        orgData as unknown as Record<string, unknown>,
+        { fields: Object.keys(orgData) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
+      updateMutation.mutate({ slug: selectedOrgSlug, operations })
     }
   }
 

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -16,7 +16,8 @@ import {
   createProjectType,
   updateProjectType,
 } from '@/api/endpoints'
-import type { ProjectType, ProjectTypeCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type { ProjectType, ProjectTypeCreate, PatchOperation } from '@/types'
 
 export function ProjectTypeManagement() {
   const { selectedOrganization } = useOrganization()
@@ -40,13 +41,14 @@ export function ProjectTypeManagement() {
   } = useAdminCrud<
     ProjectType,
     { orgSlug: string; pt: ProjectTypeCreate },
-    { orgSlug: string; slug: string; pt: ProjectTypeCreate },
+    { orgSlug: string; slug: string; operations: PatchOperation[] },
     { orgSlug: string; slug: string }
   >({
     queryKey: ['projectTypes', orgSlug],
     listFn: orgSlug ? (signal) => listProjectTypes(orgSlug, signal) : null,
     createFn: ({ orgSlug, pt }) => createProjectType(orgSlug, pt),
-    updateFn: ({ orgSlug, slug, pt }) => updateProjectType(orgSlug, slug, pt),
+    updateFn: ({ orgSlug, slug, operations }) =>
+      updateProjectType(orgSlug, slug, operations),
     deleteFn: ({ orgSlug, slug }) => deleteProjectType(orgSlug, slug),
     onMutationSuccess: goToList,
     deleteErrorLabel: 'project type',
@@ -85,11 +87,20 @@ export function ProjectTypeManagement() {
   const handleSave = (formOrgSlug: string, ptData: ProjectTypeCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate({ orgSlug: formOrgSlug, pt: ptData })
-    } else if (selectedPtSlug) {
+    } else if (selectedPtSlug && selectedProjectType) {
+      const operations = buildDiffPatch(
+        selectedProjectType as unknown as Record<string, unknown>,
+        ptData as unknown as Record<string, unknown>,
+        { fields: Object.keys(ptData) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
       updateMutation.mutate({
-        orgSlug: selectedProjectType?.organization.slug || formOrgSlug,
+        orgSlug: selectedProjectType.organization.slug || formOrgSlug,
         slug: selectedPtSlug,
-        pt: ptData,
+        operations,
       })
     }
   }

--- a/src/components/admin/RoleManagement.tsx
+++ b/src/components/admin/RoleManagement.tsx
@@ -21,6 +21,7 @@ import {
   grantPermission,
   revokePermission,
 } from '@/api/endpoints'
+import { buildDiffPatch } from '@/lib/json-patch'
 import type { RoleDetail as RoleDetailType, RoleCreate } from '@/types'
 
 type Role = Awaited<ReturnType<typeof getRoles>>[number]
@@ -137,7 +138,14 @@ export function RoleManagement() {
       }
     },
     updateFn: async ({ slug, role, permissions }) => {
-      const updated = await updateRole(slug, role)
+      const existing = await getRole(slug)
+      const operations = buildDiffPatch(
+        existing as unknown as Record<string, unknown>,
+        role as unknown as Record<string, unknown>,
+        { fields: Object.keys(role) },
+      )
+      const updated =
+        operations.length > 0 ? await updateRole(slug, operations) : existing
       try {
         await syncPermissions(updated.slug, permissions)
       } catch (err) {

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -15,10 +15,11 @@ import {
   updateServiceAccount,
   deleteServiceAccount,
 } from '@/api/endpoints'
+import { buildDiffPatch } from '@/lib/json-patch'
 import type {
   ServiceAccount,
   ServiceAccountCreate,
-  ServiceAccountUpdate,
+  PatchOperation,
 } from '@/types'
 
 type StatusFilter = 'all' | 'active' | 'inactive'
@@ -44,13 +45,13 @@ export function ServiceAccountManagement() {
   } = useAdminCrud<
     ServiceAccount,
     ServiceAccountCreate,
-    { slug: string; data: ServiceAccountUpdate },
+    { slug: string; operations: PatchOperation[] },
     string
   >({
     queryKey: ['serviceAccounts'],
     listFn: (signal) => listServiceAccounts(undefined, signal),
     createFn: createServiceAccount,
-    updateFn: ({ slug, data }) => updateServiceAccount(slug, data),
+    updateFn: ({ slug, operations }) => updateServiceAccount(slug, operations),
     deleteFn: deleteServiceAccount,
     onMutationSuccess: goToList,
     deleteErrorLabel: 'service account',
@@ -98,7 +99,16 @@ export function ServiceAccountManagement() {
     } else if (selectedAccount) {
       // Strip org/role fields for update — they're only for creation
       const { organization_slug: _, role_slug: __, ...updateData } = data
-      updateMutation.mutate({ slug: selectedAccount.slug, data: updateData })
+      const operations = buildDiffPatch(
+        selectedAccount as unknown as Record<string, unknown>,
+        updateData as unknown as Record<string, unknown>,
+        { fields: Object.keys(updateData) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
+      updateMutation.mutate({ slug: selectedAccount.slug, operations })
     }
   }
 

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -12,7 +12,8 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { listTeams, deleteTeam, createTeam, updateTeam } from '@/api/endpoints'
-import type { Team, TeamCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type { Team, TeamCreate, PatchOperation } from '@/types'
 
 export function TeamManagement() {
   const { selectedOrganization } = useOrganization()
@@ -37,13 +38,14 @@ export function TeamManagement() {
   } = useAdminCrud<
     Team,
     { orgSlug: string; team: TeamCreate },
-    { orgSlug: string; slug: string; team: TeamCreate },
+    { orgSlug: string; slug: string; operations: PatchOperation[] },
     { orgSlug: string; slug: string }
   >({
     queryKey: ['teams', orgSlug],
     listFn: orgSlug ? (signal) => listTeams(orgSlug, signal) : null,
     createFn: ({ orgSlug, team }) => createTeam(orgSlug, team),
-    updateFn: ({ orgSlug, slug, team }) => updateTeam(orgSlug, slug, team),
+    updateFn: ({ orgSlug, slug, operations }) =>
+      updateTeam(orgSlug, slug, operations),
     deleteFn: ({ orgSlug, slug }) => deleteTeam(orgSlug, slug),
     onMutationSuccess: goToList,
     deleteErrorLabel: 'team',
@@ -86,11 +88,20 @@ export function TeamManagement() {
   const handleSave = (formOrgSlug: string, teamData: TeamCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate({ orgSlug: formOrgSlug, team: teamData })
-    } else if (selectedTeamSlug) {
+    } else if (selectedTeamSlug && selectedTeam) {
+      const operations = buildDiffPatch(
+        selectedTeam as unknown as Record<string, unknown>,
+        teamData as unknown as Record<string, unknown>,
+        { fields: Object.keys(teamData) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
       updateMutation.mutate({
-        orgSlug: selectedTeam?.organization.slug || formOrgSlug,
+        orgSlug: selectedTeam.organization.slug || formOrgSlug,
         slug: selectedTeamSlug,
-        team: teamData,
+        operations,
       })
     }
   }

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -17,7 +17,12 @@ import {
 } from '@/api/endpoints'
 import { statusBadgeVariant } from '@/lib/status-colors'
 import { Badge } from '@/components/ui/badge'
-import type { ThirdPartyService, ThirdPartyServiceCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type {
+  ThirdPartyService,
+  ThirdPartyServiceCreate,
+  PatchOperation,
+} from '@/types'
 
 export function ThirdPartyServiceManagement() {
   const { selectedOrganization } = useOrganization()
@@ -43,7 +48,7 @@ export function ThirdPartyServiceManagement() {
   } = useAdminCrud<
     ThirdPartyService,
     ThirdPartyServiceCreate,
-    { slug: string; svc: ThirdPartyServiceCreate },
+    { slug: string; operations: PatchOperation[] },
     string
   >({
     queryKey: ['third-party-services', orgSlug],
@@ -54,9 +59,9 @@ export function ThirdPartyServiceManagement() {
       if (!orgSlug) throw new Error('No organization selected')
       return createThirdPartyService(orgSlug, svc)
     },
-    updateFn: ({ slug, svc }) => {
+    updateFn: ({ slug, operations }) => {
       if (!orgSlug) throw new Error('No organization selected')
-      return updateThirdPartyService(orgSlug, slug, svc)
+      return updateThirdPartyService(orgSlug, slug, operations)
     },
     deleteFn: (slug) => {
       if (!orgSlug) throw new Error('No organization selected')
@@ -101,8 +106,17 @@ export function ThirdPartyServiceManagement() {
   const handleSave = (svcData: ThirdPartyServiceCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate(svcData)
-    } else if (selectedSlug) {
-      updateMutation.mutate({ slug: selectedSlug, svc: svcData })
+    } else if (selectedSlug && selectedService) {
+      const operations = buildDiffPatch(
+        selectedService as unknown as Record<string, unknown>,
+        svcData as unknown as Record<string, unknown>,
+        { fields: Object.keys(svcData) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
+      updateMutation.mutate({ slug: selectedSlug, operations })
     }
   }
 

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -20,7 +20,8 @@ import {
   updateAdminUser,
   createAdminUser,
 } from '@/api/endpoints'
-import type { AdminUser, AdminUserCreate, AdminUserUpdate } from '@/types'
+import { buildDiffPatch, buildReplacePatch } from '@/lib/json-patch'
+import type { AdminUser, AdminUserCreate, PatchOperation } from '@/types'
 
 type UserFilter = 'all' | 'users' | 'admins'
 type StatusFilter = 'all' | 'active' | 'inactive'
@@ -48,13 +49,13 @@ export function UserManagement() {
   } = useAdminCrud<
     AdminUser,
     AdminUserCreate,
-    { email: string; user: AdminUserUpdate },
+    { email: string; operations: PatchOperation[] },
     string
   >({
     queryKey: ['adminUsers'],
     listFn: (signal) => listAdminUsers(undefined, signal),
     createFn: createAdminUser,
-    updateFn: ({ email, user }) => updateAdminUser(email, user),
+    updateFn: ({ email, operations }) => updateAdminUser(email, operations),
     deleteFn: deleteAdminUser,
     onMutationSuccess: goToList,
     deleteErrorLabel: 'user',
@@ -63,8 +64,13 @@ export function UserManagement() {
   // Toggle-active is a bespoke mutation: it fires in the list view, mustn't
   // navigate, and toasts on failure but not via useAdminCrud's update flow.
   const toggleActiveMutation = useMutation({
-    mutationFn: ({ email, user }: { email: string; user: AdminUserUpdate }) =>
-      updateAdminUser(email, user),
+    mutationFn: ({
+      email,
+      operations,
+    }: {
+      email: string
+      operations: PatchOperation[]
+    }) => updateAdminUser(email, operations),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['adminUsers'] })
     },
@@ -97,13 +103,7 @@ export function UserManagement() {
   const handleToggleActive = (user: AdminUser) => {
     toggleActiveMutation.mutate({
       email: user.email,
-      user: {
-        email: user.email,
-        display_name: user.display_name,
-        is_active: !user.is_active,
-        is_admin: user.is_admin,
-        is_service_account: user.is_service_account,
-      },
+      operations: buildReplacePatch({ is_active: !user.is_active }),
     })
   }
 
@@ -153,7 +153,16 @@ export function UserManagement() {
     } else if (selectedUser) {
       // Strip org/role fields for update — they're only for creation
       const { organization_slug: _, role_slug: __, ...updateData } = userData
-      updateMutation.mutate({ email: selectedUser.email, user: updateData })
+      const operations = buildDiffPatch(
+        selectedUser as unknown as Record<string, unknown>,
+        updateData as unknown as Record<string, unknown>,
+        { fields: Object.keys(updateData) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
+      updateMutation.mutate({ email: selectedUser.email, operations })
     }
   }
 

--- a/src/components/admin/WebhookManagement.tsx
+++ b/src/components/admin/WebhookManagement.tsx
@@ -14,7 +14,8 @@ import {
   createWebhook,
   updateWebhook,
 } from '@/api/endpoints'
-import type { Webhook, WebhookCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type { Webhook, WebhookCreate, PatchOperation } from '@/types'
 
 export function WebhookManagement() {
   const { selectedOrganization } = useOrganization()
@@ -39,7 +40,7 @@ export function WebhookManagement() {
   } = useAdminCrud<
     Webhook,
     WebhookCreate,
-    { slug: string; data: WebhookCreate },
+    { slug: string; operations: PatchOperation[] },
     string
   >({
     queryKey: ['webhooks', orgSlug],
@@ -48,9 +49,9 @@ export function WebhookManagement() {
       if (!orgSlug) throw new Error('No organization selected')
       return createWebhook(orgSlug, data)
     },
-    updateFn: ({ slug, data }) => {
+    updateFn: ({ slug, operations }) => {
       if (!orgSlug) throw new Error('No organization selected')
-      return updateWebhook(orgSlug, slug, data)
+      return updateWebhook(orgSlug, slug, operations)
     },
     deleteFn: (slug) => {
       if (!orgSlug) throw new Error('No organization selected')
@@ -85,8 +86,17 @@ export function WebhookManagement() {
   const handleSave = (data: WebhookCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate(data)
-    } else if (selectedSlug) {
-      updateMutation.mutate({ slug: selectedSlug, data })
+    } else if (selectedSlug && selectedWebhook) {
+      const operations = buildDiffPatch(
+        selectedWebhook as unknown as Record<string, unknown>,
+        data as unknown as Record<string, unknown>,
+        { fields: Object.keys(data) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
+      updateMutation.mutate({ slug: selectedSlug, operations })
     }
   }
 

--- a/src/components/admin/service-accounts/useServiceAccountMutations.ts
+++ b/src/components/admin/service-accounts/useServiceAccountMutations.ts
@@ -12,6 +12,7 @@ import {
   updateServiceAccountOrgRole,
   removeServiceAccountFromOrg,
 } from '@/api/endpoints'
+import { buildReplacePatch } from '@/lib/json-patch'
 import type { ServiceAccount, ClientCredentialCreate } from '@/types'
 
 export function useServiceAccountMutations(account: ServiceAccount) {
@@ -41,9 +42,11 @@ export function useServiceAccountMutations(account: ServiceAccount) {
       orgSlug: string
       roleSlug: string
     }) =>
-      updateServiceAccountOrgRole(account.slug, orgSlug, {
-        role_slug: roleSlug,
-      }),
+      updateServiceAccountOrgRole(
+        account.slug,
+        orgSlug,
+        buildReplacePatch({ role_slug: roleSlug }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['serviceAccounts'] })
       queryClient.invalidateQueries({

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -16,7 +16,7 @@ import {
   getApplicationSecrets,
   updateApplicationSecrets,
 } from '@/api/endpoints'
-import { buildReplacePatch } from '@/lib/json-patch'
+import { buildDiffPatch } from '@/lib/json-patch'
 import type { PatchOperation } from '@/types'
 import {
   Tooltip,
@@ -112,16 +112,32 @@ export function ApplicationSecretsPanel({
   }
 
   const handleSave = () => {
+    // Only submit fields the user actually typed into. Use trim() to detect
+    // blank input, but send the raw value so leading/trailing whitespace that
+    // is significant (PEM blocks, signing secrets with newlines) is preserved.
     const update: Record<string, string> = {}
     for (const [field, value] of Object.entries(editValues)) {
       if (value.trim()) {
-        update[field] = value.trim()
+        update[field] = value
       }
     }
     if (Object.keys(update).length === 0) {
       return
     }
-    updateMutation.mutate(buildReplacePatch(update))
+    // Diff against the currently loaded secrets so first-time sets (where the
+    // path does not yet exist) emit `add` ops instead of `replace`, which a
+    // strict RFC 6902 backend would reject.
+    const operations = buildDiffPatch(
+      (secrets as unknown as Record<string, unknown>) ?? {},
+      update as Record<string, unknown>,
+      { fields: Object.keys(update) },
+    )
+    if (operations.length === 0) {
+      setEditing(false)
+      setEditValues({})
+      return
+    }
+    updateMutation.mutate(operations)
   }
 
   const is403 = error && (error as ApiError)?.response?.status === 403

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -16,7 +16,8 @@ import {
   getApplicationSecrets,
   updateApplicationSecrets,
 } from '@/api/endpoints'
-import type { ServiceApplicationSecretsUpdate } from '@/types'
+import { buildReplacePatch } from '@/lib/json-patch'
+import type { PatchOperation } from '@/types'
 import {
   Tooltip,
   TooltipContent,
@@ -72,8 +73,8 @@ export function ApplicationSecretsPanel({
   })
 
   const updateMutation = useMutation({
-    mutationFn: (data: ServiceApplicationSecretsUpdate) =>
-      updateApplicationSecrets(orgSlug, serviceSlug, appSlug, data),
+    mutationFn: (operations: PatchOperation[]) =>
+      updateApplicationSecrets(orgSlug, serviceSlug, appSlug, operations),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['application-secrets', orgSlug, serviceSlug, appSlug],
@@ -111,16 +112,16 @@ export function ApplicationSecretsPanel({
   }
 
   const handleSave = () => {
-    const update: ServiceApplicationSecretsUpdate = {}
+    const update: Record<string, string> = {}
     for (const [field, value] of Object.entries(editValues)) {
       if (value.trim()) {
-        ;(update as Record<string, string>)[field] = value.trim()
+        update[field] = value.trim()
       }
     }
     if (Object.keys(update).length === 0) {
       return
     }
-    updateMutation.mutate(update)
+    updateMutation.mutate(buildReplacePatch(update))
   }
 
   const is403 = error && (error as ApiError)?.response?.status === 403

--- a/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationList.tsx
@@ -21,10 +21,12 @@ import {
 } from '@/api/endpoints'
 import { OAuth2ApplicationForm } from './OAuth2ApplicationForm'
 import { ApplicationSecretsPanel } from './ApplicationSecretsPanel'
+import { buildDiffPatch } from '@/lib/json-patch'
 import type {
   ServiceApplication,
   ServiceApplicationCreate,
   ServiceApplicationUpdate,
+  PatchOperation,
 } from '@/types'
 import {
   Tooltip,
@@ -86,11 +88,11 @@ export function OAuth2ApplicationList({
   const updateMutation = useMutation({
     mutationFn: ({
       appSlug,
-      data,
+      operations,
     }: {
       appSlug: string
-      data: ServiceApplicationUpdate
-    }) => updateServiceApplication(orgSlug, serviceSlug, appSlug, data),
+      operations: PatchOperation[]
+    }) => updateServiceApplication(orgSlug, serviceSlug, appSlug, operations),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['service-applications', orgSlug, serviceSlug],
@@ -125,10 +127,18 @@ export function OAuth2ApplicationList({
     if (viewMode === 'create') {
       createMutation.mutate(data as ServiceApplicationCreate)
     } else if (editingApp) {
-      updateMutation.mutate({
-        appSlug: editingApp.slug,
-        data: data as ServiceApplicationUpdate,
-      })
+      const updateData = data as ServiceApplicationUpdate
+      const operations = buildDiffPatch(
+        editingApp as unknown as Record<string, unknown>,
+        updateData as unknown as Record<string, unknown>,
+        { fields: Object.keys(updateData) },
+      )
+      if (operations.length === 0) {
+        setViewMode('list')
+        setEditingApp(null)
+        return
+      }
+      updateMutation.mutate({ appSlug: editingApp.slug, operations })
     }
   }
 

--- a/src/components/admin/third-party-services/ServiceWebhookList.tsx
+++ b/src/components/admin/third-party-services/ServiceWebhookList.tsx
@@ -22,7 +22,8 @@ import {
   updateWebhook,
   deleteWebhook,
 } from '@/api/endpoints'
-import type { WebhookCreate } from '@/types'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type { WebhookCreate, PatchOperation } from '@/types'
 import type { ViewMode } from '@/hooks/useAdminNav'
 
 interface ServiceWebhookListProps {
@@ -78,8 +79,13 @@ export function ServiceWebhookList({
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ slug, data }: { slug: string; data: WebhookCreate }) =>
-      updateWebhook(orgSlug, slug, data),
+    mutationFn: ({
+      slug,
+      operations,
+    }: {
+      slug: string
+      operations: PatchOperation[]
+    }) => updateWebhook(orgSlug, slug, operations),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['service-webhooks', orgSlug, serviceSlug],
@@ -138,8 +144,18 @@ export function ServiceWebhookList({
         ...data,
         third_party_service_slug: serviceSlug,
       })
-    } else if (selectedSlug) {
-      updateMutation.mutate({ slug: selectedSlug, data })
+    } else if (selectedSlug && selectedWebhook) {
+      const operations = buildDiffPatch(
+        selectedWebhook as unknown as Record<string, unknown>,
+        data as unknown as Record<string, unknown>,
+        { fields: Object.keys(data) },
+      )
+      if (operations.length === 0) {
+        setViewMode('list')
+        setSelectedSlug(null)
+        return
+      }
+      updateMutation.mutate({ slug: selectedSlug, operations })
     }
   }
 

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -26,6 +26,7 @@ import {
   removeUserFromOrg,
 } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { buildReplacePatch } from '@/lib/json-patch'
 import type { AdminUser, OrgMembership } from '@/types'
 import {
   Tooltip,
@@ -81,7 +82,12 @@ export function UserDetail({ user, onEdit, onBack }: UserDetailProps) {
     }: {
       orgSlug: string
       roleSlug: string
-    }) => updateUserOrgRole(user.email, orgSlug, { role_slug: roleSlug }),
+    }) =>
+      updateUserOrgRole(
+        user.email,
+        orgSlug,
+        buildReplacePatch({ role_slug: roleSlug }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['adminUsers'] })
       queryClient.invalidateQueries({ queryKey: ['adminUser', user.email] })

--- a/src/lib/json-patch.ts
+++ b/src/lib/json-patch.ts
@@ -2,6 +2,86 @@ import type { PatchOperation } from '@/types'
 
 export type { PatchOperation }
 
+function encodePointerSegment(seg: string): string {
+  return seg.replace(/~/g, '~0').replace(/\//g, '~1')
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a === null || b === null) return false
+  if (typeof a !== typeof b) return false
+  if (typeof a !== 'object') return false
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    return a.every((v, i) => deepEqual(v, b[i]))
+  }
+  const ao = a as Record<string, unknown>
+  const bo = b as Record<string, unknown>
+  const keys = new Set([...Object.keys(ao), ...Object.keys(bo)])
+  for (const k of keys) {
+    if (!deepEqual(ao[k], bo[k])) return false
+  }
+  return true
+}
+
+/**
+ * Emit one `replace` op per provided key. Use for "set these fields"
+ * mutations that don't need to diff against a prior state.
+ */
+export function buildReplacePatch(
+  updates: Record<string, unknown>,
+): PatchOperation[] {
+  return Object.entries(updates).map(([key, value]) => ({
+    op: 'replace',
+    path: `/${encodePointerSegment(key)}`,
+    value,
+  }))
+}
+
+/**
+ * Diff two records and emit add/replace/remove ops for keys that differ.
+ * `undefined` is treated as absent, matching JSON serialization semantics.
+ * By default only the keys present in `after` (or both) are considered;
+ * pass `options.fields` to scope explicitly, or `options.ignore` to skip
+ * server-managed fields.
+ */
+export function buildDiffPatch(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+  options: { fields?: string[]; ignore?: string[] } = {},
+): PatchOperation[] {
+  const { fields, ignore } = options
+  const keys = fields ?? [
+    ...new Set([...Object.keys(before), ...Object.keys(after)]),
+  ]
+  const ignoreSet = new Set(ignore ?? [])
+  const ops: PatchOperation[] = []
+  for (const key of keys) {
+    if (ignoreSet.has(key)) continue
+    const hasBefore = key in before && before[key] !== undefined
+    const hasAfter = key in after && after[key] !== undefined
+    const bv = before[key]
+    const av = after[key]
+    if (!hasAfter && hasBefore) {
+      ops.push({ op: 'remove', path: `/${encodePointerSegment(key)}` })
+    } else if (hasAfter && !hasBefore) {
+      ops.push({
+        op: 'add',
+        path: `/${encodePointerSegment(key)}`,
+        value: av,
+      })
+    } else if (hasAfter && hasBefore && !deepEqual(bv, av)) {
+      ops.push({
+        op: 'replace',
+        path: `/${encodePointerSegment(key)}`,
+        value: av,
+      })
+    }
+  }
+  return ops
+}
+
 /**
  * Apply JSON Patch operations to a top-level object.
  * Supports only `replace` and `remove` on top-level paths (`/<key>`).


### PR DESCRIPTION
## Summary

The API removed its PUT endpoints in favor of PATCH accepting RFC 6902 JSON Patch operation arrays. This rewires every admin-side update mutation to construct a patch array before calling the endpoint. Manifested as \"Admin > Environments still trying to PUT\" and similar breakage across the admin UI.

## Changes

- Expand `src/lib/json-patch.ts` with two helpers alongside the existing `applyJsonPatch`:
  - `buildReplacePatch(updates)` — one `replace` op per field, for single-field mutations.
  - `buildDiffPatch(before, after, { fields })` — diff a form's editable fields against the loaded record, emitting `add` / `replace` / `remove` ops. Treats `undefined` as absent.
- Convert 15 `update*` functions in `src/api/endpoints.ts` from `apiClient.put` to `apiClient.patch`, taking `PatchOperation[]` instead of domain bodies. Delete the dead PUT-based `updateProject` (superseded by the existing `patchProject`).
- Update every caller. Full-form edits compute `buildDiffPatch` against the loaded record; single-field mutations (user↔org role, service-account↔org role, application secrets, user toggle-active) use `buildReplacePatch`. Short-circuit when the diff is empty so we don't round-trip a no-op PATCH.
- Drop the now-orphan `AdminUserUpdate`, `ServiceAccountUpdate`, and `ServiceApplicationSecretsUpdate` type imports.

## Affected admin sections

Environments, Project Types, Teams, Organizations, Link Definitions, Blueprints, Roles, Users (incl. User↔Org role, toggle active), Third-Party Services, Service Applications (incl. Secrets rotation), Service Accounts (incl. Org role), Webhooks (org-scoped and service-scoped).

## Out of scope

`setProjectRelationships` (in `EditRelationshipsDialog`) still uses PUT. The API replaced that bulk endpoint with per-edge `POST /relationships/{target_id}` + `DELETE /relationships/{target_id}`, which needs a separate rewrite to diff the selected set against current and issue N+M calls. Tracking separately.

## Test plan

- [x] \`npm run test\` — 152 passing, no regressions.
- [x] \`tsc --noEmit\` clean.
- [x] \`npm run lint\` clean.
- [ ] Manual: edit one record in each admin section (Environments, Project Types, Teams, Organizations, Link Definitions, Blueprints, Roles, Users, Third-Party Services, Service Applications, Application Secrets, Service Accounts, Webhooks) and confirm the request goes out as PATCH with a JSON Patch body.
- [ ] Manual: the single-field mutations — user↔org role change, service-account↔org role change, user toggle-active, application secrets rotation.