### PR TITLE
Add plugins UI for configuration and logs

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/constants'
 import type {
   ActivityFeedEntry,
+  AdminPluginsResponse,
   AdminSettings,
   AdminUser,
   AdminUserCreate,
@@ -14,13 +15,17 @@ import type {
   AuthProvider,
   Blueprint,
   BlueprintCreate,
+  CatalogEntry,
   ClientCredential,
   ClientCredentialCreate,
   ClientCredentialCreated,
   CollectionResponse,
+  ConfigKeyResponse,
+  ConfigKeyValueResponse,
   CurrentReleaseEnvironment,
   Environment,
   EnvironmentCreate,
+  InstalledPlugin,
   LinkDefinition,
   LinkDefinitionCreate,
   LocalAuthConfig,
@@ -28,6 +33,7 @@ import type {
   LoginProviderRead,
   LoginProviderUpdate,
   LoginRequest,
+  LogResultResponse,
   Note,
   NoteCreate,
   NoteListResponse,
@@ -38,6 +44,11 @@ import type {
   Organization,
   OrganizationCreate,
   PatchOperation,
+  PluginAssignmentCreate,
+  PluginAssignmentResponse,
+  PluginCreate,
+  PluginResponse,
+  PluginUpdate,
   Project,
   ProjectCreate,
   ProjectRelationshipsResponse,
@@ -1558,3 +1569,207 @@ export const listCurrentReleases = async (
   )
   return Array.isArray(response) ? response : []
 }
+
+// Service Plugins
+export const listServicePlugins = (
+  orgSlug: string,
+  serviceSlug: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<PluginResponse[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/plugins/`,
+    undefined,
+    signal,
+  )
+
+export const createServicePlugin = (
+  orgSlug: string,
+  serviceSlug: string,
+  data: PluginCreate,
+) =>
+  apiClient.post<PluginResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/plugins/`,
+    data,
+  )
+
+export const updateServicePlugin = (
+  orgSlug: string,
+  serviceSlug: string,
+  pluginId: string,
+  data: PluginUpdate,
+) =>
+  apiClient.put<PluginResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/plugins/${encodeURIComponent(pluginId)}`,
+    data,
+  )
+
+export const deleteServicePlugin = (
+  orgSlug: string,
+  serviceSlug: string,
+  pluginId: string,
+  force = false,
+) =>
+  apiClient.delete<void>(
+    `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/plugins/${encodeURIComponent(pluginId)}${force ? '?force=true' : ''}`,
+  )
+
+// Project Type Plugins
+export const listProjectTypePlugins = (
+  orgSlug: string,
+  ptSlug: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<PluginAssignmentResponse[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/project-types/${encodeURIComponent(ptSlug)}/plugins/`,
+    undefined,
+    signal,
+  )
+
+export const replaceProjectTypePlugins = (
+  orgSlug: string,
+  ptSlug: string,
+  assignments: PluginAssignmentCreate[],
+) =>
+  apiClient.put<PluginAssignmentResponse[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/project-types/${encodeURIComponent(ptSlug)}/plugins/`,
+    assignments,
+  )
+
+// Project Plugins
+export const listProjectPlugins = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<PluginAssignmentResponse[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/plugins/`,
+    undefined,
+    signal,
+  )
+
+export const replaceProjectPlugins = (
+  orgSlug: string,
+  projectId: string,
+  assignments: PluginAssignmentCreate[],
+) =>
+  apiClient.put<PluginAssignmentResponse[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/plugins/`,
+    assignments,
+  )
+
+// Project Configuration
+export const listConfigurationKeys = (
+  orgSlug: string,
+  projectId: string,
+  params?: { environment?: string; source?: string },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<ConfigKeyResponse[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/configuration/`,
+    params,
+    signal,
+  )
+
+export const fetchConfigurationValues = (
+  orgSlug: string,
+  projectId: string,
+  keys: string[],
+  params?: { environment?: string; source?: string },
+) =>
+  apiClient.post<ConfigKeyValueResponse[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/configuration/values:fetch${params ? `?${new URLSearchParams(Object.entries(params).filter(([, v]) => v != null) as [string, string][]).toString()}` : ''}`,
+    { keys },
+  )
+
+export const setConfigurationValue = (
+  orgSlug: string,
+  projectId: string,
+  key: string,
+  data: { data_type: string; secret: boolean; value: unknown },
+  params?: { environment?: string; source?: string },
+) =>
+  apiClient.put<ConfigKeyResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/configuration/${encodeURIComponent(key)}${params ? `?${new URLSearchParams(Object.entries(params).filter(([, v]) => v != null) as [string, string][]).toString()}` : ''}`,
+    data,
+  )
+
+export const deleteConfigurationKey = (
+  orgSlug: string,
+  projectId: string,
+  key: string,
+  params?: { environment?: string; source?: string },
+) =>
+  apiClient.delete<void>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/configuration/${encodeURIComponent(key)}${params ? `?${new URLSearchParams(Object.entries(params).filter(([, v]) => v != null) as [string, string][]).toString()}` : ''}`,
+  )
+
+// Project Logs
+export interface LogSearchParams {
+  cursor?: string
+  end_time?: string
+  environment?: string
+  filter?: string[]
+  limit?: number
+  source?: string
+  start_time?: string
+}
+
+export const searchProjectLogs = (
+  orgSlug: string,
+  projectId: string,
+  params?: LogSearchParams,
+  signal?: AbortSignal,
+) => {
+  const query: Record<string, string | string[]> = {}
+  if (params) {
+    if (params.source) query.source = params.source
+    if (params.environment) query.environment = params.environment
+    if (params.start_time) query.start_time = params.start_time
+    if (params.end_time) query.end_time = params.end_time
+    if (params.cursor) query.cursor = params.cursor
+    if (params.limit != null) query.limit = String(params.limit)
+    if (params.filter?.length) query.filter = params.filter
+  }
+  return apiClient.get<LogResultResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/logs/`,
+    query as Record<string, string>,
+    signal,
+  )
+}
+
+export const getLogSchema = (
+  orgSlug: string,
+  projectId: string,
+  params?: { environment?: string; source?: string },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<Array<{ description?: string; name: string; type: string }>>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/logs/schema`,
+    params,
+    signal,
+  )
+
+// Admin Plugins
+export const getAdminPlugins = (signal?: AbortSignal) =>
+  apiClient.get<AdminPluginsResponse>('/admin/plugins', undefined, signal)
+
+export const getAdminPluginCatalog = (signal?: AbortSignal) =>
+  apiClient.get<CatalogEntry[]>('/admin/plugins/catalog', undefined, signal)
+
+export const getAdminPlugin = (slug: string, signal?: AbortSignal) =>
+  apiClient.get<InstalledPlugin>(
+    `/admin/plugins/${encodeURIComponent(slug)}`,
+    undefined,
+    signal,
+  )
+
+export const installPlugin = (data: { package: string; version?: string }) =>
+  apiClient.post<{ errors: string[]; loaded: number; skipped: number }>(
+    '/admin/plugins/install',
+    data,
+  )
+
+export const uninstallPlugin = (packageName: string) =>
+  apiClient.delete<void>(
+    `/admin/plugins/installed/${encodeURIComponent(packageName)}`,
+  )

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -14,6 +14,7 @@ import {
   KeyRound,
   Layers,
   Link2,
+  Puzzle,
   Shield,
   StickyNote,
   Target,
@@ -31,6 +32,7 @@ import { EnvironmentManagement } from './admin/EnvironmentManagement'
 import { LinkDefinitionManagement } from './admin/LinkDefinitionManagement'
 import { NoteTemplateManagement } from './admin/NoteTemplateManagement'
 import { OrganizationManagement } from './admin/OrganizationManagement'
+import { PluginsManagement } from './admin/PluginsManagement'
 import { ProjectTypeManagement } from './admin/ProjectTypeManagement'
 import { RoleManagement } from './admin/RoleManagement'
 import { ScoringPolicyManagement } from './admin/ScoringPolicyManagement'
@@ -47,6 +49,7 @@ type AdminSection =
   | 'note-templates'
   | 'oauth'
   | 'organizations'
+  | 'plugins'
   | 'project-types'
   | 'roles'
   | 'scoring-policies'
@@ -63,6 +66,7 @@ const VALID_SECTIONS: AdminSection[] = [
   'note-templates',
   'oauth',
   'organizations',
+  'plugins',
   'project-types',
   'roles',
   'scoring-policies',
@@ -161,6 +165,13 @@ export function Admin() {
       icon: Webhook,
       id: 'webhooks',
       label: 'Webhooks',
+      scope: 'org',
+    },
+    {
+      description: 'Manage installed plugins',
+      icon: Puzzle,
+      id: 'plugins',
+      label: 'Plugins',
       scope: 'org',
     },
   ]
@@ -349,6 +360,7 @@ export function Admin() {
               <ScoringPolicyManagement />
             )}
             {currentSection === 'oauth' && <AuthProvidersManagement />}
+            {currentSection === 'plugins' && <PluginsManagement />}
           </div>
         </main>
       </div>

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -26,6 +26,8 @@ import {
 } from '@/api/endpoints'
 import { ProjectNotesTab } from '@/components/notes/ProjectNotesTab'
 import { OperationsLog } from '@/components/OperationsLog'
+import { ConfigurationTab } from '@/components/project/ConfigurationTab'
+import { LogsTab } from '@/components/project/LogsTab'
 import { ProjectActivityLog } from '@/components/ProjectActivityLog'
 import { ProjectAttributesSection } from '@/components/ProjectAttributesSection'
 import { ProjectEnvironmentsCard } from '@/components/ProjectEnvironmentsCard'
@@ -576,7 +578,7 @@ export function ProjectDetail({
         </TabsContent>
 
         <TabsContent value="configuration">
-          <PlaceholderTab name="Configuration" />
+          <ConfigurationTab orgSlug={orgSlug} projectId={project.id} />
         </TabsContent>
         <TabsContent value="relationships">
           <ProjectRelationshipsTab
@@ -589,7 +591,7 @@ export function ProjectDetail({
           <PlaceholderTab name="Dependencies" />
         </TabsContent>
         <TabsContent value="logs">
-          <PlaceholderTab name="Logs" />
+          <LogsTab orgSlug={orgSlug} projectId={project.id} />
         </TabsContent>
         <TabsContent value="notes">
           <ProjectNotesTab

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -15,6 +15,7 @@ import {
 import { EditEnvironmentsCard } from '@/components/EditEnvironmentsCard'
 import { EditIdentifiersCard } from '@/components/EditIdentifiersCard'
 import { EditLinksCard } from '@/components/EditLinksCard'
+import { ProjectPluginsSection } from '@/components/project/ProjectPluginsSection'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -134,6 +135,8 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
         identifiers={project.identifiers || {}}
         onPatch={(entries) => patch('/identifiers', entries)}
       />
+
+      <ProjectPluginsSection orgSlug={orgSlug} projectId={project.id} />
 
       {isAdmin && (
         <Card>

--- a/src/components/admin/PluginsManagement.tsx
+++ b/src/components/admin/PluginsManagement.tsx
@@ -1,0 +1,404 @@
+import { useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  AlertTriangle,
+  BookOpen,
+  CheckCircle,
+  Download,
+  Package,
+  Trash2,
+} from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  getAdminPluginCatalog,
+  getAdminPlugins,
+  installPlugin,
+  uninstallPlugin,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type { AdminPluginsResponse, InstalledPlugin } from '@/types'
+
+interface InstalledListProps {
+  installed: InstalledPlugin[]
+  isLoading: boolean
+}
+
+type PluginTab = 'catalog' | 'installed' | 'unavailable'
+
+interface UnavailableListProps {
+  isLoading: boolean
+  unavailable: string[]
+}
+
+export function PluginsManagement() {
+  const [activeTab, setActiveTab] = useState<PluginTab>('installed')
+
+  const tabs: { id: PluginTab; label: string }[] = [
+    { id: 'installed', label: 'Installed' },
+    { id: 'catalog', label: 'Catalog' },
+    { id: 'unavailable', label: 'Unavailable' },
+  ]
+
+  const { data, isLoading } = useQuery<AdminPluginsResponse>({
+    queryFn: ({ signal }) => getAdminPlugins(signal),
+    queryKey: ['admin-plugins'],
+    staleTime: 60 * 1000,
+  })
+
+  return (
+    <div className="space-y-6">
+      <div className="border-b border-tertiary">
+        <div className="flex gap-0">
+          {tabs.map((tab) => {
+            const isActive = activeTab === tab.id
+            return (
+              <button
+                className={`border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
+                  isActive
+                    ? 'border-info text-info'
+                    : 'border-transparent text-secondary hover:text-primary'
+                }`}
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                type="button"
+              >
+                {tab.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {activeTab === 'installed' && (
+        <InstalledList
+          installed={data?.installed ?? []}
+          isLoading={isLoading}
+        />
+      )}
+      {activeTab === 'catalog' && <CatalogList />}
+      {activeTab === 'unavailable' && (
+        <UnavailableList
+          isLoading={isLoading}
+          unavailable={data?.unavailable ?? []}
+        />
+      )}
+    </div>
+  )
+}
+
+function CatalogList() {
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryFn: ({ signal }) => getAdminPluginCatalog(signal),
+    queryKey: ['admin-plugin-catalog'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const installMutation = useMutation({
+    mutationFn: (packageName: string) =>
+      installPlugin({ package: packageName }),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to install plugin')
+    },
+    onSuccess: (result, packageName) => {
+      if (result.errors?.length) {
+        toast.warning(
+          `${packageName} installed with warnings: ${result.errors.join(', ')}`,
+        )
+      } else {
+        toast.success(
+          `${packageName} installed (${result.loaded} plugin(s) loaded)`,
+        )
+      }
+      void queryClient.invalidateQueries({ queryKey: ['admin-plugins'] })
+      void queryClient.invalidateQueries({ queryKey: ['admin-plugin-catalog'] })
+    },
+  })
+
+  if (isLoading) {
+    return <LoadingState label="Loading..." />
+  }
+
+  const entries = data ?? []
+
+  return (
+    <Card>
+      <CardHeader className="px-6 py-4">
+        <CardTitle>Plugin Catalog</CardTitle>
+        <CardDescription>
+          Catalog updates ship with Imbi releases. For production persistence,
+          add plugins to the image&apos;s pyproject.toml.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        {entries.length === 0 ? (
+          <div className="py-8 text-center text-sm text-secondary">
+            No catalog entries
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Package</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead>Version</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="w-28" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {entries.map((entry) => (
+                <TableRow key={entry.package}>
+                  <TableCell>
+                    <div className="font-medium">{entry.package}</div>
+                    {entry.author && (
+                      <div className="text-xs text-secondary">
+                        by {entry.author}
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-sm text-secondary">
+                    {entry.description}
+                    {entry.docs_url && (
+                      <a
+                        className="hover:text-info/80 ml-1 inline-flex items-center gap-0.5 text-info"
+                        href={entry.docs_url}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <BookOpen className="h-3 w-3" />
+                        Docs
+                      </a>
+                    )}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {entry.version}
+                  </TableCell>
+                  <TableCell>
+                    {entry.status === 'installed' ? (
+                      <Badge
+                        className="flex w-fit items-center gap-1"
+                        variant="secondary"
+                      >
+                        <CheckCircle className="h-3 w-3" />
+                        Installed
+                      </Badge>
+                    ) : entry.status === 'update_available' ? (
+                      <Badge className="flex w-fit items-center gap-1 bg-amber-bg text-amber-text">
+                        <Download className="h-3 w-3" />
+                        Update Available
+                      </Badge>
+                    ) : (
+                      <Badge variant="secondary">Not Installed</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {entry.status !== 'installed' && (
+                      <Button
+                        disabled={installMutation.isPending}
+                        onClick={() => installMutation.mutate(entry.package)}
+                        size="sm"
+                        variant="outline"
+                      >
+                        <Download className="mr-1 h-3 w-3" />
+                        {entry.status === 'update_available'
+                          ? 'Update'
+                          : 'Install'}
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function InstalledList({ installed, isLoading }: InstalledListProps) {
+  const queryClient = useQueryClient()
+  const [confirmPkg, setConfirmPkg] = useState<null | string>(null)
+
+  const uninstallMutation = useMutation({
+    mutationFn: (packageName: string) => uninstallPlugin(packageName),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to uninstall plugin')
+    },
+    onSuccess: (_, packageName) => {
+      toast.success(`${packageName} uninstalled`)
+      setConfirmPkg(null)
+      void queryClient.invalidateQueries({ queryKey: ['admin-plugins'] })
+    },
+  })
+
+  if (isLoading) {
+    return <LoadingState label="Loading..." />
+  }
+
+  if (installed.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <Package className="mx-auto mb-3 h-8 w-8 text-secondary" />
+          <CardTitle className="mb-1">No Plugins Installed</CardTitle>
+          <CardDescription>
+            Install plugins from the Catalog tab to enable Configuration and
+            Logs features.
+          </CardDescription>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Plugin</TableHead>
+                <TableHead>Package</TableHead>
+                <TableHead>Version</TableHead>
+                <TableHead>Tabs</TableHead>
+                <TableHead className="w-20" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {installed.map((plugin) => (
+                <TableRow key={plugin.slug}>
+                  <TableCell>
+                    <div className="font-medium">{plugin.name}</div>
+                    <div className="text-xs text-secondary">
+                      {plugin.description}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <code className="rounded bg-secondary px-1.5 py-0.5 text-xs">
+                      {plugin.package_name}
+                    </code>
+                  </TableCell>
+                  <TableCell className="text-sm text-secondary">
+                    {plugin.package_version}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex gap-1">
+                      {plugin.supported_tabs.map((tab) => (
+                        <Badge key={tab} variant="secondary">
+                          {tab}
+                        </Badge>
+                      ))}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      onClick={() => setConfirmPkg(plugin.package_name)}
+                      size="icon"
+                      variant="ghost"
+                    >
+                      <Trash2 className="h-3 w-3 text-destructive" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <ConfirmDialog
+        description={`Uninstall ${confirmPkg ?? ''}? Plugin assignments will become unavailable.`}
+        onCancel={() => setConfirmPkg(null)}
+        onConfirm={() => {
+          if (confirmPkg) uninstallMutation.mutate(confirmPkg)
+        }}
+        open={confirmPkg !== null}
+        title="Uninstall Plugin"
+      />
+    </>
+  )
+}
+
+function UnavailableList({ isLoading, unavailable }: UnavailableListProps) {
+  if (isLoading) {
+    return <LoadingState label="Loading..." />
+  }
+
+  if (unavailable.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <CheckCircle className="mx-auto mb-3 h-8 w-8 text-secondary" />
+          <CardTitle className="mb-1">All Plugins Available</CardTitle>
+          <CardDescription>
+            All configured plugin nodes have a matching installed handler.
+          </CardDescription>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="px-6 py-4">
+        <CardTitle className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-destructive" />
+          Unavailable Plugins
+        </CardTitle>
+        <CardDescription>
+          These plugin slugs are referenced by Plugin nodes in the graph but
+          have no installed handler. Install the package from the Catalog tab or
+          update the image.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Slug</TableHead>
+              <TableHead>Resolution</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {unavailable.map((slug) => (
+              <TableRow key={slug}>
+                <TableCell>
+                  <code className="rounded bg-secondary px-1.5 py-0.5 text-sm">
+                    {slug}
+                  </code>
+                </TableCell>
+                <TableCell className="text-sm text-secondary">
+                  Install from the Catalog tab or add to the image&apos;s
+                  pyproject.toml
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/admin/PluginsManagement.tsx
+++ b/src/components/admin/PluginsManagement.tsx
@@ -40,13 +40,17 @@ import { extractApiErrorDetail } from '@/lib/apiError'
 import type { AdminPluginsResponse, InstalledPlugin } from '@/types'
 
 interface InstalledListProps {
+  error: unknown
   installed: InstalledPlugin[]
+  isError: boolean
   isLoading: boolean
 }
 
 type PluginTab = 'catalog' | 'installed' | 'unavailable'
 
 interface UnavailableListProps {
+  error: unknown
+  isError: boolean
   isLoading: boolean
   unavailable: string[]
 }
@@ -60,7 +64,7 @@ export function PluginsManagement() {
     { id: 'unavailable', label: 'Unavailable' },
   ]
 
-  const { data, isLoading } = useQuery<AdminPluginsResponse>({
+  const { data, error, isError, isLoading } = useQuery<AdminPluginsResponse>({
     queryFn: ({ signal }) => getAdminPlugins(signal),
     queryKey: ['admin-plugins'],
     staleTime: 60 * 1000,
@@ -92,13 +96,17 @@ export function PluginsManagement() {
 
       {activeTab === 'installed' && (
         <InstalledList
+          error={error}
           installed={data?.installed ?? []}
+          isError={isError}
           isLoading={isLoading}
         />
       )}
       {activeTab === 'catalog' && <CatalogList />}
       {activeTab === 'unavailable' && (
         <UnavailableList
+          error={error}
+          isError={isError}
           isLoading={isLoading}
           unavailable={data?.unavailable ?? []}
         />
@@ -110,7 +118,7 @@ export function PluginsManagement() {
 function CatalogList() {
   const queryClient = useQueryClient()
 
-  const { data, isLoading } = useQuery({
+  const { data, error, isError, isLoading } = useQuery({
     queryFn: ({ signal }) => getAdminPluginCatalog(signal),
     queryKey: ['admin-plugin-catalog'],
     staleTime: 5 * 60 * 1000,
@@ -139,6 +147,16 @@ function CatalogList() {
 
   if (isLoading) {
     return <LoadingState label="Loading..." />
+  }
+
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-destructive">
+          {extractApiErrorDetail(error) ?? 'Failed to load plugin catalog'}
+        </CardContent>
+      </Card>
+    )
   }
 
   const entries = data ?? []
@@ -239,7 +257,12 @@ function CatalogList() {
   )
 }
 
-function InstalledList({ installed, isLoading }: InstalledListProps) {
+function InstalledList({
+  error,
+  installed,
+  isError,
+  isLoading,
+}: InstalledListProps) {
   const queryClient = useQueryClient()
   const [confirmPkg, setConfirmPkg] = useState<null | string>(null)
 
@@ -258,6 +281,16 @@ function InstalledList({ installed, isLoading }: InstalledListProps) {
 
   if (isLoading) {
     return <LoadingState label="Loading..." />
+  }
+
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-destructive">
+          {extractApiErrorDetail(error) ?? 'Failed to load plugins'}
+        </CardContent>
+      </Card>
+    )
   }
 
   if (installed.length === 0) {
@@ -344,9 +377,24 @@ function InstalledList({ installed, isLoading }: InstalledListProps) {
   )
 }
 
-function UnavailableList({ isLoading, unavailable }: UnavailableListProps) {
+function UnavailableList({
+  error,
+  isError,
+  isLoading,
+  unavailable,
+}: UnavailableListProps) {
   if (isLoading) {
     return <LoadingState label="Loading..." />
+  }
+
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-destructive">
+          {extractApiErrorDetail(error) ?? 'Failed to load plugins'}
+        </CardContent>
+      </Card>
+    )
   }
 
   if (unavailable.length === 0) {

--- a/src/components/admin/PluginsManagement.tsx
+++ b/src/components/admin/PluginsManagement.tsx
@@ -252,6 +252,7 @@ function InstalledList({ installed, isLoading }: InstalledListProps) {
       toast.success(`${packageName} uninstalled`)
       setConfirmPkg(null)
       void queryClient.invalidateQueries({ queryKey: ['admin-plugins'] })
+      void queryClient.invalidateQueries({ queryKey: ['admin-plugin-catalog'] })
     },
   })
 
@@ -316,6 +317,7 @@ function InstalledList({ installed, isLoading }: InstalledListProps) {
                   </TableCell>
                   <TableCell>
                     <Button
+                      aria-label={`Uninstall ${plugin.name}`}
                       onClick={() => setConfirmPkg(plugin.package_name)}
                       size="icon"
                       variant="ghost"

--- a/src/components/admin/project-types/ProjectTypeDetail.tsx
+++ b/src/components/admin/project-types/ProjectTypeDetail.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
+
 import { useQuery } from '@tanstack/react-query'
-import { ArrowLeft, Edit2 } from 'lucide-react'
+import { ArrowLeft, Edit2, Info, type LucideIcon, Puzzle } from 'lucide-react'
 
 import { getProjectTypeSchema } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
@@ -9,6 +11,10 @@ import { PROJECT_TYPE_BASE_FIELDS_SET } from '@/lib/constants'
 import { useIcon } from '@/lib/icons'
 import { extractDynamicFields } from '@/lib/utils'
 import type { ProjectType } from '@/types'
+
+import { ProjectTypePlugins } from './ProjectTypePlugins'
+
+type DetailTab = 'details' | 'plugins'
 
 interface ProjectTypeDetailProps {
   onBack: () => void
@@ -21,6 +27,7 @@ export function ProjectTypeDetail({
   onEdit,
   projectType,
 }: ProjectTypeDetailProps) {
+  const [activeTab, setActiveTab] = useState<DetailTab>('details')
   const { data: ptSchema } = useQuery({
     queryFn: ({ signal }) => getProjectTypeSchema(signal),
     queryKey: ['projectTypeSchema'],
@@ -29,69 +36,108 @@ export function ProjectTypeDetail({
 
   const HeaderIcon = useIcon(projectType.icon ?? null, null)
 
+  const tabs: { icon: LucideIcon; id: DetailTab; label: string }[] = [
+    { icon: Info, id: 'details', label: 'Details' },
+    { icon: Puzzle, id: 'plugins', label: 'Plugins' },
+  ]
+
   return (
     <div className="space-y-6">
-      {/* Back button */}
-      <div>
-        <Button onClick={onBack} variant="outline">
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Back
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Button onClick={onBack} variant="outline">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back
+          </Button>
+          <div className="flex items-center gap-3">
+            {projectType.icon && HeaderIcon ? (
+              <HeaderIcon className="h-8 w-8" />
+            ) : null}
+            <CardTitle>{projectType.name}</CardTitle>
+          </div>
+        </div>
+        <Button
+          className="bg-action text-action-foreground hover:bg-action-hover"
+          onClick={onEdit}
+        >
+          <Edit2 className="mr-2 h-4 w-4" />
+          Edit Project Type
         </Button>
       </div>
 
-      {/* Project Type info card */}
-      <Card>
-        <CardHeader className="flex flex-row items-start justify-between space-y-0 border-b px-6 py-5">
-          <div>
-            <div className="flex items-center gap-3">
-              {projectType.icon && HeaderIcon ? (
-                <HeaderIcon className="h-8 w-8" />
-              ) : null}
-              <CardTitle>{projectType.name}</CardTitle>
-            </div>
+      {/* Tabs */}
+      <div className="border-b border-tertiary">
+        <div className="flex gap-0">
+          {tabs.map((tab) => {
+            const Icon = tab.icon
+            const isActive = activeTab === tab.id
+            return (
+              <button
+                className={`flex items-center gap-2 border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
+                  isActive
+                    ? 'border-info text-info'
+                    : 'border-transparent text-secondary hover:text-primary'
+                }`}
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                type="button"
+              >
+                <Icon className="h-4 w-4" />
+                {tab.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Details Tab */}
+      {activeTab === 'details' && (
+        <Card>
+          <CardHeader className="border-b px-6 py-5">
             {projectType.description && (
-              <p className="mt-1 text-sm text-secondary">
+              <p className="text-sm text-secondary">
                 {projectType.description}
               </p>
             )}
-          </div>
-          <Button
-            className="bg-action text-action-foreground hover:bg-action-hover"
-            onClick={onEdit}
-          >
-            <Edit2 className="mr-2 h-4 w-4" />
-            Edit Project Type
-          </Button>
-        </CardHeader>
+          </CardHeader>
+          <CardContent className="p-6">
+            <div className="grid grid-cols-2 gap-6">
+              <div>
+                <div className="text-sm text-secondary">Slug</div>
+                <div className="mt-1 text-primary">
+                  <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
+                    {projectType.slug}
+                  </code>
+                </div>
+              </div>
+              <div>
+                <div className="text-sm text-secondary">Organization</div>
+                <div className="mt-1 text-primary">
+                  {projectType.organization.name}
+                </div>
+              </div>
+              {ptSchema && (
+                <DynamicDetailFields
+                  data={extractDynamicFields(
+                    projectType,
+                    PROJECT_TYPE_BASE_FIELDS_SET,
+                  )}
+                  schema={ptSchema}
+                />
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
-        <CardContent className="p-6">
-          <div className="grid grid-cols-2 gap-6">
-            <div>
-              <div className="text-sm text-secondary">Slug</div>
-              <div className="mt-1 text-primary">
-                <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
-                  {projectType.slug}
-                </code>
-              </div>
-            </div>
-            <div>
-              <div className="text-sm text-secondary">Organization</div>
-              <div className="mt-1 text-primary">
-                {projectType.organization.name}
-              </div>
-            </div>
-            {ptSchema && (
-              <DynamicDetailFields
-                data={extractDynamicFields(
-                  projectType,
-                  PROJECT_TYPE_BASE_FIELDS_SET,
-                )}
-                schema={ptSchema}
-              />
-            )}
-          </div>
-        </CardContent>
-      </Card>
+      {/* Plugins Tab */}
+      {activeTab === 'plugins' && (
+        <ProjectTypePlugins
+          orgSlug={projectType.organization.slug}
+          ptSlug={projectType.slug}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/admin/project-types/ProjectTypePlugins.tsx
+++ b/src/components/admin/project-types/ProjectTypePlugins.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus, Trash2 } from 'lucide-react'
@@ -58,6 +58,7 @@ export function ProjectTypePlugins({
   const [selectedTab, setSelectedTab] = useState<PluginTab>('configuration')
   const [isDefault, setIsDefault] = useState(false)
   const [drafts, setDrafts] = useState<AssignmentDraft[]>([])
+  const hasSeeded = useRef(false)
 
   const { data: existing } = useQuery({
     queryFn: ({ signal }) => listProjectTypePlugins(orgSlug, ptSlug, signal),
@@ -80,7 +81,8 @@ export function ProjectTypePlugins({
   })
 
   useEffect(() => {
-    if (existing) {
+    if (existing && !hasSeeded.current) {
+      hasSeeded.current = true
       setDrafts(
         existing.map((a) => ({
           default: a.default,
@@ -110,6 +112,7 @@ export function ProjectTypePlugins({
     },
     onSuccess: () => {
       toast.success('Plugin assignments saved')
+      hasSeeded.current = false
       void queryClient.invalidateQueries({
         queryKey: ['project-type-plugins', orgSlug, ptSlug],
       })

--- a/src/components/admin/project-types/ProjectTypePlugins.tsx
+++ b/src/components/admin/project-types/ProjectTypePlugins.tsx
@@ -1,0 +1,325 @@
+import { useEffect, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  listProjectTypePlugins,
+  listServicePlugins,
+  listThirdPartyServices,
+  replaceProjectTypePlugins,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type { PluginAssignmentCreate, PluginTab } from '@/types'
+
+interface AssignmentDraft extends PluginAssignmentCreate {
+  label: string
+}
+
+interface ProjectTypePluginsProps {
+  orgSlug: string
+  ptSlug: string
+}
+
+export function ProjectTypePlugins({
+  orgSlug,
+  ptSlug,
+}: ProjectTypePluginsProps) {
+  const queryClient = useQueryClient()
+  const [showAdd, setShowAdd] = useState(false)
+  const [selectedService, setSelectedService] = useState('')
+  const [selectedPlugin, setSelectedPlugin] = useState('')
+  const [selectedTab, setSelectedTab] = useState<PluginTab>('configuration')
+  const [isDefault, setIsDefault] = useState(false)
+  const [drafts, setDrafts] = useState<AssignmentDraft[]>([])
+
+  const { data: existing } = useQuery({
+    queryFn: ({ signal }) => listProjectTypePlugins(orgSlug, ptSlug, signal),
+    queryKey: ['project-type-plugins', orgSlug, ptSlug],
+    staleTime: 60 * 1000,
+  })
+
+  const { data: services } = useQuery({
+    queryFn: ({ signal }) => listThirdPartyServices(orgSlug, signal),
+    queryKey: ['third-party-services', orgSlug],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const { data: servicePlugins } = useQuery({
+    enabled: !!selectedService,
+    queryFn: ({ signal }) =>
+      listServicePlugins(orgSlug, selectedService, signal),
+    queryKey: ['service-plugins', orgSlug, selectedService],
+    staleTime: 60 * 1000,
+  })
+
+  useEffect(() => {
+    if (existing) {
+      setDrafts(
+        existing.map((a) => ({
+          default: a.default,
+          label: a.label,
+          options: a.options,
+          plugin_id: a.plugin_id,
+          tab: a.tab,
+        })),
+      )
+    }
+  }, [existing])
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      replaceProjectTypePlugins(
+        orgSlug,
+        ptSlug,
+        drafts.map((d) => ({
+          default: d.default,
+          options: d.options,
+          plugin_id: d.plugin_id,
+          tab: d.tab,
+        })),
+      ),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to save assignments')
+    },
+    onSuccess: () => {
+      toast.success('Plugin assignments saved')
+      void queryClient.invalidateQueries({
+        queryKey: ['project-type-plugins', orgSlug, ptSlug],
+      })
+    },
+  })
+
+  const openAdd = () => {
+    setSelectedService('')
+    setSelectedPlugin('')
+    setSelectedTab('configuration')
+    setIsDefault(false)
+    setShowAdd(true)
+  }
+
+  const handleAdd = () => {
+    const plugin = servicePlugins?.find((p) => p.id === selectedPlugin)
+    if (!plugin) return
+    setDrafts((prev) => [
+      ...prev,
+      {
+        default: isDefault,
+        label: plugin.label,
+        options: {},
+        plugin_id: plugin.id,
+        tab: selectedTab,
+      },
+    ])
+    setShowAdd(false)
+  }
+
+  const handleRemove = (idx: number) => {
+    setDrafts((prev) => prev.filter((_, i) => i !== idx))
+  }
+
+  const toggleDefault = (idx: number) => {
+    setDrafts((prev) =>
+      prev.map((d, i) => ({
+        ...d,
+        default: i === idx ? !d.default : d.default,
+      })),
+    )
+  }
+
+  const isDirty =
+    JSON.stringify(drafts) !==
+    JSON.stringify(
+      (existing ?? []).map((a) => ({
+        default: a.default,
+        label: a.label,
+        options: a.options,
+        plugin_id: a.plugin_id,
+        tab: a.tab,
+      })),
+    )
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between px-6 py-4">
+          <CardTitle>Plugin Assignments</CardTitle>
+          <div className="flex gap-2">
+            {isDirty && (
+              <Button
+                disabled={saveMutation.isPending}
+                onClick={() => saveMutation.mutate()}
+                size="sm"
+              >
+                {saveMutation.isPending ? 'Saving…' : 'Save Changes'}
+              </Button>
+            )}
+            <Button onClick={openAdd} size="sm" variant="outline">
+              <Plus className="mr-1 h-3 w-3" />
+              Add Plugin
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {drafts.length === 0 ? (
+            <div className="py-8 text-center text-sm text-secondary">
+              No plugins assigned. Add a plugin to enable Configuration or Logs
+              tabs on projects of this type.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Plugin</TableHead>
+                  <TableHead>Tab</TableHead>
+                  <TableHead>Default</TableHead>
+                  <TableHead className="w-20" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {drafts.map((draft, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell className="font-medium">{draft.label}</TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">{draft.tab}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      <button
+                        className={`text-sm ${draft.default ? 'text-info' : 'text-secondary hover:text-primary'}`}
+                        onClick={() => toggleDefault(idx)}
+                        type="button"
+                      >
+                        {draft.default ? '✓ Default' : 'Set as default'}
+                      </button>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        onClick={() => handleRemove(idx)}
+                        size="icon"
+                        variant="ghost"
+                      >
+                        <Trash2 className="h-3 w-3 text-destructive" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog onOpenChange={setShowAdd} open={showAdd}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Plugin Assignment</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label>Tab</Label>
+              <Select
+                onValueChange={(v) => setSelectedTab(v as PluginTab)}
+                value={selectedTab}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="configuration">Configuration</SelectItem>
+                  <SelectItem value="logs">Logs</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Service</Label>
+              <Select
+                onValueChange={(v) => {
+                  setSelectedService(v)
+                  setSelectedPlugin('')
+                }}
+                value={selectedService}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select service…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {(services ?? []).map((svc) => (
+                    <SelectItem key={svc.slug} value={svc.slug}>
+                      {svc.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {selectedService && (
+              <div className="space-y-2">
+                <Label>Plugin</Label>
+                <Select
+                  onValueChange={setSelectedPlugin}
+                  value={selectedPlugin}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select plugin…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(servicePlugins ?? []).map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.label}
+                        <span className="ml-1 text-xs text-secondary">
+                          ({p.plugin_slug})
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <input
+                checked={isDefault}
+                id="is-default"
+                onChange={(e) => setIsDefault(e.target.checked)}
+                type="checkbox"
+              />
+              <Label htmlFor="is-default">Set as default for this tab</Label>
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button onClick={() => setShowAdd(false)} variant="outline">
+                Cancel
+              </Button>
+              <Button disabled={!selectedPlugin} onClick={handleAdd}>
+                Add
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/admin/third-party-services/ServicePluginList.tsx
+++ b/src/components/admin/third-party-services/ServicePluginList.tsx
@@ -1,0 +1,361 @@
+import { useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertTriangle, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  createServicePlugin,
+  deleteServicePlugin,
+  getAdminPlugins,
+  listServicePlugins,
+  updateServicePlugin,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type { PluginResponse } from '@/types'
+
+interface PluginForm {
+  label: string
+  options: string
+  plugin_slug: string
+}
+
+interface ServicePluginListProps {
+  orgSlug: string
+  serviceSlug: string
+}
+
+export function ServicePluginList({
+  orgSlug,
+  serviceSlug,
+}: ServicePluginListProps) {
+  const queryClient = useQueryClient()
+  const [showDialog, setShowDialog] = useState(false)
+  const [confirmDeleteId, setConfirmDeleteId] = useState<null | string>(null)
+  const [editingPlugin, setEditingPlugin] = useState<null | PluginResponse>(
+    null,
+  )
+  const [form, setForm] = useState<PluginForm>({
+    label: '',
+    options: '{}',
+    plugin_slug: '',
+  })
+  const [optionsError, setOptionsError] = useState('')
+
+  const { data: plugins, isLoading } = useQuery({
+    queryFn: ({ signal }) => listServicePlugins(orgSlug, serviceSlug, signal),
+    queryKey: ['service-plugins', orgSlug, serviceSlug],
+    staleTime: 60 * 1000,
+  })
+
+  const { data: adminPlugins } = useQuery({
+    queryFn: ({ signal }) => getAdminPlugins(signal),
+    queryKey: ['admin-plugins'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const installedPlugins = adminPlugins?.installed ?? []
+
+  const createMutation = useMutation({
+    mutationFn: (input: {
+      label: string
+      options: Record<string, unknown>
+      plugin_slug: string
+    }) => createServicePlugin(orgSlug, serviceSlug, input),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to create plugin')
+    },
+    onSuccess: () => {
+      toast.success('Plugin created')
+      setShowDialog(false)
+      void queryClient.invalidateQueries({
+        queryKey: ['service-plugins', orgSlug, serviceSlug],
+      })
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: (input: {
+      id: string
+      label: string
+      options: Record<string, unknown>
+    }) =>
+      updateServicePlugin(orgSlug, serviceSlug, input.id, {
+        label: input.label,
+        options: input.options,
+      }),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to update plugin')
+    },
+    onSuccess: () => {
+      toast.success('Plugin updated')
+      setShowDialog(false)
+      void queryClient.invalidateQueries({
+        queryKey: ['service-plugins', orgSlug, serviceSlug],
+      })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (pluginId: string) =>
+      deleteServicePlugin(orgSlug, serviceSlug, pluginId),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to delete plugin')
+    },
+    onSuccess: () => {
+      toast.success('Plugin removed')
+      setConfirmDeleteId(null)
+      void queryClient.invalidateQueries({
+        queryKey: ['service-plugins', orgSlug, serviceSlug],
+      })
+    },
+  })
+
+  const openAdd = () => {
+    setEditingPlugin(null)
+    setForm({ label: '', options: '{}', plugin_slug: '' })
+    setOptionsError('')
+    setShowDialog(true)
+  }
+
+  const openEdit = (plugin: PluginResponse) => {
+    setEditingPlugin(plugin)
+    setForm({
+      label: plugin.label,
+      options: JSON.stringify(plugin.options, null, 2),
+      plugin_slug: plugin.plugin_slug,
+    })
+    setOptionsError('')
+    setShowDialog(true)
+  }
+
+  const handleSubmit = () => {
+    let options: Record<string, unknown>
+    try {
+      options = JSON.parse(form.options) as Record<string, unknown>
+      setOptionsError('')
+    } catch {
+      setOptionsError('Invalid JSON')
+      return
+    }
+    if (editingPlugin) {
+      updateMutation.mutate({
+        id: editingPlugin.id,
+        label: form.label,
+        options,
+      })
+    } else {
+      createMutation.mutate({
+        label: form.label,
+        options,
+        plugin_slug: form.plugin_slug,
+      })
+    }
+  }
+
+  const isPending = createMutation.isPending || updateMutation.isPending
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between px-6 py-4">
+          <CardTitle>Plugins</CardTitle>
+          <Button
+            disabled={installedPlugins.length === 0}
+            onClick={openAdd}
+            size="sm"
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            Add Plugin
+          </Button>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <LoadingState label="Loading..." />
+          ) : (plugins ?? []).length === 0 ? (
+            <div className="py-8 text-center text-sm text-secondary">
+              No plugins configured. Add a plugin to enable configuration or log
+              access for projects using this service.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Label</TableHead>
+                  <TableHead>Plugin</TableHead>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="w-20" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(plugins ?? []).map((plugin) => (
+                  <TableRow key={plugin.id}>
+                    <TableCell className="font-medium">
+                      {plugin.label}
+                    </TableCell>
+                    <TableCell>
+                      <code className="rounded bg-secondary px-1.5 py-0.5 text-xs">
+                        {plugin.plugin_slug}
+                      </code>
+                    </TableCell>
+                    <TableCell className="text-sm text-secondary">
+                      v{plugin.api_version}
+                    </TableCell>
+                    <TableCell>
+                      {plugin.status === 'unavailable' ? (
+                        <Badge
+                          className="flex w-fit items-center gap-1"
+                          variant="destructive"
+                        >
+                          <AlertTriangle className="h-3 w-3" />
+                          Unavailable
+                        </Badge>
+                      ) : (
+                        <Badge variant="secondary">Active</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          onClick={() => openEdit(plugin)}
+                          size="sm"
+                          variant="ghost"
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          onClick={() => setConfirmDeleteId(plugin.id)}
+                          size="icon"
+                          variant="ghost"
+                        >
+                          <Trash2 className="h-3 w-3 text-destructive" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog onOpenChange={setShowDialog} open={showDialog}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {editingPlugin
+                ? `Edit Plugin: ${editingPlugin.label}`
+                : 'Add Plugin'}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            {!editingPlugin && (
+              <div className="space-y-2">
+                <Label htmlFor="plugin-slug">Plugin</Label>
+                <Select
+                  onValueChange={(v) =>
+                    setForm((f) => ({ ...f, plugin_slug: v }))
+                  }
+                  value={form.plugin_slug}
+                >
+                  <SelectTrigger id="plugin-slug">
+                    <SelectValue placeholder="Select installed plugin…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {installedPlugins.map((p) => (
+                      <SelectItem key={p.slug} value={p.slug}>
+                        {p.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="plugin-label">Label</Label>
+              <Input
+                id="plugin-label"
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, label: e.target.value }))
+                }
+                placeholder="Production SSM"
+                value={form.label}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="plugin-options">Options (JSON)</Label>
+              <Textarea
+                className="font-mono"
+                id="plugin-options"
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, options: e.target.value }))
+                }
+                rows={4}
+                value={form.options}
+              />
+              {optionsError && (
+                <p className="text-xs text-destructive">{optionsError}</p>
+              )}
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button onClick={() => setShowDialog(false)} variant="outline">
+                Cancel
+              </Button>
+              <Button
+                disabled={
+                  isPending ||
+                  !form.label ||
+                  (!editingPlugin && !form.plugin_slug)
+                }
+                onClick={handleSubmit}
+              >
+                {isPending ? 'Saving...' : 'Save'}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        description={`Remove this plugin? Projects assigned to it will lose access.`}
+        onCancel={() => setConfirmDeleteId(null)}
+        onConfirm={() => {
+          if (confirmDeleteId) deleteMutation.mutate(confirmDeleteId)
+        }}
+        open={confirmDeleteId !== null}
+        title="Remove Plugin"
+      />
+    </div>
+  )
+}

--- a/src/components/admin/third-party-services/ServicePluginList.tsx
+++ b/src/components/admin/third-party-services/ServicePluginList.tsx
@@ -122,6 +122,9 @@ export function ServicePluginList({
       void queryClient.invalidateQueries({
         queryKey: ['service-plugins', orgSlug, serviceSlug],
       })
+      void queryClient.invalidateQueries({
+        queryKey: ['project-plugins', orgSlug],
+      })
     },
   })
 
@@ -136,6 +139,9 @@ export function ServicePluginList({
       setConfirmDeleteId(null)
       void queryClient.invalidateQueries({
         queryKey: ['service-plugins', orgSlug, serviceSlug],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: ['project-plugins', orgSlug],
       })
     },
   })
@@ -161,7 +167,16 @@ export function ServicePluginList({
   const handleSubmit = () => {
     let options: Record<string, unknown>
     try {
-      options = JSON.parse(form.options) as Record<string, unknown>
+      const parsed: unknown = JSON.parse(form.options)
+      if (
+        parsed === null ||
+        typeof parsed !== 'object' ||
+        Array.isArray(parsed)
+      ) {
+        setOptionsError('Options must be a JSON object')
+        return
+      }
+      options = parsed as Record<string, unknown>
       setOptionsError('')
     } catch {
       setOptionsError('Invalid JSON')

--- a/src/components/admin/third-party-services/ServicePluginList.tsx
+++ b/src/components/admin/third-party-services/ServicePluginList.tsx
@@ -71,13 +71,22 @@ export function ServicePluginList({
   })
   const [optionsError, setOptionsError] = useState('')
 
-  const { data: plugins, isLoading } = useQuery({
+  const {
+    data: plugins,
+    error: pluginsError,
+    isError: isPluginsError,
+    isLoading,
+  } = useQuery({
     queryFn: ({ signal }) => listServicePlugins(orgSlug, serviceSlug, signal),
     queryKey: ['service-plugins', orgSlug, serviceSlug],
     staleTime: 60 * 1000,
   })
 
-  const { data: adminPlugins } = useQuery({
+  const {
+    data: adminPlugins,
+    error: adminPluginsError,
+    isError: isAdminPluginsError,
+  } = useQuery({
     queryFn: ({ signal }) => getAdminPlugins(signal),
     queryKey: ['admin-plugins'],
     staleTime: 5 * 60 * 1000,
@@ -99,6 +108,9 @@ export function ServicePluginList({
       setShowDialog(false)
       void queryClient.invalidateQueries({
         queryKey: ['service-plugins', orgSlug, serviceSlug],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: ['project-plugins', orgSlug],
       })
     },
   })
@@ -216,6 +228,10 @@ export function ServicePluginList({
         <CardContent className="p-0">
           {isLoading ? (
             <LoadingState label="Loading..." />
+          ) : isPluginsError ? (
+            <div className="py-8 text-center text-sm text-destructive">
+              {extractApiErrorDetail(pluginsError) ?? 'Failed to load plugins'}
+            </div>
           ) : (plugins ?? []).length === 0 ? (
             <div className="py-8 text-center text-sm text-secondary">
               No plugins configured. Add a plugin to enable configuration or log
@@ -269,6 +285,7 @@ export function ServicePluginList({
                           Edit
                         </Button>
                         <Button
+                          aria-label={`Remove ${plugin.label}`}
                           onClick={() => setConfirmDeleteId(plugin.id)}
                           size="icon"
                           variant="ghost"
@@ -295,6 +312,12 @@ export function ServicePluginList({
             </DialogTitle>
           </DialogHeader>
           <div className="space-y-4 py-2">
+            {!editingPlugin && isAdminPluginsError && (
+              <div className="text-sm text-destructive">
+                {extractApiErrorDetail(adminPluginsError) ??
+                  'Failed to load installed plugins'}
+              </div>
+            )}
             {!editingPlugin && (
               <div className="space-y-2">
                 <Label htmlFor="plugin-slug">Plugin</Label>

--- a/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceDetail.tsx
@@ -6,6 +6,8 @@ import {
   ExternalLink,
   Info,
   Key,
+  type LucideIcon,
+  Puzzle,
   Webhook,
 } from 'lucide-react'
 
@@ -18,9 +20,10 @@ import { statusBadgeVariant } from '@/lib/status-colors'
 import type { ThirdPartyService } from '@/types'
 
 import { OAuth2ApplicationList } from './OAuth2ApplicationList'
+import { ServicePluginList } from './ServicePluginList'
 import { ServiceWebhookList } from './ServiceWebhookList'
 
-type DetailTab = 'applications' | 'details' | 'webhooks'
+type DetailTab = 'applications' | 'details' | 'plugins' | 'webhooks'
 
 interface ThirdPartyServiceDetailProps {
   onBack: () => void
@@ -47,9 +50,10 @@ export function ThirdPartyServiceDetail({
     service.revoke_endpoint ||
     service.use_pkce != null
 
-  const tabs: { icon: typeof Info; id: DetailTab; label: string }[] = [
+  const tabs: { icon: LucideIcon; id: DetailTab; label: string }[] = [
     { icon: Info, id: 'details', label: 'Details' },
     { icon: Key, id: 'applications', label: 'Applications' },
+    { icon: Puzzle, id: 'plugins', label: 'Plugins' },
     { icon: Webhook, id: 'webhooks', label: 'Webhooks' },
   ]
 
@@ -369,6 +373,14 @@ export function ThirdPartyServiceDetail({
           onViewModeChange={(mode) =>
             setAppDetailActive(mode === 'create' || mode === 'edit')
           }
+          orgSlug={selectedOrganization?.slug || ''}
+          serviceSlug={service.slug}
+        />
+      )}
+
+      {/* Plugins Tab */}
+      {activeTab === 'plugins' && (
+        <ServicePluginList
           orgSlug={selectedOrganization?.slug || ''}
           serviceSlug={service.slug}
         />

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Eye, EyeOff, Plus, Trash2 } from 'lucide-react'
@@ -91,7 +91,13 @@ export function ConfigurationTab({
     id: a.plugin_id,
     label: a.label,
   }))
-  const activeSource = source ?? sources[0]?.id
+  const activeSource = sources.some((s) => s.id === source)
+    ? source
+    : sources[0]?.id
+
+  useEffect(() => {
+    setRevealedValues({})
+  }, [activeSource, environment])
 
   const {
     data: keys,

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -1,0 +1,449 @@
+import { useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Eye, EyeOff, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  deleteConfigurationKey,
+  fetchConfigurationValues,
+  listConfigurationKeys,
+  listProjectPlugins,
+  setConfigurationValue,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type { ConfigKeyResponse } from '@/types'
+
+interface ConfigurationTabProps {
+  environment?: string
+  orgSlug: string
+  projectId: string
+}
+
+const DATA_TYPES = ['String', 'StringList', 'SecureString'] as const
+
+type DataType = (typeof DATA_TYPES)[number]
+
+interface SetValueForm {
+  data_type: DataType
+  key: string
+  secret: boolean
+  value: string
+}
+
+export function ConfigurationTab({
+  environment,
+  orgSlug,
+  projectId,
+}: ConfigurationTabProps) {
+  const queryClient = useQueryClient()
+  const [source, setSource] = useState<string | undefined>()
+  const [revealedValues, setRevealedValues] = useState<Record<string, unknown>>(
+    {},
+  )
+  const [showSetDialog, setShowSetDialog] = useState(false)
+  const [confirmDeleteKey, setConfirmDeleteKey] = useState<null | string>(null)
+  const [editingKey, setEditingKey] = useState<ConfigKeyResponse | null>(null)
+  const [form, setForm] = useState<SetValueForm>({
+    data_type: 'String',
+    key: '',
+    secret: false,
+    value: '',
+  })
+
+  const { data: assignments } = useQuery({
+    queryFn: ({ signal }) => listProjectPlugins(orgSlug, projectId, signal),
+    queryKey: ['project-plugins', orgSlug, projectId],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const configAssignments =
+    assignments?.filter((a) => a.tab === 'configuration') ?? []
+  const sources = configAssignments.map((a) => ({
+    id: a.plugin_id,
+    label: a.label,
+  }))
+  const activeSource = source ?? sources[0]?.id
+
+  const {
+    data: keys,
+    error,
+    isLoading,
+  } = useQuery({
+    enabled: sources.length > 0,
+    queryFn: ({ signal }) =>
+      listConfigurationKeys(
+        orgSlug,
+        projectId,
+        {
+          environment: environment ?? undefined,
+          source: activeSource,
+        },
+        signal,
+      ),
+    queryKey: ['config-keys', orgSlug, projectId, activeSource, environment],
+    staleTime: 60 * 1000,
+  })
+
+  const revealMutation = useMutation({
+    mutationFn: async (keyNames: string[]) => {
+      return fetchConfigurationValues(orgSlug, projectId, keyNames, {
+        environment: environment ?? undefined,
+        source: activeSource,
+      })
+    },
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to reveal values')
+    },
+    onSuccess: (values) => {
+      setRevealedValues((prev) => {
+        const next = { ...prev }
+        for (const v of values) next[v.key] = v.value
+        return next
+      })
+    },
+  })
+
+  const setMutation = useMutation({
+    mutationFn: () =>
+      setConfigurationValue(
+        orgSlug,
+        projectId,
+        form.key,
+        {
+          data_type: form.data_type,
+          secret: form.secret,
+          value: form.value,
+        },
+        {
+          environment: environment ?? undefined,
+          source: activeSource,
+        },
+      ),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to save value')
+    },
+    onSuccess: () => {
+      toast.success(`Key "${form.key}" saved`)
+      setShowSetDialog(false)
+      setEditingKey(null)
+      void queryClient.invalidateQueries({
+        queryKey: ['config-keys', orgSlug, projectId],
+      })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (key: string) =>
+      deleteConfigurationKey(orgSlug, projectId, key, {
+        environment: environment ?? undefined,
+        source: activeSource,
+      }),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to delete key')
+    },
+    onSuccess: (_, key) => {
+      toast.success(`Key "${key}" deleted`)
+      setConfirmDeleteKey(null)
+      void queryClient.invalidateQueries({
+        queryKey: ['config-keys', orgSlug, projectId],
+      })
+    },
+  })
+
+  const openAdd = () => {
+    setEditingKey(null)
+    setForm({ data_type: 'String', key: '', secret: false, value: '' })
+    setShowSetDialog(true)
+  }
+
+  const openEdit = (keyEntry: ConfigKeyResponse) => {
+    setEditingKey(keyEntry)
+    setForm({
+      data_type: (keyEntry.data_type as DataType) ?? 'String',
+      key: keyEntry.key,
+      secret: keyEntry.secret,
+      value: '',
+    })
+    setShowSetDialog(true)
+  }
+
+  const toggleReveal = (key: string) => {
+    if (key in revealedValues) {
+      setRevealedValues((prev) => {
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    } else {
+      revealMutation.mutate([key])
+    }
+  }
+
+  const revealAll = () => {
+    const secretKeys = (keys ?? [])
+      .filter((k) => k.secret && !(k.key in revealedValues))
+      .map((k) => k.key)
+    if (secretKeys.length > 0) {
+      revealMutation.mutate(secretKeys)
+    }
+  }
+
+  if (sources.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <CardTitle className="mb-2">No Configuration Plugin</CardTitle>
+          <p className="text-sm text-secondary">
+            No configuration plugin is assigned to this project. Configure
+            plugins on the project type or in project settings.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Source picker when multiple plugins assigned */}
+      {sources.length > 1 && (
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-secondary">Source:</span>
+          <div className="flex gap-2">
+            {sources.map((s) => (
+              <Button
+                className={
+                  activeSource === s.id
+                    ? 'bg-amber-bg text-amber-text hover:bg-amber-bg'
+                    : ''
+                }
+                key={s.id}
+                onClick={() => setSource(s.id)}
+                size="sm"
+                variant="outline"
+              >
+                {s.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between px-6 py-4">
+          <CardTitle>Configuration Keys</CardTitle>
+          <div className="flex gap-2">
+            {(keys ?? []).some((k) => k.secret) && (
+              <Button onClick={revealAll} size="sm" variant="outline">
+                <Eye className="mr-1 h-3 w-3" />
+                Reveal All Secrets
+              </Button>
+            )}
+            <Button onClick={openAdd} size="sm">
+              <Plus className="mr-1 h-3 w-3" />
+              Add Key
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <LoadingState label="Loading..." />
+          ) : error ? (
+            <div className="py-8 text-center text-sm text-destructive">
+              Failed to load configuration keys
+            </div>
+          ) : (keys ?? []).length === 0 ? (
+            <div className="py-8 text-center text-sm text-secondary">
+              No configuration keys found
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Key</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Last Modified</TableHead>
+                  <TableHead>Value</TableHead>
+                  <TableHead className="w-20" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(keys ?? []).map((entry) => (
+                  <TableRow key={entry.key}>
+                    <TableCell className="font-mono text-sm">
+                      {entry.key}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">{entry.data_type}</Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-secondary">
+                      {entry.last_modified
+                        ? new Date(entry.last_modified).toLocaleString()
+                        : '—'}
+                    </TableCell>
+                    <TableCell>
+                      {entry.secret ? (
+                        <div className="flex items-center gap-2">
+                          {entry.key in revealedValues ? (
+                            <span className="font-mono text-sm">
+                              {String(revealedValues[entry.key] ?? '')}
+                            </span>
+                          ) : (
+                            <span className="text-secondary">••••••••</span>
+                          )}
+                          <Button
+                            onClick={() => toggleReveal(entry.key)}
+                            size="icon"
+                            variant="ghost"
+                          >
+                            {entry.key in revealedValues ? (
+                              <EyeOff className="h-3 w-3" />
+                            ) : (
+                              <Eye className="h-3 w-3" />
+                            )}
+                          </Button>
+                        </div>
+                      ) : (
+                        <span className="text-secondary">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          onClick={() => openEdit(entry)}
+                          size="sm"
+                          variant="ghost"
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          onClick={() => setConfirmDeleteKey(entry.key)}
+                          size="icon"
+                          variant="ghost"
+                        >
+                          <Trash2 className="h-3 w-3 text-destructive" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog onOpenChange={setShowSetDialog} open={showSetDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editingKey
+                ? `Edit Key: ${editingKey.key}`
+                : 'Add Configuration Key'}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            {!editingKey && (
+              <div className="space-y-2">
+                <Label htmlFor="cfg-key">Key</Label>
+                <Input
+                  id="cfg-key"
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, key: e.target.value }))
+                  }
+                  placeholder="/myapp/parameter"
+                  value={form.key}
+                />
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="cfg-type">Data Type</Label>
+              <Select
+                onValueChange={(v) =>
+                  setForm((f) => ({
+                    ...f,
+                    data_type: v as DataType,
+                    secret: v === 'SecureString',
+                  }))
+                }
+                value={form.data_type}
+              >
+                <SelectTrigger id="cfg-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DATA_TYPES.map((t) => (
+                    <SelectItem key={t} value={t}>
+                      {t}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cfg-value">Value</Label>
+              <Input
+                id="cfg-value"
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, value: e.target.value }))
+                }
+                placeholder={form.secret ? '••••••••' : 'value'}
+                type={form.secret ? 'password' : 'text'}
+                value={form.value}
+              />
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button onClick={() => setShowSetDialog(false)} variant="outline">
+                Cancel
+              </Button>
+              <Button
+                disabled={setMutation.isPending || !form.key || !form.value}
+                onClick={() => setMutation.mutate()}
+              >
+                {setMutation.isPending ? 'Saving...' : 'Save'}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        description={`Delete key "${confirmDeleteKey ?? ''}"? This cannot be undone.`}
+        onCancel={() => setConfirmDeleteKey(null)}
+        onConfirm={() => {
+          if (confirmDeleteKey) deleteMutation.mutate(confirmDeleteKey)
+        }}
+        open={confirmDeleteKey !== null}
+        title="Delete Configuration Key"
+      />
+    </div>
+  )
+}

--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -1,0 +1,404 @@
+import { useCallback, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { RefreshCw, Search } from 'lucide-react'
+
+import {
+  getLogSchema,
+  listProjectPlugins,
+  searchProjectLogs,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { LogEntryResponse } from '@/types'
+
+interface LogsTabProps {
+  environment?: string
+  orgSlug: string
+  projectId: string
+}
+
+type RelativeRange = '1h' | '6h' | '15m' | '24h' | '30m'
+
+const RELATIVE_RANGES: { label: string; value: RelativeRange }[] = [
+  { label: 'Last 15 min', value: '15m' },
+  { label: 'Last 30 min', value: '30m' },
+  { label: 'Last 1 hour', value: '1h' },
+  { label: 'Last 6 hours', value: '6h' },
+  { label: 'Last 24 hours', value: '24h' },
+]
+
+export function LogsTab({ environment, orgSlug, projectId }: LogsTabProps) {
+  const [source, setSource] = useState<string | undefined>()
+  const [range, setRange] = useState<RelativeRange>('30m')
+  const [filterField, setFilterField] = useState('')
+  const [filterOp, setFilterOp] = useState('eq')
+  const [filterValue, setFilterValue] = useState('')
+  const [activeFilters, setActiveFilters] = useState<string[]>([])
+  const [cursor, setCursor] = useState<null | string>(null)
+  const [allEntries, setAllEntries] = useState<LogEntryResponse[]>([])
+
+  const { data: assignments } = useQuery({
+    queryFn: ({ signal }) => listProjectPlugins(orgSlug, projectId, signal),
+    queryKey: ['project-plugins', orgSlug, projectId],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const logAssignments = assignments?.filter((a) => a.tab === 'logs') ?? []
+  const sources = logAssignments.map((a) => ({
+    id: a.plugin_id,
+    label: a.label,
+  }))
+  const activeSource = source ?? sources[0]?.id
+
+  const { data: schema } = useQuery({
+    enabled: sources.length > 0 && !!activeSource,
+    queryFn: ({ signal }) =>
+      getLogSchema(
+        orgSlug,
+        projectId,
+        { environment: environment ?? undefined, source: activeSource },
+        signal,
+      ),
+    queryKey: ['log-schema', orgSlug, projectId, activeSource],
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const datetimes = rangeToDatetimes(range)
+
+  const {
+    data: logResult,
+    isFetching,
+    refetch,
+  } = useQuery({
+    enabled: sources.length > 0 && !!activeSource,
+    queryFn: ({ signal }) =>
+      searchProjectLogs(
+        orgSlug,
+        projectId,
+        {
+          cursor: cursor ?? undefined,
+          end_time: datetimes.end,
+          environment: environment ?? undefined,
+          filter: activeFilters.length ? activeFilters : undefined,
+          limit: 100,
+          source: activeSource,
+          start_time: datetimes.start,
+        },
+        signal,
+      ),
+    queryKey: [
+      'project-logs',
+      orgSlug,
+      projectId,
+      activeSource,
+      range,
+      activeFilters,
+      cursor,
+    ],
+    staleTime: 0,
+  })
+
+  const handleSearch = useCallback(() => {
+    setAllEntries([])
+    setCursor(null)
+    void refetch()
+  }, [refetch])
+
+  const handleLoadMore = useCallback(() => {
+    if (logResult?.next_cursor) {
+      setCursor(logResult.next_cursor)
+      setAllEntries((prev) => [...prev, ...(logResult.entries ?? [])])
+    }
+  }, [logResult])
+
+  const addFilter = () => {
+    if (filterField && filterValue) {
+      const f = `${filterField}:${filterOp}:${filterValue}`
+      setActiveFilters((prev) => [...prev, f])
+      setFilterField('')
+      setFilterValue('')
+    }
+  }
+
+  const removeFilter = (idx: number) => {
+    setActiveFilters((prev) => prev.filter((_, i) => i !== idx))
+  }
+
+  const displayEntries =
+    allEntries.length > 0
+      ? [...allEntries, ...(logResult?.entries ?? [])]
+      : (logResult?.entries ?? [])
+
+  if (sources.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <CardTitle className="mb-2">No Logs Plugin</CardTitle>
+          <p className="text-sm text-secondary">
+            No logs plugin is assigned to this project. Configure plugins on the
+            project type or in project settings.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Source picker */}
+      {sources.length > 1 && (
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-secondary">Source:</span>
+          <div className="flex gap-2">
+            {sources.map((s) => (
+              <Button
+                className={
+                  activeSource === s.id
+                    ? 'bg-amber-bg text-amber-text hover:bg-amber-bg'
+                    : ''
+                }
+                key={s.id}
+                onClick={() => {
+                  setSource(s.id)
+                  handleSearch()
+                }}
+                size="sm"
+                variant="outline"
+              >
+                {s.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Controls */}
+      <Card>
+        <CardContent className="flex flex-wrap items-end gap-3 p-4">
+          {/* Time range */}
+          <div className="space-y-1">
+            <Label className="text-xs">Time Range</Label>
+            <Select
+              onValueChange={(v) => setRange(v as RelativeRange)}
+              value={range}
+            >
+              <SelectTrigger className="h-8 w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RELATIVE_RANGES.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Filter builder */}
+          {schema && schema.length > 0 && (
+            <>
+              <div className="space-y-1">
+                <Label className="text-xs">Filter Field</Label>
+                <Select onValueChange={setFilterField} value={filterField}>
+                  <SelectTrigger className="h-8 w-44">
+                    <SelectValue placeholder="Field…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {schema.map((f) => (
+                      <SelectItem key={f.name} value={f.name}>
+                        {f.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Op</Label>
+                <Select onValueChange={setFilterOp} value={filterOp}>
+                  <SelectTrigger className="h-8 w-28">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {['eq', 'ne', 'contains', 'starts_with', 'regex'].map(
+                      (op) => (
+                        <SelectItem key={op} value={op}>
+                          {op}
+                        </SelectItem>
+                      ),
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Value</Label>
+                <Input
+                  className="h-8 w-48"
+                  onChange={(e) => setFilterValue(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && addFilter()}
+                  placeholder="value"
+                  value={filterValue}
+                />
+              </div>
+              <Button
+                className="h-8"
+                disabled={!filterField || !filterValue}
+                onClick={addFilter}
+                size="sm"
+                variant="outline"
+              >
+                Add Filter
+              </Button>
+            </>
+          )}
+
+          <Button className="h-8" onClick={handleSearch} size="sm">
+            <Search className="mr-1 h-3 w-3" />
+            Search
+          </Button>
+          <Button
+            className="h-8"
+            disabled={isFetching}
+            onClick={() => void refetch()}
+            size="icon"
+            variant="outline"
+          >
+            <RefreshCw
+              className={`h-3 w-3 ${isFetching ? 'animate-spin' : ''}`}
+            />
+          </Button>
+        </CardContent>
+
+        {/* Active filters */}
+        {activeFilters.length > 0 && (
+          <CardContent className="border-t px-4 pb-3 pt-2">
+            <div className="flex flex-wrap gap-2">
+              {activeFilters.map((f, i) => (
+                <Badge
+                  className="cursor-pointer gap-1"
+                  key={i}
+                  onClick={() => removeFilter(i)}
+                  variant="secondary"
+                >
+                  {f} ✕
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        )}
+      </Card>
+
+      {/* Log entries */}
+      <Card>
+        <CardHeader className="px-6 py-4">
+          <CardTitle className="flex items-center justify-between">
+            <span>Log Entries</span>
+            {logResult?.total != null && (
+              <span className="text-sm font-normal text-secondary">
+                {logResult.total.toLocaleString()} total
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isFetching && displayEntries.length === 0 ? (
+            <LoadingState label="Loading..." />
+          ) : displayEntries.length === 0 ? (
+            <div className="py-8 text-center text-sm text-secondary">
+              No log entries found for the selected time range
+            </div>
+          ) : (
+            <div className="divide-y divide-border">
+              {displayEntries.map((entry, i) => (
+                <div className="px-6 py-3" key={i}>
+                  <div className="flex items-start gap-3">
+                    <span className="shrink-0 font-mono text-xs text-secondary">
+                      {new Date(entry.timestamp).toLocaleTimeString()}
+                    </span>
+                    {entry.level && (
+                      <Badge
+                        className="shrink-0"
+                        variant={levelBadgeVariant(entry.level)}
+                      >
+                        {entry.level}
+                      </Badge>
+                    )}
+                    <span className="min-w-0 flex-1 break-all font-mono text-sm">
+                      {entry.message}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          {logResult?.next_cursor && !isFetching && (
+            <div className="px-6 py-4">
+              <Button
+                className="w-full"
+                onClick={handleLoadMore}
+                variant="outline"
+              >
+                Load Older
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function levelBadgeVariant(
+  level: null | string,
+): 'default' | 'destructive' | 'secondary' | 'warning' {
+  switch (level?.toLowerCase()) {
+    case 'debug':
+      return 'secondary'
+    case 'error':
+    case 'fatal':
+      return 'destructive'
+    case 'warn':
+    case 'warning':
+      return 'warning'
+    default:
+      return 'default'
+  }
+}
+
+function rangeToDatetimes(range: RelativeRange): {
+  end: string
+  start: string
+} {
+  const end = new Date()
+  const start = new Date(end)
+  switch (range) {
+    case '1h':
+      start.setHours(start.getHours() - 1)
+      break
+    case '6h':
+      start.setHours(start.getHours() - 6)
+      break
+    case '15m':
+      start.setMinutes(start.getMinutes() - 15)
+      break
+    case '24h':
+      start.setHours(start.getHours() - 24)
+      break
+    case '30m':
+      start.setMinutes(start.getMinutes() - 30)
+      break
+  }
+  return { end: end.toISOString(), start: start.toISOString() }
+}

--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import { RefreshCw, Search } from 'lucide-react'
@@ -71,7 +71,7 @@ export function LogsTab({ environment, orgSlug, projectId }: LogsTabProps) {
         { environment: environment ?? undefined, source: activeSource },
         signal,
       ),
-    queryKey: ['log-schema', orgSlug, projectId, activeSource],
+    queryKey: ['log-schema', orgSlug, projectId, activeSource, environment],
     staleTime: 10 * 60 * 1000,
   })
 
@@ -103,12 +103,18 @@ export function LogsTab({ environment, orgSlug, projectId }: LogsTabProps) {
       orgSlug,
       projectId,
       activeSource,
+      environment,
       range,
       activeFilters,
       cursor,
     ],
     staleTime: 0,
   })
+
+  useEffect(() => {
+    setAllEntries([])
+    setCursor(null)
+  }, [activeSource, environment, range, activeFilters])
 
   const handleSearch = useCallback(() => {
     setAllEntries([])
@@ -170,10 +176,7 @@ export function LogsTab({ environment, orgSlug, projectId }: LogsTabProps) {
                     : ''
                 }
                 key={s.id}
-                onClick={() => {
-                  setSource(s.id)
-                  handleSearch()
-                }}
+                onClick={() => setSource(s.id)}
                 size="sm"
                 variant="outline"
               >

--- a/src/components/project/ProjectPluginsSection.tsx
+++ b/src/components/project/ProjectPluginsSection.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  listProjectPlugins,
+  listServicePlugins,
+  listThirdPartyServices,
+  replaceProjectPlugins,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type {
+  PluginAssignmentCreate,
+  PluginAssignmentResponse,
+  PluginTab,
+} from '@/types'
+
+interface OverrideDraft extends PluginAssignmentCreate {
+  label: string
+  source: PluginAssignmentResponse['source']
+}
+
+interface ProjectPluginsSectionProps {
+  orgSlug: string
+  projectId: string
+}
+
+export function ProjectPluginsSection({
+  orgSlug,
+  projectId,
+}: ProjectPluginsSectionProps) {
+  const queryClient = useQueryClient()
+  const [showAdd, setShowAdd] = useState(false)
+  const [selectedService, setSelectedService] = useState('')
+  const [selectedPlugin, setSelectedPlugin] = useState('')
+  const [selectedTab, setSelectedTab] = useState<PluginTab>('configuration')
+  const [isDefault, setIsDefault] = useState(false)
+  const [drafts, setDrafts] = useState<OverrideDraft[]>([])
+
+  const { data: merged } = useQuery({
+    queryFn: ({ signal }) => listProjectPlugins(orgSlug, projectId, signal),
+    queryKey: ['project-plugins', orgSlug, projectId],
+    staleTime: 60 * 1000,
+  })
+
+  const { data: services } = useQuery({
+    queryFn: ({ signal }) => listThirdPartyServices(orgSlug, signal),
+    queryKey: ['third-party-services', orgSlug],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const { data: servicePlugins } = useQuery({
+    enabled: !!selectedService,
+    queryFn: ({ signal }) =>
+      listServicePlugins(orgSlug, selectedService, signal),
+    queryKey: ['service-plugins', orgSlug, selectedService],
+    staleTime: 60 * 1000,
+  })
+
+  useEffect(() => {
+    if (merged) {
+      const projectOnly = merged.filter((a) => a.source === 'project')
+      setDrafts(
+        projectOnly.map((a) => ({
+          default: a.default,
+          label: a.label,
+          options: a.options,
+          plugin_id: a.plugin_id,
+          source: a.source,
+          tab: a.tab,
+        })),
+      )
+    }
+  }, [merged])
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      replaceProjectPlugins(
+        orgSlug,
+        projectId,
+        drafts.map((d) => ({
+          default: d.default,
+          options: d.options,
+          plugin_id: d.plugin_id,
+          tab: d.tab,
+        })),
+      ),
+    onError: (err) => {
+      toast.error(
+        extractApiErrorDetail(err) ?? 'Failed to save plugin overrides',
+      )
+    },
+    onSuccess: () => {
+      toast.success('Plugin overrides saved')
+      void queryClient.invalidateQueries({
+        queryKey: ['project-plugins', orgSlug, projectId],
+      })
+    },
+  })
+
+  const openAdd = () => {
+    setSelectedService('')
+    setSelectedPlugin('')
+    setSelectedTab('configuration')
+    setIsDefault(false)
+    setShowAdd(true)
+  }
+
+  const handleAdd = () => {
+    const plugin = servicePlugins?.find((p) => p.id === selectedPlugin)
+    if (!plugin) return
+    setDrafts((prev) => [
+      ...prev,
+      {
+        default: isDefault,
+        label: plugin.label,
+        options: {},
+        plugin_id: plugin.id,
+        source: 'project',
+        tab: selectedTab,
+      },
+    ])
+    setShowAdd(false)
+  }
+
+  const handleRemove = (idx: number) => {
+    setDrafts((prev) => prev.filter((_, i) => i !== idx))
+  }
+
+  const projectOnlyFromServer =
+    merged?.filter((a) => a.source === 'project') ?? []
+  const isDirty =
+    JSON.stringify(
+      drafts.map(({ default: d, label, options, plugin_id, tab }) => ({
+        default: d,
+        label,
+        options,
+        plugin_id,
+        tab,
+      })),
+    ) !==
+    JSON.stringify(
+      projectOnlyFromServer.map(
+        ({ default: d, label, options, plugin_id, tab }) => ({
+          default: d,
+          label,
+          options,
+          plugin_id,
+          tab,
+        }),
+      ),
+    )
+
+  const inherited = merged?.filter((a) => a.source === 'project_type') ?? []
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Plugins</CardTitle>
+        <CardDescription className="text-secondary">
+          Override or extend the plugin assignments inherited from the project
+          type.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 p-6 pt-0">
+        {inherited.length > 0 && (
+          <div>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wider text-secondary">
+              Inherited from project type
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {inherited.map((a) => (
+                <div
+                  className="flex items-center gap-1.5 rounded border border-tertiary bg-secondary px-2 py-1 text-xs"
+                  key={a.plugin_id}
+                >
+                  <span className="text-primary">{a.label}</span>
+                  <Badge variant="secondary">{a.tab}</Badge>
+                  {a.default && <span className="text-tertiary">default</span>}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <p className="text-xs font-medium uppercase tracking-wider text-secondary">
+              Project overrides
+            </p>
+            <div className="flex gap-2">
+              {isDirty && (
+                <Button
+                  disabled={saveMutation.isPending}
+                  onClick={() => saveMutation.mutate()}
+                  size="sm"
+                >
+                  {saveMutation.isPending ? 'Saving…' : 'Save Changes'}
+                </Button>
+              )}
+              <Button onClick={openAdd} size="sm" variant="outline">
+                <Plus className="mr-1 h-3 w-3" />
+                Add Override
+              </Button>
+            </div>
+          </div>
+
+          {drafts.length === 0 ? (
+            <p className="text-sm text-secondary">
+              No project-level overrides. Using project type defaults.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Plugin</TableHead>
+                  <TableHead>Tab</TableHead>
+                  <TableHead>Default</TableHead>
+                  <TableHead className="w-12" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {drafts.map((draft, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell className="font-medium">{draft.label}</TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">{draft.tab}</Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-secondary">
+                      {draft.default ? 'Yes' : 'No'}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        onClick={() => handleRemove(idx)}
+                        size="icon"
+                        variant="ghost"
+                      >
+                        <Trash2 className="h-3 w-3 text-destructive" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </CardContent>
+
+      <Dialog onOpenChange={setShowAdd} open={showAdd}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Plugin Override</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label>Tab</Label>
+              <Select
+                onValueChange={(v) => setSelectedTab(v as PluginTab)}
+                value={selectedTab}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="configuration">Configuration</SelectItem>
+                  <SelectItem value="logs">Logs</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Service</Label>
+              <Select
+                onValueChange={(v) => {
+                  setSelectedService(v)
+                  setSelectedPlugin('')
+                }}
+                value={selectedService}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select service…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {(services ?? []).map((svc) => (
+                    <SelectItem key={svc.slug} value={svc.slug}>
+                      {svc.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {selectedService && (
+              <div className="space-y-2">
+                <Label>Plugin</Label>
+                <Select
+                  onValueChange={setSelectedPlugin}
+                  value={selectedPlugin}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select plugin…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(servicePlugins ?? []).map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <input
+                checked={isDefault}
+                id="proj-is-default"
+                onChange={(e) => setIsDefault(e.target.checked)}
+                type="checkbox"
+              />
+              <Label htmlFor="proj-is-default">
+                Set as default for this tab
+              </Label>
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button onClick={() => setShowAdd(false)} variant="outline">
+                Cancel
+              </Button>
+              <Button disabled={!selectedPlugin} onClick={handleAdd}>
+                Add
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}

--- a/src/components/ui/inline-edit/InlineField.tsx
+++ b/src/components/ui/inline-edit/InlineField.tsx
@@ -65,7 +65,8 @@ export function InlineField({
         <InlineSwitch
           onCommit={onCommit}
           pending={pending}
-          value={raw === true || raw === 'true'}
+          renderDisplay={display}
+          value={raw == null ? null : raw === true || raw === 'true'}
         />
       )
     default:

--- a/src/components/ui/inline-edit/InlineSwitch.tsx
+++ b/src/components/ui/inline-edit/InlineSwitch.tsx
@@ -59,6 +59,7 @@ export function InlineSwitch({
       disabled={pending}
       onBlur={edit.cancel}
       onCheckedChange={async (next) => {
+        edit.setDraft(next)
         try {
           await onCommit(next)
         } catch (e) {

--- a/src/components/ui/inline-edit/InlineSwitch.tsx
+++ b/src/components/ui/inline-edit/InlineSwitch.tsx
@@ -1,11 +1,18 @@
+import type { ReactNode } from 'react'
+import { useCallback } from 'react'
+
 import { toast } from 'sonner'
 
 import { Switch } from '@/components/ui/switch'
+import { useInlineEdit } from '@/hooks/useInlineEdit'
+
+import { InlineDisplay } from './InlineDisplay'
 
 export interface InlineSwitchProps {
   onCommit: (next: boolean) => Promise<void> | void
   pending?: boolean
   readOnly?: boolean
+  renderDisplay?: ReactNode
   value: boolean | null
 }
 
@@ -13,18 +20,51 @@ export function InlineSwitch({
   onCommit,
   pending = false,
   readOnly = false,
+  renderDisplay,
   value,
 }: InlineSwitchProps) {
+  const boolValue = value ?? false
+
+  const handleCommit = useCallback(
+    async (next: boolean) => {
+      await onCommit(next)
+    },
+    [onCommit],
+  )
+
+  const edit = useInlineEdit<boolean>({
+    initial: boolValue,
+    onCommit: handleCommit,
+  })
+
+  if (!edit.isEditing) {
+    return (
+      <InlineDisplay
+        hasValue={value !== null}
+        onClick={edit.enter}
+        pending={pending}
+        readOnly={readOnly}
+      >
+        {renderDisplay ?? (
+          <span className="text-sm">{boolValue ? 'True' : 'False'}</span>
+        )}
+      </InlineDisplay>
+    )
+  }
+
   return (
     <Switch
-      checked={!!value}
-      disabled={pending || readOnly}
+      autoFocus
+      checked={edit.draft}
+      disabled={pending}
+      onBlur={edit.cancel}
       onCheckedChange={async (next) => {
-        if (readOnly) return
         try {
           await onCommit(next)
         } catch (e) {
           toast.error(e instanceof Error ? e.message : 'Save failed')
+        } finally {
+          edit.cancel()
         }
       }}
     />

--- a/src/components/ui/inline-edit/__tests__/InlineSwitch.test.tsx
+++ b/src/components/ui/inline-edit/__tests__/InlineSwitch.test.tsx
@@ -9,12 +9,14 @@ describe('InlineSwitch', () => {
   it('commits the toggled value', async () => {
     const onCommit = vi.fn().mockResolvedValue(undefined)
     render(<InlineSwitch onCommit={onCommit} value={false} />)
-    await userEvent.click(screen.getByRole('switch'))
+    await userEvent.click(screen.getByText('False'))
+    await userEvent.click(await screen.findByRole('switch'))
     await waitFor(() => expect(onCommit).toHaveBeenCalledWith(true))
   })
 
-  it('is disabled when readOnly', () => {
+  it('does not enter edit mode when readOnly', async () => {
     render(<InlineSwitch onCommit={vi.fn()} readOnly value />)
-    expect(screen.getByRole('switch')).toBeDisabled()
+    await userEvent.click(screen.getByText('True'))
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
   })
 })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -231,6 +231,11 @@ export const OPERATIONS_LOG_ENTRY_TYPES = [
   'Upgraded',
 ] as const
 
+export interface AdminPluginsResponse {
+  installed: InstalledPlugin[]
+  unavailable: string[]
+}
+
 export type AdminSettings = Schemas['AdminSettings']
 
 // `AdminUser` stays hand-written: no generated counterpart — the UI
@@ -295,11 +300,32 @@ export interface BlueprintCreate {
 // Blueprint types
 export type BlueprintFilter = Schemas['BlueprintFilter']
 
+export interface CatalogEntry {
+  author: null | string
+  description: null | string
+  docs_url: null | string
+  package: string
+  slugs: string[]
+  status: 'installed' | 'not_installed' | 'update_available'
+  version: string
+}
+
 export type ClientCredential = Schemas['ClientCredentialResponse']
 
 export type ClientCredentialCreate = Schemas['ClientCredentialCreate']
 
 export type ClientCredentialCreated = Schemas['ClientCredentialCreateResponse']
+
+export interface ConfigKeyResponse {
+  data_type: string
+  key: string
+  last_modified: null | string
+  secret: boolean
+}
+
+export interface ConfigKeyValueResponse extends ConfigKeyResponse {
+  value: unknown
+}
 
 export interface CurrentReleaseEnvironment {
   current_status: DeploymentStatus | null
@@ -322,6 +348,19 @@ export type DeploymentStatus =
   | 'pending'
   | 'rolled_back'
   | 'success'
+export interface InstalledPlugin {
+  api_version: number
+  cacheable: boolean
+  credentials: PluginCredentialField[]
+  description: string
+  docs_url: null | string
+  name: string
+  options: PluginOptionDef[]
+  package_name: string
+  package_version: string
+  slug: string
+  supported_tabs: PluginTab[]
+}
 
 // Admin local-auth (password login) toggle.
 // Hand-written: the admin endpoints aren't in the committed openapi.json
@@ -330,6 +369,13 @@ export type DeploymentStatus =
 export interface LocalAuthConfig {
   enabled: boolean
   updated_at: string
+}
+
+export interface LogEntryResponse {
+  level: null | string
+  message: string
+  raw: Record<string, unknown>
+  timestamp: string
 }
 
 export interface LoginProviderCreate {
@@ -384,9 +430,16 @@ export interface LoginProviderUpdate {
   scopes?: string[]
   usage: 'both' | 'login'
 }
+
 export interface LoginRequest {
   email: string
   password: string
+}
+
+export interface LogResultResponse {
+  entries: LogEntryResponse[]
+  next_cursor: null | string
+  total: null | number
 }
 
 export interface Note {
@@ -440,11 +493,9 @@ export interface NoteTemplateCreate {
   tags?: string[]
   title?: null | string
 }
-
 // Auth provider types — mirror the consolidated `ServiceApplication`-backed
 // shape in imbi_api/endpoints/auth_providers.py.
 export type OAuthAppType = 'github' | 'google' | 'oidc'
-
 export type OperationsLogEntryType = (typeof OPERATIONS_LOG_ENTRY_TYPES)[number]
 
 export interface OperationsLogFilters {
@@ -460,10 +511,8 @@ export interface OperationsLogFilters {
 // Raw record returned by the /operations-log/ API (distinct from the
 // activity-feed projection defined above in `OperationsLogEntry`).
 export type OperationsLogRecord = Schemas['OperationLogResponse']
-
 // Organization types
 export type Organization = Schemas['OrganizationResponse']
-
 // `OrganizationCreate` stays hand-written: the generated
 // `OrganizationRequest` requires `updated_at`/`description`/`icon` be
 // present (nullable), which the UI create form doesn't send.
@@ -477,9 +526,60 @@ export interface OrganizationCreate {
 export type OrgMembership = Schemas['OrgMembership']
 // JSON Patch operation (RFC 6902)
 export type PatchOperation = Schemas['PatchOperation']
+
 // Admin User Management Types (matching API schema)
 export type Permission = Schemas['Permission']
 
+export interface PluginAssignmentCreate {
+  default: boolean
+  options?: Record<string, unknown>
+  plugin_id: string
+  tab: PluginTab
+}
+
+export interface PluginAssignmentResponse {
+  default: boolean
+  label: string
+  options: Record<string, unknown>
+  plugin_id: string
+  plugin_slug: string
+  source: 'merged' | 'project' | 'project_type'
+  tab: PluginTab
+}
+
+export interface PluginCreate {
+  label: string
+  options?: Record<string, unknown>
+  plugin_slug: string
+}
+export interface PluginCredentialField {
+  description: null | string
+  name: string
+  required: boolean
+  secret: boolean
+}
+
+export interface PluginOptionDef {
+  description: null | string
+  name: string
+  required: boolean
+  type: string
+}
+// Plugin types (hand-written until api-generated.ts snapshot is refreshed)
+export interface PluginResponse {
+  api_version: number
+  id: string
+  label: string
+  options: Record<string, unknown>
+  plugin_slug: string
+  service_slug: null | string
+  status: 'active' | 'unavailable'
+}
+export type PluginTab = 'configuration' | 'logs'
+export interface PluginUpdate {
+  label: string
+  options?: Record<string, unknown>
+}
 export type ProjectRelationship = Schemas['ProjectRelationship']
 
 export type ProjectRelationshipsResponse =
@@ -517,20 +617,19 @@ export interface Role {
   slug: string
   updated_at?: null | string
 }
-
 export interface RoleCreate {
   description?: null | string
   name: string
   priority?: number
   slug: string
 }
-
 export interface RoleDetail extends Role {
   is_system: boolean
   parent_role?: null | Role
   permissions: Permission[]
   priority: number
 }
+
 // `RoleUser` stays hand-written: no generated counterpart (the
 // /roles/{slug}/users endpoint returns a flattened user projection).
 export interface RoleUser {
@@ -567,10 +666,14 @@ export interface SchemaProperty {
   required: boolean
   type: 'array' | 'boolean' | 'integer' | 'number' | 'object' | 'string'
 }
+
 // Service Account types
 export type ServiceAccount = Schemas['ServiceAccountResponse']
+
 export type ServiceAccountCreate = Schemas['ServiceAccountCreate']
+
 export type ServiceAccountUpdate = Schemas['ServiceAccountUpdate']
+
 // Service Application types
 // The committed openapi.json snapshot predates the OAuth-consolidation
 // fields (`usage`, `oauth_app_type`, `issuer_url`, `allowed_domains`,
@@ -590,7 +693,9 @@ export type ServiceApplicationCreate = Schemas['ServiceApplicationCreate'] & {
   oauth_app_type?: null | OAuthAppType
   usage?: ServiceApplicationUsage
 }
+
 export type ServiceApplicationSecrets = Schemas['ServiceApplicationSecrets']
+
 export type ServiceApplicationSecretsUpdate =
   Schemas['ServiceApplicationSecretsUpdate']
 
@@ -600,6 +705,7 @@ export type ServiceApplicationUpdate = Schemas['ServiceApplicationUpdate'] & {
   oauth_app_type?: null | OAuthAppType
   usage?: ServiceApplicationUsage
 }
+
 export type ServiceApplicationUsage = 'both' | 'integration' | 'login'
 
 export interface Tag {
@@ -620,8 +726,10 @@ export interface TagRef {
   name: string
   slug: string
 }
+
 // Team types
 export type Team = Schemas['TeamResponse']
+
 // `TeamCreate` stays hand-written (same reason as `OrganizationCreate`).
 export interface TeamCreate {
   [key: string]: unknown


### PR DESCRIPTION
## Summary
- Adds the admin **Plugins** section (Installed / Catalog / Unavailable) for installing, updating, and uninstalling plugins, plus surfacing plugin slugs referenced in the graph that have no installed handler.
- Adds plugin assignment editors at three scopes:
  - **Project Type → Plugins**: defaults inherited by all projects of the type.
  - **Project → Plugin Overrides**: per-project overrides on top of the type defaults.
  - **Third-Party Service → Plugins**: concrete plugin instances (label + JSON options) attached to a service so projects assigned to that service get a Configuration / Logs source.
- Adds **Configuration** and **Logs** tabs to project detail. Configuration supports reveal of secret values; Logs supports cursor-paginated search with relative time ranges and filter chips.
- `InlineSwitch` becomes click-to-edit (matching the rest of the inline-edit primitives) and now accepts a custom display node.
- Adds endpoint helpers + types for plugin admin/catalog, the three assignment scopes, project configuration keys/values, and project log search / schema.

## Test plan
- [ ] `npm run lint` passes.
- [ ] `npm run format:check` passes.
- [ ] `npm run build` passes (TypeScript + Vite production build).
- [ ] Admin > Plugins: install a plugin from Catalog, verify it appears under Installed; uninstall and verify it disappears.
- [ ] Admin > Plugins > Unavailable: shows entries when graph references a slug with no installed handler.
- [ ] Third-Party Service > Plugins: add / edit / delete a plugin instance with JSON options; invalid JSON is rejected with an inline error; the plugin Select shows the plugin's display name, not the slug.
- [ ] Project Type > Plugins: assign a plugin, save, verify dirty-state behavior on the Save button.
- [ ] Project Settings > Plugins: override an inherited project-type assignment; remove an override; verify inheritance banner.
- [ ] Project Detail > Configuration: list keys, reveal a single secret, Reveal All, edit a key, delete a key.
- [ ] Project Detail > Logs: pick range, add a filter chip, Search, Load Older, refresh; "Search" reuses the same query (no `searchTick` cache-buster).
- [ ] Project Detail > InlineSwitch: a boolean field can be entered, toggled, and committed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)