### PR TITLE
Add project scoring UI

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -49,6 +49,8 @@ import type {
   RoleCreate,
   RoleDetail,
   RoleUser,
+  ScoringPolicy,
+  ScoringPolicyCreate,
   ServiceAccount,
   ServiceAccountCreate,
   ServiceApplication,
@@ -124,6 +126,32 @@ export const getProject = (
   apiClient.get<Project>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
     undefined,
+    signal,
+  )
+
+export interface AttributeContribution {
+  attribute_name: string
+  mapped_score: number
+  policy_slug: string
+  value: unknown
+  weight: number
+  weighted_contribution: number
+}
+
+export interface ScoreBreakdown {
+  attribute_contributions: AttributeContribution[]
+  base_score: number
+  unfloored_total: number
+}
+
+export const getProjectBreakdown = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<Project & { breakdown?: ScoreBreakdown }>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
+    { breakdown: true },
     signal,
   )
 
@@ -395,6 +423,51 @@ export const getOperationsLogEntry = (entryId: string, signal?: AbortSignal) =>
     signal,
   )
 
+// Events
+export interface EventRecord {
+  attributed_to: string
+  id: string
+  metadata: Record<string, unknown>
+  payload: Record<string, unknown>
+  project_id: string
+  recorded_at: string
+  third_party_service: string
+  type: string
+}
+
+export interface EventsPage {
+  entries: EventRecord[]
+  nextCursor?: string
+}
+
+interface EventsEnvelope {
+  data: EventRecord[]
+}
+
+export const listProjectEvents = async (
+  params: {
+    cursor?: string
+    limit?: number
+    orgSlug: string
+    projectId: string
+    type?: string
+  },
+  signal?: AbortSignal,
+): Promise<EventsPage> => {
+  const query: Record<string, unknown> = { limit: params.limit ?? 50 }
+  if (params.cursor) query.cursor = params.cursor
+  if (params.type) query.type = params.type
+  const { data, headers } = await apiClient.getWithHeaders<EventsEnvelope>(
+    `/organizations/${encodeURIComponent(params.orgSlug)}/projects/${encodeURIComponent(params.projectId)}/events/`,
+    query,
+    signal,
+  )
+  return {
+    entries: Array.isArray(data?.data) ? data.data : [],
+    nextCursor: parseNextCursor(headers),
+  }
+}
+
 // Metadata
 export const getEnvironments = async (
   signal?: AbortSignal,
@@ -631,6 +704,103 @@ export const getRoleGroups = async (
   )
   return Array.isArray(response) ? response : []
 }
+
+// Admin - Scoring Policies
+export const listScoringPolicies = async (
+  signal?: AbortSignal,
+): Promise<ScoringPolicy[]> => {
+  const response = await apiClient.get<ScoringPolicy[]>(
+    '/scoring/policies/',
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const getScoringPolicy = (slug: string, signal?: AbortSignal) =>
+  apiClient.get<ScoringPolicy>(
+    `/scoring/policies/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
+  )
+
+export const createScoringPolicy = (data: ScoringPolicyCreate) =>
+  apiClient.post<ScoringPolicy>('/scoring/policies/', data)
+
+export const updateScoringPolicy = (
+  slug: string,
+  operations: PatchOperation[],
+) =>
+  apiClient.patch<ScoringPolicy>(
+    `/scoring/policies/${encodeURIComponent(slug)}`,
+    operations,
+  )
+
+export const deleteScoringPolicy = (slug: string) =>
+  apiClient.delete<void>(`/scoring/policies/${encodeURIComponent(slug)}`)
+
+export const rescoreAll = () =>
+  apiClient.post<{ enqueued: number }>('/scoring/rescore')
+
+export const rescoreProject = (projectId: string) =>
+  apiClient.post<{ enqueued: number }>('/scoring/rescore', {
+    project_id: projectId,
+  })
+
+export interface ScoreTrend {
+  current: null | number
+  delta: null | number
+  period_days: number
+  previous: null | number
+}
+
+export const getScoreTrend = (
+  orgSlug: string,
+  projectId: string,
+  days = 30,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<ScoreTrend>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/score/trend`,
+    { days },
+    signal,
+  )
+
+export type ScoreChangeReason =
+  | 'attribute_change'
+  | 'blueprint_change'
+  | 'bulk_rescore'
+  | 'policy_change'
+  | 'system'
+
+export interface ScoreHistory {
+  granularity: 'day' | 'hour' | 'raw'
+  points: ScoreHistoryPoint[]
+  project_id: string
+}
+
+export interface ScoreHistoryPoint {
+  change_reason: null | ScoreChangeReason
+  previous_score: null | number
+  score: number
+  timestamp: string
+}
+
+export const getScoreHistory = (
+  orgSlug: string,
+  projectId: string,
+  params?: {
+    from?: string
+    granularity?: 'day' | 'hour' | 'raw'
+    to?: string
+  },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<ScoreHistory>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/score/history`,
+    params,
+    signal,
+  )
 
 // Admin - Settings (reference data)
 export const getAdminSettings = (signal?: AbortSignal) =>

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -16,6 +16,7 @@ import {
   Link2,
   Shield,
   StickyNote,
+  Target,
   Users,
   UsersRound,
   Webhook,
@@ -32,6 +33,7 @@ import { NoteTemplateManagement } from './admin/NoteTemplateManagement'
 import { OrganizationManagement } from './admin/OrganizationManagement'
 import { ProjectTypeManagement } from './admin/ProjectTypeManagement'
 import { RoleManagement } from './admin/RoleManagement'
+import { ScoringPolicyManagement } from './admin/ScoringPolicyManagement'
 import { ServiceAccountManagement } from './admin/ServiceAccountManagement'
 import { TeamManagement } from './admin/TeamManagement'
 import { ThirdPartyServiceManagement } from './admin/ThirdPartyServiceManagement'
@@ -47,6 +49,7 @@ type AdminSection =
   | 'organizations'
   | 'project-types'
   | 'roles'
+  | 'scoring-policies'
   | 'service-accounts'
   | 'teams'
   | 'third-party-services'
@@ -62,6 +65,7 @@ const VALID_SECTIONS: AdminSection[] = [
   'organizations',
   'project-types',
   'roles',
+  'scoring-policies',
   'service-accounts',
   'teams',
   'third-party-services',
@@ -136,6 +140,13 @@ export function Admin() {
       icon: UsersRound,
       id: 'teams',
       label: 'Teams',
+      scope: 'org',
+    },
+    {
+      description: 'Define attribute-based project scoring policies',
+      icon: Target,
+      id: 'scoring-policies',
+      label: 'Scoring Policies',
       scope: 'org',
     },
     {
@@ -334,6 +345,9 @@ export function Admin() {
               <ServiceAccountManagement />
             )}
             {currentSection === 'roles' && <RoleManagement />}
+            {currentSection === 'scoring-policies' && (
+              <ScoringPolicyManagement />
+            )}
             {currentSection === 'oauth' && <AuthProvidersManagement />}
           </div>
         </main>

--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -1,0 +1,371 @@
+import { useMemo } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { formatDistanceToNow } from 'date-fns'
+import { History, LoaderCircle } from 'lucide-react'
+
+import {
+  listAdminUsers,
+  listEnvironments,
+  listOperationsLog,
+  listProjectEvents,
+} from '@/api/endpoints'
+import type { EventRecord } from '@/api/endpoints'
+import { EnvironmentBadge } from '@/components/ui/environment-badge'
+import { Gravatar } from '@/components/ui/gravatar'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { formatFieldKey } from '@/lib/project-field-formatting'
+import type { Environment, OperationsLogRecord } from '@/types'
+
+const MAX_ROWS = 20
+
+type ActivityItem =
+  | { data: EventRecord; kind: 'event'; ts: Date }
+  | { data: OperationsLogRecord; kind: 'ops'; ts: Date }
+
+type AvatarColor = keyof typeof DOT_CLASS
+
+interface ProjectChangePayload extends Record<string, unknown> {
+  field: string
+  new: unknown
+  old: unknown
+}
+
+interface Props {
+  orgSlug: string
+  projectId: string
+  projectSlug: string
+}
+
+const DOT_CLASS = {
+  info: 'bg-[#3d86d1]',
+  neutral: 'bg-[#888780]',
+  warning: 'bg-[#ef9f27]',
+}
+
+export function ProjectActivityLog({ orgSlug, projectId, projectSlug }: Props) {
+  const { data: eventsPage, isPending: eventsPending } = useQuery({
+    enabled: Boolean(orgSlug) && Boolean(projectId),
+    queryFn: ({ signal }) =>
+      listProjectEvents({ limit: MAX_ROWS, orgSlug, projectId }, signal),
+    queryKey: ['events', orgSlug, projectId],
+    staleTime: 0,
+  })
+
+  const { data: opsPage, isPending: opsPending } = useQuery({
+    enabled: Boolean(projectSlug),
+    queryFn: ({ signal }) =>
+      listOperationsLog(
+        { filters: { project_slug: projectSlug }, limit: MAX_ROWS },
+        signal,
+      ),
+    queryKey: ['opsLog', projectSlug],
+    staleTime: 30_000,
+  })
+
+  const { data: adminUsers = [] } = useQuery({
+    enabled: Boolean(orgSlug),
+    queryFn: ({ signal }) => listAdminUsers({ is_active: true }, signal),
+    queryKey: ['admin-users', 'active'],
+    staleTime: 5 * 60_000,
+  })
+
+  const { data: environments = [] } = useQuery({
+    enabled: Boolean(orgSlug),
+    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
+    queryKey: ['environments', orgSlug],
+    staleTime: 10 * 60_000,
+  })
+
+  const envMap = useMemo(() => {
+    const m = new Map<string, Environment>()
+    for (const e of environments) m.set(e.slug, e)
+    return m
+  }, [environments])
+
+  const displayNames = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const u of adminUsers) {
+      if (u.email && u.display_name) m.set(u.email, u.display_name)
+    }
+    return m
+  }, [adminUsers])
+
+  const isPending = eventsPending || opsPending
+
+  const merged: ActivityItem[] = useMemo(() => {
+    const events: ActivityItem[] = (eventsPage?.entries ?? []).map((e) => ({
+      data: e,
+      kind: 'event' as const,
+      ts: new Date(e.recorded_at),
+    }))
+    const ops: ActivityItem[] = (opsPage?.entries ?? []).map((o) => ({
+      data: o,
+      kind: 'ops' as const,
+      ts: new Date(o.occurred_at),
+    }))
+    return [...events, ...ops]
+      .sort((a, b) => b.ts.getTime() - a.ts.getTime())
+      .slice(0, MAX_ROWS)
+  }, [eventsPage, opsPage])
+
+  const groups = useMemo(() => {
+    const map = new Map<string, { items: ActivityItem[]; label: string }>()
+    for (const item of merged) {
+      const key = dayKey(item.ts)
+      if (!map.has(key)) map.set(key, { items: [], label: dayLabel(item.ts) })
+      map.get(key)!.items.push(item)
+    }
+    return Array.from(map.values())
+  }, [merged])
+
+  return (
+    <div>
+      {isPending ? (
+        <div className="flex items-center justify-center py-10 text-tertiary">
+          <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading activity…</span>
+        </div>
+      ) : merged.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 py-10 text-tertiary">
+          <History className="h-5 w-5" />
+          <span className="text-sm">No activity recorded yet.</span>
+        </div>
+      ) : (
+        <div>
+          {groups.map((group) => (
+            <div key={group.label}>
+              <div className="px-6 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-widest text-tertiary">
+                {group.label}
+              </div>
+
+              <div className="relative px-6">
+                <div className="absolute bottom-4 left-[26px] top-4 w-px bg-tertiary" />
+
+                {group.items.map((item, i) =>
+                  item.kind === 'event' ? (
+                    <EventEntry
+                      displayNames={displayNames}
+                      item={item}
+                      key={`event-${item.data.id}-${i}`}
+                    />
+                  ) : (
+                    <OpsEntry
+                      displayNames={displayNames}
+                      envMap={envMap}
+                      item={item}
+                      key={`ops-${item.data.id}-${i}`}
+                    />
+                  ),
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function dayKey(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+function dayLabel(d: Date): string {
+  const today = new Date()
+  if (dayKey(d) === dayKey(today)) return 'TODAY'
+  return d
+    .toLocaleDateString('en-US', { day: 'numeric', month: 'short' })
+    .toUpperCase()
+}
+
+function EntryRow({
+  avatarColor,
+  body,
+  email,
+  name,
+  ts,
+}: {
+  avatarColor: AvatarColor
+  body: React.ReactNode
+  email: string
+  name: string
+  ts: Date
+}) {
+  return (
+    <div className="relative flex gap-3 py-3">
+      <div className="relative flex w-4 shrink-0 flex-col items-center">
+        <div
+          className={`relative z-10 mt-1.5 h-2 w-2 shrink-0 rounded-full ring-2 ring-primary ${DOT_CLASS[avatarColor]}`}
+        />
+      </div>
+      <Gravatar
+        className="h-8 w-8 shrink-0 rounded-full"
+        email={email}
+        size={32}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="truncate font-semibold text-primary">{name}</span>
+          <Timestamp ts={ts} />
+        </div>
+        <div className="mt-0.5 text-sm text-secondary">{body}</div>
+      </div>
+    </div>
+  )
+}
+
+function EnvChip({ env }: { env?: Environment }) {
+  if (env) {
+    return (
+      <EnvironmentBadge
+        label_color={env.label_color}
+        name={env.name}
+        slug={env.slug}
+      />
+    )
+  }
+  return null
+}
+
+function EventEntry({
+  displayNames,
+  item,
+}: {
+  displayNames: Map<string, string>
+  item: ActivityItem & { kind: 'event' }
+}) {
+  const entry = item.data
+  const name = getDisplayName(entry.attributed_to, displayNames)
+
+  let body: React.ReactNode
+  if (
+    entry.type === 'project-change' &&
+    isProjectChangePayload(entry.payload)
+  ) {
+    const field = formatFieldKey(entry.payload.field)
+    const oldStr = formatValue(entry.payload.old)
+    const newStr = formatValue(entry.payload.new)
+    body = (
+      <span>
+        changed {field}
+        {oldStr ? (
+          <>
+            {' '}
+            <ValueChip>{oldStr}</ValueChip>
+            {' → '}
+            <ValueChip>{newStr}</ValueChip>
+          </>
+        ) : (
+          <>
+            {' to '}
+            <ValueChip>{newStr}</ValueChip>
+          </>
+        )}
+      </span>
+    )
+  } else {
+    body = (
+      <span className="text-tertiary">{entry.type.replace(/-/g, ' ')}</span>
+    )
+  }
+
+  return (
+    <EntryRow
+      avatarColor="info"
+      body={body}
+      email={entry.attributed_to}
+      name={name}
+      ts={item.ts}
+    />
+  )
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') return String(value)
+  return JSON.stringify(value)
+}
+
+function getDisplayName(
+  email: string,
+  displayNames: Map<string, string>,
+): string {
+  return displayNames.get(email) ?? email.split('@')[0] ?? email
+}
+
+function isProjectChangePayload(
+  payload: Record<string, unknown>,
+): payload is ProjectChangePayload {
+  return typeof payload.field === 'string'
+}
+
+function OpsEntry({
+  displayNames,
+  envMap,
+  item,
+}: {
+  displayNames: Map<string, string>
+  envMap: Map<string, Environment>
+  item: ActivityItem & { kind: 'ops' }
+}) {
+  const op = item.data
+  const actor = op.performed_by ?? op.recorded_by
+  const name = getDisplayName(actor, displayNames)
+  const color: AvatarColor =
+    op.entry_type === 'Deployed' ? 'warning' : 'neutral'
+
+  const body = (
+    <span>
+      {op.entry_type.toLowerCase()}
+      {op.version && (
+        <>
+          {' '}
+          <ValueChip>{op.version}</ValueChip>
+        </>
+      )}
+      {' to '}
+      <EnvChip env={envMap.get(op.environment_slug)} />
+    </span>
+  )
+
+  return (
+    <EntryRow
+      avatarColor={color}
+      body={body}
+      email={actor}
+      name={name}
+      ts={item.ts}
+    />
+  )
+}
+
+function Timestamp({ ts }: { ts: Date }) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="shrink-0 cursor-default whitespace-nowrap font-mono text-xs text-tertiary">
+            {formatDistanceToNow(ts, { addSuffix: true })}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{ts.toLocaleString()}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+function ValueChip({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="inline-rounded rounded bg-secondary px-1.5 py-0.5 font-mono text-xs text-primary">
+      {children}
+    </code>
+  )
+}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useNavigate } from 'react-router-dom'
 
@@ -6,31 +6,38 @@ import { useQuery } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
   ArrowRight,
+  ChevronDown,
+  Filter,
   Rocket,
   Settings2 as SettingsIcon,
-  TrendingDown,
-  TrendingUp,
 } from 'lucide-react'
 
 import {
+  type AttributeContribution,
+  getProjectBreakdown,
   getProjectSchema,
+  getScoreTrend,
   listCurrentReleases,
   listLinkDefinitions,
   listProjectNotes,
   listProjectTypes,
   listTeams,
+  type ScoreTrend,
 } from '@/api/endpoints'
 import { ProjectNotesTab } from '@/components/notes/ProjectNotesTab'
 import { OperationsLog } from '@/components/OperationsLog'
+import { ProjectActivityLog } from '@/components/ProjectActivityLog'
 import { ProjectAttributesSection } from '@/components/ProjectAttributesSection'
 import { ProjectEnvironmentsCard } from '@/components/ProjectEnvironmentsCard'
 import { ProjectRelationshipsTab } from '@/components/ProjectRelationshipsTab'
 import { ProjectSettingsTab } from '@/components/ProjectSettingsTab'
+import { ScoreHistoryTab } from '@/components/ScoreHistoryTab'
 import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
@@ -39,6 +46,7 @@ import { InlineSelect } from '@/components/ui/inline-edit/InlineSelect'
 import { InlineText } from '@/components/ui/inline-edit/InlineText'
 import { InlineTextarea } from '@/components/ui/inline-edit/InlineTextarea'
 import { LabelChip } from '@/components/ui/label-chip'
+import { ScoreBadge } from '@/components/ui/score-badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   Tooltip,
@@ -49,6 +57,7 @@ import {
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { getIcon, useIconRegistryVersion } from '@/lib/icons'
+import { formatFieldKey } from '@/lib/project-field-formatting'
 import { sanitizeHttpUrl, sortEnvironments } from '@/lib/utils'
 import type { Project } from '@/types'
 
@@ -67,6 +76,7 @@ const VALID_TABS = [
   'logs',
   'notes',
   'operations-log',
+  'score-history',
   'settings',
 ] as const
 
@@ -105,12 +115,6 @@ export function ProjectDetail({
     }
   }, [initialTab, navigate, project.id])
 
-  // Mock data for aspects not yet available from the API. Dev-only so
-  // production builds don't leak hardcoded placeholder content.
-  const isDev = import.meta.env.DEV
-  const healthScore = isDev ? 66 : null
-  const healthTrend = isDev ? 'down' : null
-
   const { data: currentReleases = [] } = useQuery({
     enabled: !!orgSlug && !!project.id,
     queryFn: ({ signal }) => listCurrentReleases(orgSlug, project.id, signal),
@@ -138,52 +142,7 @@ export function ProjectDetail({
     return out
   }, [currentReleases])
 
-  const feed = isDev
-    ? [
-        {
-          action: 'deployed in',
-          environment: 'Testing',
-          time: 'Nov 22, 2025, 12:28 PM',
-          user: 'Scott Miller',
-          version: '(1962b02)',
-        },
-        {
-          action: 'deployed in',
-          environment: 'Production',
-          time: 'Nov 21, 2025, 4:09 PM',
-          user: 'Scott Miller',
-          version: '(1.0.11)',
-        },
-        {
-          action: 'deployed in',
-          environment: 'Staging',
-          time: 'Nov 21, 2025, 4:08 PM',
-          user: 'Scott Miller',
-          version: '(1.0.11)',
-        },
-        {
-          action: 'deployed in',
-          environment: 'Testing',
-          time: 'Nov 21, 2025, 4:08 PM',
-          user: 'Scott Miller',
-          version: '(d504611)',
-        },
-        {
-          action: 'deployed in',
-          environment: 'Production',
-          time: 'Nov 21, 2025, 3:50 PM',
-          user: 'Scott Miller',
-          version: '(1.0.10)',
-        },
-        {
-          action: 'deployed in',
-          environment: 'Testing',
-          time: 'Nov 21, 2025, 3:45 PM',
-          user: 'Scott Miller',
-          version: '(089f7fd)',
-        },
-      ]
-    : []
+  const isDev = import.meta.env.DEV
 
   const sortedEnvironments = useMemo(
     () => sortEnvironments(project.environments || []),
@@ -195,6 +154,25 @@ export function ProjectDetail({
     queryFn: ({ signal }) => listLinkDefinitions(orgSlug, signal),
     queryKey: ['linkDefinitions', orgSlug],
   })
+
+  const { data: scoreTrend } = useQuery({
+    enabled: !!orgSlug && !!project.id,
+    queryFn: ({ signal }) => getScoreTrend(orgSlug, project.id, 30, signal),
+    queryKey: ['scoreTrend', orgSlug, project.id],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const { data: projectWithBreakdown } = useQuery({
+    enabled: !!orgSlug && !!project.id && project.score != null,
+    queryFn: ({ signal }) => getProjectBreakdown(orgSlug, project.id, signal),
+    queryKey: ['projectBreakdown', orgSlug, project.id],
+    staleTime: 5 * 60 * 1000,
+  })
+  const scoreBreakdown = projectWithBreakdown?.breakdown
+  const [breakdownOpen, setBreakdownOpen] = useState(false)
+  // Capture the score present at page load so intra-session changes are visible
+  // even when the 30d baseline equals the current live score.
+  const sessionBaseScore = useRef<null | number>(project.score ?? null)
 
   const { data: projectSchema } = useQuery({
     enabled: !!orgSlug,
@@ -311,6 +289,7 @@ export function ProjectDetail({
         return `Relationships (${total})`
       })(),
     },
+    { id: 'score-history', label: 'Score History' },
     { id: 'settings', label: '' },
   ]
 
@@ -438,7 +417,7 @@ export function ProjectDetail({
         </TabsList>
 
         <TabsContent value="overview">
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr] lg:items-start">
             {/* Left column: Details */}
             <div className="space-y-6">
               <Card>
@@ -531,93 +510,68 @@ export function ProjectDetail({
               )}
             </div>
 
-            {/* Right column: Health & Compliance + Recent Activity (dev only) */}
-            {isDev && (
-              <div className="space-y-6">
-                {/* Health & Compliance (mocked, dev only) */}
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Health &amp; compliance</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="mb-4 flex items-center gap-3">
-                      <div
-                        className={`flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg text-2xl font-medium ${
-                          (healthScore ?? 0) >= 90
-                            ? 'bg-green-50 text-green-700'
-                            : (healthScore ?? 0) >= 80
-                              ? 'bg-emerald-50 text-emerald-700'
-                              : (healthScore ?? 0) >= 70
-                                ? 'bg-amber-50 text-amber-700'
-                                : 'bg-red-50 text-red-700'
-                        }`}
+            {/* Right column: Health score + Activity */}
+            <div className="flex flex-col gap-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Health &amp; compliance</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center gap-3">
+                    <ScoreBadge
+                      score={projectWithBreakdown?.score ?? project.score}
+                      size="lg"
+                      variant="square"
+                    />
+                    <div>
+                      <p className={`text-xs ${muted}`}>Health score</p>
+                      <ScoreTrendPill
+                        liveScore={projectWithBreakdown?.score ?? project.score}
+                        scoreTrend={scoreTrend}
+                        sessionBaseScore={sessionBaseScore}
+                      />
+                    </div>
+                  </div>
+                </CardContent>
+                {scoreBreakdown &&
+                  scoreBreakdown.attribute_contributions.length > 0 && (
+                    <CardFooter className="flex-col items-start gap-0 border-t border-tertiary p-0">
+                      <button
+                        className="flex w-full items-center justify-between px-6 py-3 text-xs font-medium text-tertiary hover:text-primary"
+                        onClick={() => setBreakdownOpen((o) => !o)}
+                        type="button"
                       >
-                        {healthScore}
-                      </div>
-                      <div>
-                        <div className="flex items-center gap-1.5">
-                          {healthTrend === 'down' ? (
-                            <TrendingDown className="h-4 w-4 text-red-600" />
-                          ) : (
-                            <TrendingUp className="h-4 w-4 text-green-600" />
-                          )}
-                          <span
-                            className={`text-sm ${healthTrend === 'down' ? 'text-red-600' : 'text-green-600'}`}
-                          >
-                            {healthTrend === 'down' ? 'Declining' : 'Improving'}
-                          </span>
-                        </div>
-                        <p className={`text-xs ${muted}`}>Health score</p>
-                      </div>
-                    </div>
+                        Score breakdown
+                        <ChevronDown
+                          className={`h-3.5 w-3.5 transition-transform ${breakdownOpen ? 'rotate-180' : ''}`}
+                        />
+                      </button>
+                      {breakdownOpen && (
+                        <ScoreBreakdownDetail
+                          contributions={scoreBreakdown.attribute_contributions}
+                        />
+                      )}
+                    </CardFooter>
+                  )}
+              </Card>
 
-                    <p className={`text-sm ${muted}`}>
-                      Policy scoring and compliance checks will appear here.
-                    </p>
-                  </CardContent>
-                </Card>
-
-                {/* Recent Activity (mocked, dev only) */}
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Recent activity</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="space-y-4">
-                      {feed.map((item, index) => (
-                        <div className="flex items-start gap-2.5" key={index}>
-                          <div className="min-w-0 flex-1">
-                            <p className={`text-sm leading-snug ${value}`}>
-                              <span className="font-medium">{item.user}</span>{' '}
-                              <span className={label}>{item.action}</span>{' '}
-                              <span
-                                style={{
-                                  color:
-                                    project.environments?.find(
-                                      (e) => e.name === item.environment,
-                                    )?.label_color || undefined,
-                                }}
-                              >
-                                {item.environment}
-                              </span>
-                            </p>
-                            <div className="mt-0.5 flex items-center gap-1.5">
-                              <span className={`text-xs ${muted}`}>
-                                {item.time}
-                              </span>
-                              <span className={`text-xs ${muted}`}>&bull;</span>
-                              <span className="font-mono text-xs text-tertiary">
-                                {item.version}
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            )}
+              <Card className="flex flex-col" style={{ maxHeight: '600px' }}>
+                <CardHeader className="flex flex-row items-center justify-between">
+                  <CardTitle>Recent activity</CardTitle>
+                  <button className="inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-xs text-secondary transition-colors hover:bg-secondary hover:text-primary">
+                    <Filter className="h-3 w-3" />
+                    Filter
+                  </button>
+                </CardHeader>
+                <CardContent className="min-h-0 flex-1 overflow-y-auto p-0">
+                  <ProjectActivityLog
+                    orgSlug={project.team.organization.slug}
+                    projectId={project.id}
+                    projectSlug={project.slug}
+                  />
+                </CardContent>
+              </Card>
+            </div>
           </div>
         </TabsContent>
 
@@ -660,12 +614,22 @@ export function ProjectDetail({
             showSummary={false}
           />
         </TabsContent>
+        <TabsContent value="score-history">
+          <ScoreHistoryTab orgSlug={orgSlug} projectId={project.id} />
+        </TabsContent>
         <TabsContent value="settings">
           <ProjectSettingsTab project={project} />
         </TabsContent>
       </Tabs>
     </div>
   )
+}
+
+function fmtAttributeValue(value: unknown): string {
+  const n = Number(value)
+  return isFinite(n) && String(value).trim() !== ''
+    ? String(Math.round(n))
+    : String(value)
 }
 
 function PlaceholderTab({ name }: { name: string }) {
@@ -678,5 +642,115 @@ function PlaceholderTab({ name }: { name: string }) {
         </CardDescription>
       </CardContent>
     </Card>
+  )
+}
+
+function ScoreBreakdownDetail({
+  contributions,
+}: {
+  contributions: AttributeContribution[]
+}) {
+  const totalWeight = contributions.reduce((s, c) => s + c.weight, 0)
+  const sorted = [...contributions].sort(
+    (a, b) => b.weighted_contribution - a.weighted_contribution,
+  )
+  return (
+    <div className="w-full px-6 pb-4">
+      <p className="mb-3 text-[11px] text-tertiary">
+        {contributions.length} policies
+      </p>
+      {sorted.map((c) => {
+        const maxPts = totalWeight > 0 ? (c.weight / totalWeight) * 100 : 0
+        const fillPct =
+          maxPts > 0 ? (c.weighted_contribution / maxPts) * 100 : 0
+        const isDrag = c.mapped_score === 0
+        const isPartial = !isDrag && c.mapped_score < 100
+        const policyName = formatFieldKey(c.policy_slug.replace(/-/g, '_'))
+        return (
+          <div className="mb-3 last:mb-0" key={c.policy_slug}>
+            <div className="flex items-baseline justify-between gap-2">
+              <div className="flex min-w-0 items-baseline gap-1.5">
+                <span className="text-[13px] font-semibold text-primary">
+                  {policyName}
+                </span>
+                <span className="font-mono text-[11px] text-tertiary">
+                  w{c.weight}
+                </span>
+              </div>
+              <div className="shrink-0 font-mono text-[13px] tabular-nums">
+                <span
+                  className={
+                    isDrag
+                      ? 'font-semibold text-danger'
+                      : 'font-semibold text-primary'
+                  }
+                >
+                  {Math.round(c.weighted_contribution)}
+                </span>
+                <span className="text-tertiary"> / {Math.round(maxPts)}</span>
+              </div>
+            </div>
+            <div className="mt-1 flex items-center gap-2">
+              <span
+                className={`w-1/3 shrink-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11.5px] ${
+                  isDrag
+                    ? 'text-danger'
+                    : isPartial
+                      ? 'text-amber-text'
+                      : 'text-tertiary'
+                }`}
+              >
+                {c.value != null ? fmtAttributeValue(c.value) : 'Not set'}
+              </span>
+              <div className="relative h-1.5 flex-1 rounded-full bg-secondary">
+                {fillPct > 0 && (
+                  <div
+                    className="absolute inset-y-0 left-0 rounded-full bg-action"
+                    style={{ width: `${fillPct}%` }}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function ScoreTrendPill({
+  liveScore,
+  scoreTrend,
+  sessionBaseScore,
+}: {
+  liveScore: null | number | undefined
+  scoreTrend: ScoreTrend | undefined
+  sessionBaseScore: React.RefObject<null | number>
+}) {
+  if (liveScore == null) return null
+
+  const sessionDelta =
+    sessionBaseScore.current != null
+      ? Math.round((liveScore - sessionBaseScore.current) * 100) / 100
+      : null
+  const showSession = sessionDelta != null && sessionDelta !== 0
+
+  let delta: null | number
+  let trendLabel: string
+  if (showSession) {
+    delta = sessionDelta
+    trendLabel = 'session'
+  } else if (scoreTrend?.previous != null) {
+    delta = Math.round((liveScore - scoreTrend.previous) * 100) / 100
+    trendLabel = `${scoreTrend.period_days}d`
+  } else {
+    return null
+  }
+
+  return (
+    <p className="font-mono text-xs text-tertiary">
+      {delta > 0 ? '+' : ''}
+      {Math.round(delta)} pts / {trendLabel}
+    </p>
   )
 }

--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -45,7 +45,7 @@ export function ProjectEnvironmentsCard({
                     slug={env.slug}
                   />
                 </div>
-                <div className="flex-1 text-center">
+                <div className="w-28 flex-shrink-0 text-right">
                   <span className="font-mono text-sm text-tertiary">
                     {deployment?.version ?? ''}
                   </span>
@@ -54,7 +54,7 @@ export function ProjectEnvironmentsCard({
                   {url ? (
                     <a
                       className={
-                        'inline-flex items-center gap-1.5 text-sm text-warning hover:underline'
+                        'inline-flex items-center gap-1.5 whitespace-nowrap text-sm text-warning hover:underline'
                       }
                       href={url}
                       rel="noopener noreferrer"

--- a/src/components/ProjectRelationshipsTab.tsx
+++ b/src/components/ProjectRelationshipsTab.tsx
@@ -142,7 +142,7 @@ export function ProjectRelationshipsTab({
   if (isLoading) {
     return (
       <Card>
-        <CardContent>
+        <CardContent className="p-4">
           <p className={sub}>Loading relationships…</p>
         </CardContent>
       </Card>
@@ -151,7 +151,7 @@ export function ProjectRelationshipsTab({
   if (isError && !data) {
     return (
       <Card>
-        <CardContent>
+        <CardContent className="p-4">
           <p className={sub}>Failed to load relationships.</p>
         </CardContent>
       </Card>
@@ -217,12 +217,12 @@ export function ProjectRelationshipsTab({
     <>
       {rels.length === 0 ? (
         <Card>
-          <CardContent className="flex items-center justify-between">
+          <CardContent className="flex items-center justify-between p-4">
             <p className={sub}>This project has no relationships.</p>
             <Button
-              className="gap-1 bg-action text-action-foreground hover:bg-action-hover"
               onClick={() => setEditDialogOpen(true)}
               size="sm"
+              variant="outline"
             >
               Edit
             </Button>

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -10,6 +10,7 @@ import {
   listEnvironments,
   listLinkDefinitions,
   patchProject,
+  rescoreProject,
 } from '@/api/endpoints'
 import { EditEnvironmentsCard } from '@/components/EditEnvironmentsCard'
 import { EditIdentifiersCard } from '@/components/EditIdentifiersCard'
@@ -24,6 +25,7 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useAuth } from '@/hooks/useAuth'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { sortEnvironments } from '@/lib/utils'
@@ -34,6 +36,8 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   const orgSlug = selectedOrganization?.slug || ''
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const { user } = useAuth()
+  const isAdmin = user?.is_admin === true
   const { patch } = useProjectPatch(orgSlug, project.id)
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -52,6 +56,12 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
     mutationFn: () => deleteProject(orgSlug, project.id),
     onError: mutationErrorHandler('delete project'),
     onSuccess: () => navigate('/'),
+  })
+
+  const rescoreMutation = useMutation({
+    mutationFn: () => rescoreProject(project.id),
+    onError: mutationErrorHandler('recompute score'),
+    onSuccess: () => toast.success('Score recompute enqueued'),
   })
 
   const {
@@ -121,6 +131,29 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
         identifiers={project.identifiers || {}}
         onPatch={(entries) => patch('/identifiers', entries)}
       />
+
+      {isAdmin && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Recompute score</CardTitle>
+            <CardDescription className="text-secondary">
+              Enqueue an immediate score recompute for this project. Use this
+              after manually correcting project data or when the displayed score
+              appears stale.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button
+              disabled={rescoreMutation.isPending}
+              onClick={() => rescoreMutation.mutate()}
+              size="sm"
+              variant="outline"
+            >
+              {rescoreMutation.isPending ? 'Enqueuing...' : 'Recompute Score'}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       <Card className="border-amber-300">
         <CardHeader>

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -38,7 +38,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   const navigate = useNavigate()
   const { user } = useAuth()
   const isAdmin = user?.is_admin === true
-  const { patch } = useProjectPatch(orgSlug, project.id)
+  const { patch, scheduleScoreRefresh } = useProjectPatch(orgSlug, project.id)
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
@@ -61,7 +61,10 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   const rescoreMutation = useMutation({
     mutationFn: () => rescoreProject(project.id),
     onError: mutationErrorHandler('recompute score'),
-    onSuccess: () => toast.success('Score recompute enqueued'),
+    onSuccess: () => {
+      toast.success('Score recompute enqueued')
+      scheduleScoreRefresh()
+    },
   })
 
   const {

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -15,6 +15,7 @@ import { Button } from './ui/button'
 import { Card } from './ui/card'
 import { EnvironmentBadge } from './ui/environment-badge'
 import { Input } from './ui/input'
+import { ScoreBadge } from './ui/score-badge'
 import {
   Table,
   TableBody,
@@ -65,28 +66,6 @@ export function ProjectsView() {
     queryFn: ({ signal }) => getProjects(orgSlug, signal),
     queryKey: ['projects', orgSlug],
   })
-
-  const getHealthColor = (health: number) => {
-    if (health >= 80) return 'text-success bg-success'
-    if (health >= 70) return 'text-warning bg-warning'
-    return 'text-danger bg-danger'
-  }
-
-  const getHealthRingColor = (health: number) => {
-    if (health >= 80) return 'ring-success'
-    if (health >= 70) return 'ring-warning'
-    return 'ring-danger'
-  }
-
-  // Mock health score - deterministic from slug so it's stable across renders.
-  // Will come from the API in the future.
-  const getMockHealth = (slug: string) => {
-    let hash = 0
-    for (let i = 0; i < slug.length; i++) {
-      hash = ((hash << 5) - hash + slug.charCodeAt(i)) | 0
-    }
-    return 70 + Math.abs(hash % 30)
-  }
 
   const handleProjectSelect = (projectId: string) => {
     navigate(`/projects/${projectId}`)
@@ -186,7 +165,6 @@ export function ProjectsView() {
       ) : viewMode === 'grid' ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filteredProjects.map((project) => {
-            const health = getMockHealth(project.slug)
             return (
               <Card
                 className={`cursor-pointer p-5 transition-shadow hover:shadow-md ${''}`}
@@ -204,12 +182,12 @@ export function ProjectsView() {
                         .join(', ')}
                     </p>
                   </div>
-                  <div
-                    className={`flex h-12 w-12 items-center justify-center rounded-full ring-4 ${getHealthRingColor(
-                      health,
-                    )} ${getHealthColor(health)} ml-3 flex-shrink-0`}
-                  >
-                    <span className="text-sm font-semibold">{health}</span>
+                  <div className="ml-3">
+                    <ScoreBadge
+                      score={project.score}
+                      size="md"
+                      variant="circle"
+                    />
                   </div>
                 </div>
 
@@ -284,7 +262,6 @@ export function ProjectsView() {
               </TableHeader>
               <TableBody className="divide-y divide-tertiary">
                 {filteredProjects.map((project) => {
-                  const health = getMockHealth(project.slug)
                   return (
                     <TableRow
                       className="cursor-pointer transition-colors hover:bg-secondary"
@@ -320,13 +297,7 @@ export function ProjectsView() {
                           )}
                       </TableCell>
                       <TableCell className="px-6 py-4">
-                        <div
-                          className={`inline-flex h-10 w-10 items-center justify-center rounded-full ${getHealthColor(health)}`}
-                        >
-                          <span className="text-sm font-semibold">
-                            {health}
-                          </span>
-                        </div>
+                        <ScoreBadge score={project.score} variant="circle" />
                       </TableCell>
                     </TableRow>
                   )

--- a/src/components/ScoreHistoryTab.tsx
+++ b/src/components/ScoreHistoryTab.tsx
@@ -1,0 +1,977 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import {
+  ArrowRight,
+  Download,
+  Filter,
+  LayoutTemplate,
+  LucideProps,
+  PencilLine,
+  RefreshCw,
+  Server,
+  SlidersHorizontal,
+} from 'lucide-react'
+
+import {
+  EventRecord,
+  getScoreHistory,
+  getScoreTrend,
+  listProjectEvents,
+  ScoreChangeReason,
+  ScoreHistoryPoint,
+} from '@/api/endpoints'
+import { formatFieldKey } from '@/lib/project-field-formatting'
+
+type Granularity = 'day' | 'hour' | 'raw'
+type LucideIcon = React.FC<LucideProps>
+
+interface Props {
+  orgSlug: string
+  projectId: string
+}
+
+type Range = '1y' | '30d' | '90d' | 'all'
+
+const REASON_META: Record<
+  ScoreChangeReason,
+  {
+    bgClass: string
+    dot: string
+    Icon: LucideIcon
+    label: string
+    textClass: string
+  }
+> = {
+  attribute_change: {
+    bgClass: 'bg-info',
+    dot: '#3d86d1',
+    Icon: PencilLine,
+    label: 'Attribute',
+    textClass: 'text-info',
+  },
+  blueprint_change: {
+    bgClass: 'bg-accent',
+    dot: '#7f77dd',
+    Icon: LayoutTemplate,
+    label: 'Blueprint',
+    textClass: 'text-accent',
+  },
+  bulk_rescore: {
+    bgClass: 'bg-secondary',
+    dot: '#888780',
+    Icon: RefreshCw,
+    label: 'Rescore',
+    textClass: 'text-secondary',
+  },
+  policy_change: {
+    bgClass: 'bg-warning',
+    dot: '#ef9f27',
+    Icon: SlidersHorizontal,
+    label: 'Policy',
+    textClass: 'text-warning',
+  },
+  system: {
+    bgClass: 'bg-secondary',
+    dot: '#aaa9a5',
+    Icon: Server,
+    label: 'System',
+    textClass: 'text-secondary',
+  },
+}
+
+interface ChartProps {
+  annotations: Map<number, ScoreChangeReason>
+  eventCorrelations: Map<number, ProjectChangePayload>
+  hoveredIdx: null | number
+  points: ScoreHistoryPoint[]
+  setHoveredIdx: (i: null | number) => void
+}
+
+interface EventTimelineProps {
+  eventCorrelations: Map<number, ProjectChangePayload>
+  events: ScoreHistoryPoint[]
+  hoveredIdx: null | number
+  setHoveredIdx: (i: null | number) => void
+}
+
+interface ProjectChangePayload {
+  field: string
+  new: unknown
+  old: unknown
+}
+
+interface SegmentedItem {
+  key: string
+  label: string
+}
+
+// ---------- Segmented control ----------
+
+export function ScoreHistoryTab({ orgSlug, projectId }: Props) {
+  const [range, setRange] = useState<Range>('1y')
+  const [granularity, setGranularity] = useState<Granularity>('day')
+  const [hoveredChart, setHoveredChart] = useState<null | number>(null)
+  const [hoveredEvent, setHoveredEvent] = useState<null | number>(null)
+
+  const rangeParams = useMemo(() => getRangeParams(range), [range])
+
+  const { data: chartData, isLoading: chartLoading } = useQuery({
+    enabled: !!orgSlug && !!projectId,
+    queryFn: ({ signal }) =>
+      getScoreHistory(
+        orgSlug,
+        projectId,
+        { granularity, ...rangeParams },
+        signal,
+      ),
+    queryKey: ['scoreHistory', orgSlug, projectId, granularity, range],
+  })
+
+  const { data: rawData, isLoading: rawLoading } = useQuery({
+    // When granularity is already 'raw', chartData IS the raw data — skip the duplicate request.
+    enabled: !!orgSlug && !!projectId && granularity !== 'raw',
+    queryFn: ({ signal }) =>
+      getScoreHistory(
+        orgSlug,
+        projectId,
+        { granularity: 'raw', ...rangeParams },
+        signal,
+      ),
+    queryKey: ['scoreHistoryRaw', orgSlug, projectId, range],
+  })
+
+  const { data: trendData } = useQuery({
+    enabled: !!orgSlug && !!projectId,
+    queryFn: ({ signal }) => getScoreTrend(orgSlug, projectId, 90, signal),
+    queryKey: ['scoreTrend90', orgSlug, projectId],
+  })
+
+  const { data: projectEventsPage } = useQuery({
+    enabled: !!orgSlug && !!projectId,
+    queryFn: ({ signal }) =>
+      listProjectEvents(
+        { limit: 500, orgSlug, projectId, type: 'project-change' },
+        signal,
+      ),
+    queryKey: ['projectEvents', orgSlug, projectId, 'project-change'],
+    staleTime: 30_000,
+  })
+  const projectChangeEvents = useMemo(
+    () => projectEventsPage?.entries ?? [],
+    [projectEventsPage],
+  )
+
+  const chartPoints = useMemo(() => {
+    const pts = chartData?.points ?? []
+    if (pts.length === 0) return pts
+    const last = pts[pts.length - 1]
+    const now = new Date()
+    const lastMs = new Date(toUtc(last.timestamp)).getTime()
+    // Only append if the last point is more than a minute old
+    if (now.getTime() - lastMs > 60_000) {
+      return [
+        ...pts,
+        { ...last, change_reason: null, timestamp: now.toISOString() },
+      ]
+    }
+    return pts
+  }, [chartData])
+  const rawEvents = useMemo(
+    () =>
+      ((granularity === 'raw' ? chartData?.points : rawData?.points) ?? [])
+        .filter((p) => p.change_reason != null)
+        .reverse(),
+    [chartData, granularity, rawData],
+  )
+
+  // chart index → change_reason
+  // Raw granularity: change_reason is on each chart point directly.
+  // Day/hour granularity: the SQL aggregation drops change_reason, so map
+  // raw events to the nearest chart bucket by timestamp instead.
+  const chartAnnotations = useMemo((): Map<number, ScoreChangeReason> => {
+    const m = new Map<number, ScoreChangeReason>()
+    if (granularity === 'raw') {
+      chartPoints.forEach((p, i) => {
+        if (p.change_reason != null) m.set(i, p.change_reason)
+      })
+    } else {
+      rawEvents.forEach((e) => {
+        if (e.change_reason == null) return
+        const i = nearestChartPointIndex(
+          new Date(toUtc(e.timestamp)).getTime(),
+          chartPoints,
+        )
+        if (!m.has(i)) m.set(i, e.change_reason)
+      })
+    }
+    return m
+  }, [chartPoints, granularity, rawEvents])
+
+  // For annotation hover sync: map raw event index → nearest chart point index by timestamp
+  const syncedChartHover = useMemo(() => {
+    if (
+      hoveredEvent == null ||
+      rawEvents.length === 0 ||
+      chartPoints.length === 0
+    )
+      return null
+    return nearestChartPointIndex(
+      new Date(toUtc(rawEvents[hoveredEvent].timestamp)).getTime(),
+      chartPoints,
+    )
+  }, [hoveredEvent, rawEvents, chartPoints])
+
+  // correlate score events → project-change events by timestamp proximity.
+  // The score recomputation is debounced ~5s after the attribute change, so
+  // we look for the nearest project-change event in the 90s window before
+  // each score event.
+  const eventCorrelations = useMemo((): Map<number, ProjectChangePayload> => {
+    return buildCorrelations(rawEvents, projectChangeEvents)
+  }, [rawEvents, projectChangeEvents])
+
+  // For the chart tooltip: same correlation keyed by chart point index.
+  const chartEventCorrelations = useMemo((): Map<
+    number,
+    ProjectChangePayload
+  > => {
+    const m = new Map<number, ProjectChangePayload>()
+    chartAnnotations.forEach((reason, idx) => {
+      if (!isAttributeReason(reason)) return
+      const pt = chartPoints[idx]
+      if (!pt) return
+      // The backend stores user email addresses as the change_reason for attribute edits,
+      // so `reason` may be an email string even though ScoreChangeReason only lists known
+      // enum values. Pass it as the actor filter when it looks like an email.
+      const actor = reason.includes('@') ? reason : undefined
+      const payload = nearestProjectChange(
+        pt.timestamp,
+        projectChangeEvents,
+        actor,
+      )
+      if (payload) m.set(idx, payload)
+    })
+    return m
+  }, [chartAnnotations, chartPoints, projectChangeEvents])
+
+  const currentScore =
+    trendData?.current ?? chartPoints[chartPoints.length - 1]?.score ?? null
+
+  const rangeItems: SegmentedItem[] = [
+    { key: '30d', label: '30d' },
+    { key: '90d', label: '90d' },
+    { key: '1y', label: '1y' },
+    { key: 'all', label: 'All' },
+  ]
+
+  const granularityItems: SegmentedItem[] = [
+    { key: 'raw', label: 'Raw' },
+    { key: 'hour', label: 'Hour' },
+    { key: 'day', label: 'Day' },
+  ]
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Chart card */}
+      <div className="rounded-lg border border-tertiary bg-primary p-[18px]">
+        <div className="mb-3.5 flex items-end justify-between gap-6">
+          <div className="flex items-baseline gap-1">
+            <div className="font-mono text-[36px] font-semibold tabular-nums leading-none text-primary">
+              {currentScore != null ? Math.round(currentScore) : '—'}
+            </div>
+            <div className="text-sm text-tertiary">/ 100</div>
+          </div>
+          <div className="flex gap-2">
+            <Segmented
+              items={rangeItems}
+              onChange={(k) => setRange(k as Range)}
+              value={range}
+            />
+            <Segmented
+              items={granularityItems}
+              onChange={(k) => setGranularity(k as Granularity)}
+              value={granularity}
+            />
+          </div>
+        </div>
+
+        {chartLoading ? (
+          <div className="flex h-40 items-center justify-center text-sm text-tertiary">
+            Loading…
+          </div>
+        ) : (
+          <ScoreChart
+            annotations={chartAnnotations}
+            eventCorrelations={chartEventCorrelations}
+            hoveredIdx={hoveredChart ?? syncedChartHover}
+            points={chartPoints}
+            setHoveredIdx={setHoveredChart}
+          />
+        )}
+
+        {/* Legend */}
+        <div className="mt-2 flex flex-wrap items-center gap-4 border-t border-tertiary pt-2.5 text-sm text-tertiary">
+          <span className="font-medium text-secondary">Annotations</span>
+          {Object.entries(REASON_META).map(([key, meta]) => (
+            <span className="inline-flex items-center gap-1.5" key={key}>
+              <span
+                className="inline-block h-2 w-2 rounded-[2px]"
+                style={{ background: meta.dot }}
+              />
+              {meta.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Change events card */}
+      <div className="rounded-lg border border-tertiary bg-primary">
+        <div className="flex items-center justify-between border-b border-tertiary px-[18px] py-3.5">
+          <div>
+            <div className="text-overline uppercase tracking-wide text-tertiary">
+              Change events
+            </div>
+            <div className="mt-0.5 text-xs text-tertiary">
+              Every recomputation that moved the score, newest first.
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button className="inline-flex h-7 items-center gap-1.5 rounded px-2.5 text-xs text-secondary transition-colors hover:bg-secondary hover:text-primary">
+              <Filter size={12} />
+              All reasons
+            </button>
+            <button className="inline-flex h-7 items-center gap-1.5 rounded border border-tertiary px-2.5 text-xs text-primary transition-colors hover:bg-secondary">
+              <Download size={12} />
+              Export CSV
+            </button>
+          </div>
+        </div>
+        <div className="px-2 py-1">
+          {rawLoading ? (
+            <div className="py-10 text-center text-sm text-tertiary">
+              Loading…
+            </div>
+          ) : (
+            <EventTimeline
+              eventCorrelations={eventCorrelations}
+              events={rawEvents}
+              hoveredIdx={hoveredEvent}
+              setHoveredIdx={setHoveredEvent}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------- Helpers (alphabetical) ----------
+
+function buildCorrelations(
+  rawEvents: ScoreHistoryPoint[],
+  projectChangeEvents: EventRecord[],
+): Map<number, ProjectChangePayload> {
+  const m = new Map<number, ProjectChangePayload>()
+  rawEvents.forEach((e, i) => {
+    if (!isAttributeReason(e.change_reason ?? '')) return
+    // If reason is an email address, pass it as the preferred attributed_to
+    const actor = e.change_reason?.includes('@') ? e.change_reason : undefined
+    const payload = nearestProjectChange(
+      e.timestamp,
+      projectChangeEvents,
+      actor,
+    )
+    if (payload) m.set(i, payload)
+  })
+  return m
+}
+
+function EventTimeline({
+  eventCorrelations,
+  events,
+  hoveredIdx,
+  setHoveredIdx,
+}: EventTimelineProps) {
+  if (events.length === 0) {
+    return (
+      <div className="py-10 text-center text-sm text-tertiary">
+        No change events for this period.
+      </div>
+    )
+  }
+  return (
+    <div>
+      {events.map((e, i) => {
+        const reason = e.change_reason!
+        const delta =
+          e.previous_score != null ? e.score - e.previous_score : null
+        const positive = delta != null && delta >= 0
+        const isHov = hoveredIdx === i
+        const correlated = eventCorrelations.get(i)
+        return (
+          <div
+            className={`grid items-center gap-3 border-b border-tertiary px-3 py-3.5 transition-colors duration-fast last:border-0 ${
+              isHov ? 'bg-secondary' : ''
+            }`}
+            key={i}
+            onMouseEnter={() => setHoveredIdx(i)}
+            onMouseLeave={() => setHoveredIdx(null)}
+            style={{ cursor: 'default', gridTemplateColumns: '80px 1fr auto' }}
+          >
+            <div>
+              <div className="text-xs font-medium text-primary">
+                {fmtRel(e.timestamp)}
+              </div>
+              <div className="mt-0.5 font-mono text-[11px] text-tertiary">
+                {fmtISODate(e.timestamp)}
+              </div>
+            </div>
+            <div>
+              <div className="mb-1 flex items-center gap-2">
+                <ReasonChip reason={reason} />
+              </div>
+              {correlated ? (
+                <div className="text-[12px] text-tertiary">
+                  <span className="font-medium text-secondary">
+                    {formatFieldKey(correlated.field)}
+                  </span>
+                  {correlated.old != null && String(correlated.old) !== '' && (
+                    <span className="ml-1 font-mono">
+                      <span className="rounded bg-secondary px-1 py-0.5">
+                        {String(correlated.old)}
+                      </span>
+                      {' → '}
+                      <span className="rounded bg-secondary px-1 py-0.5">
+                        {String(correlated.new)}
+                      </span>
+                    </span>
+                  )}
+                  {(correlated.old == null ||
+                    String(correlated.old) === '') && (
+                    <span className="ml-1 font-mono">
+                      {'set to '}
+                      <span className="rounded bg-secondary px-1 py-0.5">
+                        {String(correlated.new)}
+                      </span>
+                    </span>
+                  )}
+                </div>
+              ) : (
+                <div className="font-mono text-[12px] text-tertiary">
+                  score recomputed
+                </div>
+              )}
+            </div>
+            <div className="flex items-center gap-2 font-mono tabular-nums">
+              {e.previous_score != null && (
+                <>
+                  <span className="text-xs text-tertiary">
+                    {Math.round(e.previous_score)}
+                  </span>
+                  <ArrowRight className="text-tertiary" size={11} />
+                </>
+              )}
+              <span className="text-sm font-semibold text-primary">
+                {Math.round(e.score)}
+              </span>
+              {delta != null && (
+                <span
+                  className={`min-w-[48px] text-right text-xs font-semibold ${
+                    positive ? 'text-success' : 'text-danger'
+                  }`}
+                >
+                  {positive ? '+' : ''}
+                  {Math.round(delta)}
+                </span>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function fmtDate(iso: string, withTime = false): string {
+  const d = new Date(toUtc(iso))
+  if (withTime) {
+    return d.toLocaleString('en-US', {
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      month: 'short',
+    })
+  }
+  return d.toLocaleString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+function fmtISODate(iso: string): string {
+  const d = new Date(toUtc(iso))
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function fmtRel(iso: string): string {
+  const ms = Date.now() - new Date(toUtc(iso)).getTime()
+  const min = Math.round(ms / 60000)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const dy = Math.round(hr / 24)
+  if (dy < 30) return `${dy}d ago`
+  return `${Math.round(dy / 30)}mo ago`
+}
+
+function getRangeParams(range: Range): { from?: string; to?: string } {
+  if (range === 'all') return {}
+  const days = range === '30d' ? 30 : range === '90d' ? 90 : 365
+  const from = new Date()
+  from.setDate(from.getDate() - days)
+  return { from: from.toISOString() }
+}
+
+function isAttributeReason(reason: string): boolean {
+  return !NON_ATTRIBUTE_REASONS.has(reason)
+}
+
+function nearestChartPointIndex(
+  timestampMs: number,
+  pts: ScoreHistoryPoint[],
+): number {
+  let bestI = 0
+  let bestDiff = Infinity
+  pts.forEach((p, i) => {
+    const d = Math.abs(new Date(toUtc(p.timestamp)).getTime() - timestampMs)
+    if (d < bestDiff) {
+      bestDiff = d
+      bestI = i
+    }
+  })
+  return bestI
+}
+
+function nearestProjectChange(
+  scoreTimestamp: string,
+  events: EventRecord[],
+  attributedTo?: string,
+): null | ProjectChangePayload {
+  const scoreMs = new Date(toUtc(scoreTimestamp)).getTime()
+  let best: null | ProjectChangePayload = null
+  let bestDiff = 90_000 // 90s look-back window
+  for (const e of events) {
+    const peMs = new Date(toUtc(e.recorded_at)).getTime()
+    const diff = scoreMs - peMs
+    if (diff >= 0 && diff < bestDiff) {
+      // If reason is a user email, prefer events attributed to that same user
+      if (attributedTo && e.attributed_to !== attributedTo) continue
+      const p = e.payload
+      if (typeof p.field === 'string') {
+        bestDiff = diff
+        best = p as unknown as ProjectChangePayload
+      }
+    }
+  }
+  return best
+}
+
+// Ensure bare ISO strings (no tz offset) are treated as UTC
+function toUtc(iso: string): string {
+  return /[Z+]|\d{2}:\d{2}$/.test(iso) ? iso : iso + 'Z'
+}
+
+// Reasons that represent bulk/policy operations — correlating these with a
+// specific attribute change would produce false positives.
+const NON_ATTRIBUTE_REASONS = new Set([
+  'blueprint_change',
+  'bulk_rescore',
+  'migration_backfill',
+  'policy_change',
+  'system',
+])
+
+// ---------- Event timeline ----------
+
+function ReasonChip({ reason }: { reason: string }) {
+  const meta = REASON_META[reason as ScoreChangeReason]
+  if (meta) {
+    const { Icon } = meta
+    return (
+      <span
+        className={`inline-flex h-5 items-center gap-1 rounded px-1.5 text-[11px] font-medium ${meta.bgClass} ${meta.textClass}`}
+      >
+        <Icon size={10} />
+        {meta.label}
+      </span>
+    )
+  }
+  // User email → show as an Attribute chip with the username portion
+  if (reason.includes('@')) {
+    const { Icon } = REASON_META.attribute_change
+    const username = reason.split('@')[0]
+    return (
+      <span
+        className={`inline-flex h-5 items-center gap-1 rounded px-1.5 text-[11px] font-medium ${REASON_META.attribute_change.bgClass} ${REASON_META.attribute_change.textClass}`}
+        title={reason}
+      >
+        <Icon size={10} />
+        {username}
+      </span>
+    )
+  }
+  // Service name (sonarqube, github, etc.) → capitalise
+  return (
+    <span className="inline-flex h-5 items-center rounded bg-secondary px-1.5 text-[11px] font-medium text-secondary">
+      {reason.charAt(0).toUpperCase() + reason.slice(1)}
+    </span>
+  )
+}
+
+function ScoreChart({
+  annotations,
+  eventCorrelations,
+  hoveredIdx,
+  points,
+  setHoveredIdx,
+}: ChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [W, setW] = useState(720)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const obs = new ResizeObserver(([entry]) => {
+      const w = entry.contentRect.width
+      if (w > 0) setW(Math.round(w))
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+
+  const H = 220
+  const padL = 40
+  const padR = 14
+  const padT = 14
+  const padB = 28
+  const innerW = W - padL - padR
+  const innerH = H - padT - padB
+
+  const yMin = 50
+  const yMax = 100
+
+  const xFor = (i: number) =>
+    padL + (i / Math.max(points.length - 1, 1)) * innerW
+  const yFor = (s: number) => padT + (1 - (s - yMin) / (yMax - yMin)) * innerH
+
+  const pathD = points
+    .map(
+      (p, i) =>
+        `${i === 0 ? 'M' : 'L'}${xFor(i).toFixed(1)},${yFor(p.score).toFixed(1)}`,
+    )
+    .join(' ')
+  const areaD =
+    points.length < 2
+      ? ''
+      : `${pathD} L${xFor(points.length - 1).toFixed(1)},${(padT + innerH).toFixed(1)} L${padL},${(padT + innerH).toFixed(1)} Z`
+
+  // Annotation markers: chart indices that have a mapped raw event
+  const annotated = Array.from(annotations.entries()).map(([idx, reason]) => ({
+    idx,
+    reason,
+  }))
+
+  const yTicks = [50, 60, 70, 80, 90, 100]
+
+  // 6 evenly spaced x-axis labels
+  const xTickIndices =
+    points.length <= 6
+      ? points.map((_, i) => i)
+      : [0, 1, 2, 3, 4, 5].map((n) => Math.round((n * (points.length - 1)) / 5))
+
+  if (points.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center text-sm text-tertiary">
+        No score data for this period.
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} style={{ width: '100%' }}>
+      <svg
+        height={H}
+        style={{ display: 'block', overflow: 'visible' }}
+        width={W}
+      >
+        <defs>
+          <linearGradient id="sh-area-grad" x1="0" x2="0" y1="0" y2="1">
+            <stop
+              offset="0%"
+              stopColor="var(--color-action-bg)"
+              stopOpacity="0.18"
+            />
+            <stop
+              offset="100%"
+              stopColor="var(--color-action-bg)"
+              stopOpacity="0"
+            />
+          </linearGradient>
+        </defs>
+
+        {/* y-axis grid */}
+        {yTicks.map((t) => (
+          <g key={t}>
+            <line
+              stroke="var(--color-border-tertiary)"
+              strokeWidth="1"
+              x1={padL}
+              x2={W - padR}
+              y1={yFor(t)}
+              y2={yFor(t)}
+            />
+            <text
+              fill="var(--color-text-tertiary)"
+              fontFamily="var(--font-sans)"
+              fontSize="11"
+              textAnchor="end"
+              x={padL - 4}
+              y={yFor(t) + 4}
+            >
+              {t}
+            </text>
+          </g>
+        ))}
+
+        {/* x-axis labels */}
+        {xTickIndices.map((i) => (
+          <text
+            fill="var(--color-text-tertiary)"
+            fontFamily="var(--font-sans)"
+            fontSize="11"
+            key={i}
+            textAnchor="middle"
+            x={xFor(i)}
+            y={H - 6}
+          >
+            {fmtDate(points[i].timestamp)}
+          </text>
+        ))}
+
+        {/* area fill + line */}
+        {areaD && <path d={areaD} fill="url(#sh-area-grad)" />}
+        <path
+          d={pathD}
+          fill="none"
+          stroke="var(--color-action-bg)"
+          strokeWidth="1"
+        />
+
+        {/* annotation verticals */}
+        {annotated.map(({ idx, reason }) => {
+          const meta = REASON_META[reason]
+          if (!meta) return null
+          const isHov = hoveredIdx === idx
+          const x = xFor(idx)
+          const y = yFor(points[idx].score)
+          return (
+            <g
+              key={idx}
+              onMouseEnter={() => setHoveredIdx(idx)}
+              onMouseLeave={() => setHoveredIdx(null)}
+              style={{ cursor: 'pointer' }}
+            >
+              <line
+                opacity={isHov ? 0.85 : 0.45}
+                stroke={meta.dot}
+                strokeDasharray="3 3"
+                strokeWidth={isHov ? 1.5 : 1}
+                x1={x}
+                x2={x}
+                y1={padT}
+                y2={padT + innerH}
+              />
+              <rect
+                fill="transparent"
+                height={innerH}
+                width="16"
+                x={x - 8}
+                y={padT}
+              />
+              <circle
+                cx={x}
+                cy={y}
+                fill="var(--color-background-primary)"
+                r={isHov ? 5 : 3.5}
+                stroke={meta.dot}
+                strokeWidth="1.5"
+              />
+            </g>
+          )
+        })}
+
+        {/* hover tooltip */}
+        {hoveredIdx != null &&
+          (() => {
+            const entry = annotated.find((a) => a.idx === hoveredIdx)
+            if (!entry) return null
+            const reason = entry.reason
+            const meta = REASON_META[reason]
+            if (!meta) return null
+            const point = points[entry.idx]
+            const x = xFor(entry.idx)
+            const y = yFor(point.score)
+            const correlated = eventCorrelations.get(entry.idx)
+            const tipW = 220
+            const hasDetail = !!correlated
+            const tipH = hasDetail ? 86 : 68
+            const flip = x + tipW + 12 > W - padR
+            const tx = flip ? x - tipW - 12 : x + 12
+            const ty = Math.max(
+              padT,
+              Math.min(y - tipH / 2, padT + innerH - tipH),
+            )
+            const delta =
+              point.previous_score != null
+                ? point.score - point.previous_score
+                : null
+            return (
+              <g style={{ pointerEvents: 'none' }}>
+                <rect
+                  fill="var(--color-background-primary)"
+                  filter="drop-shadow(0 4px 10px rgba(26,26,24,0.10))"
+                  height={tipH}
+                  rx="8"
+                  stroke="var(--color-border-secondary)"
+                  width={tipW}
+                  x={tx}
+                  y={ty}
+                />
+                <text
+                  fill={meta.dot}
+                  fontFamily="var(--font-sans)"
+                  fontSize="8"
+                  fontWeight="600"
+                  letterSpacing="0.06em"
+                  x={tx + 12}
+                  y={ty + 18}
+                >
+                  {meta.label.toUpperCase()} ·{' '}
+                  {fmtDate(point.timestamp, true).toUpperCase()}
+                </text>
+                {hasDetail ? (
+                  <>
+                    <text
+                      fill="var(--color-text-secondary)"
+                      fontFamily="var(--font-sans)"
+                      fontSize="10"
+                      x={tx + 12}
+                      y={ty + 34}
+                    >
+                      {formatFieldKey(correlated.field)}
+                      {correlated.old != null && String(correlated.old) !== ''
+                        ? `  ${String(correlated.old)} → ${String(correlated.new)}`
+                        : `  → ${String(correlated.new)}`}
+                    </text>
+                    <text
+                      fill="var(--color-text-primary)"
+                      fontFamily="var(--font-sans)"
+                      fontSize="12.5"
+                      fontWeight="600"
+                      x={tx + 12}
+                      y={ty + 54}
+                    >
+                      {point.previous_score != null
+                        ? `${Math.round(point.previous_score)} → ${Math.round(point.score)}`
+                        : Math.round(point.score)}
+                    </text>
+                    {delta != null && (
+                      <text
+                        fill={
+                          delta >= 0
+                            ? 'var(--color-text-success)'
+                            : 'var(--color-text-danger)'
+                        }
+                        fontFamily="var(--font-sans)"
+                        fontSize="11"
+                        x={tx + 12}
+                        y={ty + 74}
+                      >
+                        {delta >= 0 ? '+' : ''}
+                        {Math.round(delta)} pts
+                      </text>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <text
+                      fill="var(--color-text-primary)"
+                      fontFamily="var(--font-sans)"
+                      fontSize="12.5"
+                      fontWeight="600"
+                      x={tx + 12}
+                      y={ty + 38}
+                    >
+                      {point.previous_score != null
+                        ? `${Math.round(point.previous_score)} → ${Math.round(point.score)}`
+                        : Math.round(point.score)}
+                    </text>
+                    {delta != null && (
+                      <text
+                        fill={
+                          delta >= 0
+                            ? 'var(--color-text-success)'
+                            : 'var(--color-text-danger)'
+                        }
+                        fontFamily="var(--font-sans)"
+                        fontSize="11"
+                        x={tx + 12}
+                        y={ty + 56}
+                      >
+                        {delta >= 0 ? '+' : ''}
+                        {Math.round(delta)} pts
+                      </text>
+                    )}
+                  </>
+                )}
+              </g>
+            )
+          })()}
+      </svg>
+    </div>
+  )
+}
+
+// ---------- Main tab ----------
+
+function Segmented({
+  items,
+  onChange,
+  value,
+}: {
+  items: SegmentedItem[]
+  onChange: (k: string) => void
+  value: string
+}) {
+  return (
+    <div className="inline-flex gap-0.5 rounded-md border border-tertiary bg-primary p-0.5">
+      {items.map((it) => (
+        <button
+          className={`inline-flex h-6 items-center rounded px-2.5 text-xs transition-colors duration-fast ${
+            value === it.key
+              ? 'bg-secondary font-medium text-primary'
+              : 'text-secondary hover:text-primary'
+          }`}
+          key={it.key}
+          onClick={() => onChange(it.key)}
+        >
+          {it.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -1,0 +1,245 @@
+import { useMemo, useState } from 'react'
+
+import { useMutation } from '@tanstack/react-query'
+import { CheckCircle, RefreshCw, XCircle } from 'lucide-react'
+
+import {
+  createScoringPolicy,
+  deleteScoringPolicy,
+  listScoringPolicies,
+  rescoreAll,
+  updateScoringPolicy,
+} from '@/api/endpoints'
+import { AdminTable } from '@/components/ui/admin-table'
+import { Button } from '@/components/ui/button'
+import { useAdminCrud } from '@/hooks/useAdminCrud'
+import { useAdminNav } from '@/hooks/useAdminNav'
+import { buildDiffPatch } from '@/lib/json-patch'
+import type {
+  PatchOperation,
+  ScoringPolicy,
+  ScoringPolicyCreate,
+} from '@/types'
+
+import { AdminSection } from './AdminSection'
+import { ScoringPolicyForm } from './scoring-policies/ScoringPolicyForm'
+
+export function ScoringPolicyManagement() {
+  const {
+    goToCreate,
+    goToEdit,
+    goToList,
+    slug: selectedSlug,
+    viewMode,
+  } = useAdminNav()
+  const [searchQuery, setSearchQuery] = useState('')
+  const [enabledFilter, setEnabledFilter] = useState('')
+  const [rescoreResult, setRescoreResult] = useState<null | number>(null)
+
+  const rescoreMutation = useMutation({
+    mutationFn: rescoreAll,
+    onSuccess: (data) => {
+      setRescoreResult(data.enqueued)
+      setTimeout(() => setRescoreResult(null), 4000)
+    },
+  })
+
+  const {
+    createMutation,
+    deleteMutation,
+    error,
+    isLoading,
+    items: policies,
+    updateMutation,
+  } = useAdminCrud<
+    ScoringPolicy,
+    ScoringPolicyCreate,
+    { operations: PatchOperation[]; slug: string },
+    string
+  >({
+    createFn: createScoringPolicy,
+    deleteErrorLabel: 'scoring policy',
+    deleteFn: deleteScoringPolicy,
+    listFn: listScoringPolicies,
+    onMutationSuccess: goToList,
+    queryKey: ['scoring-policies'],
+    updateFn: ({ operations, slug }) => updateScoringPolicy(slug, operations),
+  })
+
+  const selectedPolicy = useMemo(
+    () => policies.find((p) => p.slug === selectedSlug) ?? null,
+    [policies, selectedSlug],
+  )
+
+  const filteredPolicies = policies.filter((p) => {
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      if (
+        !p.name.toLowerCase().includes(q) &&
+        !p.slug.toLowerCase().includes(q) &&
+        !(p.description?.toLowerCase().includes(q) ?? false) &&
+        !p.attribute_name.toLowerCase().includes(q)
+      )
+        return false
+    }
+    if (enabledFilter === 'enabled' && !p.enabled) return false
+    if (enabledFilter === 'disabled' && p.enabled) return false
+    return true
+  })
+
+  const handleSave = (data: ScoringPolicyCreate) => {
+    if (viewMode === 'create') {
+      createMutation.mutate(data)
+    } else if (selectedSlug && selectedPolicy) {
+      const operations = buildDiffPatch(
+        selectedPolicy as unknown as Record<string, unknown>,
+        data as unknown as Record<string, unknown>,
+        { fields: Object.keys(data) },
+      )
+      if (operations.length === 0) {
+        goToList()
+        return
+      }
+      updateMutation.mutate({ operations, slug: selectedSlug })
+    }
+  }
+
+  const handleCancel = () => {
+    createMutation.reset()
+    updateMutation.reset()
+    goToList()
+  }
+
+  if (viewMode === 'create' || viewMode === 'edit') {
+    return (
+      <ScoringPolicyForm
+        error={createMutation.error ?? updateMutation.error}
+        isLoading={createMutation.isPending || updateMutation.isPending}
+        onCancel={handleCancel}
+        onSave={handleSave}
+        policy={viewMode === 'edit' ? selectedPolicy : null}
+      />
+    )
+  }
+
+  return (
+    <AdminSection
+      createLabel="New Policy"
+      error={error}
+      errorTitle="Failed to load scoring policies"
+      headerActions={
+        <Button
+          disabled={rescoreMutation.isPending}
+          onClick={() => rescoreMutation.mutate()}
+          variant="outline"
+        >
+          <RefreshCw
+            className={`mr-2 h-4 w-4 ${rescoreMutation.isPending ? 'animate-spin' : ''}`}
+          />
+          {rescoreResult !== null
+            ? `Enqueued ${rescoreResult}`
+            : 'Recompute Scores'}
+        </Button>
+      }
+      headerExtras={
+        <select
+          className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground"
+          onChange={(e) => setEnabledFilter(e.target.value)}
+          value={enabledFilter}
+        >
+          <option value="">All</option>
+          <option value="enabled">Enabled</option>
+          <option value="disabled">Disabled</option>
+        </select>
+      }
+      isLoading={isLoading}
+      loadingLabel="Loading scoring policies..."
+      onCreate={goToCreate}
+      onSearchChange={setSearchQuery}
+      search={searchQuery}
+      searchPlaceholder="Search policies..."
+    >
+      <AdminTable<ScoringPolicy>
+        columns={[
+          {
+            cellAlign: 'left',
+            header: 'Policy',
+            headerAlign: 'left',
+            key: 'name',
+            render: (p) => (
+              <div>
+                <div className="font-medium text-primary">{p.name}</div>
+                {p.description && (
+                  <div className="mt-0.5 text-xs text-tertiary">
+                    {p.description}
+                  </div>
+                )}
+              </div>
+            ),
+          },
+          {
+            cellAlign: 'left',
+            header: 'Attribute',
+            headerAlign: 'left',
+            key: 'attribute',
+            render: (p) => (
+              <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
+                {p.attribute_name}
+              </code>
+            ),
+          },
+          {
+            cellAlign: 'center',
+            header: 'Weight',
+            headerAlign: 'center',
+            key: 'weight',
+            render: (p) => <span className="text-secondary">{p.weight}</span>,
+          },
+          {
+            cellAlign: 'center',
+            header: 'Priority',
+            headerAlign: 'center',
+            key: 'priority',
+            render: (p) => <span className="text-secondary">{p.priority}</span>,
+          },
+          {
+            cellAlign: 'left',
+            header: 'Targets',
+            headerAlign: 'left',
+            key: 'targets',
+            render: (p) => (
+              <span className="text-xs text-tertiary">
+                {(p.targets ?? []).length === 0
+                  ? 'All types'
+                  : (p.targets ?? []).join(', ')}
+              </span>
+            ),
+          },
+          {
+            cellAlign: 'center',
+            header: 'Enabled',
+            headerAlign: 'center',
+            key: 'enabled',
+            render: (p) =>
+              p.enabled ? (
+                <CheckCircle className="mx-auto h-4 w-4 text-success" />
+              ) : (
+                <XCircle className="mx-auto h-4 w-4 text-tertiary" />
+              ),
+          },
+        ]}
+        emptyMessage={
+          searchQuery || enabledFilter
+            ? 'No policies match your filters.'
+            : 'No scoring policies defined yet.'
+        }
+        getDeleteLabel={(p) => p.name}
+        getRowKey={(p) => p.slug}
+        isDeleting={deleteMutation.isPending}
+        onDelete={(p) => deleteMutation.mutate(p.slug)}
+        onRowClick={(p) => goToEdit(p.slug)}
+        rows={filteredPolicies}
+      />
+    </AdminSection>
+  )
+}

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -1,0 +1,477 @@
+import { useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { AlertCircle, Plus, Trash2 } from 'lucide-react'
+
+import { listProjectTypes } from '@/api/endpoints'
+import { FormHeader } from '@/components/admin/form-header'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { ErrorBanner } from '@/components/ui/error-banner'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { slugify } from '@/lib/utils'
+import type { ScoringPolicy, ScoringPolicyCreate } from '@/types'
+
+interface MapRow {
+  key: string
+  score: string
+}
+
+type MapType = 'range' | 'value'
+
+interface ScoringPolicyFormProps {
+  error?: unknown
+  isLoading?: boolean
+  onCancel: () => void
+  onSave: (data: ScoringPolicyCreate) => void
+  policy: null | ScoringPolicy
+}
+
+export function ScoringPolicyForm({
+  error,
+  isLoading = false,
+  onCancel,
+  onSave,
+  policy,
+}: ScoringPolicyFormProps) {
+  const isEditing = policy !== null
+
+  const [name, setName] = useState(policy?.name ?? '')
+  const [slug, setSlug] = useState(policy?.slug ?? '')
+  const [description, setDescription] = useState(policy?.description ?? '')
+  const [attributeName, setAttributeName] = useState(
+    policy?.attribute_name ?? '',
+  )
+  const [weight, setWeight] = useState(String(policy?.weight ?? 50))
+  const [priority, setPriority] = useState(String(policy?.priority ?? 0))
+  const [enabled, setEnabled] = useState(policy?.enabled ?? true)
+  const [targets, setTargets] = useState<string[]>(policy?.targets ?? [])
+  const [mapType, setMapType] = useState<MapType>(
+    policy?.range_score_map != null ? 'range' : 'value',
+  )
+  const [mapRows, setMapRows] = useState<MapRow[]>(
+    mapType === 'range'
+      ? parseMapToRows(policy?.range_score_map)
+      : parseMapToRows(policy?.value_score_map),
+  )
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug
+
+  const {
+    data: projectTypes = [],
+    isError: ptIsError,
+    isLoading: ptLoading,
+  } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => listProjectTypes(orgSlug!, signal),
+    queryKey: ['projectTypes', orgSlug],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const handleNameChange = (value: string) => {
+    setName(value)
+    if (!isEditing) setSlug(slugify(value))
+  }
+
+  const handleMapTypeChange = (type: MapType) => {
+    setMapType(type)
+    setMapRows([{ key: '', score: '' }])
+  }
+
+  const addMapRow = () =>
+    setMapRows((prev) => [...prev, { key: '', score: '' }])
+
+  const removeMapRow = (i: number) =>
+    setMapRows((prev) => prev.filter((_, idx) => idx !== i))
+
+  const updateMapRow = (i: number, field: 'key' | 'score', value: string) => {
+    setMapRows((prev) => {
+      const next = [...prev]
+      next[i] = { ...next[i], [field]: value }
+      return next
+    })
+  }
+
+  const toggleTarget = (slug: string) => {
+    setTargets((prev) =>
+      prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug],
+    )
+  }
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {}
+    if (!name.trim()) newErrors.name = 'Name is required'
+    if (!slug.trim()) newErrors.slug = 'Slug is required'
+    if (slug && !/^[a-z0-9_-]+$/.test(slug))
+      newErrors.slug =
+        'Slug must be lowercase letters, numbers, hyphens, or underscores'
+    if (!attributeName.trim())
+      newErrors.attribute_name = 'Attribute name is required'
+    const w = parseInt(weight, 10)
+    if (isNaN(w) || w < 0 || w > 100) newErrors.weight = 'Weight must be 0–100'
+    const hasMap = mapRows.some((r) => r.key.trim() && r.score.trim())
+    if (!hasMap) newErrors.map = 'At least one mapping entry is required'
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSave = () => {
+    if (!validate()) return
+    const map = rowsToMap(mapRows)
+    onSave({
+      attribute_name: attributeName.trim(),
+      description: description.trim() || null,
+      enabled,
+      name: name.trim(),
+      priority: parseInt(priority, 10) || 0,
+      range_score_map: mapType === 'range' ? map : null,
+      slug: slug.trim(),
+      targets,
+      value_score_map: mapType === 'value' ? map : null,
+      weight: parseInt(weight, 10),
+    })
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    handleSave()
+  }
+
+  const fieldError = (key: string) =>
+    errors[key] ? (
+      <div className="mt-1 flex items-center gap-1 text-xs text-danger">
+        <AlertCircle className="h-3 w-3" />
+        {errors[key]}
+      </div>
+    ) : null
+
+  return (
+    <div className="space-y-6">
+      <FormHeader
+        createLabel="Create Policy"
+        isEditing={isEditing}
+        isLoading={isLoading}
+        onCancel={onCancel}
+        onSave={handleSave}
+        subtitle={
+          isEditing ? 'Update scoring policy' : 'Create a new scoring policy'
+        }
+        title={isEditing ? 'Edit Scoring Policy' : 'Create Scoring Policy'}
+      />
+
+      {!!error && (
+        <ErrorBanner error={error} title="Failed to save scoring policy" />
+      )}
+
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        {/* Identity */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Identity</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <label
+                  className="mb-1.5 block text-sm text-secondary"
+                  htmlFor="sp-name"
+                >
+                  Name <span className="text-danger">*</span>
+                </label>
+                <Input
+                  className={errors.name ? 'border-danger' : ''}
+                  disabled={isLoading}
+                  id="sp-name"
+                  onChange={(e) => handleNameChange(e.target.value)}
+                  placeholder="e.g., Test Coverage"
+                  value={name}
+                />
+                {fieldError('name')}
+              </div>
+              <div>
+                <label
+                  className="mb-1.5 block text-sm text-secondary"
+                  htmlFor="sp-slug"
+                >
+                  Slug <span className="text-danger">*</span>
+                </label>
+                <Input
+                  className={errors.slug ? 'border-danger' : ''}
+                  disabled={isEditing || isLoading}
+                  id="sp-slug"
+                  onChange={(e) => setSlug(e.target.value)}
+                  placeholder="e.g., test-coverage"
+                  value={slug}
+                />
+                {fieldError('slug')}
+              </div>
+            </div>
+
+            <div>
+              <label
+                className="mb-1.5 block text-sm text-secondary"
+                htmlFor="sp-description"
+              >
+                Description
+              </label>
+              <textarea
+                className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
+                disabled={isLoading}
+                id="sp-description"
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What does this policy measure?"
+                rows={2}
+                value={description}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Policy settings */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Policy Settings</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label
+                className="mb-1.5 block text-sm text-secondary"
+                htmlFor="sp-attribute"
+              >
+                Attribute Name <span className="text-danger">*</span>
+              </label>
+              <Input
+                className={errors.attribute_name ? 'border-danger' : ''}
+                disabled={isLoading}
+                id="sp-attribute"
+                onChange={(e) => setAttributeName(e.target.value)}
+                placeholder="e.g., test_coverage"
+                value={attributeName}
+              />
+              <p className="mt-1 text-xs text-tertiary">
+                The blueprint attribute key this policy evaluates
+              </p>
+              {fieldError('attribute_name')}
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              <div>
+                <label
+                  className="mb-1.5 block text-sm text-secondary"
+                  htmlFor="sp-weight"
+                >
+                  Weight (0–100) <span className="text-danger">*</span>
+                </label>
+                <Input
+                  className={errors.weight ? 'border-danger' : ''}
+                  disabled={isLoading}
+                  id="sp-weight"
+                  max={100}
+                  min={0}
+                  onChange={(e) => setWeight(e.target.value)}
+                  type="number"
+                  value={weight}
+                />
+                {fieldError('weight')}
+              </div>
+
+              <div>
+                <label
+                  className="mb-1.5 block text-sm text-secondary"
+                  htmlFor="sp-priority"
+                >
+                  Priority
+                </label>
+                <Input
+                  disabled={isLoading}
+                  id="sp-priority"
+                  onChange={(e) => setPriority(e.target.value)}
+                  type="number"
+                  value={priority}
+                />
+                <p className="mt-1 text-xs text-tertiary">
+                  Lower numbers run first
+                </p>
+              </div>
+
+              <div className="flex flex-col justify-center gap-1.5">
+                <label className="text-sm text-secondary">Enabled</label>
+                <Switch
+                  checked={enabled}
+                  disabled={isLoading}
+                  onCheckedChange={setEnabled}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Score mapping */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Score Mapping</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="mb-1.5 block text-sm text-secondary">
+                Mapping type
+              </label>
+              <div className="flex gap-3">
+                {(['value', 'range'] as const).map((t) => (
+                  <button
+                    className={`rounded-lg border px-4 py-2 text-sm transition-colors ${
+                      mapType === t
+                        ? 'border-amber-text bg-amber-bg text-amber-text'
+                        : 'border-input text-secondary hover:bg-secondary'
+                    }`}
+                    disabled={isLoading}
+                    key={t}
+                    onClick={() => handleMapTypeChange(t)}
+                    type="button"
+                  >
+                    {t === 'value' ? 'Value map' : 'Range map'}
+                  </button>
+                ))}
+              </div>
+              <p className="mt-1.5 text-xs text-tertiary">
+                {mapType === 'value'
+                  ? 'Maps exact attribute values (strings) to scores'
+                  : 'Maps numeric ranges like "0..70" to scores'}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="grid grid-cols-[1fr_100px_32px] gap-2 text-xs text-tertiary">
+                <span>
+                  {mapType === 'value' ? 'Value (string)' : 'Range (lo..hi)'}
+                </span>
+                <span>Score (0–100)</span>
+                <span />
+              </div>
+
+              {mapRows.map((row, i) => (
+                <div
+                  className="grid grid-cols-[1fr_100px_32px] items-center gap-2"
+                  key={i}
+                >
+                  <Input
+                    disabled={isLoading}
+                    onChange={(e) => updateMapRow(i, 'key', e.target.value)}
+                    placeholder={
+                      mapType === 'value' ? 'e.g., passing' : 'e.g., 80..100'
+                    }
+                    value={row.key}
+                  />
+                  <Input
+                    disabled={isLoading}
+                    max={100}
+                    min={0}
+                    onChange={(e) => updateMapRow(i, 'score', e.target.value)}
+                    placeholder="100"
+                    type="number"
+                    value={row.score}
+                  />
+                  <Button
+                    disabled={isLoading || mapRows.length === 1}
+                    onClick={() => removeMapRow(i)}
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <Trash2 className="h-4 w-4 text-secondary" />
+                  </Button>
+                </div>
+              ))}
+
+              <Button
+                className="mt-1"
+                disabled={isLoading}
+                onClick={addMapRow}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                Add entry
+              </Button>
+
+              {fieldError('map')}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Target project types */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Target Project Types</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="mb-3 text-sm text-tertiary">
+              Leave all unchecked to apply this policy to every project type.
+            </p>
+            {ptLoading ? (
+              <p className="text-xs italic text-tertiary">
+                Loading project types...
+              </p>
+            ) : ptIsError ? (
+              <p className="text-xs italic text-danger">
+                Failed to load project types
+              </p>
+            ) : projectTypes.length === 0 ? (
+              <p className="text-xs italic text-tertiary">
+                No project types available
+              </p>
+            ) : (
+              <div className="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3">
+                {projectTypes.map((pt) => (
+                  <div className="flex items-center gap-2" key={pt.slug}>
+                    <Checkbox
+                      checked={targets.includes(pt.slug)}
+                      disabled={isLoading}
+                      id={`target-pt-${pt.slug}`}
+                      onCheckedChange={() => toggleTarget(pt.slug)}
+                    />
+                    <label
+                      className="cursor-pointer select-none text-sm text-secondary"
+                      htmlFor={`target-pt-${pt.slug}`}
+                    >
+                      {pt.name}
+                    </label>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </form>
+    </div>
+  )
+}
+
+function parseMapToRows(
+  map: null | Record<string, number> | undefined,
+): MapRow[] {
+  if (!map) return [{ key: '', score: '' }]
+  const rows = Object.entries(map).map(([key, score]) => ({
+    key,
+    score: String(score),
+  }))
+  return rows.length > 0 ? rows : [{ key: '', score: '' }]
+}
+
+function rowsToMap(rows: MapRow[]): null | Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const row of rows) {
+    const trimmed = row.key.trim()
+    const val = parseInt(row.score, 10)
+    if (trimmed && !isNaN(val)) {
+      out[trimmed] = val
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null
+}

--- a/src/components/ui/environment-badge.tsx
+++ b/src/components/ui/environment-badge.tsx
@@ -17,7 +17,7 @@ export function EnvironmentBadge({
 
   return (
     <span
-      className="rounded px-2 py-1 text-xs font-medium"
+      className="inline-block whitespace-nowrap rounded px-2 py-1 text-xs font-medium"
       key={slug}
       style={
         derived

--- a/src/components/ui/inline-edit/InlineSwitch.tsx
+++ b/src/components/ui/inline-edit/InlineSwitch.tsx
@@ -1,6 +1,10 @@
+import { useEffect, useRef, useState } from 'react'
+
 import { toast } from 'sonner'
 
 import { Switch } from '@/components/ui/switch'
+
+import { InlineDisplay } from './InlineDisplay'
 
 export interface InlineSwitchProps {
   onCommit: (next: boolean) => Promise<void> | void
@@ -15,17 +19,53 @@ export function InlineSwitch({
   readOnly = false,
   value,
 }: InlineSwitchProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const wrapperRef = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    if (!isEditing) return
+    const handlePointerDown = (e: PointerEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) {
+        setIsEditing(false)
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [isEditing])
+
+  if (!isEditing) {
+    return (
+      <InlineDisplay
+        hasValue={value != null}
+        onClick={() => setIsEditing(true)}
+        pending={pending}
+        readOnly={readOnly}
+      >
+        {value ? 'True' : value === false ? 'False' : null}
+      </InlineDisplay>
+    )
+  }
+
   return (
-    <Switch
-      checked={!!value}
-      disabled={readOnly || pending}
-      onCheckedChange={async (next) => {
-        try {
-          await onCommit(next)
-        } catch (e) {
-          toast.error(e instanceof Error ? e.message : 'Save failed')
-        }
+    <span
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') setIsEditing(false)
       }}
-    />
+      ref={wrapperRef}
+    >
+      <Switch
+        checked={!!value}
+        disabled={pending}
+        onCheckedChange={async (next) => {
+          try {
+            await onCommit(next)
+          } catch (e) {
+            toast.error(e instanceof Error ? e.message : 'Save failed')
+          } finally {
+            setIsEditing(false)
+          }
+        }}
+      />
+    </span>
   )
 }

--- a/src/components/ui/inline-edit/InlineSwitch.tsx
+++ b/src/components/ui/inline-edit/InlineSwitch.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
-
 import { toast } from 'sonner'
 
 import { Switch } from '@/components/ui/switch'
-
-import { InlineDisplay } from './InlineDisplay'
 
 export interface InlineSwitchProps {
   onCommit: (next: boolean) => Promise<void> | void
@@ -19,53 +15,18 @@ export function InlineSwitch({
   readOnly = false,
   value,
 }: InlineSwitchProps) {
-  const [isEditing, setIsEditing] = useState(false)
-  const wrapperRef = useRef<HTMLSpanElement>(null)
-
-  useEffect(() => {
-    if (!isEditing) return
-    const handlePointerDown = (e: PointerEvent) => {
-      if (!wrapperRef.current?.contains(e.target as Node)) {
-        setIsEditing(false)
-      }
-    }
-    document.addEventListener('pointerdown', handlePointerDown)
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [isEditing])
-
-  if (!isEditing) {
-    return (
-      <InlineDisplay
-        hasValue={value != null}
-        onClick={() => setIsEditing(true)}
-        pending={pending}
-        readOnly={readOnly}
-      >
-        {value ? 'True' : value === false ? 'False' : null}
-      </InlineDisplay>
-    )
-  }
-
   return (
-    <span
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') setIsEditing(false)
+    <Switch
+      checked={!!value}
+      disabled={pending || readOnly}
+      onCheckedChange={async (next) => {
+        if (readOnly) return
+        try {
+          await onCommit(next)
+        } catch (e) {
+          toast.error(e instanceof Error ? e.message : 'Save failed')
+        }
       }}
-      ref={wrapperRef}
-    >
-      <Switch
-        checked={!!value}
-        disabled={pending}
-        onCheckedChange={async (next) => {
-          try {
-            await onCommit(next)
-          } catch (e) {
-            toast.error(e instanceof Error ? e.message : 'Save failed')
-          } finally {
-            setIsEditing(false)
-          }
-        }}
-      />
-    </span>
+    />
   )
 }

--- a/src/components/ui/score-badge.tsx
+++ b/src/components/ui/score-badge.tsx
@@ -30,7 +30,7 @@ export function ScoreBadge({
   }
 
   const display = Math.round(score)
-  const { bg, ring, text } = scoreClasses(score)
+  const { bg, ring, text } = scoreClasses(display)
 
   if (size === 'lg') {
     return (

--- a/src/components/ui/score-badge.tsx
+++ b/src/components/ui/score-badge.tsx
@@ -13,7 +13,7 @@ export function ScoreBadge({
 }: ScoreBadgeProps) {
   const rounded = variant === 'circle' ? 'rounded-full' : 'rounded-lg'
 
-  if (score == null) {
+  if (score == null || !Number.isFinite(score)) {
     const dims =
       size === 'lg'
         ? 'h-16 w-16 text-2xl'

--- a/src/components/ui/score-badge.tsx
+++ b/src/components/ui/score-badge.tsx
@@ -1,0 +1,82 @@
+interface ScoreBadgeProps {
+  score?: null | number
+  /** sm = compact table cell; md = card with ring; lg = detail sidebar */
+  size?: 'lg' | 'md' | 'sm'
+  /** circle: rounded-full (projects list); square: rounded-lg (project detail) */
+  variant?: 'circle' | 'square'
+}
+
+export function ScoreBadge({
+  score,
+  size = 'sm',
+  variant = 'circle',
+}: ScoreBadgeProps) {
+  const rounded = variant === 'circle' ? 'rounded-full' : 'rounded-lg'
+
+  if (score == null) {
+    const dims =
+      size === 'lg'
+        ? 'h-16 w-16 text-2xl'
+        : size === 'md'
+          ? 'h-12 w-12 text-sm'
+          : 'h-10 w-10 text-sm'
+    return (
+      <div
+        className={`flex flex-shrink-0 items-center justify-center font-medium text-tertiary ${rounded} ${dims}`}
+      >
+        —
+      </div>
+    )
+  }
+
+  const display = Math.round(score)
+  const { bg, ring, text } = scoreClasses(score)
+
+  if (size === 'lg') {
+    return (
+      <div
+        className={`flex h-16 w-16 flex-shrink-0 items-center justify-center text-2xl font-medium ${rounded} ${bg} ${text}`}
+      >
+        {display}
+      </div>
+    )
+  }
+
+  if (size === 'md') {
+    return (
+      <div
+        className={`flex h-12 w-12 flex-shrink-0 items-center justify-center ring-4 ${rounded} ${bg} ${text} ${ring}`}
+      >
+        <span className="text-sm font-semibold">{display}</span>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`inline-flex h-10 w-10 items-center justify-center ${rounded} ${bg} ${text}`}
+    >
+      <span className="text-sm font-semibold">{display}</span>
+    </div>
+  )
+}
+
+function scoreClasses(score: number): {
+  bg: string
+  ring: string
+  text: string
+} {
+  if (score >= 80)
+    return {
+      bg: 'bg-success',
+      ring: 'ring-success',
+      text: 'text-success',
+    }
+  if (score >= 70)
+    return {
+      bg: 'bg-warning',
+      ring: 'ring-warning',
+      text: 'text-warning',
+    }
+  return { bg: 'bg-danger', ring: 'ring-danger', text: 'text-danger' }
+}

--- a/src/hooks/useInfiniteEvents.ts
+++ b/src/hooks/useInfiniteEvents.ts
@@ -1,0 +1,65 @@
+import { type InfiniteData, useInfiniteQuery } from '@tanstack/react-query'
+
+import {
+  type EventRecord,
+  type EventsPage,
+  listProjectEvents,
+} from '@/api/endpoints'
+
+const PAGE_SIZE = 100
+
+interface SelectedEventsData {
+  entries: EventRecord[]
+  pageParams: Array<string | undefined>
+  pages: EventsPage[]
+}
+
+export function useInfiniteProjectEvents(
+  orgSlug: string,
+  projectId: string,
+  type?: string,
+) {
+  return useInfiniteQuery<
+    EventsPage,
+    Error,
+    SelectedEventsData,
+    readonly unknown[],
+    string | undefined
+  >({
+    enabled: Boolean(orgSlug) && Boolean(projectId),
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (!lastPage.nextCursor) return undefined
+      if (lastPage.nextCursor === lastPageParam) return undefined
+      return lastPage.nextCursor
+    },
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam, signal }) =>
+      listProjectEvents(
+        {
+          cursor: pageParam as string | undefined,
+          limit: PAGE_SIZE,
+          orgSlug,
+          projectId,
+          type,
+        },
+        signal,
+      ),
+    queryKey: ['events', 'infinite', orgSlug, projectId, type],
+    select: (data: InfiniteData<EventsPage, string | undefined>) => {
+      const seen = new Set<string>()
+      const entries: EventRecord[] = []
+      for (const page of data.pages) {
+        for (const entry of page.entries) {
+          if (seen.has(entry.id)) continue
+          seen.add(entry.id)
+          entries.push(entry)
+        }
+      }
+      return {
+        entries,
+        pageParams: data.pageParams,
+        pages: data.pages,
+      }
+    },
+  })
+}

--- a/src/hooks/useProjectPatch.ts
+++ b/src/hooks/useProjectPatch.ts
@@ -8,11 +8,14 @@ import { extractApiErrorDetail } from '@/lib/apiError'
 import { applyJsonPatch } from '@/lib/json-patch'
 import type { PatchOperation, Project } from '@/types'
 
-const SCORE_REFRESH_DELAY = 5_000
+const SCORE_REFRESH_INITIAL_DELAY = 3_000
+const SCORE_REFRESH_MAX_ATTEMPTS = 5
+const SCORE_REFRESH_BACKOFF_FACTOR = 2
 
 export interface UseProjectPatchResult {
   patch: (path: string, value: unknown) => Promise<void>
   pendingPath: null | string
+  scheduleScoreRefresh: () => void
 }
 
 export function useProjectPatch(
@@ -22,6 +25,7 @@ export function useProjectPatch(
   const qc = useQueryClient()
   const [pendingPath, setPendingPath] = useState<null | string>(null)
   const scoreRefreshTimer = useRef<null | ReturnType<typeof setTimeout>>(null)
+  const scoreRefreshAttempt = useRef(0)
 
   useEffect(() => {
     return () => {
@@ -31,30 +35,39 @@ export function useProjectPatch(
     }
   }, [])
 
+  const invalidateScoreQueries = useCallback(() => {
+    qc.invalidateQueries({ queryKey: ['project', orgSlug, projectId] })
+    qc.invalidateQueries({ queryKey: ['scoreTrend', orgSlug, projectId] })
+    qc.invalidateQueries({ queryKey: ['scoreTrend90', orgSlug, projectId] })
+    qc.invalidateQueries({
+      queryKey: ['projectBreakdown', orgSlug, projectId],
+    })
+    qc.invalidateQueries({ queryKey: ['scoreHistory', orgSlug, projectId] })
+    qc.invalidateQueries({
+      queryKey: ['scoreHistoryRaw', orgSlug, projectId],
+    })
+  }, [qc, orgSlug, projectId])
+
   const scheduleScoreRefresh = useCallback(() => {
     if (scoreRefreshTimer.current !== null) {
       clearTimeout(scoreRefreshTimer.current)
     }
-    scoreRefreshTimer.current = setTimeout(() => {
+    scoreRefreshAttempt.current = 0
+
+    const attempt = () => {
       scoreRefreshTimer.current = null
-      qc.invalidateQueries({ queryKey: ['project', orgSlug, projectId] })
-      qc.invalidateQueries({
-        queryKey: ['scoreTrend', orgSlug, projectId],
-      })
-      qc.invalidateQueries({
-        queryKey: ['scoreTrend90', orgSlug, projectId],
-      })
-      qc.invalidateQueries({
-        queryKey: ['projectBreakdown', orgSlug, projectId],
-      })
-      qc.invalidateQueries({
-        queryKey: ['scoreHistory', orgSlug, projectId],
-      })
-      qc.invalidateQueries({
-        queryKey: ['scoreHistoryRaw', orgSlug, projectId],
-      })
-    }, SCORE_REFRESH_DELAY)
-  }, [qc, orgSlug, projectId])
+      invalidateScoreQueries()
+      scoreRefreshAttempt.current += 1
+      if (scoreRefreshAttempt.current < SCORE_REFRESH_MAX_ATTEMPTS) {
+        const delay =
+          SCORE_REFRESH_INITIAL_DELAY *
+          SCORE_REFRESH_BACKOFF_FACTOR ** scoreRefreshAttempt.current
+        scoreRefreshTimer.current = setTimeout(attempt, delay)
+      }
+    }
+
+    scoreRefreshTimer.current = setTimeout(attempt, SCORE_REFRESH_INITIAL_DELAY)
+  }, [invalidateScoreQueries])
 
   const patch = useCallback(
     async (path: string, value: unknown) => {
@@ -106,7 +119,7 @@ export function useProjectPatch(
     [qc, orgSlug, projectId, scheduleScoreRefresh],
   )
 
-  return { patch, pendingPath }
+  return { patch, pendingPath, scheduleScoreRefresh }
 }
 
 function buildOp(path: string, value: unknown): PatchOperation {

--- a/src/hooks/useProjectPatch.ts
+++ b/src/hooks/useProjectPatch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -7,6 +7,8 @@ import { patchProject } from '@/api/endpoints'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { applyJsonPatch } from '@/lib/json-patch'
 import type { PatchOperation, Project } from '@/types'
+
+const SCORE_REFRESH_DELAY = 5_000
 
 export interface UseProjectPatchResult {
   patch: (path: string, value: unknown) => Promise<void>
@@ -19,6 +21,40 @@ export function useProjectPatch(
 ): UseProjectPatchResult {
   const qc = useQueryClient()
   const [pendingPath, setPendingPath] = useState<null | string>(null)
+  const scoreRefreshTimer = useRef<null | ReturnType<typeof setTimeout>>(null)
+
+  useEffect(() => {
+    return () => {
+      if (scoreRefreshTimer.current !== null) {
+        clearTimeout(scoreRefreshTimer.current)
+      }
+    }
+  }, [])
+
+  const scheduleScoreRefresh = useCallback(() => {
+    if (scoreRefreshTimer.current !== null) {
+      clearTimeout(scoreRefreshTimer.current)
+    }
+    scoreRefreshTimer.current = setTimeout(() => {
+      scoreRefreshTimer.current = null
+      qc.invalidateQueries({ queryKey: ['project', orgSlug, projectId] })
+      qc.invalidateQueries({
+        queryKey: ['scoreTrend', orgSlug, projectId],
+      })
+      qc.invalidateQueries({
+        queryKey: ['scoreTrend90', orgSlug, projectId],
+      })
+      qc.invalidateQueries({
+        queryKey: ['projectBreakdown', orgSlug, projectId],
+      })
+      qc.invalidateQueries({
+        queryKey: ['scoreHistory', orgSlug, projectId],
+      })
+      qc.invalidateQueries({
+        queryKey: ['scoreHistoryRaw', orgSlug, projectId],
+      })
+    }, SCORE_REFRESH_DELAY)
+  }, [qc, orgSlug, projectId])
 
   const patch = useCallback(
     async (path: string, value: unknown) => {
@@ -51,6 +87,11 @@ export function useProjectPatch(
         // GET returns (e.g. environments as a map vs. an array). Invalidate
         // so the next read comes from the canonical GET.
         qc.invalidateQueries({ queryKey: key })
+        // Activity events are written synchronously — refresh immediately.
+        qc.invalidateQueries({
+          queryKey: ['events', orgSlug, projectId],
+        })
+        scheduleScoreRefresh()
       } catch (error) {
         // Rollback optimistic update
         if (optimisticApplied && snapshot !== undefined) {
@@ -62,7 +103,7 @@ export function useProjectPatch(
         setPendingPath(null)
       }
     },
-    [qc, orgSlug, projectId],
+    [qc, orgSlug, projectId, scheduleScoreRefresh],
   )
 
   return { patch, pendingPath }

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -28,6 +28,7 @@ export function ProjectDetailPage() {
     enabled: !!orgSlug && !!projectId,
     queryFn: ({ signal }) => getProject(orgSlug, projectId!, signal),
     queryKey: ['project', orgSlug, projectId],
+    staleTime: 120_000,
   })
 
   usePageTitle(project?.name ?? 'Project')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -118,6 +118,7 @@ export interface Project {
     outbound_count?: number
     team?: RelationshipLink
   }
+  score?: null | number
   slug: string
   team: {
     name: string
@@ -174,6 +175,34 @@ export interface ProjectTypeCreate {
 }
 
 export type RelationshipLink = Schemas['RelationshipLink']
+
+export interface ScoringPolicy {
+  attribute_name: string
+  category: 'attribute'
+  description?: null | string
+  enabled: boolean
+  id: string
+  name: string
+  priority: number
+  range_score_map?: null | Record<string, number>
+  slug: string
+  targets?: string[]
+  value_score_map?: null | Record<string, number>
+  weight: number
+}
+
+export interface ScoringPolicyCreate {
+  attribute_name: string
+  description?: null | string
+  enabled: boolean
+  name: string
+  priority: number
+  range_score_map?: null | Record<string, number>
+  slug: string
+  targets: string[]
+  value_score_map?: null | Record<string, number>
+  weight: number
+}
 
 // `User` is the UI-side profile shape used by auth/session consumers.
 // It does not map cleanly to the backend `UserResponse` (different key set:


### PR DESCRIPTION
## Summary

- **ScoreBadge** component (sm/md/lg, circle/square variants) with green/yellow/red colour coding at 80/70 thresholds
- **ProjectsView**: score column in the project list table
- **ProjectDetail**: score badge + breakdown panel in the sidebar showing per-attribute contributions with weight and mapped score
- **ScoreHistoryTab**: SVG line chart with range (30d/90d/1y/all) and granularity (raw/hour/day) controls; annotated change-event verticals that correlate to attribute-change diffs
- **ProjectActivityLog**: infinite-scroll event log using cursor-based pagination
- **ScoringPolicyManagement** admin panel: list with search/filter, create/edit/delete, bulk rescore trigger
- **ScoringPolicyForm**: value-score map and range-score map editors, target project-type selection
- New API endpoints: score history, score trend, project events, scoring policy CRUD, rescore-all
- `useInfiniteEvents` hook for cursor-based pagination of the events API

## Test plan

- [ ] Projects list shows score badge for projects that have a score; shows `—` for unscored projects
- [ ] Project detail sidebar shows score badge and breakdown table; breakdown panel absent when score is null
- [ ] Score History tab renders chart with range/granularity toggles; change-event annotations appear and sync with the timeline below
- [ ] Event timeline rows highlight on hover and correlate attribute-change diffs where available
- [ ] Admin → Scoring Policies: list, create, edit (PATCH diff), delete all work
- [ ] Recompute Scores button triggers rescore and shows enqueued count briefly
- [ ] Enabled/disabled filter and search box narrow the policy list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)