### PR TITLE
Route upload icon URLs through VITE_API_URL

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,10 @@
 import { useAuthStore } from '@/stores/authStore'
 import type { TokenResponse } from '@/types'
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api'
+export const API_BASE_URL = import.meta.env.VITE_API_URL
+
+export const apiUrl = (path: string): string =>
+  path.startsWith('/') ? `${API_BASE_URL}${path}` : `${API_BASE_URL}/${path}`
 
 export class ApiError<T = unknown> extends Error {
   readonly data: T | undefined

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,6 +2,9 @@ import { useAuthStore } from '@/stores/authStore'
 import type { TokenResponse } from '@/types'
 
 export const API_BASE_URL = import.meta.env.VITE_API_URL
+if (!API_BASE_URL) {
+  throw new Error('VITE_API_URL is required')
+}
 
 export const apiUrl = (path: string): string =>
   path.startsWith('/') ? `${API_BASE_URL}${path}` : `${API_BASE_URL}/${path}`

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -64,7 +64,7 @@ import type {
   WebhookCreate,
 } from '@/types'
 
-import { apiClient } from './client'
+import { apiClient, apiUrl } from './client'
 
 // Re-export for backward compatibility with modules that import from here.
 export type { PatchOperation }
@@ -1010,15 +1010,11 @@ export const uploadFile = (file: File): Promise<Upload> => {
   return apiClient.postFormData<Upload>('/uploads/', formData)
 }
 
-export const getUploadUrl = (id: string): string => {
-  const baseUrl = import.meta.env.VITE_API_URL || '/api'
-  return `${baseUrl}/uploads/${encodeURIComponent(id)}`
-}
+export const getUploadUrl = (id: string): string =>
+  apiUrl(`/uploads/${encodeURIComponent(id)}`)
 
-export const getUploadThumbnailUrl = (id: string): string => {
-  const baseUrl = import.meta.env.VITE_API_URL || '/api'
-  return `${baseUrl}/uploads/${encodeURIComponent(id)}/thumbnail`
-}
+export const getUploadThumbnailUrl = (id: string): string =>
+  apiUrl(`/uploads/${encodeURIComponent(id)}/thumbnail`)
 
 export const deleteUpload = (id: string) =>
   apiClient.delete<void>(`/uploads/${encodeURIComponent(id)}`)

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,8 @@ import logoLight from '@/assets/logo-light.svg'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useAuth } from '@/hooks/useAuth'
+import { useIcon } from '@/lib/icons'
+import type { Organization } from '@/types'
 import { UserResponse } from '@/types'
 
 import { Button } from './ui/button'
@@ -158,15 +160,10 @@ export function Navigation({
                 size="sm"
                 variant="outline"
               >
-                {selectedOrganization.icon ? (
-                  <img
-                    alt=""
-                    className="h-4 w-4 flex-shrink-0 rounded object-cover"
-                    src={selectedOrganization.icon}
-                  />
-                ) : (
-                  <Building2 className="h-4 w-4 flex-shrink-0" />
-                )}
+                <OrgIcon
+                  className="h-4 w-4 flex-shrink-0 rounded object-cover"
+                  org={selectedOrganization}
+                />
                 <span className="truncate">{selectedOrganization.name}</span>
               </Button>
             ) : (
@@ -177,15 +174,10 @@ export function Navigation({
                     size="sm"
                     variant="outline"
                   >
-                    {selectedOrganization.icon ? (
-                      <img
-                        alt=""
-                        className="h-4 w-4 flex-shrink-0 rounded object-cover"
-                        src={selectedOrganization.icon}
-                      />
-                    ) : (
-                      <Building2 className="h-4 w-4 flex-shrink-0" />
-                    )}
+                    <OrgIcon
+                      className="h-4 w-4 flex-shrink-0 rounded object-cover"
+                      org={selectedOrganization}
+                    />
                     <span className="truncate">
                       {selectedOrganization.name}
                     </span>
@@ -204,15 +196,10 @@ export function Navigation({
                       onClick={() => setSelectedOrganization(org)}
                     >
                       <div className="flex items-center gap-2">
-                        {org.icon ? (
-                          <img
-                            alt=""
-                            className="h-4 w-4 flex-shrink-0 rounded object-cover"
-                            src={org.icon}
-                          />
-                        ) : (
-                          <Building2 className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
-                        )}
+                        <OrgIcon
+                          className="h-4 w-4 flex-shrink-0 rounded object-cover"
+                          org={org}
+                        />
                         <div className="flex flex-col">
                           <span>{org.name}</span>
                           <span className="text-xs text-muted-foreground">
@@ -314,4 +301,9 @@ export function Navigation({
       </div>
     </nav>
   )
+}
+
+function OrgIcon({ className, org }: { className: string; org: Organization }) {
+  const Icon = useIcon(org.icon ?? null, Building2)
+  return <Icon className={className} />
 }

--- a/src/components/admin/project-types/ProjectTypeDetail.tsx
+++ b/src/components/admin/project-types/ProjectTypeDetail.tsx
@@ -44,16 +44,9 @@ export function ProjectTypeDetail({
         <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
           <div>
             <div className="flex items-center gap-3">
-              {projectType.icon &&
-                (projectType.icon.startsWith('/uploads/') ? (
-                  <img
-                    alt=""
-                    className="h-8 w-8 rounded object-cover"
-                    src={projectType.icon}
-                  />
-                ) : HeaderIcon ? (
-                  <HeaderIcon className="h-8 w-8" />
-                ) : null)}
+              {projectType.icon && HeaderIcon ? (
+                <HeaderIcon className="h-8 w-8" />
+              ) : null}
               <CardTitle>{projectType.name}</CardTitle>
             </div>
             {projectType.description && (

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -2,6 +2,7 @@ import { useSyncExternalStore } from 'react'
 
 import { ExternalLink } from 'lucide-react'
 
+import { apiUrl } from '@/api/client'
 import { iconRegistry } from '@/lib/icon-registry'
 import type { IconComponent } from '@/lib/icon-registry'
 import { createImgComponent } from '@/lib/icon-sets/utils'
@@ -132,11 +133,10 @@ export function getIcon(
   if (!iconName) return fb
 
   // Uploaded files or absolute URLs → render as <img>
-  if (
-    iconName.startsWith('/uploads/') ||
-    iconName.startsWith('http://') ||
-    iconName.startsWith('https://')
-  ) {
+  if (iconName.startsWith('/uploads/')) {
+    return createImgComponent(apiUrl(iconName))
+  }
+  if (iconName.startsWith('http://') || iconName.startsWith('https://')) {
     return createImgComponent(iconName)
   }
 
@@ -222,8 +222,7 @@ export function useIconUrl(
 
 function computeIconUrl(iconName: string, color?: string): null | string {
   if (iconName.startsWith('/uploads/')) {
-    const baseUrl = import.meta.env.VITE_API_URL || '/api'
-    return `${baseUrl}${iconName}`
+    return apiUrl(iconName)
   }
   if (iconName.startsWith('http://') || iconName.startsWith('https://')) {
     return iconName

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,10 @@ import '@testing-library/jest-dom'
 import { cleanup } from '@testing-library/react'
 import { afterEach, vi } from 'vitest'
 
+// VITE_API_URL is required by src/api/client.ts at module load. Stub a value
+// for tests so the fail-fast guard does not abort suite initialization.
+vi.stubEnv('VITE_API_URL', 'http://localhost:8000')
+
 afterEach(() => {
   cleanup()
 })

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,7 +6,7 @@ interface ImportMeta {
 
 interface ImportMetaEnv {
   readonly VITE_API_TOKEN?: string
-  readonly VITE_API_URL?: string
+  readonly VITE_API_URL: string
   readonly VITE_OAUTH_CLIENT_ID?: string
   readonly VITE_OAUTH_REDIRECT_URI?: string
 }


### PR DESCRIPTION
## Summary
- Adds `apiUrl(path)` helper in `api/client.ts`; `getUploadUrl`/`getUploadThumbnailUrl` and the upload-rendering paths in `lib/icons.ts` use it instead of duplicating `import.meta.env.VITE_API_URL || '/api'`.
- Drops the `|| '/api'` fallback so `VITE_API_URL` is the single authoritative source (matches how `IMBI_API_API_PREFIX` is treated server-side); marks the env var required in `vite-env.d.ts`.
- Replaces ad-hoc `<img src={org.icon}>` in `Navigation.tsx` and `<img src={projectType.icon}>` in `ProjectTypeDetail.tsx` with `useIcon`, so upload paths flow through `apiUrl()` and icon-set names render the proper components.

## Why
With AWeber-Imbi/imbi-api#252, `/uploads` now lives under the API prefix. Components that render `org.icon` / `projectType.icon` as raw `<img src>` were 404'ing because the stored value is `/uploads/{id}`, not `/api/uploads/{id}`.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [ ] Verify upload-icon thumbnails render in the org switcher and project-type detail in the Okteto deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)