### PR TITLE
Add OAuth 2.0 fields to ThirdPartyService UI; move callback_url to ApplicationForm

### DIFF
--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -55,6 +55,9 @@ export function OAuth2ApplicationForm({
   const [applicationUrl, setApplicationUrl] = useState(
     application?.application_url || '',
   )
+  const [callbackUrl, setCallbackUrl] = useState(
+    application?.callback_url || '',
+  )
   const [clientId, setClientId] = useState(application?.client_id || '')
   const [scopes, setScopes] = useState(application?.scopes?.join(', ') || '')
   const [status, setStatus] = useState<AppStatus>(
@@ -100,6 +103,7 @@ export function OAuth2ApplicationForm({
       const data: ServiceApplicationUpdate = {
         app_type: appType,
         application_url: applicationUrl || null,
+        callback_url: callbackUrl || null,
         client_id: clientId,
         description: description || null,
         name,
@@ -117,6 +121,7 @@ export function OAuth2ApplicationForm({
       const data: ServiceApplicationCreate = {
         app_type: appType,
         application_url: applicationUrl || null,
+        callback_url: callbackUrl || null,
         client_id: clientId,
         client_secret: clientSecret,
         description: description || null,
@@ -207,14 +212,25 @@ export function OAuth2ApplicationForm({
           />
         </div>
 
-        <div>
-          <label className={labelClass}>Application URL</label>
-          <Input
-            className={inputClass}
-            onChange={(e) => setApplicationUrl(e.target.value)}
-            placeholder="https://github.com/settings/apps/my-app"
-            value={applicationUrl}
-          />
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className={labelClass}>Application URL</label>
+            <Input
+              className={inputClass}
+              onChange={(e) => setApplicationUrl(e.target.value)}
+              placeholder="https://github.com/settings/apps/my-app"
+              value={applicationUrl}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Callback URL</label>
+            <Input
+              className={inputClass}
+              onChange={(e) => setCallbackUrl(e.target.value)}
+              placeholder="https://app.example.com/auth/callback"
+              value={callbackUrl}
+            />
+          </div>
         </div>
 
         <div className="grid grid-cols-2 gap-4">

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -102,8 +102,8 @@ export function OAuth2ApplicationForm({
     if (isEdit) {
       const data: ServiceApplicationUpdate = {
         app_type: appType,
-        application_url: applicationUrl || null,
-        callback_url: callbackUrl || null,
+        application_url: applicationUrl.trim() || null,
+        callback_url: callbackUrl.trim() || null,
         client_id: clientId,
         description: description || null,
         name,
@@ -120,8 +120,8 @@ export function OAuth2ApplicationForm({
     } else {
       const data: ServiceApplicationCreate = {
         app_type: appType,
-        application_url: applicationUrl || null,
-        callback_url: callbackUrl || null,
+        application_url: applicationUrl.trim() || null,
+        callback_url: callbackUrl.trim() || null,
         client_id: clientId,
         client_secret: clientSecret,
         description: description || null,

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -212,7 +212,7 @@ export function OAuth2ApplicationForm({
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div>
             <label className={labelClass}>Application URL</label>
             <Input

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -189,7 +189,7 @@ export function ThirdPartyServiceDetail({
                 <CardTitle>OAuth 2.0 Configuration</CardTitle>
               </CardHeader>
               <CardContent className="p-6">
-                <div className="grid grid-cols-2 gap-6">
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                   {service.api_endpoint && (
                     <div>
                       <div className="text-sm text-secondary">API Endpoint</div>

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -40,6 +40,12 @@ export function ThirdPartyServiceDetail({
   const statusVariant = statusBadgeVariant(service.status)
   const linkEntries = Object.entries(service.links || {})
   const identifierEntries = Object.entries(service.identifiers || {})
+  const hasOAuthConfig =
+    service.api_endpoint ||
+    service.authorization_endpoint ||
+    service.token_endpoint ||
+    service.revoke_endpoint ||
+    service.use_pkce != null
 
   const tabs: { icon: typeof Info; id: DetailTab; label: string }[] = [
     { icon: Info, id: 'details', label: 'Details' },
@@ -175,6 +181,97 @@ export function ThirdPartyServiceDetail({
               </div>
             </CardContent>
           </Card>
+
+          {/* OAuth 2.0 Configuration */}
+          {hasOAuthConfig && (
+            <Card>
+              <CardHeader className="px-6 pb-0 pt-5">
+                <CardTitle>OAuth 2.0 Configuration</CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                <div className="grid grid-cols-2 gap-6">
+                  {service.api_endpoint && (
+                    <div>
+                      <div className="text-sm text-secondary">API Endpoint</div>
+                      <div className="mt-1">
+                        <a
+                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                          href={service.api_endpoint}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          {service.api_endpoint}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    </div>
+                  )}
+                  {service.authorization_endpoint && (
+                    <div>
+                      <div className="text-sm text-secondary">
+                        Authorization Endpoint
+                      </div>
+                      <div className="mt-1">
+                        <a
+                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                          href={service.authorization_endpoint}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          {service.authorization_endpoint}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    </div>
+                  )}
+                  {service.token_endpoint && (
+                    <div>
+                      <div className="text-sm text-secondary">
+                        Token Endpoint
+                      </div>
+                      <div className="mt-1">
+                        <a
+                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                          href={service.token_endpoint}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          {service.token_endpoint}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    </div>
+                  )}
+                  {service.revoke_endpoint && (
+                    <div>
+                      <div className="text-sm text-secondary">
+                        Revoke Endpoint
+                      </div>
+                      <div className="mt-1">
+                        <a
+                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                          href={service.revoke_endpoint}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          {service.revoke_endpoint}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    </div>
+                  )}
+                  {service.use_pkce != null && (
+                    <div>
+                      <div className="text-sm text-secondary">Use PKCE</div>
+                      <div className="mt-1 text-primary">
+                        {service.use_pkce ? 'Yes' : 'No'}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
 
           {/* Links */}
           {linkEntries.length > 0 && (

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -164,15 +164,21 @@ export function ThirdPartyServiceDetail({
                   <div className="text-sm text-secondary">Service URL</div>
                   <div className="mt-1">
                     {service.service_url ? (
-                      <a
-                        className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
-                        href={service.service_url}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        {service.service_url}
-                        <ExternalLink className="h-3 w-3" />
-                      </a>
+                      isSafeUrl(service.service_url) ? (
+                        <a
+                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                          href={service.service_url}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          {service.service_url}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 text-sm">
+                          {service.service_url}
+                        </span>
+                      )
                     ) : (
                       <span className="text-tertiary">Not set</span>
                     )}
@@ -309,15 +315,21 @@ export function ThirdPartyServiceDetail({
                     <div key={label}>
                       <div className="text-sm text-secondary">{label}</div>
                       <div className="mt-1">
-                        <a
-                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
-                          href={String(url)}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          {String(url)}
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
+                        {isSafeUrl(String(url)) ? (
+                          <a
+                            className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                            href={String(url)}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            {String(url)}
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-sm">
+                            {String(url)}
+                          </span>
+                        )}
                       </div>
                     </div>
                   ))}

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -194,15 +194,21 @@ export function ThirdPartyServiceDetail({
                     <div>
                       <div className="text-sm text-secondary">API Endpoint</div>
                       <div className="mt-1">
-                        <a
-                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
-                          href={service.api_endpoint}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          {service.api_endpoint}
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
+                        {isSafeUrl(service.api_endpoint) ? (
+                          <a
+                            className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                            href={service.api_endpoint}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            {service.api_endpoint}
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-sm">
+                            {service.api_endpoint}
+                          </span>
+                        )}
                       </div>
                     </div>
                   )}
@@ -212,15 +218,21 @@ export function ThirdPartyServiceDetail({
                         Authorization Endpoint
                       </div>
                       <div className="mt-1">
-                        <a
-                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
-                          href={service.authorization_endpoint}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          {service.authorization_endpoint}
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
+                        {isSafeUrl(service.authorization_endpoint) ? (
+                          <a
+                            className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                            href={service.authorization_endpoint}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            {service.authorization_endpoint}
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-sm">
+                            {service.authorization_endpoint}
+                          </span>
+                        )}
                       </div>
                     </div>
                   )}
@@ -230,15 +242,21 @@ export function ThirdPartyServiceDetail({
                         Token Endpoint
                       </div>
                       <div className="mt-1">
-                        <a
-                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
-                          href={service.token_endpoint}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          {service.token_endpoint}
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
+                        {isSafeUrl(service.token_endpoint) ? (
+                          <a
+                            className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                            href={service.token_endpoint}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            {service.token_endpoint}
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-sm">
+                            {service.token_endpoint}
+                          </span>
+                        )}
                       </div>
                     </div>
                   )}
@@ -248,15 +266,21 @@ export function ThirdPartyServiceDetail({
                         Revoke Endpoint
                       </div>
                       <div className="mt-1">
-                        <a
-                          className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
-                          href={service.revoke_endpoint}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          {service.revoke_endpoint}
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
+                        {isSafeUrl(service.revoke_endpoint) ? (
+                          <a
+                            className="hover:text-info/80 inline-flex items-center gap-1 text-sm text-info"
+                            href={service.revoke_endpoint}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            {service.revoke_endpoint}
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-sm">
+                            {service.revoke_endpoint}
+                          </span>
+                        )}
                       </div>
                     </div>
                   )}
@@ -350,4 +374,13 @@ export function ThirdPartyServiceDetail({
       )}
     </div>
   )
+}
+
+function isSafeUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
 }

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -9,6 +9,13 @@ import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
 import { KeyValueEditor } from '@/components/ui/key-value-editor'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
@@ -106,7 +113,8 @@ export function ThirdPartyServiceForm({
       ['revoke_endpoint', revokeEndpoint],
     ]
     for (const [field, value] of urlFields) {
-      if (value.trim() && !/^https?:\/\/.+/.test(value.trim())) {
+      const trimmed = value.trim()
+      if (trimmed && !/^https?:\/\/.+/.test(trimmed)) {
         newErrors[field] =
           'Must be a valid URL starting with http:// or https://'
       }
@@ -506,21 +514,22 @@ export function ThirdPartyServiceForm({
                 <label className="mb-1.5 block text-sm text-secondary">
                   Use PKCE
                 </label>
-                <div className="flex items-center gap-3">
-                  <select
-                    className={selectClass}
-                    disabled={isLoading}
-                    onChange={(e) => {
-                      const v = e.target.value
-                      setUsePkce(v === '' ? null : v === 'true')
-                    }}
-                    value={usePkce === null ? '' : String(usePkce)}
-                  >
-                    <option value="">Not set</option>
-                    <option value="true">Yes</option>
-                    <option value="false">No</option>
-                  </select>
-                </div>
+                <Select
+                  disabled={isLoading}
+                  onValueChange={(v) =>
+                    setUsePkce(v === 'unset' ? null : v === 'true')
+                  }
+                  value={usePkce === null ? 'unset' : String(usePkce)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Not set" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="unset">Not set</SelectItem>
+                    <SelectItem value="true">Yes</SelectItem>
+                    <SelectItem value="false">No</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
             </div>
           </div>

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -46,6 +46,19 @@ export function ThirdPartyServiceForm({
   const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [vendor, setVendor] = useState(service?.vendor || '')
   const [serviceUrl, setServiceUrl] = useState(service?.service_url || '')
+  const [apiEndpoint, setApiEndpoint] = useState(service?.api_endpoint || '')
+  const [authorizationEndpoint, setAuthorizationEndpoint] = useState(
+    service?.authorization_endpoint || '',
+  )
+  const [tokenEndpoint, setTokenEndpoint] = useState(
+    service?.token_endpoint || '',
+  )
+  const [revokeEndpoint, setRevokeEndpoint] = useState(
+    service?.revoke_endpoint || '',
+  )
+  const [usePkce, setUsePkce] = useState<boolean | null>(
+    service?.use_pkce ?? null,
+  )
   const [category, setCategory] = useState(service?.category || '')
   const [status, setStatus] = useState<
     'active' | 'deprecated' | 'evaluating' | 'inactive'
@@ -86,6 +99,17 @@ export function ThirdPartyServiceForm({
       newErrors.service_url =
         'Must be a valid URL starting with http:// or https://'
     }
+    const urlFields: Array<[string, string]> = [
+      ['api_endpoint', apiEndpoint],
+      ['authorization_endpoint', authorizationEndpoint],
+      ['token_endpoint', tokenEndpoint],
+      ['revoke_endpoint', revokeEndpoint],
+    ]
+    for (const [field, value] of urlFields) {
+      if (value && !/^https?:\/\/.+/.test(value)) {
+        newErrors[field] = 'Must be a valid URL starting with http:// or https://'
+      }
+    }
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
   }
@@ -94,16 +118,21 @@ export function ThirdPartyServiceForm({
     if (!validate()) return
 
     onSave({
+      api_endpoint: apiEndpoint.trim() || null,
+      authorization_endpoint: authorizationEndpoint.trim() || null,
       category: category.trim() || null,
       description: description.trim() || null,
       icon: icon.trim() || null,
       identifiers,
       links: links as Record<string, string>,
       name: name.trim(),
+      revoke_endpoint: revokeEndpoint.trim() || null,
       service_url: serviceUrl.trim() || null,
       slug: slug.trim(),
       status,
       team_slug: teamSlug || null,
+      token_endpoint: tokenEndpoint.trim() || null,
+      use_pkce: usePkce,
       vendor: vendor.trim(),
     })
   }
@@ -375,6 +404,121 @@ export function ThirdPartyServiceForm({
                         : ''
                     }
                   />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* OAuth 2.0 Configuration */}
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h3 className="mb-4 text-sm font-medium text-primary">
+            OAuth 2.0 Configuration
+          </h3>
+          <p className="mb-4 text-sm text-secondary">
+            Optional OAuth 2.0 endpoints and settings for this service.
+          </p>
+
+          <div className="space-y-4">
+            <div>
+              <label className="mb-1.5 block text-sm text-secondary">
+                API Endpoint
+              </label>
+              <Input
+                className={errors.api_endpoint ? 'border-danger' : ''}
+                disabled={isLoading}
+                onChange={(e) => setApiEndpoint(e.target.value)}
+                placeholder="https://api.example.com"
+                value={apiEndpoint}
+              />
+              {errors.api_endpoint && (
+                <div className="mt-1 flex items-center gap-1 text-xs text-danger">
+                  <AlertCircle className="h-3 w-3" />
+                  {errors.api_endpoint}
+                </div>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Authorization Endpoint
+                </label>
+                <Input
+                  className={
+                    errors.authorization_endpoint ? 'border-danger' : ''
+                  }
+                  disabled={isLoading}
+                  onChange={(e) => setAuthorizationEndpoint(e.target.value)}
+                  placeholder="https://auth.example.com/authorize"
+                  value={authorizationEndpoint}
+                />
+                {errors.authorization_endpoint && (
+                  <div className="mt-1 flex items-center gap-1 text-xs text-danger">
+                    <AlertCircle className="h-3 w-3" />
+                    {errors.authorization_endpoint}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Token Endpoint
+                </label>
+                <Input
+                  className={errors.token_endpoint ? 'border-danger' : ''}
+                  disabled={isLoading}
+                  onChange={(e) => setTokenEndpoint(e.target.value)}
+                  placeholder="https://auth.example.com/token"
+                  value={tokenEndpoint}
+                />
+                {errors.token_endpoint && (
+                  <div className="mt-1 flex items-center gap-1 text-xs text-danger">
+                    <AlertCircle className="h-3 w-3" />
+                    {errors.token_endpoint}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Revoke Endpoint
+                </label>
+                <Input
+                  className={errors.revoke_endpoint ? 'border-danger' : ''}
+                  disabled={isLoading}
+                  onChange={(e) => setRevokeEndpoint(e.target.value)}
+                  placeholder="https://auth.example.com/revoke"
+                  value={revokeEndpoint}
+                />
+                {errors.revoke_endpoint && (
+                  <div className="mt-1 flex items-center gap-1 text-xs text-danger">
+                    <AlertCircle className="h-3 w-3" />
+                    {errors.revoke_endpoint}
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-col justify-center">
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Use PKCE
+                </label>
+                <div className="flex items-center gap-3">
+                  <select
+                    className={selectClass}
+                    disabled={isLoading}
+                    onChange={(e) => {
+                      const v = e.target.value
+                      setUsePkce(v === '' ? null : v === 'true')
+                    }}
+                    value={usePkce === null ? '' : String(usePkce)}
+                  >
+                    <option value="">Not set</option>
+                    <option value="true">Yes</option>
+                    <option value="false">No</option>
+                  </select>
                 </div>
               </div>
             </div>

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -106,8 +106,9 @@ export function ThirdPartyServiceForm({
       ['revoke_endpoint', revokeEndpoint],
     ]
     for (const [field, value] of urlFields) {
-      if (value && !/^https?:\/\/.+/.test(value)) {
-        newErrors[field] = 'Must be a valid URL starting with http:// or https://'
+      if (value.trim() && !/^https?:\/\/.+/.test(value.trim())) {
+        newErrors[field] =
+          'Must be a valid URL starting with http:// or https://'
       }
     }
     setErrors(newErrors)

--- a/src/types/api-generated.ts
+++ b/src/types/api-generated.ts
@@ -4405,6 +4405,8 @@ export interface components {
             app_type: string;
             /** Application Url */
             application_url?: string | null;
+            /** Callback Url */
+            callback_url?: string | null;
             /** Client Id */
             client_id: string;
             /** Client Secret */
@@ -4443,6 +4445,8 @@ export interface components {
             app_type: string;
             /** Application Url */
             application_url?: string | null;
+            /** Callback Url */
+            callback_url?: string | null;
             /** Client Id */
             client_id: string;
             /**
@@ -4506,6 +4510,8 @@ export interface components {
             app_type: string;
             /** Application Url */
             application_url?: string | null;
+            /** Callback Url */
+            callback_url?: string | null;
             /** Client Id */
             client_id: string;
             /** Scopes */
@@ -4582,6 +4588,16 @@ export interface components {
             icon?: string | null;
             /** Service Url */
             service_url?: string | null;
+            /** Api Endpoint */
+            api_endpoint?: string | null;
+            /** Authorization Endpoint */
+            authorization_endpoint?: string | null;
+            /** Token Endpoint */
+            token_endpoint?: string | null;
+            /** Revoke Endpoint */
+            revoke_endpoint?: string | null;
+            /** Use Pkce */
+            use_pkce?: boolean | null;
             /** Category */
             category?: string | null;
             /**
@@ -4616,6 +4632,16 @@ export interface components {
             icon?: string | null;
             /** Service Url */
             service_url?: string | null;
+            /** Api Endpoint */
+            api_endpoint?: string | null;
+            /** Authorization Endpoint */
+            authorization_endpoint?: string | null;
+            /** Token Endpoint */
+            token_endpoint?: string | null;
+            /** Revoke Endpoint */
+            revoke_endpoint?: string | null;
+            /** Use Pkce */
+            use_pkce?: boolean | null;
             /** Category */
             category?: string | null;
             /**
@@ -4671,6 +4697,16 @@ export interface components {
             icon?: string | null;
             /** Service Url */
             service_url?: string | null;
+            /** Api Endpoint */
+            api_endpoint?: string | null;
+            /** Authorization Endpoint */
+            authorization_endpoint?: string | null;
+            /** Token Endpoint */
+            token_endpoint?: string | null;
+            /** Revoke Endpoint */
+            revoke_endpoint?: string | null;
+            /** Use Pkce */
+            use_pkce?: boolean | null;
             /** Category */
             category?: string | null;
             /**


### PR DESCRIPTION
## Summary

Adds OAuth 2.0 configuration fields to the third-party service create/edit form and detail view, and moves `callback_url` to the service application form where it belongs.

## Problem

The Imbi API now supports `api_endpoint`, `authorization_endpoint`, `token_endpoint`, `revoke_endpoint`, and `use_pkce` on `ThirdPartyService`, and `callback_url` on `ServiceApplication`. The UI had no way to set or view any of these fields.

## Solution

**ThirdPartyServiceForm**: Added an "OAuth 2.0 Configuration" section with URL inputs for the four endpoint fields and a Yes/No/Not-set select for `use_pkce`. All URL fields validate the `http(s)://` format before submitting.

**ThirdPartyServiceDetail**: Added an "OAuth 2.0 Configuration" card in the Details tab that renders only when at least one OAuth field is set, showing endpoints as external links and `use_pkce` as Yes/No.

**OAuth2ApplicationForm**: Added a `callback_url` input alongside `application_url`, included in both create and edit payloads.

**api-generated.ts**: Updated `ThirdPartyServiceCreate`, `ThirdPartyServiceResponse`, `ThirdPartyServiceUpdate`, `ServiceApplicationCreate`, `ServiceApplicationResponse`, and `ServiceApplicationUpdate` to reflect the new field layout.

## Impact

UI-only change; no new API calls. All new fields are optional and default to empty/unset. Existing services and applications display and edit as before.