### PR TITLE
Show current release per environment on project page

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install just
         uses: extractions/setup-just@v2
+        with:
+          just-version: '1.47.1'
 
       - name: Run CI checks
         run: just ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,11 @@ jobs:
           cache: 'npm'
 
       - name: Install just
-        uses: extractions/setup-just@v2
-        with:
-          just-version: '1.47.1'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl --fail --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+            | bash -s -- --to "$HOME/.local/bin" --tag 1.47.1
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run CI checks
         run: just ci

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -62,6 +62,7 @@ import type {
   NoteCreate,
   NoteListResponse,
   Tag,
+  CurrentReleaseEnvironment,
 } from '@/types'
 
 // Re-export for backward compatibility with modules that import from here.
@@ -1313,3 +1314,17 @@ export const createTag = (
     `/organizations/${encodeURIComponent(orgSlug)}/tags/`,
     data,
   )
+
+// Releases
+export const listCurrentReleases = async (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<CurrentReleaseEnvironment[]> => {
+  const response = await apiClient.get<CurrentReleaseEnvironment[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/releases/current`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -34,6 +34,7 @@ import {
   listProjectNotes,
   listTeams,
   listProjectTypes,
+  listCurrentReleases,
 } from '@/api/endpoints'
 import { OperationsLog } from '@/components/OperationsLog'
 import type { Project } from '@/types'
@@ -107,21 +108,32 @@ export function ProjectDetail({
   const healthScore = isDev ? 66 : null
   const healthTrend = isDev ? 'down' : null
 
+  const { data: currentReleases = [] } = useQuery({
+    queryKey: ['currentReleases', orgSlug, project.id],
+    queryFn: ({ signal }) => listCurrentReleases(orgSlug, project.id, signal),
+    enabled: !!orgSlug && !!project.id,
+  })
+
   const deploymentStatus: Record<
     string,
     { version: string; status: string; updated: string }
-  > = isDev
-    ? {
-        'infrastructure-testing': {
-          version: '1962b02',
-          status: 'success',
-          updated: '2m ago',
-        },
-        testing: { version: '1962b02', status: 'success', updated: '2m ago' },
-        staging: { version: '1.0.11', status: 'success', updated: '1h ago' },
-        production: { version: '1.0.10', status: 'success', updated: '3h ago' },
+  > = useMemo(() => {
+    const out: Record<
+      string,
+      { version: string; status: string; updated: string }
+    > = {}
+    for (const row of currentReleases) {
+      if (!row.release || !row.last_event_at) continue
+      out[row.environment.slug] = {
+        version: row.release.version,
+        status: row.current_status ?? '',
+        updated: formatDistanceToNow(new Date(row.last_event_at), {
+          addSuffix: true,
+        }),
       }
-    : {}
+    }
+    return out
+  }, [currentReleases])
 
   const feed = isDev
     ? [
@@ -316,8 +328,8 @@ export function ProjectDetail({
             </div>
           </div>
 
-          {/* Deployment Pipeline (mocked, dev only) */}
-          {isDev && (
+          {/* Deployment Pipeline */}
+          {Object.keys(deploymentStatus).length > 0 && (
             <div className="flex items-center gap-2">
               {sortedEnvironments
                 .filter((env) => !!deploymentStatus[env.slug])
@@ -344,14 +356,16 @@ export function ProjectDetail({
                     </span>
                   )
                 })}
-              <Button
-                variant="outline"
-                size="sm"
-                className="ml-4 border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100"
-              >
-                <Rocket className="mr-1 h-4 w-4" />
-                Deploy
-              </Button>
+              {isDev && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="ml-4 border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100"
+                >
+                  <Rocket className="mr-1 h-4 w-4" />
+                  Deploy
+                </Button>
+              )}
             </div>
           )}
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -554,3 +554,36 @@ export interface NoteTemplateCreate {
   project_type_slugs?: string[]
   sort_order?: number
 }
+
+// Releases
+export type DeploymentStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'success'
+  | 'failed'
+  | 'rolled_back'
+
+export interface ReleaseLink {
+  type: string
+  url: string
+  label?: string | null
+}
+
+export interface Release {
+  id: string
+  project_id: string
+  version: string
+  title: string
+  description?: string | null
+  links: ReleaseLink[]
+  created_at: string
+  updated_at?: string | null
+  created_by: string
+}
+
+export interface CurrentReleaseEnvironment {
+  environment: { slug: string; name: string }
+  release: Release | null
+  current_status: DeploymentStatus | null
+  last_event_at: string | null
+}


### PR DESCRIPTION
## Summary

Replaces the dev-only `deploymentStatus` mock in `ProjectDetail` with a `useQuery` against the new `GET /releases/current` endpoint (imbi-api#246). Real data now drives both the Environments card version column and the deployment-pipeline header chips.

## Why

The card shape — `{version, status, updated}` per environment — was already in place but only populated from a hardcoded dev-only object. With the API now able to return the latest deployment event per environment, we can render real state.

## Changes

- `src/api/endpoints.ts`: new `listCurrentReleases(orgSlug, projectId, signal)`.
- `src/types/index.ts`: hand-rolled `CurrentReleaseEnvironment`, `Release`, `ReleaseLink`, `DeploymentStatus`. The `api-generated.ts` snapshot will pick up matching backend schemas on the next `npm run codegen:fetch`.
- `src/components/ProjectDetail.tsx`: replaces the mock with a query keyed on `['currentReleases', orgSlug, project.id]`; maps response into the existing display shape via `formatDistanceToNow`. Header pipeline now renders whenever real data exists; the unimplemented Deploy button stays gated to dev.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Load a project page with populated releases and verify the env card + header pipeline reflect the latest deployment events
- [ ] Verify env rows with no deployments still render (blank version, dash for url) — outer join in the API ensures the env appears in the response

## Depends on

- imbi-api#246 (the `/releases/current` endpoint must be deployed for this to render data; otherwise the card silently stays empty)