### PR TITLE
Add Project Notes tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,7 +122,7 @@ function App() {
                   }
                 />
                 <Route
-                  path="/projects/:projectId/:tab?"
+                  path="/projects/:projectId/:tab?/:subId?/:subAction?"
                   element={
                     <ProtectedRoute>
                       <ProjectDetailPage />

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -56,6 +56,10 @@ import type {
   PatchOperation,
   OperationsLogRecord,
   OperationsLogFilters,
+  Note,
+  NoteCreate,
+  NoteListResponse,
+  Tag,
 } from '@/types'
 
 // Re-export for backward compatibility with modules that import from here.
@@ -1182,4 +1186,83 @@ export const deleteProjectService = (
 ) =>
   apiClient.delete<void>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectSlug)}/services/${encodeURIComponent(serviceSlug)}`,
+  )
+
+// Notes (project-scoped)
+export const listProjectNotes = async (
+  orgSlug: string,
+  projectId: string,
+  params?: { limit?: number; cursor?: string; tag?: string },
+  signal?: AbortSignal,
+): Promise<Note[]> => {
+  const response = await apiClient.get<NoteListResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/`,
+    params,
+    signal,
+  )
+  return response?.data ?? []
+}
+
+export const getProjectNote = (
+  orgSlug: string,
+  projectId: string,
+  noteId: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<Note>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/${encodeURIComponent(noteId)}`,
+    undefined,
+    signal,
+  )
+
+export const createProjectNote = (
+  orgSlug: string,
+  projectId: string,
+  data: NoteCreate,
+) =>
+  apiClient.post<Note>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/`,
+    data,
+  )
+
+export const patchProjectNote = (
+  orgSlug: string,
+  projectId: string,
+  noteId: string,
+  operations: PatchOperation[],
+) =>
+  apiClient.patch<Note>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/${encodeURIComponent(noteId)}`,
+    operations,
+  )
+
+export const deleteProjectNote = (
+  orgSlug: string,
+  projectId: string,
+  noteId: string,
+) =>
+  apiClient.delete<void>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/${encodeURIComponent(noteId)}`,
+  )
+
+// Tags (org-scoped)
+export const listTags = async (
+  orgSlug: string,
+  signal?: AbortSignal,
+): Promise<Tag[]> => {
+  const response = await apiClient.get<Tag[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/tags/`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const createTag = (
+  orgSlug: string,
+  data: { name: string; slug?: string | null; description?: string | null },
+) =>
+  apiClient.post<Tag>(
+    `/organizations/${encodeURIComponent(orgSlug)}/tags/`,
+    data,
   )

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1,7 +1,7 @@
 import {
   TrendingUp,
   TrendingDown,
-  Settings as SettingsIcon,
+  Settings2 as SettingsIcon,
   ArrowRight,
   Rocket,
 } from 'lucide-react'
@@ -31,6 +31,7 @@ import { sanitizeHttpUrl, sortEnvironments } from '@/lib/utils'
 import {
   listLinkDefinitions,
   getProjectSchema,
+  listProjectNotes,
   listTeams,
   listProjectTypes,
 } from '@/api/endpoints'
@@ -45,10 +46,13 @@ import { ProjectRelationshipsTab } from '@/components/ProjectRelationshipsTab'
 import { ProjectEnvironmentsCard } from '@/components/ProjectEnvironmentsCard'
 import { ProjectAttributesSection } from '@/components/ProjectAttributesSection'
 import { ProjectSettingsTab } from '@/components/ProjectSettingsTab'
+import { ProjectNotesTab } from '@/components/notes/ProjectNotesTab'
 
 interface ProjectDetailProps {
   project: Project
   initialTab?: string
+  initialSubId?: string
+  initialSubAction?: string
 }
 
 const VALID_TABS = [
@@ -66,7 +70,12 @@ type TabType = (typeof VALID_TABS)[number]
 
 const VALID_TAB_SET: Set<string> = new Set(VALID_TABS)
 
-export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
+export function ProjectDetail({
+  project,
+  initialTab,
+  initialSubId,
+  initialSubAction,
+}: ProjectDetailProps) {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug || ''
   const { patch, pendingPath } = useProjectPatch(orgSlug, project.id)
@@ -188,6 +197,12 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
     queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
     enabled: !!orgSlug,
   })
+  const { data: projectNotes = [] } = useQuery({
+    queryKey: ['projectNotes', orgSlug, project.id],
+    queryFn: ({ signal }) =>
+      listProjectNotes(orgSlug, project.id, undefined, signal),
+    enabled: !!orgSlug && !!project.id,
+  })
 
   // Bumps when an icon-set chunk finishes loading; include in useMemo deps
   // where icons are resolved so they refresh once available.
@@ -267,7 +282,11 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
     { id: 'configuration', label: 'Configuration' },
     { id: 'dependencies', label: 'Dependencies' },
     { id: 'logs', label: 'Logs' },
-    { id: 'notes', label: 'Notes' },
+    {
+      id: 'notes',
+      label:
+        projectNotes.length > 0 ? `Notes (${projectNotes.length})` : 'Notes',
+    },
     { id: 'operations-log', label: 'Operations Log' },
     {
       id: 'relationships',
@@ -375,19 +394,30 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={handleTabChange}>
         <TabsList className="mb-6">
-          {tabs.map((tab) => (
-            <TabsTrigger
-              key={tab.id}
-              value={tab.id}
-              aria-label={tab.id === 'settings' ? 'Settings' : undefined}
-            >
-              {tab.id === 'settings' ? (
-                <SettingsIcon className="h-4 w-4" />
-              ) : (
-                tab.label
-              )}
-            </TabsTrigger>
-          ))}
+          {tabs.map((tab) =>
+            tab.id === 'settings' ? (
+              <TooltipProvider key={tab.id} delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <TabsTrigger
+                      value={tab.id}
+                      aria-label="Project Settings"
+                      className="ml-auto"
+                    >
+                      <SettingsIcon className="h-4 w-4" />
+                    </TabsTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Project Settings</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <TabsTrigger key={tab.id} value={tab.id}>
+                {tab.label}
+              </TabsTrigger>
+            ),
+          )}
         </TabsList>
 
         <TabsContent value="overview">
@@ -591,7 +621,12 @@ export function ProjectDetail({ project, initialTab }: ProjectDetailProps) {
           <PlaceholderTab name="Logs" />
         </TabsContent>
         <TabsContent value="notes">
-          <PlaceholderTab name="Notes" />
+          <ProjectNotesTab
+            orgSlug={project.team.organization.slug}
+            projectId={project.id}
+            initialNoteId={activeTab === 'notes' ? initialSubId : undefined}
+            initialAction={activeTab === 'notes' ? initialSubAction : undefined}
+          />
         </TabsContent>
         <TabsContent value="operations-log">
           <OperationsLog

--- a/src/components/notes/NoteTagChip.tsx
+++ b/src/components/notes/NoteTagChip.tsx
@@ -23,8 +23,19 @@ export function NoteTagChip({ tag, size = 'md', className, onClick }: Props) {
     >
       <span
         onClick={onClick}
+        onKeyDown={
+          onClick
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  onClick()
+                }
+              }
+            : undefined
+        }
         className="inline-flex items-center gap-1"
         role={onClick ? 'button' : undefined}
+        tabIndex={onClick ? 0 : undefined}
       >
         <span
           aria-hidden

--- a/src/components/notes/NoteTagChip.tsx
+++ b/src/components/notes/NoteTagChip.tsx
@@ -1,0 +1,38 @@
+import { LabelChip } from '@/components/ui/label-chip'
+import { cn } from '@/lib/utils'
+import { colorForTag } from './notesHelpers'
+import type { TagRef } from '@/types'
+
+interface Props {
+  tag: TagRef
+  size?: 'sm' | 'md'
+  className?: string
+  onClick?: () => void
+}
+
+export function NoteTagChip({ tag, size = 'md', className, onClick }: Props) {
+  const hex = colorForTag(tag.slug)
+  return (
+    <LabelChip
+      hex={hex}
+      className={cn(
+        size === 'sm' ? 'px-1.5 py-0 text-[10.5px]' : 'px-2 py-0.5 text-xs',
+        onClick && 'cursor-pointer',
+        className,
+      )}
+    >
+      <span
+        onClick={onClick}
+        className="inline-flex items-center gap-1"
+        role={onClick ? 'button' : undefined}
+      >
+        <span
+          aria-hidden
+          className="inline-block rounded-full"
+          style={{ width: 4, height: 4, backgroundColor: hex }}
+        />
+        {tag.name}
+      </span>
+    </LabelChip>
+  )
+}

--- a/src/components/notes/NotesFilterRail.tsx
+++ b/src/components/notes/NotesFilterRail.tsx
@@ -1,0 +1,140 @@
+import { Search } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { colorForTag } from './notesHelpers'
+import type { TagRef } from '@/types'
+
+interface Props {
+  tags: TagRef[]
+  counts: Record<string, number>
+  active: ReadonlySet<string>
+  onToggle: (slug: string) => void
+  onClear: () => void
+  search: string
+  onSearchChange: (value: string) => void
+  totalFiltered: number
+  highlightedSlugs?: ReadonlySet<string>
+  disabled?: boolean
+}
+
+export function NotesFilterRail({
+  tags,
+  counts,
+  active,
+  onToggle,
+  onClear,
+  search,
+  onSearchChange,
+  totalFiltered,
+  highlightedSlugs,
+  disabled = false,
+}: Props) {
+  const activeCount = active.size
+  return (
+    <aside
+      className={cn(
+        'sticky top-5 self-start',
+        disabled && 'pointer-events-none select-none opacity-50',
+      )}
+      aria-disabled={disabled || undefined}
+    >
+      <div className="relative mb-3">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
+        <Input
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search notes"
+          className="h-8 pl-8 text-xs"
+          disabled={disabled}
+          tabIndex={disabled ? -1 : undefined}
+        />
+      </div>
+
+      {activeCount > 0 && (
+        <div className="mb-3 flex items-center justify-between gap-2 rounded-md border border-warning bg-warning px-2.5 py-1.5">
+          <span className="text-[11.5px] text-warning">
+            {activeCount} filter{activeCount > 1 ? 's' : ''} · {totalFiltered}{' '}
+            notes
+          </span>
+          <button
+            type="button"
+            onClick={onClear}
+            className="cursor-pointer border-0 bg-transparent p-0 text-[11.5px] text-warning hover:underline"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+
+      {tags.length > 0 && (
+        <div>
+          <div className="mb-1.5 text-overline uppercase text-tertiary">
+            Tags
+          </div>
+          <div className="flex flex-col gap-0.5">
+            {tags.map((t) => {
+              const count = counts[t.slug] ?? 0
+              if (!count) return null
+              return (
+                <TagButton
+                  key={t.slug}
+                  tag={t}
+                  count={count}
+                  active={active.has(t.slug)}
+                  highlighted={highlightedSlugs?.has(t.slug)}
+                  onClick={() => onToggle(t.slug)}
+                />
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </aside>
+  )
+}
+
+function TagButton({
+  tag,
+  count,
+  active,
+  highlighted,
+  onClick,
+}: {
+  tag: TagRef
+  count: number
+  active: boolean
+  highlighted?: boolean
+  onClick: () => void
+}) {
+  const hex = colorForTag(tag.slug)
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-md border-0 px-2 py-1 text-left transition-colors',
+        active ? 'bg-secondary' : 'bg-transparent hover:bg-secondary',
+      )}
+    >
+      <span
+        aria-hidden
+        className="flex-shrink-0 rounded-sm"
+        style={{
+          width: 10,
+          height: 10,
+          backgroundColor: `${hex}55`,
+          border: `0.5px solid ${hex}`,
+        }}
+      />
+      <span
+        className={cn(
+          'flex-1 truncate text-[12.5px]',
+          active || highlighted ? 'font-medium text-primary' : 'text-secondary',
+        )}
+      >
+        {tag.name}
+      </span>
+      <span className="font-mono text-[11px] text-tertiary">{count}</span>
+    </button>
+  )
+}

--- a/src/components/notes/NotesPinboard.tsx
+++ b/src/components/notes/NotesPinboard.tsx
@@ -1,0 +1,287 @@
+import { ArrowUpRight, Pin, Plus } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { UserDisplay } from '@/components/ui/user-display'
+import { cn } from '@/lib/utils'
+import { NotesFilterRail } from './NotesFilterRail'
+import { NoteTagChip } from './NoteTagChip'
+import {
+  deriveExcerpt,
+  noteTitle,
+  formatUpdated,
+  tagCounts,
+  uniqueTagsFromNotes,
+} from './notesHelpers'
+import type { Note } from '@/types'
+
+interface Props {
+  notes: Note[]
+  displayNames?: Map<string, string>
+  onOpen: (noteId: string) => void
+  onCreate: () => void
+  onTogglePin: (note: Note) => void
+}
+
+export function NotesPinboard({
+  notes,
+  displayNames,
+  onOpen,
+  onCreate,
+  onTogglePin,
+}: Props) {
+  const [active, setActive] = useState<Set<string>>(new Set())
+  const [search, setSearch] = useState('')
+
+  const tags = useMemo(() => uniqueTagsFromNotes(notes), [notes])
+  const counts = useMemo(() => tagCounts(notes), [notes])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return notes.filter((n) => {
+      for (const slug of active) {
+        if (!n.tags.some((t) => t.slug === slug)) return false
+      }
+      if (!q) return true
+      const title = noteTitle(n).toLowerCase()
+      const content = n.content.toLowerCase()
+      return title.includes(q) || content.includes(q)
+    })
+  }, [notes, active, search])
+
+  const pinned = useMemo(() => filtered.filter((n) => n.is_pinned), [filtered])
+  const rest = useMemo(() => filtered.filter((n) => !n.is_pinned), [filtered])
+
+  const toggle = useCallback((slug: string) => {
+    setActive((prev) => {
+      const next = new Set(prev)
+      if (next.has(slug)) next.delete(slug)
+      else next.add(slug)
+      return next
+    })
+  }, [])
+
+  return (
+    <div className="grid grid-cols-[220px_1fr] gap-5">
+      <NotesFilterRail
+        tags={tags}
+        counts={counts}
+        active={active}
+        onToggle={toggle}
+        onClear={() => setActive(new Set())}
+        search={search}
+        onSearchChange={setSearch}
+        totalFiltered={filtered.length}
+      />
+
+      <div>
+        <section className="mb-6 flex items-start gap-3.5">
+          {pinned.length > 0 && (
+            <div className="grid min-w-0 flex-1 grid-cols-2 gap-3.5">
+              {pinned.map((n) => (
+                <HeroCard
+                  key={n.id}
+                  note={n}
+                  displayNames={displayNames}
+                  onOpen={onOpen}
+                />
+              ))}
+            </div>
+          )}
+          <Button
+            size="sm"
+            onClick={onCreate}
+            className={cn('gap-1.5', pinned.length === 0 && 'ml-auto')}
+          >
+            <Plus className="h-3 w-3" />
+            New note
+          </Button>
+        </section>
+
+        <section>
+          <div className="overflow-hidden rounded-lg border border-tertiary bg-primary">
+            <div
+              className="grid items-center gap-3.5 border-b border-tertiary bg-secondary px-3.5 py-2 text-overline uppercase text-tertiary"
+              style={{
+                gridTemplateColumns:
+                  'minmax(0, 1.6fr) minmax(0, 1fr) 100px 60px 60px',
+              }}
+            >
+              <span>Note</span>
+              <span>Tags</span>
+              <span>Author</span>
+              <span className="text-right">Updated</span>
+              <span />
+            </div>
+            {rest.map((n) => (
+              <IndexRow
+                key={n.id}
+                note={n}
+                displayNames={displayNames}
+                onOpen={onOpen}
+                onTogglePin={onTogglePin}
+              />
+            ))}
+            {rest.length === 0 && (
+              <div className="px-8 py-7 text-center text-sm text-tertiary">
+                {filtered.length === 0
+                  ? 'No notes match the current filters.'
+                  : 'All remaining notes are pinned.'}
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function HeroCard({
+  note,
+  displayNames,
+  onOpen,
+}: {
+  note: Note
+  displayNames?: Map<string, string>
+  onOpen: (noteId: string) => void
+}) {
+  const title = noteTitle(note)
+  const excerpt = deriveExcerpt(note.content)
+  return (
+    <Card
+      onClick={() => onOpen(note.id)}
+      className="flex cursor-pointer flex-col transition-colors hover:border-secondary hover:shadow-md"
+    >
+      <CardHeader className="space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-[17px] font-medium leading-[1.3] tracking-[-0.01em] text-primary">
+            {title}
+          </CardTitle>
+          <span className="inline-flex flex-shrink-0 items-center gap-1 text-[11px] text-warning">
+            <Pin className="h-2.5 w-2.5" />
+            Pinned
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-2.5">
+        <p className="m-0 line-clamp-3 text-[13px] leading-[1.55] text-secondary">
+          {excerpt}
+        </p>
+        {note.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {note.tags.map((t) => (
+              <NoteTagChip key={t.slug} tag={t} size="sm" />
+            ))}
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="mt-auto gap-2 border-t border-tertiary pt-3 text-[11.5px] text-tertiary">
+        <UserDisplay
+          email={note.created_by}
+          displayNames={displayNames}
+          size={16}
+          className="text-secondary"
+          textClassName="font-medium"
+        />
+        <span className="text-tertiary">·</span>
+        <span>Updated {formatUpdated(note)}</span>
+      </CardFooter>
+    </Card>
+  )
+}
+
+function IndexRow({
+  note,
+  displayNames,
+  onOpen,
+  onTogglePin,
+}: {
+  note: Note
+  displayNames?: Map<string, string>
+  onOpen: (noteId: string) => void
+  onTogglePin: (note: Note) => void
+}) {
+  const pinned = note.is_pinned
+  const title = noteTitle(note)
+  const excerpt = deriveExcerpt(note.content)
+  const author = note.created_by
+  return (
+    <div
+      onClick={() => onOpen(note.id)}
+      className="grid cursor-pointer items-center gap-3.5 border-b border-tertiary px-3.5 py-2.5 last:border-b-0 hover:bg-secondary"
+      style={{
+        gridTemplateColumns: 'minmax(0, 1.6fr) minmax(0, 1fr) 100px 60px 60px',
+      }}
+    >
+      <div className="min-w-0">
+        <div className="truncate text-[13.5px] font-medium text-primary">
+          {title}
+        </div>
+        <div className="mt-0.5 truncate text-xs text-tertiary">{excerpt}</div>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {note.tags.slice(0, 3).map((t) => (
+          <NoteTagChip key={t.slug} tag={t} />
+        ))}
+      </div>
+      <UserDisplay
+        email={author}
+        displayNames={displayNames}
+        size={18}
+        className="text-xs text-secondary"
+      />
+      <div className="text-right font-mono text-[11.5px] text-tertiary">
+        {formatUpdated(note)}
+      </div>
+      <div className="flex justify-end gap-0.5">
+        <RowIconButton
+          onClick={(e) => {
+            e.stopPropagation()
+            onTogglePin(note)
+          }}
+          title={pinned ? 'Unpin note' : 'Pin note'}
+        >
+          <Pin
+            className={cn('h-3 w-3', pinned ? 'text-warning' : 'text-tertiary')}
+          />
+        </RowIconButton>
+        <RowIconButton
+          onClick={(e) => {
+            e.stopPropagation()
+            onOpen(note.id)
+          }}
+          title="Open note"
+        >
+          <ArrowUpRight className="h-3 w-3 text-tertiary" />
+        </RowIconButton>
+      </div>
+    </div>
+  )
+}
+
+function RowIconButton({
+  children,
+  onClick,
+  title,
+}: {
+  children: React.ReactNode
+  onClick: (e: React.MouseEvent) => void
+  title: string
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className="inline-flex h-[22px] w-[22px] cursor-pointer items-center justify-center rounded border-0 bg-transparent text-tertiary hover:bg-tertiary"
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -71,96 +71,70 @@ const TEMPLATES: Template[] = [
 
 export function NotesPinboardEmpty({ onCreate }: Props) {
   return (
-    <div className="grid grid-cols-[220px_1fr] gap-5">
-      {/* Dimmed rail preserved for parity */}
-      <aside className="sticky top-5 self-start opacity-50" aria-hidden>
-        <div className="mb-3 h-8 rounded-md border border-tertiary bg-primary" />
-        <div>
-          <div className="mb-1.5 text-overline uppercase text-tertiary">
-            Tags
-          </div>
-          <div className="flex flex-col gap-1">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-2 px-2 py-1">
-                <span className="h-2.5 w-2.5 flex-shrink-0 rounded-sm bg-secondary" />
-                <span
-                  className="h-2 rounded bg-secondary"
-                  style={{ width: 60 + i * 14 }}
-                />
-              </div>
-            ))}
-          </div>
-        </div>
-      </aside>
+    <div>
+      <div className="mb-5 flex items-center justify-end">
+        <Button size="sm" className="gap-1.5" onClick={() => onCreate()}>
+          <Plus className="h-3 w-3" />
+          New note
+        </Button>
+      </div>
 
-      <div>
-        <div className="mb-5 flex items-center gap-2.5">
-          <div className="text-xs text-tertiary">0 notes on this project</div>
-          <div className="ml-auto">
-            <Button size="sm" className="gap-1.5" onClick={() => onCreate()}>
-              <Plus className="h-3 w-3" />
-              New note
-            </Button>
+      <div className="flex flex-col items-center gap-4 rounded-lg border border-tertiary bg-primary px-10 py-14 text-center">
+        <div className="relative flex h-[108px] w-[108px] items-center justify-center">
+          <div className="absolute inset-[18px] -rotate-[7deg] rounded-[10px] border border-tertiary bg-secondary" />
+          <div className="absolute inset-[14px] rotate-[4deg] rounded-[10px] border border-tertiary bg-primary shadow-sm" />
+          <div className="relative inline-flex h-[68px] w-[68px] items-center justify-center rounded-xl border border-warning bg-warning text-warning">
+            <StickyNote className="h-7 w-7" />
           </div>
         </div>
 
-        <div className="flex flex-col items-center gap-4 rounded-lg border border-tertiary bg-primary px-10 py-14 text-center">
-          <div className="relative flex h-[108px] w-[108px] items-center justify-center">
-            <div className="absolute inset-[18px] -rotate-[7deg] rounded-[10px] border border-tertiary bg-secondary" />
-            <div className="absolute inset-[14px] rotate-[4deg] rounded-[10px] border border-tertiary bg-primary shadow-sm" />
-            <div className="relative inline-flex h-[68px] w-[68px] items-center justify-center rounded-xl border border-warning bg-warning text-warning">
-              <StickyNote className="h-7 w-7" />
-            </div>
-          </div>
+        <h2 className="m-0 text-h2 font-medium tracking-[-0.015em]">
+          No notes yet for this project
+        </h2>
+        <p className="m-0 max-w-[520px] text-sm leading-[1.6] text-secondary">
+          Notes capture decisions, reviews, and patterns that outlive any one
+          deploy. They render as Markdown, carry tags you can filter from the
+          rail, and can be pinned so they stay at the top of this tab.
+        </p>
 
-          <h2 className="m-0 text-h2 font-medium tracking-[-0.015em]">
-            No notes yet for this project
-          </h2>
-          <p className="m-0 max-w-[520px] text-sm leading-[1.6] text-secondary">
-            Notes capture decisions, reviews, and patterns that outlive any one
-            deploy. They render as Markdown, carry tags you can filter from the
-            rail, and can be pinned so they stay at the top of this tab.
-          </p>
+        <div className="mt-1 flex gap-2">
+          <Button className="gap-1.5" onClick={() => onCreate()}>
+            <Plus className="h-3 w-3" />
+            New note
+          </Button>
+          <Button variant="outline" className="gap-1.5">
+            <BookOpen className="h-3 w-3" />
+            How notes work
+          </Button>
+        </div>
 
-          <div className="mt-1 flex gap-2">
-            <Button className="gap-1.5" onClick={() => onCreate()}>
-              <Plus className="h-3 w-3" />
-              New note
-            </Button>
-            <Button variant="outline" className="gap-1.5">
-              <BookOpen className="h-3 w-3" />
-              How notes work
-            </Button>
-          </div>
-
-          <div className="mt-5 grid w-full max-w-[720px] grid-cols-3 gap-2.5 text-left">
-            {TEMPLATES.map((t) => {
-              const Icon = t.icon
-              return (
-                <button
-                  key={t.slug}
-                  type="button"
-                  onClick={() => onCreate(t.slug)}
-                  className="flex cursor-pointer flex-col gap-1.5 rounded-lg border border-tertiary bg-primary p-3.5 text-left hover:border-secondary hover:shadow-sm"
-                >
-                  <div className="flex items-center gap-2">
-                    <div className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-md bg-secondary text-secondary">
-                      <Icon className="h-3.5 w-3.5" />
-                    </div>
-                    <span className="text-[13.5px] font-medium text-primary">
-                      {t.label}
-                    </span>
-                    <span className="ml-auto">
-                      <NoteTagChip tag={t.tag} size="sm" />
-                    </span>
+        <div className="mt-5 grid w-full max-w-[720px] grid-cols-3 gap-2.5 text-left">
+          {TEMPLATES.map((t) => {
+            const Icon = t.icon
+            return (
+              <button
+                key={t.slug}
+                type="button"
+                onClick={() => onCreate(t.slug)}
+                className="flex cursor-pointer flex-col gap-1.5 rounded-lg border border-tertiary bg-primary p-3.5 text-left hover:border-secondary hover:shadow-sm"
+              >
+                <div className="flex items-center gap-2">
+                  <div className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-md bg-secondary text-secondary">
+                    <Icon className="h-3.5 w-3.5" />
                   </div>
-                  <div className="text-xs leading-[1.5] text-tertiary">
-                    {t.hint}
-                  </div>
-                </button>
-              )
-            })}
-          </div>
+                  <span className="text-[13.5px] font-medium text-primary">
+                    {t.label}
+                  </span>
+                  <span className="ml-auto">
+                    <NoteTagChip tag={t.tag} size="sm" />
+                  </span>
+                </div>
+                <div className="text-xs leading-[1.5] text-tertiary">
+                  {t.hint}
+                </div>
+              </button>
+            )
+          })}
         </div>
       </div>
     </div>

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { NoteTagChip } from './NoteTagChip'
+import type { TagRef } from '@/types'
 
 interface Props {
   onCreate: (templateSlug?: string) => void
@@ -21,7 +22,7 @@ interface Template {
   label: string
   hint: string
   icon: LucideIcon
-  tag: { name: string; slug: string }
+  tag: TagRef
 }
 
 const TEMPLATES: Template[] = [

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -1,0 +1,172 @@
+import {
+  AlertTriangle,
+  BookOpen,
+  FileText,
+  Map,
+  Plus,
+  ShieldCheck,
+  Sparkles,
+  StickyNote,
+  type LucideIcon,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { NoteTagChip } from './NoteTagChip'
+
+interface Props {
+  onCreate: (templateSlug?: string) => void
+}
+
+interface Template {
+  slug: string
+  label: string
+  hint: string
+  icon: LucideIcon
+  tag: { name: string; slug: string }
+}
+
+const TEMPLATES: Template[] = [
+  {
+    slug: 'adr',
+    label: 'ADR',
+    hint: 'Context · Decision · Trade-offs',
+    icon: FileText,
+    tag: { name: 'ADR', slug: 'adr' },
+  },
+  {
+    slug: 'security',
+    label: 'Security review',
+    hint: 'Findings · Follow-ups',
+    icon: ShieldCheck,
+    tag: { name: 'Security', slug: 'security' },
+  },
+  {
+    slug: 'incident',
+    label: 'Incident',
+    hint: 'Timeline · Root cause · Actions',
+    icon: AlertTriangle,
+    tag: { name: 'Incident', slug: 'incident' },
+  },
+  {
+    slug: 'roadmap',
+    label: 'Roadmap',
+    hint: 'Proposal · Milestones',
+    icon: Map,
+    tag: { name: 'Roadmap', slug: 'roadmap' },
+  },
+  {
+    slug: 'pattern',
+    label: 'Pattern',
+    hint: 'When to reach for this',
+    icon: Sparkles,
+    tag: { name: 'Pattern', slug: 'pattern' },
+  },
+  {
+    slug: 'runbook',
+    label: 'Runbook',
+    hint: 'Steps · Verification',
+    icon: BookOpen,
+    tag: { name: 'Runbook', slug: 'runbook' },
+  },
+]
+
+export function NotesPinboardEmpty({ onCreate }: Props) {
+  return (
+    <div className="grid grid-cols-[220px_1fr] gap-5">
+      {/* Dimmed rail preserved for parity */}
+      <aside className="sticky top-5 self-start opacity-60" aria-hidden>
+        <div className="mb-3 h-8 rounded-md border border-tertiary bg-primary" />
+        <div className="flex flex-col gap-4">
+          {['Kind', 'Tags'].map((title) => (
+            <div key={title}>
+              <div className="mb-1.5 text-overline uppercase text-tertiary">
+                {title}
+              </div>
+              <div className="flex flex-col gap-1">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-2 px-2 py-1">
+                    <span className="h-2.5 w-2.5 flex-shrink-0 rounded-sm bg-secondary" />
+                    <span
+                      className="h-2 rounded bg-secondary"
+                      style={{ width: 60 + i * 14 }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </aside>
+
+      <div>
+        <div className="mb-5 flex items-center gap-2.5">
+          <div className="text-xs text-tertiary">0 notes on this project</div>
+          <div className="ml-auto">
+            <Button size="sm" className="gap-1.5" onClick={() => onCreate()}>
+              <Plus className="h-3 w-3" />
+              New note
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center gap-4 rounded-lg border border-tertiary bg-primary px-10 py-14 text-center">
+          <div className="relative flex h-[108px] w-[108px] items-center justify-center">
+            <div className="absolute inset-[18px] -rotate-[7deg] rounded-[10px] border border-tertiary bg-secondary" />
+            <div className="absolute inset-[14px] rotate-[4deg] rounded-[10px] border border-tertiary bg-primary shadow-sm" />
+            <div className="relative inline-flex h-[68px] w-[68px] items-center justify-center rounded-xl border border-warning bg-warning text-warning">
+              <StickyNote className="h-7 w-7" />
+            </div>
+          </div>
+
+          <h2 className="m-0 text-h2 font-medium tracking-[-0.015em]">
+            No notes yet for this project
+          </h2>
+          <p className="m-0 max-w-[520px] text-sm leading-[1.6] text-secondary">
+            Notes capture decisions, reviews, and patterns that outlive any one
+            deploy. They render as Markdown, carry tags you can filter from the
+            rail, and can be pinned so they stay at the top of this tab.
+          </p>
+
+          <div className="mt-1 flex gap-2">
+            <Button className="gap-1.5" onClick={() => onCreate()}>
+              <Plus className="h-3 w-3" />
+              New note
+            </Button>
+            <Button variant="outline" className="gap-1.5">
+              <BookOpen className="h-3 w-3" />
+              How notes work
+            </Button>
+          </div>
+
+          <div className="mt-5 grid w-full max-w-[720px] grid-cols-3 gap-2.5 text-left">
+            {TEMPLATES.map((t) => {
+              const Icon = t.icon
+              return (
+                <button
+                  key={t.slug}
+                  type="button"
+                  onClick={() => onCreate(t.slug)}
+                  className="flex cursor-pointer flex-col gap-1.5 rounded-lg border border-tertiary bg-primary p-3.5 text-left hover:border-secondary hover:shadow-sm"
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-md bg-secondary text-secondary">
+                      <Icon className="h-3.5 w-3.5" />
+                    </div>
+                    <span className="text-[13.5px] font-medium text-primary">
+                      {t.label}
+                    </span>
+                    <span className="ml-auto">
+                      <NoteTagChip tag={t.tag} size="sm" />
+                    </span>
+                  </div>
+                  <div className="text-xs leading-[1.5] text-tertiary">
+                    {t.hint}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -83,7 +83,7 @@ export function NotesPinboardEmpty({ onCreate }: Props) {
       <h2 className="m-0 text-h2 font-medium tracking-[-0.015em]">
         No notes yet for this project
       </h2>
-      <p className="m-0 max-w-[520px] text-sm leading-[1.6] text-secondary">
+      <p className="m-0 max-w-[720px] text-sm leading-[1.6] text-secondary">
         Notes capture decisions, reviews, and patterns that outlive any one
         deploy. They render as Markdown, carry tags you can filter, and can be
         pinned to stay at the top of this tab. Notes are also exposed to agents

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -71,71 +71,56 @@ const TEMPLATES: Template[] = [
 
 export function NotesPinboardEmpty({ onCreate }: Props) {
   return (
-    <div>
-      <div className="mb-5 flex items-center justify-end">
-        <Button size="sm" className="gap-1.5" onClick={() => onCreate()}>
-          <Plus className="h-3 w-3" />
-          New note
-        </Button>
+    <div className="flex flex-col items-center gap-4 rounded-lg border border-tertiary bg-primary px-10 py-14 text-center">
+      <div className="relative flex h-[108px] w-[108px] items-center justify-center">
+        <div className="absolute inset-[18px] -rotate-[7deg] rounded-[10px] border border-tertiary bg-secondary" />
+        <div className="absolute inset-[14px] rotate-[4deg] rounded-[10px] border border-tertiary bg-primary shadow-sm" />
+        <div className="relative inline-flex h-[68px] w-[68px] items-center justify-center rounded-xl border border-warning bg-warning text-warning">
+          <StickyNote className="h-7 w-7" />
+        </div>
       </div>
 
-      <div className="flex flex-col items-center gap-4 rounded-lg border border-tertiary bg-primary px-10 py-14 text-center">
-        <div className="relative flex h-[108px] w-[108px] items-center justify-center">
-          <div className="absolute inset-[18px] -rotate-[7deg] rounded-[10px] border border-tertiary bg-secondary" />
-          <div className="absolute inset-[14px] rotate-[4deg] rounded-[10px] border border-tertiary bg-primary shadow-sm" />
-          <div className="relative inline-flex h-[68px] w-[68px] items-center justify-center rounded-xl border border-warning bg-warning text-warning">
-            <StickyNote className="h-7 w-7" />
-          </div>
-        </div>
+      <h2 className="m-0 text-h2 font-medium tracking-[-0.015em]">
+        No notes yet for this project
+      </h2>
+      <p className="m-0 max-w-[520px] text-sm leading-[1.6] text-secondary">
+        Notes capture decisions, reviews, and patterns that outlive any one
+        deploy. They render as Markdown, carry tags you can filter from the
+        rail, and can be pinned so they stay at the top of this tab.
+      </p>
 
-        <h2 className="m-0 text-h2 font-medium tracking-[-0.015em]">
-          No notes yet for this project
-        </h2>
-        <p className="m-0 max-w-[520px] text-sm leading-[1.6] text-secondary">
-          Notes capture decisions, reviews, and patterns that outlive any one
-          deploy. They render as Markdown, carry tags you can filter from the
-          rail, and can be pinned so they stay at the top of this tab.
-        </p>
+      <Button className="mt-1 gap-1.5" onClick={() => onCreate()}>
+        <Plus className="h-3 w-3" />
+        New note
+      </Button>
 
-        <div className="mt-1 flex gap-2">
-          <Button className="gap-1.5" onClick={() => onCreate()}>
-            <Plus className="h-3 w-3" />
-            New note
-          </Button>
-          <Button variant="outline" className="gap-1.5">
-            <BookOpen className="h-3 w-3" />
-            How notes work
-          </Button>
-        </div>
-
-        <div className="mt-5 grid w-full max-w-[720px] grid-cols-3 gap-2.5 text-left">
-          {TEMPLATES.map((t) => {
-            const Icon = t.icon
-            return (
-              <button
-                key={t.slug}
-                type="button"
-                onClick={() => onCreate(t.slug)}
-                className="flex cursor-pointer flex-col gap-1.5 rounded-lg border border-tertiary bg-primary p-3.5 text-left hover:border-secondary hover:shadow-sm"
-              >
-                <div className="flex items-center gap-2">
-                  <div className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-md bg-secondary text-secondary">
-                    <Icon className="h-3.5 w-3.5" />
-                  </div>
-                  <span className="text-[13.5px] font-medium text-primary">
-                    {t.label}
-                  </span>
-                  <span className="ml-auto">
-                    <NoteTagChip tag={t.tag} size="sm" />
-                  </span>
+      <div className="mt-5 grid w-full max-w-[720px] grid-cols-3 gap-2.5 text-left">
+        {TEMPLATES.map((t) => {
+          const Icon = t.icon
+          return (
+            <button
+              key={t.slug}
+              type="button"
+              onClick={() => onCreate(t.slug)}
+              className="flex cursor-pointer flex-col gap-1.5 rounded-lg border border-tertiary bg-primary p-3.5 text-left hover:border-secondary hover:shadow-sm"
+            >
+              <div className="flex items-center gap-2">
+                <div className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-md bg-secondary text-secondary">
+                  <Icon className="h-3.5 w-3.5" />
                 </div>
-                <div className="text-xs leading-[1.5] text-tertiary">
-                  {t.hint}
-                </div>
-              </button>
-            )
-          })}
-        </div>
+                <span className="text-[13.5px] font-medium text-primary">
+                  {t.label}
+                </span>
+                <span className="ml-auto">
+                  <NoteTagChip tag={t.tag} size="sm" />
+                </span>
+              </div>
+              <div className="text-xs leading-[1.5] text-tertiary">
+                {t.hint}
+              </div>
+            </button>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -1,74 +1,11 @@
-import {
-  AlertTriangle,
-  BookOpen,
-  FileText,
-  Map,
-  Plus,
-  ShieldCheck,
-  Sparkles,
-  StickyNote,
-  type LucideIcon,
-} from 'lucide-react'
+import { Plus, StickyNote } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { NoteTagChip } from './NoteTagChip'
-import type { TagRef } from '@/types'
+import { NOTE_TEMPLATES } from './notesTemplates'
 
 interface Props {
   onCreate: (templateSlug?: string) => void
 }
-
-interface Template {
-  slug: string
-  label: string
-  hint: string
-  icon: LucideIcon
-  tag: TagRef
-}
-
-const TEMPLATES: Template[] = [
-  {
-    slug: 'adr',
-    label: 'ADR',
-    hint: 'Context · Decision · Trade-offs',
-    icon: FileText,
-    tag: { name: 'ADR', slug: 'adr' },
-  },
-  {
-    slug: 'security',
-    label: 'Security review',
-    hint: 'Findings · Follow-ups',
-    icon: ShieldCheck,
-    tag: { name: 'Security', slug: 'security' },
-  },
-  {
-    slug: 'incident',
-    label: 'Incident',
-    hint: 'Timeline · Root cause · Actions',
-    icon: AlertTriangle,
-    tag: { name: 'Incident', slug: 'incident' },
-  },
-  {
-    slug: 'roadmap',
-    label: 'Roadmap',
-    hint: 'Proposal · Milestones',
-    icon: Map,
-    tag: { name: 'Roadmap', slug: 'roadmap' },
-  },
-  {
-    slug: 'pattern',
-    label: 'Pattern',
-    hint: 'When to reach for this',
-    icon: Sparkles,
-    tag: { name: 'Pattern', slug: 'pattern' },
-  },
-  {
-    slug: 'runbook',
-    label: 'Runbook',
-    hint: 'Steps · Verification',
-    icon: BookOpen,
-    tag: { name: 'Runbook', slug: 'runbook' },
-  },
-]
 
 export function NotesPinboardEmpty({ onCreate }: Props) {
   return (
@@ -100,7 +37,7 @@ export function NotesPinboardEmpty({ onCreate }: Props) {
         Or choose a template
       </div>
       <div className="grid w-full max-w-[720px] grid-cols-3 gap-2.5 text-left">
-        {TEMPLATES.map((t) => {
+        {NOTE_TEMPLATES.map((t) => {
           const Icon = t.icon
           return (
             <button

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -95,7 +95,10 @@ export function NotesPinboardEmpty({ onCreate }: Props) {
         New note
       </Button>
 
-      <div className="mt-5 grid w-full max-w-[720px] grid-cols-3 gap-2.5 text-left">
+      <div className="mt-5 w-full max-w-[720px] text-overline uppercase text-tertiary">
+        Or choose a template
+      </div>
+      <div className="grid w-full max-w-[720px] grid-cols-3 gap-2.5 text-left">
         {TEMPLATES.map((t) => {
           const Icon = t.icon
           return (

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -73,27 +73,23 @@ export function NotesPinboardEmpty({ onCreate }: Props) {
   return (
     <div className="grid grid-cols-[220px_1fr] gap-5">
       {/* Dimmed rail preserved for parity */}
-      <aside className="sticky top-5 self-start opacity-60" aria-hidden>
+      <aside className="sticky top-5 self-start opacity-50" aria-hidden>
         <div className="mb-3 h-8 rounded-md border border-tertiary bg-primary" />
-        <div className="flex flex-col gap-4">
-          {['Kind', 'Tags'].map((title) => (
-            <div key={title}>
-              <div className="mb-1.5 text-overline uppercase text-tertiary">
-                {title}
+        <div>
+          <div className="mb-1.5 text-overline uppercase text-tertiary">
+            Tags
+          </div>
+          <div className="flex flex-col gap-1">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-2 px-2 py-1">
+                <span className="h-2.5 w-2.5 flex-shrink-0 rounded-sm bg-secondary" />
+                <span
+                  className="h-2 rounded bg-secondary"
+                  style={{ width: 60 + i * 14 }}
+                />
               </div>
-              <div className="flex flex-col gap-1">
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <div key={i} className="flex items-center gap-2 px-2 py-1">
-                    <span className="h-2.5 w-2.5 flex-shrink-0 rounded-sm bg-secondary" />
-                    <span
-                      className="h-2 rounded bg-secondary"
-                      style={{ width: 60 + i * 14 }}
-                    />
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </aside>
 

--- a/src/components/notes/NotesPinboardEmpty.tsx
+++ b/src/components/notes/NotesPinboardEmpty.tsx
@@ -85,8 +85,9 @@ export function NotesPinboardEmpty({ onCreate }: Props) {
       </h2>
       <p className="m-0 max-w-[520px] text-sm leading-[1.6] text-secondary">
         Notes capture decisions, reviews, and patterns that outlive any one
-        deploy. They render as Markdown, carry tags you can filter from the
-        rail, and can be pinned so they stay at the top of this tab.
+        deploy. They render as Markdown, carry tags you can filter, and can be
+        pinned to stay at the top of this tab. Notes are also exposed to agents
+        in the graph, providing project-level context across your workflows.
       </p>
 
       <Button className="mt-1 gap-1.5" onClick={() => onCreate()}>

--- a/src/components/notes/NotesPinboardNew.tsx
+++ b/src/components/notes/NotesPinboardNew.tsx
@@ -174,10 +174,9 @@ export function NotesPinboardNew({
           {/* Editor panes */}
           <div
             className={cn(
-              'mt-5 grid border-t border-tertiary',
+              'mt-5 grid min-h-[560px] border-t border-tertiary',
               mode === 'split' ? 'grid-cols-2' : 'grid-cols-1',
             )}
-            style={{ minHeight: 560 }}
           >
             {showEditor && (
               <textarea

--- a/src/components/notes/NotesPinboardNew.tsx
+++ b/src/components/notes/NotesPinboardNew.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, Check, Columns2, Eye, PencilLine } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button } from '@/components/ui/button'
@@ -52,11 +52,14 @@ export function NotesPinboardNew({
         : [],
   )
 
-  const isValid = title.trim().length > 0 && content.trim().length > 0
+  const trimmedTitle = title.trim()
+  const isValid = trimmedTitle.length > 0 && content.trim().length > 0
   const dirty = useMemo(() => {
     if (!initialNote)
-      return title.length > 0 || content.length > 0 || tags.length > 0
-    if (title !== initialNote.title) return true
+      return trimmedTitle.length > 0 || content.length > 0 || tags.length > 0
+    // Compare against the trimmed save value so trailing-space-only edits
+    // don't masquerade as dirty.
+    if (trimmedTitle !== initialNote.title.trim()) return true
     if (content !== initialNote.content) return true
     const initialSlugs = initialNote.tags
       .map((t) => t.slug)
@@ -67,7 +70,7 @@ export function NotesPinboardNew({
       .sort()
       .join(',')
     return initialSlugs !== currentSlugs
-  }, [initialNote, title, content, tags])
+  }, [initialNote, trimmedTitle, content, tags])
   const canSave = isValid && dirty
 
   const handleSave = () => {
@@ -215,9 +218,9 @@ function ModeButton({
   children,
 }: {
   active: boolean
-  icon: React.ReactNode
+  icon: ReactNode
   onClick: () => void
-  children: React.ReactNode
+  children: ReactNode
 }) {
   return (
     <button

--- a/src/components/notes/NotesPinboardNew.tsx
+++ b/src/components/notes/NotesPinboardNew.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { NotesFilterRail } from './NotesFilterRail'
 import { EMPTY_ACTIVE, tagCounts, uniqueTagsFromNotes } from './notesHelpers'
+import { findTemplate } from './notesTemplates'
 import { TagCombobox } from './TagCombobox'
 import type { Note, TagRef } from '@/types'
 
@@ -15,6 +16,11 @@ interface Props {
   orgSlug: string
   allNotes?: Note[]
   initialNote?: Note | null
+  /**
+   * When creating a new note, pre-seed the form from a template (currently
+   * just its tag). Ignored when `initialNote` is provided.
+   */
+  templateSlug?: string
   onDiscard: () => void
   onSave: (draft: { title: string; content: string; tags: string[] }) => void
   saving?: boolean
@@ -26,6 +32,7 @@ export function NotesPinboardNew({
   orgSlug,
   allNotes = [],
   initialNote,
+  templateSlug,
   onDiscard,
   onSave,
   saving = false,
@@ -33,13 +40,16 @@ export function NotesPinboardNew({
   const railTags = useMemo(() => uniqueTagsFromNotes(allNotes), [allNotes])
   const railCounts = useMemo(() => tagCounts(allNotes), [allNotes])
   const isEditing = !!initialNote
+  const template = !initialNote ? findTemplate(templateSlug) : null
   const [mode, setMode] = useState<EditorMode>('split')
   const [title, setTitle] = useState(initialNote?.title ?? '')
   const [content, setContent] = useState(initialNote?.content ?? '')
   const [tags, setTags] = useState<TagRef[]>(
     initialNote
       ? initialNote.tags.map((t) => ({ name: t.name, slug: t.slug }))
-      : [],
+      : template
+        ? [template.tag]
+        : [],
   )
 
   const isValid = title.trim().length > 0 && content.trim().length > 0

--- a/src/components/notes/NotesPinboardNew.tsx
+++ b/src/components/notes/NotesPinboardNew.tsx
@@ -1,0 +1,243 @@
+import { ArrowLeft, Check, Columns2, Eye, PencilLine } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { NotesFilterRail } from './NotesFilterRail'
+import { EMPTY_ACTIVE, tagCounts, uniqueTagsFromNotes } from './notesHelpers'
+import { TagCombobox } from './TagCombobox'
+import type { Note, TagRef } from '@/types'
+
+type EditorMode = 'split' | 'write' | 'preview'
+
+interface Props {
+  orgSlug: string
+  allNotes?: Note[]
+  initialNote?: Note | null
+  onDiscard: () => void
+  onSave: (draft: { title: string; content: string; tags: string[] }) => void
+  saving?: boolean
+}
+
+const NOOP = () => {}
+
+export function NotesPinboardNew({
+  orgSlug,
+  allNotes = [],
+  initialNote,
+  onDiscard,
+  onSave,
+  saving = false,
+}: Props) {
+  const railTags = useMemo(() => uniqueTagsFromNotes(allNotes), [allNotes])
+  const railCounts = useMemo(() => tagCounts(allNotes), [allNotes])
+  const isEditing = !!initialNote
+  const [mode, setMode] = useState<EditorMode>('split')
+  const [title, setTitle] = useState(initialNote?.title ?? '')
+  const [content, setContent] = useState(initialNote?.content ?? '')
+  const [tags, setTags] = useState<TagRef[]>(
+    initialNote
+      ? initialNote.tags.map((t) => ({ name: t.name, slug: t.slug }))
+      : [],
+  )
+
+  const isValid = title.trim().length > 0 && content.trim().length > 0
+  const dirty = useMemo(() => {
+    if (!initialNote)
+      return title.length > 0 || content.length > 0 || tags.length > 0
+    if (title !== initialNote.title) return true
+    if (content !== initialNote.content) return true
+    const initialSlugs = initialNote.tags
+      .map((t) => t.slug)
+      .sort()
+      .join(',')
+    const currentSlugs = tags
+      .map((t) => t.slug)
+      .sort()
+      .join(',')
+    return initialSlugs !== currentSlugs
+  }, [initialNote, title, content, tags])
+  const canSave = isValid && dirty
+
+  const handleSave = () => {
+    if (!canSave || saving) return
+    onSave({
+      title: title.trim(),
+      content,
+      tags: tags.map((t) => t.slug),
+    })
+  }
+
+  const showEditor = mode !== 'preview'
+  const showPreview = mode !== 'write'
+
+  return (
+    <div className="grid grid-cols-[220px_1fr] gap-5">
+      {/* Rail stays visible but disabled while composing — preserves spatial continuity. */}
+      <NotesFilterRail
+        tags={railTags}
+        counts={railCounts}
+        active={EMPTY_ACTIVE}
+        onToggle={NOOP}
+        onClear={NOOP}
+        search=""
+        onSearchChange={NOOP}
+        totalFiltered={allNotes.length}
+        disabled
+      />
+
+      <div>
+        {/* Toolbar */}
+        <div className="mb-3.5 flex flex-wrap items-center gap-2.5">
+          <button
+            type="button"
+            onClick={onDiscard}
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded border-0 bg-transparent px-1.5 py-1 text-xs text-secondary hover:bg-secondary hover:text-primary"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            All notes
+          </button>
+          <span className="text-tertiary">/</span>
+          <span className="text-xs font-medium text-primary">
+            {isEditing ? 'Edit note' : 'New note'}
+          </span>
+
+          <div className="ml-auto inline-flex gap-0.5 rounded-md border border-secondary bg-primary p-0.5">
+            <ModeButton
+              active={mode === 'split'}
+              icon={<Columns2 className="h-3 w-3" />}
+              onClick={() => setMode('split')}
+            >
+              Split
+            </ModeButton>
+            <ModeButton
+              active={mode === 'write'}
+              icon={<PencilLine className="h-3 w-3" />}
+              onClick={() => setMode('write')}
+            >
+              Write
+            </ModeButton>
+            <ModeButton
+              active={mode === 'preview'}
+              icon={<Eye className="h-3 w-3" />}
+              onClick={() => setMode('preview')}
+            >
+              Preview
+            </ModeButton>
+          </div>
+          <div className="h-5 w-px bg-tertiary" />
+          <Button variant="ghost" size="sm" onClick={onDiscard}>
+            Discard
+          </Button>
+          <Button
+            size="sm"
+            className="gap-1.5"
+            onClick={handleSave}
+            disabled={!canSave || saving}
+          >
+            <Check className="h-3 w-3" />
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+
+        <article className="overflow-hidden rounded-lg border border-tertiary bg-primary">
+          {/* Title + tag picker */}
+          <div className="px-7 pt-6">
+            <div className="flex items-start gap-4">
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Title"
+                autoFocus
+                className="flex-1 border-0 bg-transparent p-0 text-[26px] font-medium leading-[1.2] tracking-[-0.015em] text-primary outline-none placeholder:text-tertiary"
+              />
+              <TagCombobox
+                orgSlug={orgSlug}
+                selected={tags}
+                onChange={setTags}
+              />
+            </div>
+          </div>
+
+          {/* Editor panes */}
+          <div
+            className={cn(
+              'mt-5 grid border-t border-tertiary',
+              mode === 'split' ? 'grid-cols-2' : 'grid-cols-1',
+            )}
+            style={{ minHeight: 560 }}
+          >
+            {showEditor && (
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="Start writing… Markdown supported."
+                className={cn(
+                  'min-h-[560px] w-full resize-none border-0 bg-primary px-7 py-5 font-mono text-[13px] leading-[1.65] text-primary outline-none placeholder:text-tertiary',
+                  mode === 'split' && 'border-r border-tertiary',
+                )}
+                spellCheck
+              />
+            )}
+            {showPreview && (
+              <div className="flex flex-col">
+                <div className="flex items-center gap-1.5 border-b border-tertiary bg-primary px-5 py-2 text-overline uppercase text-tertiary">
+                  <Eye className="h-3 w-3" />
+                  Preview
+                </div>
+                <div className="flex-1 bg-primary px-7 py-5">
+                  <PreviewPane content={content} />
+                </div>
+              </div>
+            )}
+          </div>
+        </article>
+      </div>
+    </div>
+  )
+}
+
+function ModeButton({
+  active,
+  icon,
+  onClick,
+  children,
+}: {
+  active: boolean
+  icon: React.ReactNode
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex h-6 items-center gap-1.5 rounded-[5px] border-0 px-2.5 text-[12.5px] transition-colors',
+        active
+          ? 'bg-secondary text-primary'
+          : 'bg-transparent text-secondary hover:text-primary',
+      )}
+    >
+      {icon}
+      {children}
+    </button>
+  )
+}
+
+function PreviewPane({ content }: { content: string }) {
+  if (!content.trim()) {
+    return (
+      <div className="text-sm italic text-tertiary">
+        Preview updates as you type.
+      </div>
+    )
+  }
+  return (
+    <div className="note-markdown">
+      <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
+    </div>
+  )
+}

--- a/src/components/notes/NotesPinboardNew.tsx
+++ b/src/components/notes/NotesPinboardNew.tsx
@@ -225,7 +225,7 @@ function ModeButton({
       type="button"
       onClick={onClick}
       className={cn(
-        'inline-flex h-6 items-center gap-1.5 rounded-[5px] border-0 px-2.5 text-[12.5px] transition-colors',
+        'inline-flex h-6 cursor-pointer items-center gap-1.5 rounded-[5px] border-0 px-2.5 text-[12.5px] transition-colors',
         active
           ? 'bg-secondary text-primary'
           : 'bg-transparent text-secondary hover:text-primary',

--- a/src/components/notes/NotesPinboardReader.tsx
+++ b/src/components/notes/NotesPinboardReader.tsx
@@ -83,7 +83,6 @@ function extractHeadings(content: string): Heading[] {
  */
 function useActiveHeading(slugs: string[]): string | null {
   const [active, setActive] = useState<string | null>(slugs[0] ?? null)
-  const key = slugs.join('|')
   useEffect(() => {
     if (!slugs.length) {
       setActive(null)
@@ -107,7 +106,7 @@ function useActiveHeading(slugs: string[]): string | null {
       window.removeEventListener('scroll', update)
       window.removeEventListener('resize', update)
     }
-  }, [key])
+  }, [slugs])
   return active
 }
 

--- a/src/components/notes/NotesPinboardReader.tsx
+++ b/src/components/notes/NotesPinboardReader.tsx
@@ -1,0 +1,365 @@
+import { ArrowLeft, Clock, Pencil, Pin, PinOff, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { UserDisplay } from '@/components/ui/user-display'
+import { cn } from '@/lib/utils'
+import { NotesFilterRail } from './NotesFilterRail'
+import { NoteTagChip } from './NoteTagChip'
+import {
+  EMPTY_ACTIVE,
+  noteTitle,
+  formatFull,
+  formatUpdated,
+  tagCounts,
+  uniqueTagsFromNotes,
+} from './notesHelpers'
+import type { Note } from '@/types'
+
+interface Props {
+  note: Note
+  allNotes: Note[]
+  displayNames?: Map<string, string>
+  onBack: () => void
+  onOpen: (noteId: string) => void
+  onTogglePin: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+  deleting?: boolean
+}
+
+interface Heading {
+  level: 2 | 3
+  text: string
+  slug: string
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+}
+
+function headingTextFromChildren(children: React.ReactNode): string {
+  let out = ''
+  const visit = (node: React.ReactNode) => {
+    if (typeof node === 'string' || typeof node === 'number') {
+      out += String(node)
+    } else if (Array.isArray(node)) {
+      node.forEach(visit)
+    } else if (
+      typeof node === 'object' &&
+      node !== null &&
+      'props' in node &&
+      (node as { props?: { children?: React.ReactNode } }).props
+    ) {
+      visit((node as { props: { children?: React.ReactNode } }).props.children)
+    }
+  }
+  visit(children)
+  return out
+}
+
+function extractHeadings(content: string): Heading[] {
+  const out: Heading[] = []
+  for (const raw of content.split('\n')) {
+    const m = raw.match(/^(#{2,3})\s+(.+?)\s*#*$/)
+    if (!m) continue
+    const level = (m[1].length === 2 ? 2 : 3) as 2 | 3
+    const text = m[2].trim()
+    out.push({ level, text, slug: slugify(text) })
+  }
+  return out
+}
+
+/**
+ * Track which heading is currently nearest the top of the viewport. Picks the
+ * last heading whose top has scrolled above the offset; falls back to the
+ * first when nothing has scrolled past yet.
+ */
+function useActiveHeading(slugs: string[]): string | null {
+  const [active, setActive] = useState<string | null>(slugs[0] ?? null)
+  const key = slugs.join('|')
+  useEffect(() => {
+    if (!slugs.length) {
+      setActive(null)
+      return
+    }
+    const offset = 120
+    const update = () => {
+      let current = slugs[0]
+      for (const slug of slugs) {
+        const el = document.getElementById(slug)
+        if (!el) continue
+        if (el.getBoundingClientRect().top - offset <= 0) current = slug
+        else break
+      }
+      setActive((prev) => (prev === current ? prev : current))
+    }
+    update()
+    window.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+    return () => {
+      window.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+    }
+  }, [key])
+  return active
+}
+
+export function NotesPinboardReader({
+  note,
+  allNotes,
+  onBack,
+  onOpen,
+  onTogglePin,
+  onEdit,
+  onDelete,
+  deleting = false,
+  displayNames,
+}: Props) {
+  const [search, setSearch] = useState('')
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const pinned = note.is_pinned
+  const title = noteTitle(note)
+
+  const tags = useMemo(() => uniqueTagsFromNotes(allNotes), [allNotes])
+  const counts = useMemo(() => tagCounts(allNotes), [allNotes])
+  const highlightedSlugs = useMemo(
+    () => new Set(note.tags.map((t) => t.slug)),
+    [note.tags],
+  )
+
+  const related = useMemo(() => {
+    const noteTags = new Set(note.tags.map((t) => t.slug))
+    return allNotes
+      .filter(
+        (n) => n.id !== note.id && n.tags.some((t) => noteTags.has(t.slug)),
+      )
+      .slice(0, 4)
+  }, [allNotes, note])
+
+  const headings = useMemo(() => extractHeadings(note.content), [note.content])
+  const headingSlugs = useMemo(() => headings.map((h) => h.slug), [headings])
+  const activeSlug = useActiveHeading(headingSlugs)
+
+  // Reader is navigable from the same tab; filter rail keeps rail semantics.
+  return (
+    <div className="grid grid-cols-[220px_1fr] gap-5">
+      <NotesFilterRail
+        tags={tags}
+        counts={counts}
+        active={EMPTY_ACTIVE}
+        onToggle={() => onBack()}
+        onClear={() => onBack()}
+        search={search}
+        onSearchChange={setSearch}
+        totalFiltered={allNotes.length}
+        highlightedSlugs={highlightedSlugs}
+      />
+
+      <div>
+        <div className="mb-3.5 grid items-start gap-5 [grid-template-columns:minmax(0,1fr)_260px]">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <button
+              type="button"
+              onClick={onBack}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded border-0 bg-transparent px-1.5 py-1 text-xs text-secondary hover:bg-secondary hover:text-primary"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              All notes
+            </button>
+            <div className="ml-auto flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-1.5"
+                onClick={onTogglePin}
+              >
+                {pinned ? (
+                  <>
+                    <PinOff className="h-3 w-3" />
+                    Unpin
+                  </>
+                ) : (
+                  <>
+                    <Pin className="h-3 w-3" />
+                    Pin
+                  </>
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-1.5"
+                onClick={onEdit}
+                disabled={!onEdit}
+              >
+                <Pencil className="h-3 w-3" />
+                Edit
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                title="Delete note"
+                onClick={() => setConfirmDelete(true)}
+                disabled={!onDelete || deleting}
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid items-start gap-5 [grid-template-columns:minmax(0,1fr)_260px]">
+          <article className="rounded-lg border border-tertiary bg-primary px-8 py-7">
+            <h1 className="m-0 text-[26px] font-medium leading-[1.2] tracking-[-0.015em] text-primary">
+              {title}
+            </h1>
+
+            <div className="mt-3.5 flex flex-wrap items-center gap-2.5">
+              <div className="inline-flex items-center gap-2 text-[12.5px] text-tertiary">
+                <UserDisplay
+                  email={note.created_by}
+                  displayNames={displayNames}
+                  size={22}
+                  className="text-secondary"
+                  textClassName="text-[12.5px] text-secondary"
+                />
+                <span className="text-tertiary">·</span>
+                <span>Updated {formatUpdated(note)}</span>
+              </div>
+              <div className="h-3.5 w-px bg-tertiary" />
+              <div className="flex flex-wrap gap-1">
+                {note.tags.map((t) => (
+                  <NoteTagChip key={t.slug} tag={t} />
+                ))}
+              </div>
+            </div>
+
+            <div className="note-markdown mt-6">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  h2: ({ children, ...props }) => (
+                    <h2
+                      id={slugify(headingTextFromChildren(children))}
+                      className="scroll-mt-20"
+                      {...props}
+                    >
+                      {children}
+                    </h2>
+                  ),
+                  h3: ({ children, ...props }) => (
+                    <h3
+                      id={slugify(headingTextFromChildren(children))}
+                      className="scroll-mt-20"
+                      {...props}
+                    >
+                      {children}
+                    </h3>
+                  ),
+                }}
+              >
+                {note.content}
+              </Markdown>
+            </div>
+
+            <div className="mt-7 flex flex-wrap items-center gap-2.5 border-t border-tertiary pt-4 text-[11.5px] text-tertiary">
+              <Clock className="h-3 w-3" />
+              <span>Created {formatFull(note.created_at)}</span>
+              {note.updated_at && (
+                <>
+                  <span className="text-tertiary">·</span>
+                  <span>Last updated {formatFull(note.updated_at)}</span>
+                </>
+              )}
+            </div>
+          </article>
+
+          <div className="sticky top-5 flex flex-col gap-4">
+            {headings.length > 0 && (
+              <div>
+                <div className="mb-2 text-overline uppercase text-tertiary">
+                  On this page
+                </div>
+                <div className="flex flex-col gap-0.5 border-l border-tertiary">
+                  {headings.map((h, i) => {
+                    const isActive = h.slug === activeSlug
+                    return (
+                      <a
+                        key={`${h.slug}-${i}`}
+                        href={`#${h.slug}`}
+                        className={cn(
+                          '-ml-px border-l-2 text-[12.5px] no-underline transition-colors',
+                          h.level === 3
+                            ? 'py-0.5 pl-5 pr-2'
+                            : 'py-0.5 pl-3 pr-2',
+                          isActive
+                            ? 'border-action font-medium text-primary'
+                            : cn(
+                                'border-transparent',
+                                h.level === 3
+                                  ? 'text-secondary'
+                                  : 'text-primary',
+                              ),
+                        )}
+                      >
+                        {h.text}
+                      </a>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {related.length > 0 && (
+              <div>
+                <div className="mb-2 text-overline uppercase text-tertiary">
+                  Related notes
+                </div>
+                <div className="flex flex-col gap-2">
+                  {related.map((r) => (
+                    <button
+                      key={r.id}
+                      type="button"
+                      onClick={() => onOpen(r.id)}
+                      className="block cursor-pointer rounded-lg border border-tertiary bg-primary p-2 text-left hover:border-secondary"
+                    >
+                      <div className="line-clamp-2 text-[12.5px] font-medium leading-[1.35] text-primary">
+                        {noteTitle(r)}
+                      </div>
+                      <div className="mt-1 flex items-center gap-1.5 text-[11px] text-tertiary">
+                        <UserDisplay
+                          email={r.created_by}
+                          displayNames={displayNames}
+                          size={14}
+                        />
+                        <span>· {formatUpdated(r)}</span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <ConfirmDialog
+        open={confirmDelete}
+        title="Delete note?"
+        description={`"${title}" will be permanently removed.`}
+        confirmLabel={deleting ? 'Deleting…' : 'Delete'}
+        onConfirm={() => {
+          setConfirmDelete(false)
+          onDelete?.()
+        }}
+        onCancel={() => setConfirmDelete(false)}
+      />
+    </div>
+  )
+}

--- a/src/components/notes/ProjectNotesTab.tsx
+++ b/src/components/notes/ProjectNotesTab.tsx
@@ -225,6 +225,17 @@ export function ProjectNotesTab({
     [notes, view],
   )
 
+  // If a deep-linked note id doesn't exist (deleted, wrong id), surface a
+  // toast and bounce back to the list view rather than silently rendering
+  // the empty list.
+  useEffect(() => {
+    if (isLoading) return
+    if (view.kind !== 'reading' && view.kind !== 'editing') return
+    if (notes.some((n) => n.id === view.noteId)) return
+    toast.error('Note not found')
+    navigateToView({ kind: 'list' })
+  }, [isLoading, navigateToView, notes, view])
+
   const handleCreate = useCallback(
     (templateSlug?: string) => {
       navigateToView({ kind: 'creating', templateSlug })

--- a/src/components/notes/ProjectNotesTab.tsx
+++ b/src/components/notes/ProjectNotesTab.tsx
@@ -28,7 +28,7 @@ interface Props {
 type View =
   | { kind: 'list' }
   | { kind: 'reading'; noteId: string }
-  | { kind: 'creating' }
+  | { kind: 'creating'; templateSlug?: string }
   | { kind: 'editing'; noteId: string }
 
 function viewFromUrl(
@@ -225,9 +225,12 @@ export function ProjectNotesTab({
     [notes, view],
   )
 
-  const handleCreate = useCallback(() => {
-    navigateToView({ kind: 'creating' })
-  }, [navigateToView])
+  const handleCreate = useCallback(
+    (templateSlug?: string) => {
+      navigateToView({ kind: 'creating', templateSlug })
+    },
+    [navigateToView],
+  )
 
   const handleDiscard = useCallback(() => {
     if (view.kind === 'editing') {
@@ -256,6 +259,7 @@ export function ProjectNotesTab({
       <NotesPinboardNew
         orgSlug={orgSlug}
         allNotes={notes}
+        templateSlug={view.templateSlug}
         onDiscard={handleDiscard}
         onSave={handleSave}
         saving={createMutation.isPending}

--- a/src/components/notes/ProjectNotesTab.tsx
+++ b/src/components/notes/ProjectNotesTab.tsx
@@ -104,10 +104,22 @@ export function ProjectNotesTab({
     enabled: !!orgSlug && !!projectId,
   })
 
-  const { data: users = [] } = useQuery({
+  const { data: users = [], error: usersError } = useQuery({
     queryKey: ['admin-users', 'active'],
     queryFn: ({ signal }) => listAdminUsers({ is_active: true }, signal),
   })
+
+  // Display-name enrichment is non-essential — when the admin-users fetch
+  // fails, fall back to raw author IDs (existing UserDisplay behavior) but
+  // log so the failure is diagnosable rather than truly silent.
+  useEffect(() => {
+    if (usersError) {
+      console.warn(
+        'Failed to load admin users for note display names',
+        usersError,
+      )
+    }
+  }, [usersError])
 
   const displayNames = useMemo(() => {
     const m = new Map<string, string>()
@@ -227,14 +239,16 @@ export function ProjectNotesTab({
 
   // If a deep-linked note id doesn't exist (deleted, wrong id), surface a
   // toast and bounce back to the list view rather than silently rendering
-  // the empty list.
+  // the empty list. Skip while the notes query is loading or errored —
+  // the error banner (rendered below) already covers fetch failures and
+  // an empty-on-error notes array shouldn't masquerade as a missing note.
   useEffect(() => {
-    if (isLoading) return
+    if (isLoading || error) return
     if (view.kind !== 'reading' && view.kind !== 'editing') return
     if (notes.some((n) => n.id === view.noteId)) return
     toast.error('Note not found')
     navigateToView({ kind: 'list' })
-  }, [isLoading, navigateToView, notes, view])
+  }, [error, isLoading, navigateToView, notes, view])
 
   const handleCreate = useCallback(
     (templateSlug?: string) => {

--- a/src/components/notes/ProjectNotesTab.tsx
+++ b/src/components/notes/ProjectNotesTab.tsx
@@ -1,0 +1,311 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+import { LoadingState } from '@/components/ui/loading-state'
+import { ErrorBanner } from '@/components/ui/error-banner'
+import {
+  createProjectNote,
+  deleteProjectNote,
+  listAdminUsers,
+  listProjectNotes,
+  patchProjectNote,
+} from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import { NotesPinboard } from './NotesPinboard'
+import { NotesPinboardEmpty } from './NotesPinboardEmpty'
+import { NotesPinboardNew } from './NotesPinboardNew'
+import { NotesPinboardReader } from './NotesPinboardReader'
+import type { Note } from '@/types'
+
+interface Props {
+  orgSlug: string
+  projectId: string
+  initialNoteId?: string
+  initialAction?: string
+}
+
+type View =
+  | { kind: 'list' }
+  | { kind: 'reading'; noteId: string }
+  | { kind: 'creating' }
+  | { kind: 'editing'; noteId: string }
+
+function viewFromUrl(
+  initialNoteId: string | undefined,
+  initialAction: string | undefined,
+): View {
+  if (initialNoteId === 'new') return { kind: 'creating' }
+  if (initialNoteId && initialAction === 'edit') {
+    return { kind: 'editing', noteId: initialNoteId }
+  }
+  if (initialNoteId) return { kind: 'reading', noteId: initialNoteId }
+  return { kind: 'list' }
+}
+
+export function ProjectNotesTab({
+  orgSlug,
+  projectId,
+  initialNoteId,
+  initialAction,
+}: Props) {
+  const navigate = useNavigate()
+  const [view, setView] = useState<View>(() =>
+    viewFromUrl(initialNoteId, initialAction),
+  )
+  const qc = useQueryClient()
+
+  const navigateToView = useCallback(
+    (next: View) => {
+      setView(next)
+      const base = `/projects/${projectId}/notes`
+      if (next.kind === 'reading') {
+        navigate(`${base}/${encodeURIComponent(next.noteId)}`, {
+          replace: true,
+        })
+      } else if (next.kind === 'editing') {
+        navigate(`${base}/${encodeURIComponent(next.noteId)}/edit`, {
+          replace: true,
+        })
+      } else if (next.kind === 'creating') {
+        navigate(`${base}/new`, { replace: true })
+      } else {
+        navigate(base, { replace: true })
+      }
+    },
+    [navigate, projectId],
+  )
+
+  // Reflect URL changes (e.g. browser back/forward) into local view state.
+  useEffect(() => {
+    const next = viewFromUrl(initialNoteId, initialAction)
+    setView((prev) => {
+      if (
+        prev.kind === next.kind &&
+        ('noteId' in prev ? prev.noteId : null) ===
+          ('noteId' in next ? next.noteId : null)
+      ) {
+        return prev
+      }
+      return next
+    })
+  }, [initialNoteId, initialAction])
+
+  const notesKey = ['projectNotes', orgSlug, projectId] as const
+
+  const {
+    data: notes = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: notesKey,
+    queryFn: ({ signal }) =>
+      listProjectNotes(orgSlug, projectId, undefined, signal),
+    enabled: !!orgSlug && !!projectId,
+  })
+
+  const { data: users = [] } = useQuery({
+    queryKey: ['admin-users', 'active'],
+    queryFn: ({ signal }) => listAdminUsers({ is_active: true }, signal),
+  })
+
+  const displayNames = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const u of users) {
+      if (u.email && u.display_name) m.set(u.email, u.display_name)
+    }
+    return m
+  }, [users])
+
+  const pinMutation = useMutation({
+    mutationFn: ({ noteId, pinned }: { noteId: string; pinned: boolean }) =>
+      patchProjectNote(orgSlug, projectId, noteId, [
+        { op: 'replace', path: '/is_pinned', value: pinned },
+      ]),
+    onMutate: async ({ noteId, pinned }) => {
+      await qc.cancelQueries({ queryKey: notesKey })
+      const previous = qc.getQueryData<Note[]>(notesKey)
+      if (previous) {
+        qc.setQueryData<Note[]>(
+          notesKey,
+          previous.map((n) =>
+            n.id === noteId ? { ...n, is_pinned: pinned } : n,
+          ),
+        )
+      }
+      return { previous }
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) qc.setQueryData(notesKey, ctx.previous)
+      toast.error(`Pin failed: ${extractApiErrorDetail(err)}`)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: notesKey })
+    },
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (draft: { title: string; content: string; tags: string[] }) =>
+      createProjectNote(orgSlug, projectId, draft),
+    onSuccess: (note) => {
+      qc.setQueryData<Note[]>(notesKey, (prev) =>
+        prev ? [note, ...prev] : [note],
+      )
+      qc.invalidateQueries({ queryKey: notesKey })
+      toast.success('Note saved')
+      navigateToView({ kind: 'reading', noteId: note.id })
+    },
+    onError: (err) => {
+      toast.error(`Save failed: ${extractApiErrorDetail(err)}`)
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({
+      noteId,
+      draft,
+    }: {
+      noteId: string
+      draft: { title: string; content: string; tags: string[] }
+    }) =>
+      patchProjectNote(orgSlug, projectId, noteId, [
+        { op: 'replace', path: '/title', value: draft.title },
+        { op: 'replace', path: '/content', value: draft.content },
+        { op: 'replace', path: '/tags', value: draft.tags },
+      ]),
+    onSuccess: (note) => {
+      qc.setQueryData<Note[]>(notesKey, (prev) =>
+        prev ? prev.map((n) => (n.id === note.id ? note : n)) : [note],
+      )
+      qc.invalidateQueries({ queryKey: notesKey })
+      toast.success('Note updated')
+      navigateToView({ kind: 'reading', noteId: note.id })
+    },
+    onError: (err) => {
+      toast.error(`Update failed: ${extractApiErrorDetail(err)}`)
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (noteId: string) =>
+      deleteProjectNote(orgSlug, projectId, noteId),
+    onSuccess: (_data, noteId) => {
+      qc.setQueryData<Note[]>(notesKey, (prev) =>
+        prev ? prev.filter((n) => n.id !== noteId) : [],
+      )
+      qc.invalidateQueries({ queryKey: notesKey })
+      toast.success('Note deleted')
+      navigateToView({ kind: 'list' })
+    },
+    onError: (err) => {
+      toast.error(`Delete failed: ${extractApiErrorDetail(err)}`)
+    },
+  })
+
+  const togglePin = useCallback(
+    (note: Note) => {
+      pinMutation.mutate({ noteId: note.id, pinned: !note.is_pinned })
+    },
+    [pinMutation],
+  )
+
+  const selectedNote = useMemo(
+    () =>
+      view.kind === 'reading'
+        ? (notes.find((n) => n.id === view.noteId) ?? null)
+        : null,
+    [notes, view],
+  )
+
+  const editingNote = useMemo(
+    () =>
+      view.kind === 'editing'
+        ? (notes.find((n) => n.id === view.noteId) ?? null)
+        : null,
+    [notes, view],
+  )
+
+  const handleCreate = useCallback(() => {
+    navigateToView({ kind: 'creating' })
+  }, [navigateToView])
+
+  const handleDiscard = useCallback(() => {
+    if (view.kind === 'editing') {
+      navigateToView({ kind: 'reading', noteId: view.noteId })
+    } else {
+      navigateToView({ kind: 'list' })
+    }
+  }, [navigateToView, view])
+
+  const handleSave = useCallback(
+    (draft: { title: string; content: string; tags: string[] }) => {
+      if (view.kind === 'editing') {
+        updateMutation.mutate({ noteId: view.noteId, draft })
+      } else {
+        createMutation.mutate(draft)
+      }
+    },
+    [createMutation, updateMutation, view],
+  )
+
+  if (isLoading) return <LoadingState label="Loading notes…" />
+  if (error) return <ErrorBanner error={error} title="Failed to load notes" />
+
+  if (view.kind === 'creating') {
+    return (
+      <NotesPinboardNew
+        orgSlug={orgSlug}
+        allNotes={notes}
+        onDiscard={handleDiscard}
+        onSave={handleSave}
+        saving={createMutation.isPending}
+      />
+    )
+  }
+
+  if (editingNote) {
+    return (
+      <NotesPinboardNew
+        key={editingNote.id}
+        orgSlug={orgSlug}
+        allNotes={notes}
+        initialNote={editingNote}
+        onDiscard={handleDiscard}
+        onSave={handleSave}
+        saving={updateMutation.isPending}
+      />
+    )
+  }
+
+  if (selectedNote) {
+    return (
+      <NotesPinboardReader
+        note={selectedNote}
+        allNotes={notes}
+        displayNames={displayNames}
+        onBack={() => navigateToView({ kind: 'list' })}
+        onOpen={(id) => navigateToView({ kind: 'reading', noteId: id })}
+        onTogglePin={() => togglePin(selectedNote)}
+        onEdit={() =>
+          navigateToView({ kind: 'editing', noteId: selectedNote.id })
+        }
+        onDelete={() => deleteMutation.mutate(selectedNote.id)}
+        deleting={deleteMutation.isPending}
+      />
+    )
+  }
+
+  if (notes.length === 0) {
+    return <NotesPinboardEmpty onCreate={handleCreate} />
+  }
+
+  return (
+    <NotesPinboard
+      notes={notes}
+      displayNames={displayNames}
+      onOpen={(id) => navigateToView({ kind: 'reading', noteId: id })}
+      onCreate={handleCreate}
+      onTogglePin={togglePin}
+    />
+  )
+}

--- a/src/components/notes/TagCombobox.tsx
+++ b/src/components/notes/TagCombobox.tsx
@@ -1,0 +1,235 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { CornerDownLeft, Plus, Tag as TagIcon, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { createTag, listTags } from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import { cn } from '@/lib/utils'
+import { NoteTagChip } from './NoteTagChip'
+import type { Tag, TagRef } from '@/types'
+
+interface Props {
+  orgSlug: string
+  selected: TagRef[]
+  onChange: (tags: TagRef[]) => void
+}
+
+/**
+ * Multi-select tag combobox. Type to filter existing org tags; Enter on an
+ * unmatched query creates a new tag server-side and attaches it.
+ */
+export function TagCombobox({ orgSlug, selected, onChange }: Props) {
+  const [query, setQuery] = useState('')
+  const [open, setOpen] = useState(false)
+  const [activeIdx, setActiveIdx] = useState(0)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const qc = useQueryClient()
+
+  const tagsKey = ['tags', orgSlug] as const
+  const { data: allTags = [] } = useQuery({
+    queryKey: tagsKey,
+    queryFn: ({ signal }) => listTags(orgSlug, signal),
+    enabled: !!orgSlug,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (name: string) => createTag(orgSlug, { name }),
+    onSuccess: (tag) => {
+      qc.setQueryData<Tag[]>(tagsKey, (prev) => [...(prev ?? []), tag])
+      onChange([...selected, { name: tag.name, slug: tag.slug }])
+      setQuery('')
+      setActiveIdx(0)
+    },
+    onError: (err) => {
+      toast.error(`Create tag failed: ${extractApiErrorDetail(err)}`)
+    },
+  })
+
+  const selectedSlugs = useMemo(
+    () => new Set(selected.map((t) => t.slug)),
+    [selected],
+  )
+
+  const q = query.trim().toLowerCase()
+  const matches = useMemo(() => {
+    return allTags.filter(
+      (t) =>
+        !selectedSlugs.has(t.slug) &&
+        (q === '' ||
+          t.name.toLowerCase().includes(q) ||
+          t.slug.toLowerCase().includes(q)),
+    )
+  }, [allTags, selectedSlugs, q])
+
+  const exactName = useMemo(
+    () =>
+      q
+        ? allTags.some((t) => t.name.toLowerCase() === q) ||
+          selected.some((t) => t.name.toLowerCase() === q)
+        : false,
+    [q, allTags, selected],
+  )
+  const canCreate = q.length > 0 && !exactName
+
+  useEffect(() => {
+    setActiveIdx(0)
+  }, [query, open])
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const addExisting = (tag: Tag | TagRef) => {
+    onChange([...selected, { name: tag.name, slug: tag.slug }])
+    setQuery('')
+    setActiveIdx(0)
+  }
+
+  const removeTag = (slug: string) => {
+    onChange(selected.filter((t) => t.slug !== slug))
+  }
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIdx((i) => Math.min(i + 1, matches.length))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIdx((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (activeIdx < matches.length) {
+        addExisting(matches[activeIdx])
+      } else if (canCreate && !createMutation.isPending) {
+        createMutation.mutate(query.trim())
+      }
+    } else if (e.key === 'Backspace' && query === '' && selected.length > 0) {
+      removeTag(selected[selected.length - 1].slug)
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+      inputRef.current?.blur()
+    }
+  }
+
+  return (
+    <div ref={rootRef} className="relative flex flex-col items-end gap-2">
+      <div
+        onClick={() => {
+          setOpen(true)
+          inputRef.current?.focus()
+        }}
+        className={cn(
+          'flex min-w-[260px] max-w-[380px] flex-wrap items-center gap-1 rounded-md border bg-primary px-2 py-1 text-xs transition-colors',
+          open
+            ? 'ring-action/20 border-action ring-2'
+            : 'border-secondary hover:border-primary',
+        )}
+      >
+        <TagIcon className="h-3 w-3 flex-shrink-0 text-tertiary" />
+        {selected.map((t) => (
+          <span
+            key={t.slug}
+            className="inline-flex items-center gap-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <NoteTagChip tag={t} size="sm" />
+            <button
+              type="button"
+              onClick={() => removeTag(t.slug)}
+              className="rounded border-0 bg-transparent p-0 text-tertiary hover:text-primary"
+              aria-label={`Remove tag ${t.name}`}
+            >
+              <X className="h-2.5 w-2.5" />
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => setOpen(true)}
+          onKeyDown={handleKey}
+          placeholder={selected.length === 0 ? 'Add tags…' : ''}
+          className="flex-1 border-0 bg-transparent p-0 text-xs text-primary outline-none placeholder:text-tertiary"
+          style={{ minWidth: 80 }}
+        />
+      </div>
+
+      {open && (
+        <div className="absolute right-0 top-[calc(100%+6px)] z-10 max-h-80 w-[320px] overflow-auto rounded-lg border border-secondary bg-primary p-1 shadow-md">
+          {matches.length > 0 && (
+            <div>
+              <div className="px-2 py-1 text-overline uppercase text-tertiary">
+                Existing tags
+              </div>
+              {matches.map((t, i) => {
+                const isActive = i === activeIdx
+                return (
+                  <button
+                    key={t.slug}
+                    type="button"
+                    onMouseDown={(e) => {
+                      e.preventDefault()
+                      addExisting(t)
+                    }}
+                    onMouseEnter={() => setActiveIdx(i)}
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded border-0 px-2 py-1.5 text-left',
+                      isActive ? 'bg-secondary' : 'bg-transparent',
+                    )}
+                  >
+                    <NoteTagChip tag={t} size="sm" />
+                    <span className="ml-auto text-[11px] text-tertiary">
+                      {isActive && (
+                        <CornerDownLeft className="h-3 w-3 text-tertiary" />
+                      )}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+          {canCreate && (
+            <>
+              {matches.length > 0 && <div className="my-1 h-px bg-secondary" />}
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  if (!createMutation.isPending)
+                    createMutation.mutate(query.trim())
+                }}
+                onMouseEnter={() => setActiveIdx(matches.length)}
+                disabled={createMutation.isPending}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded border-0 px-2 py-1.5 text-left text-xs text-secondary',
+                  activeIdx === matches.length
+                    ? 'bg-secondary'
+                    : 'bg-transparent',
+                )}
+              >
+                <Plus className="h-3 w-3 text-tertiary" />
+                Create{' '}
+                <span className="font-medium text-primary">“{query}”</span>
+                <span className="ml-auto text-[11px] text-tertiary">Enter</span>
+              </button>
+            </>
+          )}
+          {matches.length === 0 && !canCreate && (
+            <div className="px-3 py-2 text-xs text-tertiary">
+              {allTags.length === 0
+                ? 'No tags yet — type to create one.'
+                : 'No matches.'}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/notes/notesHelpers.ts
+++ b/src/components/notes/notesHelpers.ts
@@ -1,0 +1,138 @@
+import { LABEL_SWATCHES } from '@/lib/chip-colors'
+import type { Note, TagRef } from '@/types'
+
+/**
+ * Deterministic color for a tag slug. Stable hash keeps each tag on the same
+ * swatch across renders without requiring color in the API schema.
+ */
+export function colorForTag(slug: string): string {
+  let hash = 0
+  for (let i = 0; i < slug.length; i++) {
+    hash = (hash * 31 + slug.charCodeAt(i)) | 0
+  }
+  const idx = Math.abs(hash) % LABEL_SWATCHES.length
+  return LABEL_SWATCHES[idx].hex
+}
+
+const TITLE_MAX = 120
+const EXCERPT_MAX = 240
+
+/**
+ * Prefer the note's explicit title; fall back to the first heading or line
+ * of content for rows written before the title column existed.
+ */
+export function noteTitle(note: Note): string {
+  const explicit = (note.title ?? '').trim()
+  if (explicit) return truncate(explicit, TITLE_MAX)
+  const lines = note.content.split('\n')
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+    const heading = line.match(/^#{1,6}\s+(.+?)\s*#*$/)
+    if (heading) return truncate(heading[1], TITLE_MAX)
+    return truncate(line.replace(/^[*_>`~-]+\s*/, ''), TITLE_MAX)
+  }
+  return 'Untitled note'
+}
+
+/** First paragraph of body text (after title), stripped of basic markdown. */
+export function deriveExcerpt(content: string): string {
+  const lines = content.split('\n')
+  let sawTitle = false
+  const buf: string[] = []
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line) {
+      if (buf.length) break
+      continue
+    }
+    if (!sawTitle && /^#{1,6}\s+/.test(line)) {
+      sawTitle = true
+      continue
+    }
+    sawTitle = true
+    if (/^[-*+]\s+/.test(line) || /^\d+\.\s+/.test(line)) {
+      buf.push(line.replace(/^[-*+]\s+|^\d+\.\s+/, ''))
+      continue
+    }
+    if (/^[#>`|]/.test(line)) continue
+    buf.push(line)
+  }
+  const text = buf
+    .join(' ')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+  return truncate(text, EXCERPT_MAX)
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max - 1).trimEnd() + '…'
+}
+
+export function formatUpdated(note: Note): string {
+  const iso = note.updated_at ?? note.created_at
+  return relativeShort(iso)
+}
+
+export function formatFull(iso: string | null | undefined): string {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function relativeShort(iso: string | null | undefined): string {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (!Number.isFinite(then)) return ''
+  const diff = Date.now() - then
+  const m = Math.round(diff / 60000)
+  if (m < 1) return 'just now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.round(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.round(h / 24)
+  if (d < 14) return `${d}d ago`
+  const w = Math.round(d / 7)
+  if (w < 8) return `${w}w ago`
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/)
+  if (!parts.length) return '?'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export const EMPTY_ACTIVE: ReadonlySet<string> = new Set()
+
+export function tagCounts(notes: Note[]): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const n of notes) {
+    for (const t of n.tags) counts[t.slug] = (counts[t.slug] ?? 0) + 1
+  }
+  return counts
+}
+
+/** Dedupe tags by slug across the whole note list. */
+export function uniqueTagsFromNotes(notes: Note[]): TagRef[] {
+  const seen = new Map<string, TagRef>()
+  for (const n of notes) {
+    for (const t of n.tags) {
+      if (!seen.has(t.slug)) seen.set(t.slug, t)
+    }
+  }
+  return Array.from(seen.values()).sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/src/components/notes/notesHelpers.ts
+++ b/src/components/notes/notesHelpers.ts
@@ -110,8 +110,9 @@ function relativeShort(iso: string | null | undefined): string {
 }
 
 export function initials(name: string): string {
-  const parts = name.trim().split(/\s+/)
-  if (!parts.length) return '?'
+  const trimmed = name.trim()
+  if (!trimmed) return '?'
+  const parts = trimmed.split(/\s+/)
   if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
 }

--- a/src/components/notes/notesTemplates.ts
+++ b/src/components/notes/notesTemplates.ts
@@ -1,0 +1,73 @@
+import {
+  AlertTriangle,
+  BookOpen,
+  FileText,
+  Map,
+  ShieldCheck,
+  Sparkles,
+  type LucideIcon,
+} from 'lucide-react'
+import type { TagRef } from '@/types'
+
+/**
+ * Note templates surfaced from the empty-state grid. Each template seeds the
+ * compose view with a starter tag so the template choice carries through to
+ * the new-note form.
+ */
+export interface NoteTemplate {
+  slug: string
+  label: string
+  hint: string
+  icon: LucideIcon
+  tag: TagRef
+}
+
+export const NOTE_TEMPLATES: NoteTemplate[] = [
+  {
+    slug: 'adr',
+    label: 'ADR',
+    hint: 'Context · Decision · Trade-offs',
+    icon: FileText,
+    tag: { name: 'ADR', slug: 'adr' },
+  },
+  {
+    slug: 'security',
+    label: 'Security review',
+    hint: 'Findings · Follow-ups',
+    icon: ShieldCheck,
+    tag: { name: 'Security', slug: 'security' },
+  },
+  {
+    slug: 'incident',
+    label: 'Incident',
+    hint: 'Timeline · Root cause · Actions',
+    icon: AlertTriangle,
+    tag: { name: 'Incident', slug: 'incident' },
+  },
+  {
+    slug: 'roadmap',
+    label: 'Roadmap',
+    hint: 'Proposal · Milestones',
+    icon: Map,
+    tag: { name: 'Roadmap', slug: 'roadmap' },
+  },
+  {
+    slug: 'pattern',
+    label: 'Pattern',
+    hint: 'When to reach for this',
+    icon: Sparkles,
+    tag: { name: 'Pattern', slug: 'pattern' },
+  },
+  {
+    slug: 'runbook',
+    label: 'Runbook',
+    hint: 'Steps · Verification',
+    icon: BookOpen,
+    tag: { name: 'Runbook', slug: 'runbook' },
+  },
+]
+
+export function findTemplate(slug: string | undefined): NoteTemplate | null {
+  if (!slug) return null
+  return NOTE_TEMPLATES.find((t) => t.slug === slug) ?? null
+}

--- a/src/components/ui/user-display.tsx
+++ b/src/components/ui/user-display.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils'
+import { Gravatar } from './gravatar'
+
+interface Props {
+  email: string
+  displayNames?: Map<string, string>
+  size?: number
+  className?: string
+  textClassName?: string
+  hideName?: boolean
+  title?: string
+}
+
+/**
+ * Compact user identity: Gravatar + display name (or local-part fallback).
+ * Pass `displayNames` to resolve email → display_name.
+ */
+export function UserDisplay({
+  email,
+  displayNames,
+  size = 18,
+  className,
+  textClassName,
+  hideName = false,
+  title,
+}: Props) {
+  const name = displayNames?.get(email) ?? email.split('@')[0] ?? email
+  return (
+    <span
+      className={cn('inline-flex items-center gap-1.5 truncate', className)}
+      title={title ?? name}
+    >
+      <Gravatar
+        email={email}
+        size={size}
+        className="flex-shrink-0 rounded-full"
+      />
+      {!hideName && (
+        <span className={cn('truncate', textClassName)}>{name}</span>
+      )}
+    </span>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -141,3 +141,107 @@
     line-height: 1.5;
   }
 }
+
+@layer components {
+  .note-markdown {
+    font-size: 14.5px;
+    line-height: 1.65;
+    color: var(--color-text-primary);
+  }
+  .note-markdown h1,
+  .note-markdown h2,
+  .note-markdown h3,
+  .note-markdown h4 {
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--color-text-primary);
+    margin: 1em 0 0.4em;
+  }
+  .note-markdown h1 {
+    font-size: 22px;
+  }
+  .note-markdown h2 {
+    font-size: 17px;
+  }
+  .note-markdown h3 {
+    font-size: 15px;
+  }
+  .note-markdown h4 {
+    font-size: 13.5px;
+  }
+  .note-markdown p,
+  .note-markdown ul,
+  .note-markdown ol {
+    margin: 0.5em 0;
+  }
+  .note-markdown ul,
+  .note-markdown ol {
+    padding-left: 1.2em;
+  }
+  .note-markdown li {
+    margin: 0.25em 0;
+  }
+  .note-markdown a {
+    color: var(--color-text-warning);
+    text-decoration: none;
+  }
+  .note-markdown a:hover {
+    text-decoration: underline;
+  }
+  .note-markdown code {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    background: var(--color-background-secondary);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+  }
+  .note-markdown pre {
+    margin: 0.75em 0;
+    padding: 10px 12px;
+    background: var(--color-background-secondary);
+    border: 0.5px solid var(--color-border-tertiary);
+    border-radius: 8px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.55;
+    overflow: auto;
+  }
+  .note-markdown pre code {
+    background: transparent;
+    padding: 0;
+    font-size: inherit;
+  }
+  .note-markdown blockquote {
+    margin: 0.5em 0;
+    padding: 0.25em 0.75em;
+    border-left: 2px solid var(--color-border-tertiary);
+    color: var(--color-text-secondary);
+  }
+  .note-markdown table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12.5px;
+    border: 0.5px solid var(--color-border-tertiary);
+    border-radius: 8px;
+    overflow: hidden;
+    margin: 0.75em 0;
+  }
+  .note-markdown th,
+  .note-markdown td {
+    padding: 8px 10px;
+    text-align: left;
+    border-top: 0.5px solid var(--color-border-tertiary);
+  }
+  .note-markdown thead th {
+    background: var(--color-background-secondary);
+    color: var(--color-text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 11.5px;
+    font-weight: 600;
+    border-top: 0;
+  }
+  .note-markdown input[type='checkbox'] {
+    margin-right: 0.5em;
+  }
+}

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -8,7 +8,12 @@ import { usePageTitle } from '@/hooks/usePageTitle'
 import { getProject } from '@/api/endpoints'
 
 export function ProjectDetailPage() {
-  const { projectId, tab } = useParams<{ projectId: string; tab?: string }>()
+  const { projectId, tab, subId, subAction } = useParams<{
+    projectId: string
+    tab?: string
+    subId?: string
+    subAction?: string
+  }>()
   const { selectedOrganization } = useOrganization()
 
   const orgSlug = selectedOrganization?.slug || ''
@@ -55,7 +60,14 @@ export function ProjectDetailPage() {
             </div>
           </div>
         )}
-        {project && <ProjectDetail project={project} initialTab={tab} />}
+        {project && (
+          <ProjectDetail
+            project={project}
+            initialTab={tab}
+            initialSubId={subId}
+            initialSubAction={subAction}
+          />
+        )}
       </main>
       <CommandBar />
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -512,9 +512,7 @@ export interface NoteCreate {
   tags?: string[]
 }
 
-export interface NoteListResponse {
-  data: Note[]
-}
+export type NoteListResponse = CollectionResponse<Note>
 
 export interface Tag {
   id: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -483,3 +483,45 @@ export type ProjectRelationshipsResponse =
 
 // JSON Patch operation (RFC 6902)
 export type PatchOperation = Schemas['PatchOperation']
+
+// Notes & tags. Inlined here (not from api-generated.ts) because the
+// committed openapi.json snapshot predates the notes endpoints.
+// Regenerate with `npm run codegen:fetch` once the snapshot is refreshed
+// and switch these to `Schemas['NoteResponse']` etc.
+export interface TagRef {
+  name: string
+  slug: string
+}
+
+export interface Note {
+  id: string
+  title: string
+  content: string
+  created_by: string
+  created_at: string
+  updated_by?: string | null
+  updated_at?: string | null
+  project_id: string
+  is_pinned: boolean
+  tags: TagRef[]
+}
+
+export interface NoteCreate {
+  title: string
+  content: string
+  tags?: string[]
+}
+
+export interface NoteListResponse {
+  data: Note[]
+}
+
+export interface Tag {
+  id: string
+  name: string
+  slug: string
+  description?: string | null
+  created_at?: string | null
+  updated_at?: string | null
+  organization: { name: string; slug: string }
+}


### PR DESCRIPTION
## Summary

Introduces a full Project Notes experience on each project detail page.

- **Views** — `ProjectNotesTab` orchestrates list / reader / create / edit, with pin/create/patch/delete mutations wired through React Query.
- **Pinboard** — pinned-first cards, per-tag filtering, search.
- **Reader** — sticky TOC with a scroll-position scrollspy that highlights the nearest heading as the reader scrolls; click-to-jump updates the highlight naturally.
- **Compose** — `NotesPinboardNew` provides split/write/preview modes with markdown; the `NotesFilterRail` now supports a `disabled` mode so the rail stays visible (dimmed) during composition instead of collapsing the layout.
- **Tag picker** — `TagCombobox` lets users pick existing or freshly-created tags.
- **Deep linking** — route params expanded to `:tab?/:subId?/:subAction?` so URLs like `/projects/:id/notes/:noteId/edit` work.
- **Shared** — new `UserDisplay` avatar + display-name component; `.note-markdown` styles scope typography and code/table treatments to note bodies.

Note and Tag types are inlined in `types/index.ts` pending an `openapi.json` regeneration — the committed snapshot predates the notes endpoints. Once refreshed, switch to `Schemas['NoteResponse']` etc.

Depends on:
- AWeber-Imbi/imbi-common#60
- AWeber-Imbi/imbi-api#243

## Test plan

- [ ] Navigate to a project → Notes tab → create a note with title + tags → verify it lands in the list, renders in the reader, and the URL tracks `/notes/:id`.
- [ ] Edit the note → verify the compose view loads with existing content, Save updates it, Discard returns to the reader.
- [ ] Pin and unpin → verify optimistic update and that pinned notes sort to the top.
- [ ] Delete a note → verify confirmation dialog and removal from the list.
- [ ] Scroll a long note → verify the TOC highlight tracks the current section; click a TOC entry → highlight updates and page jumps to the heading.
- [ ] Filter by a tag in the rail → list reduces; clear filter → full list returns.
- [ ] Deep link directly to `/projects/:id/notes/:noteId/edit` → loads the editor.