### PR TITLE
Webhook UI: system-generated slugs, nanoid id field

### DIFF
--- a/src/components/admin/WebhookManagement.tsx
+++ b/src/components/admin/WebhookManagement.tsx
@@ -18,7 +18,7 @@ import type { PatchOperation, Webhook, WebhookCreate } from '@/types'
 
 import { AdminSection } from './AdminSection'
 import { WebhookDetail } from './webhooks/WebhookDetail'
-import { WebhookForm } from './webhooks/WebhookForm'
+import { WebhookForm, type WebhookSaveData } from './webhooks/WebhookForm'
 
 export function WebhookManagement() {
   const { selectedOrganization } = useOrganization()
@@ -51,16 +51,16 @@ export function WebhookManagement() {
       return createWebhook(orgSlug, data)
     },
     deleteErrorLabel: 'webhook',
-    deleteFn: (slug) => {
+    deleteFn: (webhookSlug) => {
       if (!orgSlug) throw new Error('No organization selected')
-      return deleteWebhook(orgSlug, slug)
+      return deleteWebhook(orgSlug, webhookSlug)
     },
     listFn: orgSlug ? (signal) => listWebhooks(orgSlug, signal) : null,
     onMutationSuccess: goToList,
     queryKey: ['webhooks', orgSlug],
-    updateFn: ({ operations, slug }) => {
+    updateFn: ({ operations, slug: webhookSlug }) => {
       if (!orgSlug) throw new Error('No organization selected')
-      return updateWebhook(orgSlug, slug, operations)
+      return updateWebhook(orgSlug, webhookSlug, operations)
     },
   })
 
@@ -86,14 +86,20 @@ export function WebhookManagement() {
     deleteMutation.mutate(wh.slug)
   }
 
-  const handleSave = (data: WebhookCreate) => {
+  const handleSave = (data: WebhookSaveData) => {
     if (viewMode === 'create') {
-      createMutation.mutate(data)
+      // slug is not included in create payload — it's system-generated.
+      const { slug: _slug, ...createData } = data
+      createMutation.mutate(createData)
     } else if (selectedSlug && selectedWebhook) {
+      // diff against all editable fields, including slug.
+      const fields = Object.keys(data).filter(
+        (k) => k !== 'id' && k !== 'notification_path',
+      )
       const operations = buildDiffPatch(
         selectedWebhook as unknown as Record<string, unknown>,
         data as unknown as Record<string, unknown>,
-        { fields: Object.keys(data) },
+        { fields },
       )
       if (operations.length === 0) {
         goToList()

--- a/src/components/admin/third-party-services/ServiceWebhookList.tsx
+++ b/src/components/admin/third-party-services/ServiceWebhookList.tsx
@@ -27,7 +27,7 @@ import { buildDiffPatch } from '@/lib/json-patch'
 import type { PatchOperation, WebhookCreate } from '@/types'
 
 import { WebhookDetail } from '../webhooks/WebhookDetail'
-import { WebhookForm } from '../webhooks/WebhookForm'
+import { WebhookForm, type WebhookSaveData } from '../webhooks/WebhookForm'
 
 interface ServiceWebhookListProps {
   onViewModeChange?: (mode: ViewMode) => void
@@ -141,17 +141,22 @@ export function ServiceWebhookList({
     }
   }
 
-  const handleSave = (data: WebhookCreate) => {
+  const handleSave = (data: WebhookSaveData) => {
     if (viewMode === 'create') {
+      // slug is system-generated on create; third_party_service_slug is forced.
+      const { slug: _slug, ...createData } = data
       createMutation.mutate({
-        ...data,
+        ...createData,
         third_party_service_slug: serviceSlug,
       })
     } else if (selectedSlug && selectedWebhook) {
+      const fields = Object.keys(data).filter(
+        (k) => k !== 'id' && k !== 'notification_path',
+      )
       const operations = buildDiffPatch(
         selectedWebhook as unknown as Record<string, unknown>,
         data as unknown as Record<string, unknown>,
-        { fields: Object.keys(data) },
+        { fields },
       )
       if (operations.length === 0) {
         setViewMode('list')

--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -67,10 +67,10 @@ export function WebhookDetail({ onBack, onEdit, webhook }: WebhookDetailProps) {
         <CardContent>
           <div className="grid grid-cols-2 gap-6">
             <div>
-              <div className="text-sm text-secondary">Slug</div>
+              <div className="text-sm text-secondary">ID</div>
               <div className="mt-1">
                 <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
-                  {webhook.slug}
+                  {webhook.id}
                 </code>
               </div>
             </div>
@@ -79,6 +79,14 @@ export function WebhookDetail({ onBack, onEdit, webhook }: WebhookDetailProps) {
               <div className="mt-1">
                 <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
                   {webhook.notification_path}
+                </code>
+              </div>
+            </div>
+            <div>
+              <div className="text-sm text-secondary">Slug</div>
+              <div className="mt-1">
+                <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
+                  {webhook.slug}
                 </code>
               </div>
             </div>

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -72,8 +72,8 @@ export function WebhookForm({
   // service+name pair (mirrors _compute_webhook_slug in the API).
   const computePreviewSlug = (svc: string, n: string) => {
     const namePart = slugify(n)
-    if (svc) return `${svc}-${namePart}`.slice(0, 64)
-    return namePart.slice(0, 64)
+    if (svc) return `${svc}-${namePart}`.slice(0, 64).replace(/-+$/, '')
+    return namePart.slice(0, 64).replace(/-+$/, '')
   }
 
   const validate = () => {

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -17,6 +17,9 @@ import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
 import type { Webhook, WebhookCreate, WebhookRule } from '@/types'
 
+/** WebhookCreate plus an optional slug included only when editing. */
+export type WebhookSaveData = WebhookCreate & { slug?: string }
+
 type RuleDraft = WebhookRule & { _clientId: string }
 
 interface WebhookFormProps {
@@ -24,7 +27,7 @@ interface WebhookFormProps {
   error?: ApiError<{ detail?: string }> | Error | null
   isLoading?: boolean
   onCancel: () => void
-  onSave: (data: WebhookCreate) => void
+  onSave: (data: WebhookSaveData) => void
   webhook: null | Webhook
 }
 
@@ -45,9 +48,6 @@ export function WebhookForm({
   const [description, setDescription] = useState(webhook?.description || '')
   const [icon, setIcon] = useState(webhook?.icon || '')
   const handleIconChange = useIconWithCleanup(icon, setIcon)
-  const [notificationPath, setNotificationPath] = useState(
-    webhook?.notification_path || '/',
-  )
   const [secret, setSecret] = useState('')
   const [tpsSlug, setTpsSlug] = useState(
     (webhook?.third_party_service?.slug as string | undefined) ||
@@ -68,18 +68,23 @@ export function WebhookForm({
     queryKey: ['third-party-services', orgSlug],
   })
 
+  // Compute what the auto-generated slug would look like for a given
+  // service+name pair (mirrors _compute_webhook_slug in the API).
+  const computePreviewSlug = (svc: string, n: string) => {
+    const namePart = slugify(n)
+    if (svc) return `${svc}-${namePart}`.slice(0, 64)
+    return namePart.slice(0, 64)
+  }
+
   const validate = () => {
     const newErrors: Record<string, string> = {}
     if (!name.trim()) newErrors.name = 'Name is required'
-    if (!slug.trim()) newErrors.slug = 'Slug is required'
-    if (slug && !/^[a-z]([a-z0-9-]*[a-z0-9])?$/.test(slug)) {
-      newErrors.slug =
-        'Slug must start with a letter and contain only lowercase letters, numbers, and hyphens'
-    }
-    if (!notificationPath.trim())
-      newErrors.notification_path = 'Notification path is required'
-    if (notificationPath && !notificationPath.startsWith('/')) {
-      newErrors.notification_path = 'Path must start with /'
+    if (isEditing) {
+      if (!slug.trim()) newErrors.slug = 'Slug is required'
+      if (slug && !/^[a-z]([a-z0-9-]*[a-z0-9])?$/.test(slug)) {
+        newErrors.slug =
+          'Slug must start with a letter and contain only lowercase letters, numbers, and hyphens'
+      }
     }
     if (identifierSelector && !tpsSlug) {
       newErrors.identifier_selector =
@@ -100,21 +105,22 @@ export function WebhookForm({
   const handleSave = () => {
     if (!validate()) return
 
-    onSave({
+    const payload: WebhookSaveData = {
       description: description.trim() || null,
       icon: icon.trim() || null,
       identifier_selector: identifierSelector.trim() || null,
       name: name.trim(),
-      notification_path: notificationPath.trim(),
       rules: rules.map((r) => ({
         filter_expression: r.filter_expression.trim(),
         handler: r.handler.trim(),
         handler_config: r.handler_config,
       })),
       secret: secret.trim() || null,
-      slug: slug.trim(),
       third_party_service_slug: tpsSlug || null,
-    })
+      // Include slug only when editing so the PATCH can update it.
+      ...(isEditing ? { slug: slug.trim() } : {}),
+    }
+    onSave(payload)
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -125,7 +131,18 @@ export function WebhookForm({
   const handleNameChange = (value: string) => {
     setName(value)
     if (!isEditing) {
-      setSlug(slugify(value))
+      // Preview only — actual slug is computed by the API on save.
+      // When editing, the slug field is directly managed by the user.
+    }
+  }
+
+  const handleServiceChange = (newTps: string) => {
+    setTpsSlug(newTps)
+    if (!newTps) setIdentifierSelector('')
+    // In edit mode, auto-update the displayed slug to the computed value
+    // so the user can see what will be saved if they don't override it.
+    if (isEditing) {
+      setSlug(computePreviewSlug(newTps, name))
     }
   }
 
@@ -212,104 +229,109 @@ export function WebhookForm({
         {/* Basic Information */}
         <Card>
           <CardContent className="space-y-4 pt-6">
-            <div
-              className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
-            >
-              <div>
-                <label className="mb-1.5 block text-sm text-secondary">
-                  Name <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  className={` ${errors.name ? 'border-red-500' : ''}`}
-                  disabled={isLoading}
-                  onChange={(e) => handleNameChange(e.target.value)}
-                  placeholder="e.g., GitHub Push Events"
-                  value={name}
-                />
-                {errors.name && (
-                  <div
-                    className={
-                      'mt-1 flex items-center gap-1 text-xs text-danger'
-                    }
-                  >
-                    <AlertCircle className="h-3 w-3" />
-                    {errors.name}
-                  </div>
-                )}
-              </div>
-
-              {!isEditing && (
-                <div>
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Slug <span className="text-red-500">*</span>
-                  </label>
-                  <Input
-                    className={` ${errors.slug ? 'border-red-500' : ''}`}
-                    disabled={isLoading}
-                    onChange={(e) => setSlug(e.target.value)}
-                    placeholder="e.g., github-push-events"
-                    value={slug}
-                  />
-                  {errors.slug && (
-                    <div
-                      className={
-                        'mt-1 flex items-center gap-1 text-xs text-danger'
-                      }
-                    >
-                      <AlertCircle className="h-3 w-3" />
-                      {errors.slug}
-                    </div>
-                  )}
+            <div>
+              <label className="mb-1.5 block text-sm text-secondary">
+                Name <span className="text-red-500">*</span>
+              </label>
+              <Input
+                className={` ${errors.name ? 'border-red-500' : ''}`}
+                disabled={isLoading}
+                onChange={(e) => handleNameChange(e.target.value)}
+                placeholder="e.g., GitHub Push Events"
+                value={name}
+              />
+              {errors.name && (
+                <div
+                  className={'mt-1 flex items-center gap-1 text-xs text-danger'}
+                >
+                  <AlertCircle className="h-3 w-3" />
+                  {errors.name}
                 </div>
+              )}
+              {!isEditing && name && (
+                <p className="mt-1 text-xs text-tertiary">
+                  Slug will be auto-generated:{' '}
+                  <code>{computePreviewSlug(tpsSlug, name)}</code>
+                </p>
               )}
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {/* Slug — only shown and editable when editing an existing webhook */}
+            {isEditing && (
               <div>
                 <label className="mb-1.5 block text-sm text-secondary">
-                  Notification Path <span className="text-red-500">*</span>
+                  Slug{' '}
+                  <span className="text-xs text-tertiary">
+                    (auto-regenerated when service changes; editable)
+                  </span>
                 </label>
                 <Input
-                  className={` ${
-                    errors.notification_path ? 'border-red-500' : ''
-                  }`}
+                  className={` ${errors.slug ? 'border-red-500' : ''}`}
                   disabled={isLoading}
-                  onChange={(e) => setNotificationPath(e.target.value)}
-                  placeholder="/webhooks/github"
-                  value={notificationPath}
+                  onChange={(e) => setSlug(e.target.value)}
+                  placeholder="e.g., github-push-events"
+                  value={slug}
                 />
-                {errors.notification_path && (
+                {errors.slug && (
                   <div
                     className={
                       'mt-1 flex items-center gap-1 text-xs text-danger'
                     }
                   >
                     <AlertCircle className="h-3 w-3" />
-                    {errors.notification_path}
+                    {errors.slug}
                   </div>
                 )}
               </div>
+            )}
 
-              <div>
-                <label className="mb-1.5 block text-sm text-secondary">
-                  Secret{' '}
-                  {isEditing && (
-                    <span className="text-xs text-tertiary">
-                      (leave blank to keep current)
-                    </span>
-                  )}
-                </label>
-                <Input
-                  className=""
-                  disabled={isLoading}
-                  onChange={(e) => setSecret(e.target.value)}
-                  placeholder={
-                    isEditing ? '(unchanged)' : 'HMAC verification secret'
-                  }
-                  type="password"
-                  value={secret}
-                />
+            {/* Read-only system fields when editing */}
+            {isEditing && webhook && (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <label className="mb-1.5 block text-sm text-secondary">
+                    ID{' '}
+                    <span className="text-xs text-tertiary">(read-only)</span>
+                  </label>
+                  <div className="rounded-lg border border-input bg-muted px-3 py-2">
+                    <code className="text-sm text-muted-foreground">
+                      {webhook.id}
+                    </code>
+                  </div>
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm text-secondary">
+                    Notification Path{' '}
+                    <span className="text-xs text-tertiary">(read-only)</span>
+                  </label>
+                  <div className="rounded-lg border border-input bg-muted px-3 py-2">
+                    <code className="text-sm text-muted-foreground">
+                      {webhook.notification_path}
+                    </code>
+                  </div>
+                </div>
               </div>
+            )}
+
+            <div>
+              <label className="mb-1.5 block text-sm text-secondary">
+                Secret{' '}
+                {isEditing && (
+                  <span className="text-xs text-tertiary">
+                    (leave blank to keep current)
+                  </span>
+                )}
+              </label>
+              <Input
+                className=""
+                disabled={isLoading}
+                onChange={(e) => setSecret(e.target.value)}
+                placeholder={
+                  isEditing ? '(unchanged)' : 'HMAC verification secret'
+                }
+                type="password"
+                value={secret}
+              />
             </div>
 
             <div>
@@ -365,7 +387,12 @@ export function WebhookForm({
           <CardContent className="space-y-4 pt-6">
             <p className="mb-4 text-sm text-secondary">
               Optionally link this webhook to a third-party service for
-              automatic project resolution.
+              automatic project resolution.{' '}
+              {isEditing && (
+                <span className="text-xs text-tertiary">
+                  Changing the service will auto-regenerate the slug.
+                </span>
+              )}
             </p>
 
             <div className="space-y-4">
@@ -376,10 +403,7 @@ export function WebhookForm({
                 <select
                   className={selectClass}
                   disabled={isLoading}
-                  onChange={(e) => {
-                    setTpsSlug(e.target.value)
-                    if (!e.target.value) setIdentifierSelector('')
-                  }}
+                  onChange={(e) => handleServiceChange(e.target.value)}
                   value={tpsSlug}
                 >
                   <option value="">None</option>
@@ -624,7 +648,6 @@ export function WebhookForm({
 }
 
 // Per-row client id so React preserves correct instances after reorder/remove.
-// crypto.randomUUID is available in modern browsers; fall back for older envs.
 function makeClientId(): string {
   if (
     typeof crypto !== 'undefined' &&

--- a/src/components/ui/inline-edit/InlineDate.tsx
+++ b/src/components/ui/inline-edit/InlineDate.tsx
@@ -54,6 +54,7 @@ export function InlineDate({
       </PopoverTrigger>
       <PopoverContent align="start" className="w-auto p-2">
         <DayPicker
+          defaultMonth={hasValid ? current : undefined}
           mode="single"
           onSelect={async (d) => {
             setOpen(false)

--- a/src/types/api-generated.ts
+++ b/src/types/api-generated.ts
@@ -4880,22 +4880,15 @@ export interface components {
         };
         /**
          * WebhookCreate
-         * @description Request model for creating a webhook.
+         * @description Request model for creating a webhook. slug, id, and notification_path are system-generated.
          */
         WebhookCreate: {
             /** Name */
             name: string;
-            /** Slug */
-            slug: string;
             /** Description */
             description?: string | null;
             /** Icon */
             icon?: string | null;
-            /**
-             * Notification Path
-             * @description URL path for receiving webhooks (must start with /)
-             */
-            notification_path: string;
             /** Secret */
             secret?: string | null;
             /** Third Party Service Slug */
@@ -4913,15 +4906,17 @@ export interface components {
          * @description Response model for a webhook.
          */
         WebhookResponse: {
+            /** Id — stable surrogate key, never changes */
+            id: string;
             /** Name */
             name: string;
-            /** Slug */
+            /** Slug — editable unique key */
             slug: string;
             /** Description */
             description?: string | null;
             /** Icon */
             icon?: string | null;
-            /** Notification Path */
+            /** Notification Path — system-generated, read-only */
             notification_path: string;
             /** Third Party Service */
             third_party_service?: {


### PR DESCRIPTION
## Summary

Updates the webhook admin UI to match the new backend contract: slugs and IDs are system-generated, not supplied by the user.

## Problem

The previous WebhookForm sent `slug` and `notification_path` in the create payload, which the API no longer accepts. The `tiny_id` field has been renamed to `id` throughout. Users also had no way to see or edit the slug after creation.

## Solution

- **Create form**: slug and notification_path inputs removed; a preview of the auto-generated slug is shown below the name field
- **Edit form**: editable slug field shown; read-only `id` and `notification_path` displayed in muted boxes; service change auto-updates the slug preview
- **TypeScript types**: `WebhookResponse.tiny_id` renamed to `id` in the generated types
- **PATCH diff**: `id` and `notification_path` excluded from the field list sent to `buildDiffPatch` (previously `tiny_id`)
- **WebhookDetail**: shows `id` in the Configuration grid (was `tiny_id`)

## Impact

Requires imbi-api PR #258 and imbi-common PR #63 to be deployed first. No user-visible regressions — the form looks the same to users, with the slug field shifting to edit-only.