### PR TITLE
Redesign user admin form

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -79,7 +79,8 @@ interface SectionDef {
 
 export function Admin() {
   const navigate = useNavigate()
-  const { section } = useParams<{ section?: string }>()
+  const { section, slug } = useParams<{ section?: string; slug?: string }>()
+  const isSubPage = !!slug
   const currentSection: AdminSection = isValidSection(section)
     ? section
     : 'blueprints'
@@ -296,9 +297,19 @@ export function Admin() {
                 {currentSectionData && (
                   <currentSectionData.icon className="h-5 w-5 text-amber-text" />
                 )}
-                <h1 className="text-xl font-semibold text-primary">
-                  {currentSectionData?.label}
-                </h1>
+                {isSubPage ? (
+                  <button
+                    className="text-xl font-semibold text-primary hover:text-amber-text"
+                    onClick={() => navigate(`/admin/${currentSection}`)}
+                    type="button"
+                  >
+                    {currentSectionData?.label}
+                  </button>
+                ) : (
+                  <h1 className="text-xl font-semibold text-primary">
+                    {currentSectionData?.label}
+                  </h1>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -279,7 +279,7 @@ export function Admin() {
                   style={{ paddingTop: '2em' }}
                 >
                   <Globe className="h-3 w-3" />
-                  System Admin
+                  Global Admin
                 </div>
               )}
               {systemAdminSections.map(renderSectionButton)}

--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -475,7 +475,6 @@ function buildUserContext(
   user: null | {
     display_name: string
     email: string
-    groups?: string[]
     is_admin?: boolean
     roles?: string[]
   },
@@ -485,7 +484,6 @@ function buildUserContext(
   const parts: string[] = []
   parts.push(`User: ${user.display_name} (${user.email})`)
   if (user.is_admin) parts.push('Role: Administrator')
-  if (user.groups?.length) parts.push(`Groups: ${user.groups.join(', ')}`)
   if (user.roles?.length) parts.push(`Roles: ${user.roles.join(', ')}`)
   if (org) parts.push(`Organization: ${org.name} (${org.slug})`)
   return `<context>\n${parts.join('\n')}\n</context>\n\n`

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -201,8 +201,10 @@ export function UserManagement() {
     return (
       <UserForm
         error={createMutation.error || updateMutation.error}
+        isDeleting={deleteMutation.isPending}
         isLoading={createMutation.isPending || updateMutation.isPending}
         onCancel={handleCancel}
+        onDelete={handleDelete}
         onSave={handleSave}
         user={selectedUser}
       />
@@ -340,10 +342,7 @@ export function UserManagement() {
             ? 'No users match your filters'
             : 'No users created yet'
         }
-        getDeleteLabel={(user) => user.display_name}
         getRowKey={(user) => user.email}
-        isDeleting={deleteMutation.isPending}
-        onDelete={handleDelete}
         onRowClick={(user) => handleViewClick(user)}
         rows={filteredUsers}
       />

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -125,11 +125,6 @@ export function UserManagement() {
     })
   }
 
-  const getGroupNames = (user: AdminUser): string => {
-    if (!user.groups || user.groups.length === 0) return '-'
-    return user.groups.map((g) => g.name).join(', ')
-  }
-
   // Fetch full user detail (with orgs) when viewing/editing a specific user
   const {
     data: selectedUser = null,
@@ -154,10 +149,19 @@ export function UserManagement() {
     if (viewMode === 'create') {
       createMutation.mutate(userData)
     } else if (selectedUser) {
-      // Strip org/role fields for update — they're only for creation
+      // Strip create-only single-org fields; memberships flow via `organizations`
       const { organization_slug: _, role_slug: __, ...updateData } = userData
+      // Normalize selectedUser.organizations to {organization_slug, role}
+      // so the diff doesn't see organization_name as a phantom change.
+      const before = {
+        ...selectedUser,
+        organizations: (selectedUser.organizations ?? []).map((m) => ({
+          organization_slug: m.organization_slug,
+          role: m.role,
+        })),
+      }
       const operations = buildDiffPatch(
-        selectedUser as unknown as Record<string, unknown>,
+        before as unknown as Record<string, unknown>,
         updateData as unknown as Record<string, unknown>,
         { fields: Object.keys(updateData) },
       )
@@ -266,13 +270,8 @@ export function UserManagement() {
                   email={user.email}
                   size={32}
                 />
-                <div>
-                  <div className="text-sm font-medium text-primary">
-                    {user.display_name}
-                  </div>
-                  <div className="text-xs text-secondary">
-                    {getGroupNames(user)}
-                  </div>
+                <div className="text-sm font-medium text-primary">
+                  {user.display_name}
                 </div>
               </div>
             ),

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -51,8 +51,8 @@ export function UserForm({
   // Account type
   const [isActive, setIsActive] = useState(user?.is_active ?? true)
   const [isAdmin, setIsAdmin] = useState(user?.is_admin ?? false)
-  const [isServiceAccount, setIsServiceAccount] = useState(
-    user?.is_service_account ?? false,
+  const [emailNotifications, setEmailNotifications] = useState(
+    user?.email_notifications ?? true,
   )
 
   // Organization membership (for creation only)
@@ -61,6 +61,16 @@ export function UserForm({
     organizations.length === 1 ? organizations[0].slug : '',
   )
   const [roleSlug, setRoleSlug] = useState('')
+
+  // Memberships (for edit mode)
+  const [memberships, setMemberships] = useState<
+    { organization_slug: string; role: string }[]
+  >(
+    (user?.organizations ?? []).map((m) => ({
+      organization_slug: m.organization_slug,
+      role: m.role,
+    })),
+  )
 
   // Fetch available roles
   const { data: availableRoles = [], isLoading: rolesLoading } = useQuery({
@@ -171,11 +181,16 @@ export function UserForm({
     const userData: AdminUserCreate = {
       display_name: displayName.trim(),
       email: email.trim(),
+      email_notifications: emailNotifications,
       is_active: isActive,
       is_admin: isAdmin,
-      is_service_account: isServiceAccount,
+      is_service_account: false,
       organization_slug: organizationSlug,
       role_slug: roleSlug,
+    }
+
+    if (isEditing) {
+      userData.organizations = memberships
     }
 
     // Only include password if changing it or creating new user
@@ -225,41 +240,40 @@ export function UserForm({
         <CardContent className="space-y-4 pt-6">
           <div className="grid grid-cols-2 gap-4">
             {/* Email */}
-            {!isEditing && (
-              <div className="col-span-2">
-                <FormField
-                  error={validationErrors.email}
-                  label="Email"
-                  required
-                  touched={touched.email}
-                >
-                  <Input
-                    className=""
-                    disabled={isLoading}
-                    onBlur={() => {
-                      setTouched({ ...touched, email: true })
-                      const error = validateEmail(email)
-                      if (error) {
-                        setValidationErrors({
-                          ...validationErrors,
-                          email: error,
-                        })
-                      }
-                    }}
-                    onChange={(e) => {
-                      setEmail(e.target.value)
-                      handleFieldChange('email')
-                    }}
-                    placeholder="john.doe@company.com"
-                    type="email"
-                    value={email}
-                  />
-                </FormField>
-              </div>
-            )}
+            <div>
+              <FormField
+                error={validationErrors.email}
+                label="Email"
+                required
+                touched={touched.email}
+              >
+                <Input
+                  className=""
+                  disabled={isLoading || isEditing}
+                  onBlur={() => {
+                    setTouched({ ...touched, email: true })
+                    const error = validateEmail(email)
+                    if (error) {
+                      setValidationErrors({
+                        ...validationErrors,
+                        email: error,
+                      })
+                    }
+                  }}
+                  onChange={(e) => {
+                    setEmail(e.target.value)
+                    handleFieldChange('email')
+                  }}
+                  placeholder="john.doe@company.com"
+                  readOnly={isEditing}
+                  type="email"
+                  value={email}
+                />
+              </FormField>
+            </div>
 
             {/* Display Name */}
-            <div className="col-span-2">
+            <div>
               <FormField
                 error={validationErrors.display_name}
                 label="Display Name"
@@ -334,7 +348,7 @@ export function UserForm({
 
             {(changePassword || !isEditing) && (
               <>
-                <div className="col-span-2">
+                <div>
                   <FormField
                     error={validationErrors.password}
                     label="Password"
@@ -462,7 +476,7 @@ export function UserForm({
                   )}
                 </div>
 
-                <div className="col-span-2">
+                <div>
                   <FormField
                     error={validationErrors.confirmPassword}
                     label="Confirm Password"
@@ -495,114 +509,174 @@ export function UserForm({
               </>
             )}
           </div>
-        </CardContent>
-      </Card>
-
-      {/* Section 2: Account Type */}
-      <Card>
-        <CardContent className="space-y-4 pt-6">
-          <div>
-            <label className="mb-2 block text-sm text-secondary">
-              Account Type
-            </label>
-            <div className="space-y-2">
-              <label
-                className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${
-                  !isAdmin && !isServiceAccount
-                    ? 'border-info bg-info'
-                    : 'border-secondary'
-                }`}
-              >
-                <input
-                  checked={!isAdmin && !isServiceAccount}
-                  className="mt-0.5"
-                  disabled={isLoading}
-                  name="accountType"
-                  onChange={() => {
-                    setIsAdmin(false)
-                    setIsServiceAccount(false)
-                  }}
-                  type="radio"
-                />
-                <div className="flex-1">
-                  <div className="text-primary">Regular User</div>
-                  <div className="text-sm text-secondary">
-                    Standard user account with role-based permissions
-                  </div>
-                </div>
+          {/* Section 2: Account Type + Status */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-2 block text-sm text-secondary">
+                Account Type
               </label>
+              <div className="space-y-2">
+                <label
+                  className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${
+                    !isAdmin ? 'border-info bg-info' : 'border-secondary'
+                  }`}
+                >
+                  <input
+                    checked={!isAdmin}
+                    className="mt-0.5"
+                    disabled={isLoading}
+                    name="accountType"
+                    onChange={() => {
+                      setIsAdmin(false)
+                    }}
+                    type="radio"
+                  />
+                  <div className="flex-1">
+                    <div className="text-primary">Regular User</div>
+                    <div className="text-sm text-secondary">
+                      Standard user account with role-based permissions
+                    </div>
+                  </div>
+                </label>
 
-              <label
-                className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${
-                  isServiceAccount
-                    ? 'border-purple-300 bg-purple-50 dark:border-purple-700 dark:bg-purple-900/20'
-                    : 'border-secondary'
-                }`}
-              >
-                <input
-                  checked={isServiceAccount}
-                  className="mt-0.5"
-                  disabled={isLoading}
-                  name="accountType"
-                  onChange={() => {
-                    setIsServiceAccount(true)
-                    setIsAdmin(false)
-                  }}
-                  type="radio"
-                />
-                <div className="flex-1">
-                  <div className="text-primary">Service Account</div>
-                  <div className="text-sm text-secondary">
-                    Automated system account for API access
+                <label
+                  className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${
+                    isAdmin ? 'border-danger bg-danger' : 'border-secondary'
+                  }`}
+                >
+                  <input
+                    checked={isAdmin}
+                    className="mt-0.5"
+                    disabled={isLoading}
+                    name="accountType"
+                    onChange={() => {
+                      setIsAdmin(true)
+                    }}
+                    type="radio"
+                  />
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 text-primary">
+                      Administrator
+                      <AlertTriangle className="h-4 w-4 text-red-500" />
+                    </div>
+                    <div className="text-sm text-secondary">
+                      Super-user with full system access (bypasses all
+                      permission checks)
+                    </div>
                   </div>
-                </div>
-              </label>
+                </label>
+              </div>
+            </div>
 
-              <label
-                className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${
-                  isAdmin ? 'border-danger bg-danger' : 'border-secondary'
-                }`}
-              >
-                <input
-                  checked={isAdmin}
-                  className="mt-0.5"
-                  disabled={isLoading}
-                  name="accountType"
-                  onChange={() => {
-                    setIsAdmin(true)
-                    setIsServiceAccount(false)
-                  }}
-                  type="radio"
-                />
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 text-primary">
-                    Administrator
-                    <AlertTriangle className="h-4 w-4 text-red-500" />
-                  </div>
-                  <div className="text-sm text-secondary">
-                    Super-user with full system access (bypasses all permission
-                    checks)
-                  </div>
-                </div>
-              </label>
+            <div className="space-y-4">
+              <div>
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input
+                    checked={isActive}
+                    className="rounded"
+                    disabled={isLoading}
+                    onChange={(e) => setIsActive(e.target.checked)}
+                    type="checkbox"
+                  />
+                  <span className="text-secondary">Account Active</span>
+                </label>
+                <p className="ml-6 mt-1 text-sm text-secondary">
+                  Inactive accounts cannot authenticate
+                </p>
+              </div>
+              <div>
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input
+                    checked={emailNotifications}
+                    className="rounded"
+                    disabled={isLoading}
+                    onChange={(e) => setEmailNotifications(e.target.checked)}
+                    type="checkbox"
+                  />
+                  <span className="text-secondary">Email Notifications</span>
+                </label>
+                <p className="ml-6 mt-1 text-sm text-secondary">
+                  Receive system notifications by email
+                </p>
+              </div>
             </div>
           </div>
 
-          <div>
-            <label className="flex cursor-pointer items-center gap-2">
-              <input
-                checked={isActive}
-                className="rounded"
-                disabled={isLoading}
-                onChange={(e) => setIsActive(e.target.checked)}
-                type="checkbox"
-              />
-              <span className="text-secondary">Account Active</span>
-            </label>
-            <p className="ml-6 mt-1 text-sm text-secondary">
-              Inactive accounts cannot authenticate
-            </p>
-          </div>
+          {/* Section 3 (edit): Organization Memberships */}
+          {isEditing && (
+            <div>
+              <label className="mb-2 block text-sm text-secondary">
+                Organization Memberships
+              </label>
+              <div className="space-y-2">
+                {organizations.map((org) => {
+                  const idx = memberships.findIndex(
+                    (m) => m.organization_slug === org.slug,
+                  )
+                  const checked = idx !== -1
+                  const isLastChecked = checked && memberships.length === 1
+                  return (
+                    <div
+                      className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-lg border border-secondary p-3"
+                      key={org.slug}
+                    >
+                      <input
+                        checked={checked}
+                        className="rounded"
+                        disabled={isLoading || isLastChecked}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            const defaultRole = availableRoles[0]?.slug ?? ''
+                            setMemberships([
+                              ...memberships,
+                              {
+                                organization_slug: org.slug,
+                                role: defaultRole,
+                              },
+                            ])
+                          } else {
+                            setMemberships(
+                              memberships.filter(
+                                (m) => m.organization_slug !== org.slug,
+                              ),
+                            )
+                          }
+                        }}
+                        type="checkbox"
+                      />
+                      <span className="text-primary">{org.name}</span>
+                      {checked ? (
+                        <label className="flex items-center gap-2">
+                          <span className="text-sm text-secondary">Role:</span>
+                          <select
+                            className="rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            disabled={isLoading || rolesLoading}
+                            onChange={(e) => {
+                              const next = [...memberships]
+                              next[idx] = {
+                                ...next[idx],
+                                role: e.target.value,
+                              }
+                              setMemberships(next)
+                            }}
+                            value={memberships[idx].role}
+                          >
+                            {availableRoles.map((r) => (
+                              <option key={r.slug} value={r.slug}>
+                                {r.name}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      ) : (
+                        <span />
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -1,68 +1,112 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import {
   AlertCircle,
   AlertTriangle,
   Check,
+  Copy,
   Eye,
   EyeOff,
+  Info,
+  KeyRound,
+  LogOut,
+  RefreshCw,
+  Save,
+  Shield,
+  ShieldAlert,
+  Trash2,
+  User,
   X as XIcon,
 } from 'lucide-react'
 
-import { getRoles } from '@/api/endpoints'
+import { getLocalAuthConfig, getRoles } from '@/api/endpoints'
 import { FormHeader } from '@/components/admin/form-header'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { FormField } from '@/components/ui/form-field'
+import { Switch } from '@/components/ui/switch'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
+import { cn } from '@/lib/utils'
 import type { AdminUser, AdminUserCreate } from '@/types'
 
-import { Card, CardContent } from '../../ui/card'
 import { Gravatar } from '../../ui/gravatar'
 import { Input } from '../../ui/input'
 
+interface FormSectionProps {
+  children: React.ReactNode
+  description: string
+  label: string
+}
+
+interface ResetPasswordModalProps {
+  email: string
+  isLoading: boolean
+  onClose: () => void
+  onConfirm: (password: string) => void
+  open: boolean
+}
+
+interface ToggleRowProps {
+  description: string
+  disabled?: boolean
+  id: string
+  label: string
+  onChange: (value: boolean) => void
+  value: boolean
+}
+
 interface UserFormProps {
   error?: null | { message?: string; response?: { data?: { detail?: string } } }
+  isDeleting?: boolean
   isLoading?: boolean
   onCancel: () => void
+  onDelete?: (user: AdminUser) => void
   onSave: (user: AdminUserCreate) => void
   user: AdminUser | null
 }
 
 export function UserForm({
   error,
+  isDeleting = false,
   isLoading = false,
   onCancel,
+  onDelete,
   onSave,
   user,
 }: UserFormProps) {
   const isEditing = !!user
 
-  // Basic info
   const [email, setEmail] = useState(user?.email || '')
   const [displayName, setDisplayName] = useState(user?.display_name || '')
 
-  // Password
   const [changePassword, setChangePassword] = useState(!isEditing)
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
 
-  // Account type
   const [isActive, setIsActive] = useState(user?.is_active ?? true)
   const [isAdmin, setIsAdmin] = useState(user?.is_admin ?? false)
   const [emailNotifications, setEmailNotifications] = useState(
     user?.email_notifications ?? true,
   )
 
-  // Organization membership (for creation only)
   const { organizations } = useOrganization()
   const [organizationSlug, setOrganizationSlug] = useState(
     organizations.length === 1 ? organizations[0].slug : '',
   )
   const [roleSlug, setRoleSlug] = useState('')
 
-  // Memberships (for edit mode)
   const [memberships, setMemberships] = useState<
     { organization_slug: string; role: string }[]
   >(
@@ -72,13 +116,20 @@ export function UserForm({
     })),
   )
 
-  // Fetch available roles
+  const [resetOpen, setResetOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
   const { data: availableRoles = [], isLoading: rolesLoading } = useQuery({
     queryFn: ({ signal }) => getRoles(signal),
     queryKey: ['roles'],
   })
 
-  // Validation state
+  const { data: localAuth } = useQuery({
+    queryFn: ({ signal }) => getLocalAuthConfig(signal),
+    queryKey: ['admin', 'local-auth'],
+  })
+  const localAuthEnabled = localAuth?.enabled ?? false
+
   const {
     handleFieldChange,
     setTouched,
@@ -87,7 +138,6 @@ export function UserForm({
     validationErrors,
   } = useFormScaffold()
 
-  // Password strength
   const getPasswordStrength = (
     pwd: string,
   ): { color: string; label: string; score: number } => {
@@ -108,7 +158,6 @@ export function UserForm({
 
   const passwordStrength = getPasswordStrength(password)
 
-  // Validation functions
   const validateEmail = (value: string): string => {
     if (!value.trim()) return 'Email is required'
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) return 'Invalid email format'
@@ -120,8 +169,10 @@ export function UserForm({
     return ''
   }
 
+  const passwordRequired = localAuthEnabled && (changePassword || !isEditing)
+
   const validatePassword = (value: string): string => {
-    if (changePassword || !isEditing) {
+    if (passwordRequired) {
       if (!value) return 'Password is required'
       if (value.length < 12) return 'Password must be at least 12 characters'
       if (passwordStrength.score < 3) return 'Password is too weak'
@@ -130,13 +181,12 @@ export function UserForm({
   }
 
   const validateConfirmPassword = (value: string): string => {
-    if ((changePassword || !isEditing) && value !== password) {
+    if (passwordRequired && value !== password) {
       return 'Passwords do not match'
     }
     return ''
   }
 
-  // Validate all fields
   const validateForm = (): boolean => {
     const errors: Record<string, string> = {}
 
@@ -146,7 +196,7 @@ export function UserForm({
     const displayNameError = validateDisplayName(displayName)
     if (displayNameError) errors.display_name = displayNameError
 
-    if (changePassword || !isEditing) {
+    if (passwordRequired) {
       const passwordError = validatePassword(password)
       if (passwordError) errors.password = passwordError
 
@@ -173,6 +223,17 @@ export function UserForm({
     return Object.keys(errors).length === 0
   }
 
+  const formatDate = (value?: null | string) => {
+    if (!value) return 'Never'
+    return new Date(value).toLocaleString('en-US', {
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    })
+  }
+
   const handleSave = () => {
     if (!validateForm()) {
       return
@@ -193,8 +254,7 @@ export function UserForm({
       userData.organizations = memberships
     }
 
-    // Only include password if changing it or creating new user
-    if (changePassword || !isEditing) {
+    if (localAuthEnabled && (changePassword || !isEditing)) {
       userData.password = password
     }
 
@@ -203,22 +263,50 @@ export function UserForm({
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <FormHeader
-        createLabel="Create User"
-        isEditing={isEditing}
-        isLoading={isLoading}
-        onCancel={onCancel}
-        onSave={handleSave}
-        subtitle={
-          isEditing
-            ? `Editing ${user?.display_name}`
-            : 'Add a new user account to the system'
-        }
-        title={isEditing ? 'Edit User' : 'Create New User'}
-      />
+      {isEditing ? (
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <Gravatar
+              alt={user.display_name}
+              className="size-12 rounded-full"
+              email={user.email}
+              size={48}
+            />
+            <div className="min-w-0">
+              <h1 className="truncate text-base font-medium text-primary">
+                {user.display_name}
+              </h1>
+              <p className="font-mono text-xs text-tertiary">{user.email}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              disabled={isLoading}
+              onClick={onCancel}
+              type="button"
+              variant="outline"
+            >
+              <XIcon className="mr-2 h-4 w-4" />
+              Cancel
+            </Button>
+            <Button disabled={isLoading} onClick={handleSave} type="button">
+              <Save className="mr-2 h-4 w-4" />
+              {isLoading ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <FormHeader
+          createLabel="Create User"
+          isEditing={false}
+          isLoading={isLoading}
+          onCancel={onCancel}
+          onSave={handleSave}
+          subtitle="Add a new user account to the system"
+          title="Create New User"
+        />
+      )}
 
-      {/* API Error Display */}
       {error && (
         <div className="rounded-lg border border-danger bg-danger p-4">
           <div className="flex items-start gap-3">
@@ -235,30 +323,56 @@ export function UserForm({
         </div>
       )}
 
-      {/* Section 1: Basic Information */}
-      <Card>
-        <CardContent className="space-y-4 pt-6">
-          <div className="grid grid-cols-2 gap-4">
-            {/* Email */}
+      <Card className="overflow-hidden p-0">
+        {/* Identity */}
+        <FormSection
+          description="Profile fields shown across Imbi."
+          label="Identity"
+        >
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <FormField
+              error={validationErrors.display_name}
+              htmlFor="user-display-name"
+              label="Display Name"
+              required
+              touched={touched.display_name}
+            >
+              <Input
+                disabled={isLoading}
+                id="user-display-name"
+                onBlur={() => {
+                  setTouched({ ...touched, display_name: true })
+                  const e = validateDisplayName(displayName)
+                  if (e)
+                    setValidationErrors({
+                      ...validationErrors,
+                      display_name: e,
+                    })
+                }}
+                onChange={(e) => {
+                  setDisplayName(e.target.value)
+                  handleFieldChange('display_name')
+                }}
+                placeholder="John Doe"
+                value={displayName}
+              />
+            </FormField>
             <div>
               <FormField
                 error={validationErrors.email}
+                htmlFor="user-email"
                 label="Email"
                 required
                 touched={touched.email}
               >
                 <Input
-                  className=""
                   disabled={isLoading || isEditing}
+                  id="user-email"
                   onBlur={() => {
                     setTouched({ ...touched, email: true })
-                    const error = validateEmail(email)
-                    if (error) {
-                      setValidationErrors({
-                        ...validationErrors,
-                        email: error,
-                      })
-                    }
+                    const e = validateEmail(email)
+                    if (e)
+                      setValidationErrors({ ...validationErrors, email: e })
                   }}
                   onChange={(e) => {
                     setEmail(e.target.value)
@@ -270,87 +384,314 @@ export function UserForm({
                   value={email}
                 />
               </FormField>
+              {email && validateEmail(email) === '' && (
+                <p className="mt-1.5 text-xs text-tertiary">
+                  Avatar uses{' '}
+                  <a
+                    className="text-amber-text hover:underline"
+                    href="https://gravatar.com"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Gravatar
+                  </a>{' '}
+                  for this address.
+                </p>
+              )}
             </div>
+          </div>
+        </FormSection>
 
-            {/* Display Name */}
-            <div>
-              <FormField
-                error={validationErrors.display_name}
-                label="Display Name"
-                required
-                touched={touched.display_name}
+        {/* Access */}
+        <FormSection
+          description="What this user can do across the system, and whether they can sign in at all."
+          label="Access"
+        >
+          <div>
+            <div className="mb-1.5 text-sm text-secondary">Account type</div>
+            <div
+              aria-label="Account type"
+              className="inline-flex gap-1 rounded-md border border-tertiary bg-secondary p-1"
+              role="radiogroup"
+            >
+              <button
+                aria-checked={!isAdmin}
+                className={cn(
+                  'inline-flex h-8 items-center gap-2 rounded px-3 text-sm font-medium transition-colors',
+                  !isAdmin
+                    ? 'bg-background text-primary shadow-sm'
+                    : 'text-secondary hover:text-primary',
+                )}
+                disabled={isLoading}
+                onClick={() => setIsAdmin(false)}
+                role="radio"
+                type="button"
               >
-                <Input
-                  className=""
+                <User className="h-3.5 w-3.5" />
+                Regular user
+              </button>
+              <button
+                aria-checked={isAdmin}
+                className={cn(
+                  'inline-flex h-8 items-center gap-2 rounded px-3 text-sm font-medium transition-colors',
+                  isAdmin
+                    ? 'bg-background text-amber-700 shadow-sm dark:text-amber-400'
+                    : 'text-secondary hover:text-primary',
+                )}
+                disabled={isLoading}
+                onClick={() => setIsAdmin(true)}
+                role="radio"
+                type="button"
+              >
+                <Shield className="h-3.5 w-3.5" />
+                Administrator
+              </button>
+            </div>
+            {isAdmin ? (
+              <p className="mt-2 flex items-start gap-1.5 text-sm text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                Super-user with full system access (bypasses all permission
+                checks)
+              </p>
+            ) : (
+              <p className="mt-2 flex items-start gap-1.5 text-sm text-tertiary">
+                <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                Permissions come from organization roles below.
+              </p>
+            )}
+          </div>
+
+          <div className="mt-2">
+            <ToggleRow
+              description="Inactive accounts cannot authenticate or use the API."
+              disabled={isLoading}
+              id="user-active"
+              label="Account active"
+              onChange={setIsActive}
+              value={isActive}
+            />
+            <ToggleRow
+              description="Send system notifications, deploy summaries, and incident alerts by email."
+              disabled={isLoading}
+              id="user-email-notif"
+              label="Email notifications"
+              onChange={setEmailNotifications}
+              value={emailNotifications}
+            />
+          </div>
+        </FormSection>
+
+        {/* Memberships */}
+        {isEditing && (
+          <FormSection
+            description="Organizations this user belongs to and the role they hold in each. Roles drive permissions."
+            label="Memberships"
+          >
+            <div className="overflow-hidden rounded-md border border-tertiary">
+              <div className="grid grid-cols-[1fr_180px] gap-4 border-b border-tertiary bg-secondary px-4 py-2.5 text-xs font-semibold uppercase tracking-wider text-tertiary">
+                <span>Organization</span>
+                <span>Role</span>
+              </div>
+              {organizations.map((org) => {
+                const idx = memberships.findIndex(
+                  (m) => m.organization_slug === org.slug,
+                )
+                const checked = idx !== -1
+                return (
+                  <label
+                    className={cn(
+                      'grid cursor-pointer grid-cols-[1fr_180px] items-center gap-4 border-b border-tertiary px-4 py-2.5 last:border-b-0 hover:bg-secondary/50',
+                      !checked && 'opacity-60',
+                    )}
+                    key={org.slug}
+                  >
+                    <div className="flex min-w-0 items-center gap-3">
+                      <input
+                        checked={checked}
+                        className="size-4 rounded border-tertiary"
+                        disabled={isLoading}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            const defaultRole = availableRoles[0]?.slug ?? ''
+                            setMemberships([
+                              ...memberships,
+                              {
+                                organization_slug: org.slug,
+                                role: defaultRole,
+                              },
+                            ])
+                          } else {
+                            setMemberships(
+                              memberships.filter(
+                                (m) => m.organization_slug !== org.slug,
+                              ),
+                            )
+                          }
+                        }}
+                        type="checkbox"
+                      />
+                      <span className="truncate text-sm font-medium text-primary">
+                        {org.name}
+                      </span>
+                    </div>
+                    <select
+                      className="rounded-md border border-input bg-background px-2 py-1 text-sm text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                      disabled={!checked || isLoading || rolesLoading}
+                      onChange={(e) => {
+                        const next = [...memberships]
+                        next[idx] = { ...next[idx], role: e.target.value }
+                        setMemberships(next)
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      value={checked ? memberships[idx].role : ''}
+                    >
+                      {availableRoles.map((r) => (
+                        <option key={r.slug} value={r.slug}>
+                          {r.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )
+              })}
+            </div>
+          </FormSection>
+        )}
+
+        {/* Initial organization (creation only) */}
+        {!isEditing && (
+          <FormSection
+            description="Users must belong to at least one organization with a role to have any permissions."
+            label="Membership"
+          >
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <FormField
+                error={validationErrors.organization_slug}
+                label="Organization"
+                required
+                touched={touched.organization_slug}
+              >
+                <select
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
                   disabled={isLoading}
-                  onBlur={() => {
-                    setTouched({ ...touched, display_name: true })
-                    const error = validateDisplayName(displayName)
-                    if (error) {
-                      setValidationErrors({
-                        ...validationErrors,
-                        display_name: error,
-                      })
-                    }
-                  }}
                   onChange={(e) => {
-                    setDisplayName(e.target.value)
-                    handleFieldChange('display_name')
+                    setOrganizationSlug(e.target.value)
+                    handleFieldChange('organization_slug')
                   }}
-                  placeholder="John Doe"
-                  value={displayName}
-                />
+                  value={organizationSlug}
+                >
+                  <option value="">Select an organization...</option>
+                  {organizations.map((org) => (
+                    <option key={org.slug} value={org.slug}>
+                      {org.name}
+                    </option>
+                  ))}
+                </select>
+              </FormField>
+              <FormField
+                error={validationErrors.role_slug}
+                label="Role"
+                required
+                touched={touched.role_slug}
+              >
+                {rolesLoading ? (
+                  <p className="text-sm text-secondary">Loading roles...</p>
+                ) : (
+                  <select
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+                    disabled={isLoading}
+                    onChange={(e) => {
+                      setRoleSlug(e.target.value)
+                      handleFieldChange('role_slug')
+                    }}
+                    value={roleSlug}
+                  >
+                    <option value="">Select a role...</option>
+                    {availableRoles.map((role) => (
+                      <option key={role.slug} value={role.slug}>
+                        {role.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
               </FormField>
             </div>
+          </FormSection>
+        )}
 
-            {/* Gravatar Preview */}
-            {email && validateEmail(email) === '' && (
-              <div className="col-span-2">
-                <FormField label="Avatar (Gravatar)">
-                  <div className="flex items-center gap-3">
-                    <Gravatar
-                      className="h-16 w-16 rounded-full border-2 border-gray-300 dark:border-gray-600"
-                      email={email}
-                      size={64}
-                    />
-                    <p className="text-sm text-secondary">
-                      Avatar will be loaded from{' '}
-                      <a
-                        className="text-blue-500 hover:underline"
-                        href="https://gravatar.com"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Gravatar
-                      </a>{' '}
-                      based on email address
+        {/* Security */}
+        {localAuthEnabled && (
+          <FormSection
+            description="Sensitive actions. Each one is recorded in the operations log."
+            label="Security"
+          >
+            {isEditing && (
+              <div>
+                <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-tertiary py-3 first:pt-0">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-primary">
+                      Password
+                    </div>
+                    <p className="mt-0.5 text-sm text-secondary">
+                      Reset to issue a temporary local password the user must
+                      change at next sign-in.
+                    </p>
+                    {changePassword && password && (
+                      <p className="mt-1 font-mono text-xs text-amber-700 dark:text-amber-400">
+                        Will reset on save
+                      </p>
+                    )}
+                  </div>
+                  <Button
+                    disabled={isLoading}
+                    onClick={() => setResetOpen(true)}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    <KeyRound className="mr-2 h-4 w-4" />
+                    Reset password
+                  </Button>
+                </div>
+                <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-tertiary py-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-primary">
+                      Multi-factor authentication
+                    </div>
+                    <p className="mt-0.5 text-sm text-secondary">
+                      Force re-enrollment of multi-factor authentication on next
+                      sign-in.
                     </p>
                   </div>
-                </FormField>
+                  <Button disabled size="sm" type="button" variant="outline">
+                    <ShieldAlert className="mr-2 h-4 w-4" />
+                    Reset MFA
+                  </Button>
+                </div>
+                <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 py-3 last:pb-0">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-primary">
+                      Active sessions
+                    </div>
+                    <p className="mt-0.5 text-sm text-secondary">
+                      Revoke all active sessions and force a fresh sign-in
+                      everywhere.
+                    </p>
+                  </div>
+                  <Button disabled size="sm" type="button" variant="outline">
+                    <LogOut className="mr-2 h-4 w-4" />
+                    Sign out everywhere
+                  </Button>
+                </div>
               </div>
             )}
 
-            {/* Password Section */}
-            {isEditing && (
-              <div className="col-span-2">
-                <label className="flex cursor-pointer items-center gap-2">
-                  <input
-                    checked={changePassword}
-                    className="rounded"
-                    disabled={isLoading}
-                    onChange={(e) => setChangePassword(e.target.checked)}
-                    type="checkbox"
-                  />
-                  <span className="text-secondary">Change Password</span>
-                </label>
-              </div>
-            )}
-
-            {(changePassword || !isEditing) && (
-              <>
+            {!isEditing && (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <FormField
                     error={validationErrors.password}
+                    htmlFor="user-password"
                     label="Password"
                     required
                     touched={touched.password}
@@ -359,15 +700,15 @@ export function UserForm({
                       <Input
                         className="pr-10"
                         disabled={isLoading}
+                        id="user-password"
                         onBlur={() => {
                           setTouched({ ...touched, password: true })
-                          const error = validatePassword(password)
-                          if (error) {
+                          const e = validatePassword(password)
+                          if (e)
                             setValidationErrors({
                               ...validationErrors,
-                              password: error,
+                              password: e,
                             })
-                          }
                         }}
                         onChange={(e) => {
                           setPassword(e.target.value)
@@ -394,359 +735,396 @@ export function UserForm({
                   {password && !validationErrors.password && (
                     <div className="mt-2">
                       <div className="mb-1 flex items-center gap-2">
-                        <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                        <div className="h-2 flex-1 overflow-hidden rounded-full bg-secondary">
                           <div
-                            className={`h-full transition-all ${
-                              passwordStrength.color === 'red'
-                                ? 'bg-red-500'
-                                : passwordStrength.color === 'yellow'
-                                  ? 'bg-yellow-500'
-                                  : 'bg-green-500'
-                            }`}
+                            className={cn(
+                              'h-full transition-all',
+                              passwordStrength.color === 'red' && 'bg-red-500',
+                              passwordStrength.color === 'yellow' &&
+                                'bg-yellow-500',
+                              passwordStrength.color === 'green' &&
+                                'bg-green-500',
+                            )}
                             style={{
                               width: `${(passwordStrength.score / 6) * 100}%`,
                             }}
                           />
                         </div>
                         <span
-                          className={`text-xs ${
-                            passwordStrength.color === 'red'
-                              ? 'text-red-500'
-                              : passwordStrength.color === 'yellow'
-                                ? 'text-yellow-500'
-                                : 'text-green-500'
-                          }`}
+                          className={cn(
+                            'text-xs',
+                            passwordStrength.color === 'red' && 'text-red-500',
+                            passwordStrength.color === 'yellow' &&
+                              'text-yellow-500',
+                            passwordStrength.color === 'green' &&
+                              'text-green-500',
+                          )}
                         >
                           {passwordStrength.label}
                         </span>
                       </div>
                       <ul className="space-y-0.5 text-xs text-secondary">
-                        <li
-                          className={`flex items-center gap-1 ${password.length >= 12 ? 'text-green-600 dark:text-green-400' : ''}`}
-                        >
-                          {password.length >= 12 ? (
-                            <Check className="h-3 w-3" />
-                          ) : (
-                            <XIcon className="h-3 w-3" />
-                          )}
-                          At least 12 characters
-                        </li>
-                        <li
-                          className={`flex items-center gap-1 ${/[A-Z]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
-                        >
-                          {/[A-Z]/.test(password) ? (
-                            <Check className="h-3 w-3" />
-                          ) : (
-                            <XIcon className="h-3 w-3" />
-                          )}
-                          Uppercase letter
-                        </li>
-                        <li
-                          className={`flex items-center gap-1 ${/[a-z]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
-                        >
-                          {/[a-z]/.test(password) ? (
-                            <Check className="h-3 w-3" />
-                          ) : (
-                            <XIcon className="h-3 w-3" />
-                          )}
-                          Lowercase letter
-                        </li>
-                        <li
-                          className={`flex items-center gap-1 ${/[0-9]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
-                        >
-                          {/[0-9]/.test(password) ? (
-                            <Check className="h-3 w-3" />
-                          ) : (
-                            <XIcon className="h-3 w-3" />
-                          )}
-                          Number
-                        </li>
-                        <li
-                          className={`flex items-center gap-1 ${/[^a-zA-Z0-9]/.test(password) ? 'text-green-600 dark:text-green-400' : ''}`}
-                        >
-                          {/[^a-zA-Z0-9]/.test(password) ? (
-                            <Check className="h-3 w-3" />
-                          ) : (
-                            <XIcon className="h-3 w-3" />
-                          )}
-                          Special character
-                        </li>
+                        {[
+                          {
+                            label: 'At least 12 characters',
+                            test: password.length >= 12,
+                          },
+                          {
+                            label: 'Uppercase letter',
+                            test: /[A-Z]/.test(password),
+                          },
+                          {
+                            label: 'Lowercase letter',
+                            test: /[a-z]/.test(password),
+                          },
+                          { label: 'Number', test: /[0-9]/.test(password) },
+                          {
+                            label: 'Special character',
+                            test: /[^a-zA-Z0-9]/.test(password),
+                          },
+                        ].map((req) => (
+                          <li
+                            className={cn(
+                              'flex items-center gap-1',
+                              req.test && 'text-green-600 dark:text-green-400',
+                            )}
+                            key={req.label}
+                          >
+                            {req.test ? (
+                              <Check className="h-3 w-3" />
+                            ) : (
+                              <XIcon className="h-3 w-3" />
+                            )}
+                            {req.label}
+                          </li>
+                        ))}
                       </ul>
                     </div>
                   )}
                 </div>
 
-                <div>
-                  <FormField
-                    error={validationErrors.confirmPassword}
-                    label="Confirm Password"
-                    required
-                    touched={touched.confirmPassword}
-                  >
-                    <Input
-                      className=""
-                      disabled={isLoading}
-                      onBlur={() => {
-                        setTouched({ ...touched, confirmPassword: true })
-                        const error = validateConfirmPassword(confirmPassword)
-                        if (error) {
-                          setValidationErrors({
-                            ...validationErrors,
-                            confirmPassword: error,
-                          })
-                        }
-                      }}
-                      onChange={(e) => {
-                        setConfirmPassword(e.target.value)
-                        handleFieldChange('confirmPassword')
-                      }}
-                      placeholder="Re-enter password"
-                      type={showPassword ? 'text' : 'password'}
-                      value={confirmPassword}
-                    />
-                  </FormField>
-                </div>
-              </>
+                <FormField
+                  error={validationErrors.confirmPassword}
+                  htmlFor="user-confirm-password"
+                  label="Confirm Password"
+                  required
+                  touched={touched.confirmPassword}
+                >
+                  <Input
+                    disabled={isLoading}
+                    id="user-confirm-password"
+                    onBlur={() => {
+                      setTouched({ ...touched, confirmPassword: true })
+                      const e = validateConfirmPassword(confirmPassword)
+                      if (e)
+                        setValidationErrors({
+                          ...validationErrors,
+                          confirmPassword: e,
+                        })
+                    }}
+                    onChange={(e) => {
+                      setConfirmPassword(e.target.value)
+                      handleFieldChange('confirmPassword')
+                    }}
+                    placeholder="Re-enter password"
+                    type={showPassword ? 'text' : 'password'}
+                    value={confirmPassword}
+                  />
+                </FormField>
+              </div>
             )}
+          </FormSection>
+        )}
+
+        {isEditing && (
+          <div className="flex items-center gap-1.5 border-t border-tertiary bg-secondary px-6 py-3 text-xs text-tertiary">
+            <Info className="h-3 w-3" />
+            <span>Created {formatDate(user.created_at)}</span>
+            <span>·</span>
+            <span>
+              Last sign-in{' '}
+              <span className="font-mono">{formatDate(user.last_login)}</span>
+            </span>
           </div>
-          {/* Section 2: Account Type + Status */}
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="mb-2 block text-sm text-secondary">
-                Account Type
-              </label>
-              <div className="space-y-2">
-                <label
-                  className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${
-                    !isAdmin ? 'border-info bg-info' : 'border-secondary'
-                  }`}
-                >
-                  <input
-                    checked={!isAdmin}
-                    className="mt-0.5"
-                    disabled={isLoading}
-                    name="accountType"
-                    onChange={() => {
-                      setIsAdmin(false)
-                    }}
-                    type="radio"
-                  />
-                  <div className="flex-1">
-                    <div className="text-primary">Regular User</div>
-                    <div className="text-sm text-secondary">
-                      Standard user account with role-based permissions
-                    </div>
-                  </div>
-                </label>
-
-                <label
-                  className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 ${
-                    isAdmin ? 'border-danger bg-danger' : 'border-secondary'
-                  }`}
-                >
-                  <input
-                    checked={isAdmin}
-                    className="mt-0.5"
-                    disabled={isLoading}
-                    name="accountType"
-                    onChange={() => {
-                      setIsAdmin(true)
-                    }}
-                    type="radio"
-                  />
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 text-primary">
-                      Administrator
-                      <AlertTriangle className="h-4 w-4 text-red-500" />
-                    </div>
-                    <div className="text-sm text-secondary">
-                      Super-user with full system access (bypasses all
-                      permission checks)
-                    </div>
-                  </div>
-                </label>
-              </div>
-            </div>
-
-            <div className="space-y-4">
-              <div>
-                <label className="flex cursor-pointer items-center gap-2">
-                  <input
-                    checked={isActive}
-                    className="rounded"
-                    disabled={isLoading}
-                    onChange={(e) => setIsActive(e.target.checked)}
-                    type="checkbox"
-                  />
-                  <span className="text-secondary">Account Active</span>
-                </label>
-                <p className="ml-6 mt-1 text-sm text-secondary">
-                  Inactive accounts cannot authenticate
-                </p>
-              </div>
-              <div>
-                <label className="flex cursor-pointer items-center gap-2">
-                  <input
-                    checked={emailNotifications}
-                    className="rounded"
-                    disabled={isLoading}
-                    onChange={(e) => setEmailNotifications(e.target.checked)}
-                    type="checkbox"
-                  />
-                  <span className="text-secondary">Email Notifications</span>
-                </label>
-                <p className="ml-6 mt-1 text-sm text-secondary">
-                  Receive system notifications by email
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Section 3 (edit): Organization Memberships */}
-          {isEditing && (
-            <div>
-              <label className="mb-2 block text-sm text-secondary">
-                Organization Memberships
-              </label>
-              <div className="space-y-2">
-                {organizations.map((org) => {
-                  const idx = memberships.findIndex(
-                    (m) => m.organization_slug === org.slug,
-                  )
-                  const checked = idx !== -1
-                  const isLastChecked = checked && memberships.length === 1
-                  return (
-                    <div
-                      className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-lg border border-secondary p-3"
-                      key={org.slug}
-                    >
-                      <input
-                        checked={checked}
-                        className="rounded"
-                        disabled={isLoading || isLastChecked}
-                        onChange={(e) => {
-                          if (e.target.checked) {
-                            const defaultRole = availableRoles[0]?.slug ?? ''
-                            setMemberships([
-                              ...memberships,
-                              {
-                                organization_slug: org.slug,
-                                role: defaultRole,
-                              },
-                            ])
-                          } else {
-                            setMemberships(
-                              memberships.filter(
-                                (m) => m.organization_slug !== org.slug,
-                              ),
-                            )
-                          }
-                        }}
-                        type="checkbox"
-                      />
-                      <span className="text-primary">{org.name}</span>
-                      {checked ? (
-                        <label className="flex items-center gap-2">
-                          <span className="text-sm text-secondary">Role:</span>
-                          <select
-                            className="rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            disabled={isLoading || rolesLoading}
-                            onChange={(e) => {
-                              const next = [...memberships]
-                              next[idx] = {
-                                ...next[idx],
-                                role: e.target.value,
-                              }
-                              setMemberships(next)
-                            }}
-                            value={memberships[idx].role}
-                          >
-                            {availableRoles.map((r) => (
-                              <option key={r.slug} value={r.slug}>
-                                {r.name}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      ) : (
-                        <span />
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
-          )}
-        </CardContent>
+        )}
       </Card>
 
-      {/* Section 3: Organization Membership (creation only) */}
-      {!isEditing && (
-        <Card>
-          <CardContent className="space-y-4 pt-6">
-            <p className="mb-4 text-sm text-secondary">
-              Users must belong to at least one organization with a role to have
-              any permissions.
-            </p>
-
-            <div className="grid grid-cols-2 gap-4">
-              {/* Organization */}
-              <FormField
-                error={validationErrors.organization_slug}
-                label="Organization"
-                required
-                touched={touched.organization_slug}
-              >
-                <select
-                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  disabled={isLoading}
-                  onChange={(e) => {
-                    setOrganizationSlug(e.target.value)
-                    handleFieldChange('organization_slug')
-                  }}
-                  value={organizationSlug}
-                >
-                  <option value="">Select an organization...</option>
-                  {organizations.map((org) => (
-                    <option key={org.slug} value={org.slug}>
-                      {org.name}
-                    </option>
-                  ))}
-                </select>
-              </FormField>
-
-              {/* Role */}
-              <FormField
-                error={validationErrors.role_slug}
-                label="Role"
-                required
-                touched={touched.role_slug}
-              >
-                {rolesLoading ? (
-                  <p className="text-sm text-secondary">Loading roles...</p>
-                ) : (
-                  <select
-                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    disabled={isLoading}
-                    onChange={(e) => {
-                      setRoleSlug(e.target.value)
-                      handleFieldChange('role_slug')
-                    }}
-                    value={roleSlug}
-                  >
-                    <option value="">Select a role...</option>
-                    {availableRoles.map((role) => (
-                      <option key={role.slug} value={role.slug}>
-                        {role.name}
-                      </option>
-                    ))}
-                  </select>
-                )}
-              </FormField>
+      {isEditing && onDelete && (
+        <div className="grid grid-cols-[1fr_auto] items-center gap-4 rounded-lg border border-danger bg-card p-5">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-semibold text-danger">
+              <Trash2 className="h-4 w-4" />
+              Delete user
             </div>
-          </CardContent>
-        </Card>
+            <p className="mt-1 text-sm text-secondary">
+              Removes the account and revokes all tokens. Project ownership is
+              reassigned to the organization owner.
+            </p>
+          </div>
+          <Button
+            disabled={isDeleting}
+            onClick={() => setDeleteOpen(true)}
+            type="button"
+            variant="destructive"
+          >
+            {isDeleting ? 'Deleting...' : 'Delete user'}
+          </Button>
+        </div>
       )}
+
+      {isEditing && (
+        <ResetPasswordModal
+          email={user.email}
+          isLoading={isLoading}
+          onClose={() => setResetOpen(false)}
+          onConfirm={(newPassword) => {
+            setPassword(newPassword)
+            setConfirmPassword(newPassword)
+            setChangePassword(true)
+            setResetOpen(false)
+          }}
+          open={resetOpen}
+        />
+      )}
+
+      {isEditing && onDelete && (
+        <ConfirmDialog
+          confirmLabel="Delete user"
+          description={`Permanently delete ${user.display_name}? This cannot be undone.`}
+          onCancel={() => setDeleteOpen(false)}
+          onConfirm={() => {
+            setDeleteOpen(false)
+            onDelete(user)
+          }}
+          open={deleteOpen}
+          title="Delete user"
+        />
+      )}
+    </div>
+  )
+}
+
+function FormSection({ children, description, label }: FormSectionProps) {
+  return (
+    <div className="grid grid-cols-1 gap-6 border-t border-tertiary px-6 py-6 first:border-t-0 md:grid-cols-[200px_1fr] md:gap-8">
+      <div>
+        <div className="text-xs font-semibold uppercase tracking-wider text-tertiary">
+          {label}
+        </div>
+        <p className="mt-1.5 text-sm text-secondary">{description}</p>
+      </div>
+      <div className="min-w-0 space-y-4">{children}</div>
+    </div>
+  )
+}
+
+function RadioDot({ active }: { active: boolean }) {
+  return (
+    <div
+      className={cn(
+        'relative mt-0.5 size-4 flex-shrink-0 rounded-full border-[1.5px]',
+        active ? 'border-amber-border' : 'border-secondary',
+      )}
+    >
+      {active && (
+        <div className="absolute inset-1 rounded-full bg-amber-border" />
+      )}
+    </div>
+  )
+}
+
+function ResetPasswordModal({
+  email,
+  isLoading,
+  onClose,
+  onConfirm,
+  open,
+}: ResetPasswordModalProps) {
+  const [mode, setMode] = useState<'auto' | 'create'>('auto')
+  const [generated, setGenerated] = useState('')
+  const [manual, setManual] = useState('')
+  const [confirmManual, setConfirmManual] = useState('')
+  const [copied, setCopied] = useState(false)
+
+  const generatePassword = () => {
+    const charset =
+      'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789!@#$%^&*'
+    const arr = new Uint32Array(16)
+    crypto.getRandomValues(arr)
+    return Array.from(arr, (n) => charset[n % charset.length]).join('')
+  }
+
+  useEffect(() => {
+    if (open) {
+      setMode('auto')
+      setGenerated(generatePassword())
+      setManual('')
+      setConfirmManual('')
+      setCopied(false)
+    }
+  }, [open])
+
+  const canConfirm =
+    mode === 'auto' ? !!generated : !!manual && manual === confirmManual
+
+  return (
+    <Dialog
+      onOpenChange={(o) => {
+        if (!o) onClose()
+      }}
+      open={open}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Reset password</DialogTitle>
+          <DialogDescription className="font-mono">{email}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <button
+            className={cn(
+              'grid w-full grid-cols-[18px_1fr] items-start gap-3 rounded-md border p-3 text-left transition-colors',
+              mode === 'auto'
+                ? 'border-amber-border bg-amber-bg'
+                : 'border-tertiary hover:bg-secondary',
+            )}
+            onClick={() => setMode('auto')}
+            type="button"
+          >
+            <RadioDot active={mode === 'auto'} />
+            <div>
+              <div className="text-sm font-medium text-primary">
+                Automatically generate a password
+              </div>
+              <p className="mt-0.5 text-xs text-secondary">
+                The password will be displayed below — copy it before closing.
+              </p>
+              {mode === 'auto' && (
+                <div className="mt-2 flex items-center gap-2">
+                  <code className="flex-1 truncate rounded border border-tertiary bg-background px-2 py-1.5 font-mono text-xs text-primary">
+                    {generated}
+                  </code>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setGenerated(generatePassword())
+                      setCopied(false)
+                    }}
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <RefreshCw className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      void navigator.clipboard.writeText(generated)
+                      setCopied(true)
+                    }}
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    {copied ? (
+                      <Check className="h-3.5 w-3.5" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </div>
+              )}
+            </div>
+          </button>
+
+          <button
+            className={cn(
+              'grid w-full grid-cols-[18px_1fr] items-start gap-3 rounded-md border p-3 text-left transition-colors',
+              mode === 'create'
+                ? 'border-amber-border bg-amber-bg'
+                : 'border-tertiary hover:bg-secondary',
+            )}
+            onClick={() => setMode('create')}
+            type="button"
+          >
+            <RadioDot active={mode === 'create'} />
+            <div>
+              <div className="text-sm font-medium text-primary">
+                Create password
+              </div>
+              <p className="mt-0.5 text-xs text-secondary">
+                Set a temporary password the user must change at next sign-in.
+              </p>
+              {mode === 'create' && (
+                <div className="mt-2 space-y-2">
+                  <Input
+                    onChange={(e) => setManual(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    placeholder="Minimum 12 characters"
+                    type="password"
+                    value={manual}
+                  />
+                  <Input
+                    onChange={(e) => setConfirmManual(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    placeholder="Confirm password"
+                    type="password"
+                    value={confirmManual}
+                  />
+                </div>
+              )}
+            </div>
+          </button>
+        </div>
+
+        <DialogFooter>
+          <Button
+            disabled={isLoading}
+            onClick={onClose}
+            type="button"
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!canConfirm || isLoading}
+            onClick={() => onConfirm(mode === 'auto' ? generated : manual)}
+            type="button"
+          >
+            <KeyRound className="mr-2 h-4 w-4" />
+            Reset password
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ToggleRow({
+  description,
+  disabled,
+  id,
+  label,
+  onChange,
+  value,
+}: ToggleRowProps) {
+  return (
+    <div className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-tertiary py-3 first:pt-0 last:border-b-0 last:pb-0">
+      <div>
+        <label
+          className="block cursor-pointer text-sm font-medium text-primary"
+          htmlFor={id}
+        >
+          {label}
+        </label>
+        <p className="mt-0.5 text-sm text-secondary">{description}</p>
+      </div>
+      <Switch
+        checked={value}
+        disabled={disabled}
+        id={id}
+        onCheckedChange={onChange}
+      />
     </div>
   )
 }

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -66,12 +66,12 @@ interface AdminTableProps<T> {
   canDelete?: (row: T) => CanDeleteResult
   columns: AdminTableColumn<T>[]
   emptyMessage?: string
-  getDeleteLabel: (row: T) => string
+  getDeleteLabel?: (row: T) => string
   getRowKey: (row: T) => string
   getRowLabel?: (row: T) => string
   isDeleting?: boolean
   isRowClickable?: (row: T) => boolean
-  onDelete: (row: T) => void
+  onDelete?: (row: T) => void
   onRowClick?: (row: T) => void
   rows: T[]
 }
@@ -133,11 +133,13 @@ export function AdminTable<T>({
   }
 
   const handleDeleteConfirm = () => {
-    if (deleteTarget) {
+    if (deleteTarget && onDelete) {
       onDelete(deleteTarget)
       // Don't close here — caller signals success by completing the mutation
     }
   }
+
+  const showActions = !!onDelete || !!actions
 
   return (
     <>
@@ -156,7 +158,9 @@ export function AdminTable<T>({
           </DialogHeader>
           {blockedTarget &&
             (() => {
-              const name = getDeleteLabel(blockedTarget.row)
+              const name = getDeleteLabel
+                ? getDeleteLabel(blockedTarget.row)
+                : ''
               const { blockedBy, reason } = blockedTarget.result
               if (blockedBy && blockedBy.length > 0) {
                 const parts = blockedBy.map((b, i) => (
@@ -225,7 +229,10 @@ export function AdminTable<T>({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Delete &quot;{deleteTarget ? getDeleteLabel(deleteTarget) : ''}
+              Delete &quot;
+              {deleteTarget && getDeleteLabel
+                ? getDeleteLabel(deleteTarget)
+                : ''}
               &quot;?
             </AlertDialogTitle>
             <AlertDialogDescription>
@@ -257,7 +264,9 @@ export function AdminTable<T>({
                     {col.header}
                   </TableHead>
                 ))}
-                <TableHead className="text-right">Actions</TableHead>
+                {showActions && (
+                  <TableHead className="text-right">Actions</TableHead>
+                )}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -265,7 +274,7 @@ export function AdminTable<T>({
                 <TableRow>
                   <TableCell
                     className="py-12 text-center text-muted-foreground"
-                    colSpan={columns.length + 1}
+                    colSpan={columns.length + (showActions ? 1 : 0)}
                   >
                     {emptyMessage}
                   </TableCell>
@@ -275,7 +284,9 @@ export function AdminTable<T>({
                   const key = getRowKey(row)
                   const label = getRowLabel
                     ? getRowLabel(row)
-                    : getDeleteLabel(row)
+                    : getDeleteLabel
+                      ? getDeleteLabel(row)
+                      : ''
                   const deleteCheck = canDelete
                     ? canDelete(row)
                     : { allowed: true }
@@ -311,45 +322,49 @@ export function AdminTable<T>({
                           {col.render(row)}
                         </TableCell>
                       ))}
-                      <TableCell
-                        className="text-right"
-                        onClick={(e) => e.stopPropagation()}
-                        onKeyDown={(e) => e.stopPropagation()}
-                      >
-                        <div className="flex items-center justify-end gap-2">
-                          {actions && actions(row)}
-                          <TooltipProvider delayDuration={200}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="inline-flex">
-                                  <Button
-                                    aria-label={`Delete ${label}`}
-                                    className={cn(
-                                      'text-destructive hover:bg-destructive/10 hover:text-destructive',
-                                      isDeleting &&
-                                        'pointer-events-none opacity-30',
-                                      !canDeleteRow && 'opacity-30',
-                                    )}
-                                    disabled={isDeleting}
-                                    onClick={(e) =>
-                                      handleDeleteClick(row, e, deleteCheck)
-                                    }
-                                    size="sm"
-                                    variant="ghost"
-                                  >
-                                    <Trash2 className="h-4 w-4" />
-                                  </Button>
-                                </span>
-                              </TooltipTrigger>
-                              {deleteReason && (
-                                <TooltipContent>
-                                  <p>{deleteReason}</p>
-                                </TooltipContent>
-                              )}
-                            </Tooltip>
-                          </TooltipProvider>
-                        </div>
-                      </TableCell>
+                      {showActions && (
+                        <TableCell
+                          className="text-right"
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => e.stopPropagation()}
+                        >
+                          <div className="flex items-center justify-end gap-2">
+                            {actions && actions(row)}
+                            {onDelete && (
+                              <TooltipProvider delayDuration={200}>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <span className="inline-flex">
+                                      <Button
+                                        aria-label={`Delete ${label}`}
+                                        className={cn(
+                                          'text-destructive hover:bg-destructive/10 hover:text-destructive',
+                                          isDeleting &&
+                                            'pointer-events-none opacity-30',
+                                          !canDeleteRow && 'opacity-30',
+                                        )}
+                                        disabled={isDeleting}
+                                        onClick={(e) =>
+                                          handleDeleteClick(row, e, deleteCheck)
+                                        }
+                                        size="sm"
+                                        variant="ghost"
+                                      >
+                                        <Trash2 className="h-4 w-4" />
+                                      </Button>
+                                    </span>
+                                  </TooltipTrigger>
+                                  {deleteReason && (
+                                    <TooltipContent>
+                                      <p>{deleteReason}</p>
+                                    </TooltipContent>
+                                  )}
+                                </Tooltip>
+                              </TooltipProvider>
+                            )}
+                          </div>
+                        </TableCell>
+                      )}
                     </TableRow>
                   )
                 })

--- a/src/components/ui/inline-edit/InlineDate.tsx
+++ b/src/components/ui/inline-edit/InlineDate.tsx
@@ -54,6 +54,7 @@ export function InlineDate({
       </PopoverTrigger>
       <PopoverContent align="start" className="w-auto p-2">
         <DayPicker
+          defaultMonth={hasValid ? current : undefined}
           mode="single"
           onSelect={async (d) => {
             setOpen(false)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -211,12 +211,7 @@ export interface AdminUser {
   created_at: string
   display_name: string
   email: string
-  groups: {
-    description?: null | string
-    name: string
-    roles: Role[]
-    slug: string
-  }[]
+  email_notifications: boolean
   is_active: boolean
   is_admin: boolean
   is_service_account: boolean
@@ -225,7 +220,10 @@ export interface AdminUser {
   roles: Role[]
 }
 
-export type AdminUserCreate = Schemas['UserCreate']
+export type AdminUserCreate = Schemas['UserCreate'] & {
+  email_notifications?: boolean
+  organizations?: { organization_slug: string; role: string }[]
+}
 
 export type AdminUserUpdate = Schemas['UserUpdate']
 


### PR DESCRIPTION
## Summary
- Reorganize the user edit page into Identity / Access / Memberships / Security sections inside a single card, using shadcn primitives and the standard admin heading sizes
- Replace the generic "Edit User" header with avatar + name + email
- Add Reset Password modal (auto-generate or manual), Created / Last sign-in footer strip, and a Delete user danger card at the bottom
- Hide the Security section when local authentication is disabled (skips password validation accordingly)
- AdminTable: \`onDelete\` and \`getDeleteLabel\` are now optional — the Actions column is omitted when neither is supplied. UserManagement drops the per-row delete (delete lives on the edit page now)
- Admin section header becomes a button that returns to the list when on a sub-page (edit/create/detail), generic across all admin sections

This PR also bundles a previously unpushed local commit (\`Refresh user admin form and sidebar nav\`) that was sitting on \`main\` from a prior session.

## Test plan
- [ ] Edit an existing user — confirm avatar/name header, all four sections render
- [ ] Toggle Local Authentication off in Auth Providers — Security section disappears on the user form, save still works
- [ ] Toggle Local Authentication on — Security section returns; Reset Password modal stages a password to be applied on Save
- [ ] Click "User Management" header from the edit page — returns to the list
- [ ] User list — no per-row delete icon; deletion happens from the edit page's Danger Zone
- [ ] Create a new user with local auth enabled and disabled — password is required only when enabled