### PR TITLE
Add Reports tab with Team KPI and Monthly Improvement reports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,9 @@ const OperationsLogPage = lazy(() =>
 const AdminPage = lazy(() =>
   import('./pages/AdminPage').then((m) => ({ default: m.AdminPage })),
 )
+const ReportsPage = lazy(() =>
+  import('./pages/ReportsPage').then((m) => ({ default: m.ReportsPage })),
+)
 const SettingsPage = lazy(() =>
   import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage })),
 )
@@ -107,6 +110,14 @@ function App() {
                     </ProtectedRoute>
                   }
                   path="/operations-log"
+                />
+                <Route
+                  element={
+                    <ProtectedRoute>
+                      <ReportsPage />
+                    </ProtectedRoute>
+                  }
+                  path="/reports"
                 />
                 <Route
                   element={

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1749,6 +1749,47 @@ export const getLogSchema = (
     signal,
   )
 
+// Scoring Rollup
+export interface ScoreRollupRow {
+  avg_score: number
+  dimension: 'organization' | 'project_type' | 'team'
+  key: string
+  last_updated: null | string
+  latest_score: number
+}
+
+export const getScoreRollup = (
+  dimension: 'organization' | 'project_type' | 'team' = 'team',
+  signal?: AbortSignal,
+) => apiClient.get<ScoreRollupRow[]>('/scores/rollup', { dimension }, signal)
+
+export interface MonthlyImprovementRow {
+  current_avg_score: null | number
+  dimension: string
+  improvement: null | number
+  key: string
+  previous_avg_score: null | number
+  project_count: number
+}
+
+export const getMonthlyImprovement = (
+  params: {
+    dimension?: 'organization' | 'project_type' | 'team'
+    month: number
+    year: number
+  },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<MonthlyImprovementRow[]>(
+    '/scores/monthly-improvement',
+    {
+      dimension: params.dimension ?? 'team',
+      month: params.month,
+      year: params.year,
+    },
+    signal,
+  )
+
 // Admin Plugins
 export const getAdminPlugins = (signal?: AbortSignal) =>
   apiClient.get<AdminPluginsResponse>('/admin/plugins', undefined, signal)

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -133,6 +133,13 @@ export function Admin() {
       scope: 'org',
     },
     {
+      description: 'Manage installed plugins',
+      icon: Puzzle,
+      id: 'plugins',
+      label: 'Plugins',
+      scope: 'org',
+    },
+    {
       description: 'Manage project types',
       icon: FolderTree,
       id: 'project-types',
@@ -165,13 +172,6 @@ export function Admin() {
       icon: Webhook,
       id: 'webhooks',
       label: 'Webhooks',
-      scope: 'org',
-    },
-    {
-      description: 'Manage installed plugins',
-      icon: Puzzle,
-      id: 'plugins',
-      label: 'Plugins',
       scope: 'org',
     },
   ]

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -360,7 +360,7 @@ export function BlueprintManagement() {
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{isCopied ? 'Copied!' : 'Copy as JSON'}</p>
+                  <p>{isCopied ? 'Copied!' : 'Copy Definition'}</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -1,7 +1,14 @@
 import { useMemo, useState } from 'react'
 
 import { useMutation } from '@tanstack/react-query'
-import { CheckCircle, RefreshCw, XCircle } from 'lucide-react'
+import {
+  Check,
+  CheckCircle,
+  Copy,
+  RefreshCw,
+  Upload,
+  XCircle,
+} from 'lucide-react'
 
 import {
   createScoringPolicy,
@@ -22,6 +29,7 @@ import type {
 } from '@/types'
 
 import { AdminSection } from './AdminSection'
+import { ImportScoringPolicyDialog } from './scoring-policies/ImportScoringPolicyDialog'
 import { ScoringPolicyForm } from './scoring-policies/ScoringPolicyForm'
 
 export function ScoringPolicyManagement() {
@@ -35,6 +43,8 @@ export function ScoringPolicyManagement() {
   const [searchQuery, setSearchQuery] = useState('')
   const [enabledFilter, setEnabledFilter] = useState('')
   const [rescoreResult, setRescoreResult] = useState<null | number>(null)
+  const [importDialogOpen, setImportDialogOpen] = useState(false)
+  const [copiedSlug, setCopiedSlug] = useState<null | string>(null)
 
   const rescoreMutation = useMutation({
     mutationFn: rescoreAll,
@@ -87,6 +97,42 @@ export function ScoringPolicyManagement() {
     return true
   })
 
+  const handleCopy = (policy: ScoringPolicy) => {
+    const exportObj = {
+      attribute_name: policy.attribute_name,
+      ...(policy.description ? { description: policy.description } : {}),
+      enabled: policy.enabled,
+      name: policy.name,
+      priority: policy.priority,
+      ...(policy.range_score_map
+        ? { range_score_map: policy.range_score_map }
+        : {}),
+      slug: policy.slug,
+      targets: policy.targets ?? [],
+      ...(policy.value_score_map
+        ? { value_score_map: policy.value_score_map }
+        : {}),
+      weight: policy.weight,
+    }
+    navigator.clipboard
+      .writeText(JSON.stringify(exportObj, null, 2))
+      .then(() => {
+        setCopiedSlug(policy.slug)
+        setTimeout(() => setCopiedSlug(null), 2000)
+      })
+  }
+
+  const handleImport = (data: ScoringPolicyCreate) => {
+    createMutation.mutate(data, {
+      onSuccess: () => setImportDialogOpen(false),
+    })
+  }
+
+  const handleOpenImport = () => {
+    createMutation.reset()
+    setImportDialogOpen(true)
+  }
+
   const handleSave = (data: ScoringPolicyCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate(data)
@@ -123,123 +169,158 @@ export function ScoringPolicyManagement() {
   }
 
   return (
-    <AdminSection
-      createLabel="New Policy"
-      error={error}
-      errorTitle="Failed to load scoring policies"
-      headerActions={
-        <Button
-          disabled={rescoreMutation.isPending}
-          onClick={() => rescoreMutation.mutate()}
-          variant="outline"
-        >
-          <RefreshCw
-            className={`mr-2 h-4 w-4 ${rescoreMutation.isPending ? 'animate-spin' : ''}`}
-          />
-          {rescoreResult !== null
-            ? `Enqueued ${rescoreResult}`
-            : 'Recompute Scores'}
-        </Button>
-      }
-      headerExtras={
-        <select
-          className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground"
-          onChange={(e) => setEnabledFilter(e.target.value)}
-          value={enabledFilter}
-        >
-          <option value="">All</option>
-          <option value="enabled">Enabled</option>
-          <option value="disabled">Disabled</option>
-        </select>
-      }
-      isLoading={isLoading}
-      loadingLabel="Loading scoring policies..."
-      onCreate={goToCreate}
-      onSearchChange={setSearchQuery}
-      search={searchQuery}
-      searchPlaceholder="Search policies..."
-    >
-      <AdminTable<ScoringPolicy>
-        columns={[
-          {
-            cellAlign: 'left',
-            header: 'Policy',
-            headerAlign: 'left',
-            key: 'name',
-            render: (p) => (
-              <div>
-                <div className="font-medium text-primary">{p.name}</div>
-                {p.description && (
-                  <div className="mt-0.5 text-xs text-tertiary">
-                    {p.description}
-                  </div>
-                )}
-              </div>
-            ),
-          },
-          {
-            cellAlign: 'left',
-            header: 'Attribute',
-            headerAlign: 'left',
-            key: 'attribute',
-            render: (p) => (
-              <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
-                {p.attribute_name}
-              </code>
-            ),
-          },
-          {
-            cellAlign: 'center',
-            header: 'Weight',
-            headerAlign: 'center',
-            key: 'weight',
-            render: (p) => <span className="text-secondary">{p.weight}</span>,
-          },
-          {
-            cellAlign: 'center',
-            header: 'Priority',
-            headerAlign: 'center',
-            key: 'priority',
-            render: (p) => <span className="text-secondary">{p.priority}</span>,
-          },
-          {
-            cellAlign: 'left',
-            header: 'Targets',
-            headerAlign: 'left',
-            key: 'targets',
-            render: (p) => (
-              <span className="text-xs text-tertiary">
-                {(p.targets ?? []).length === 0
-                  ? 'All types'
-                  : (p.targets ?? []).join(', ')}
-              </span>
-            ),
-          },
-          {
-            cellAlign: 'center',
-            header: 'Enabled',
-            headerAlign: 'center',
-            key: 'enabled',
-            render: (p) =>
-              p.enabled ? (
-                <CheckCircle className="mx-auto h-4 w-4 text-success" />
-              ) : (
-                <XCircle className="mx-auto h-4 w-4 text-tertiary" />
-              ),
-          },
-        ]}
-        emptyMessage={
-          searchQuery || enabledFilter
-            ? 'No policies match your filters.'
-            : 'No scoring policies defined yet.'
+    <>
+      <AdminSection
+        createLabel="New Policy"
+        error={error}
+        errorTitle="Failed to load scoring policies"
+        headerActions={
+          <>
+            <Button onClick={handleOpenImport} variant="outline">
+              <Upload className="mr-2 h-4 w-4" />
+              Import
+            </Button>
+            <Button
+              disabled={rescoreMutation.isPending}
+              onClick={() => rescoreMutation.mutate()}
+              variant="outline"
+            >
+              <RefreshCw
+                className={`mr-2 h-4 w-4 ${rescoreMutation.isPending ? 'animate-spin' : ''}`}
+              />
+              {rescoreResult !== null
+                ? `Enqueued ${rescoreResult}`
+                : 'Recompute Scores'}
+            </Button>
+          </>
         }
-        getDeleteLabel={(p) => p.name}
-        getRowKey={(p) => p.slug}
-        isDeleting={deleteMutation.isPending}
-        onDelete={(p) => deleteMutation.mutate(p.slug)}
-        onRowClick={(p) => goToEdit(p.slug)}
-        rows={filteredPolicies}
+        headerExtras={
+          <select
+            className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground"
+            onChange={(e) => setEnabledFilter(e.target.value)}
+            value={enabledFilter}
+          >
+            <option value="">All</option>
+            <option value="enabled">Enabled</option>
+            <option value="disabled">Disabled</option>
+          </select>
+        }
+        isLoading={isLoading}
+        loadingLabel="Loading scoring policies..."
+        onCreate={goToCreate}
+        onSearchChange={setSearchQuery}
+        search={searchQuery}
+        searchPlaceholder="Search policies..."
+      >
+        <AdminTable<ScoringPolicy>
+          actions={(p) => (
+            <Button
+              aria-label={`Copy ${p.name}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                handleCopy(p)
+              }}
+              size="sm"
+              variant="ghost"
+            >
+              {copiedSlug === p.slug ? (
+                <Check className="h-4 w-4 text-green-500" />
+              ) : (
+                <Copy className="h-4 w-4 text-secondary" />
+              )}
+            </Button>
+          )}
+          columns={[
+            {
+              cellAlign: 'left',
+              header: 'Policy',
+              headerAlign: 'left',
+              key: 'name',
+              render: (p) => (
+                <div>
+                  <div className="font-medium text-primary">{p.name}</div>
+                  {p.description && (
+                    <div className="mt-0.5 text-xs text-tertiary">
+                      {p.description}
+                    </div>
+                  )}
+                </div>
+              ),
+            },
+            {
+              cellAlign: 'left',
+              header: 'Attribute',
+              headerAlign: 'left',
+              key: 'attribute',
+              render: (p) => (
+                <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
+                  {p.attribute_name}
+                </code>
+              ),
+            },
+            {
+              cellAlign: 'center',
+              header: 'Weight',
+              headerAlign: 'center',
+              key: 'weight',
+              render: (p) => <span className="text-secondary">{p.weight}</span>,
+            },
+            {
+              cellAlign: 'center',
+              header: 'Priority',
+              headerAlign: 'center',
+              key: 'priority',
+              render: (p) => (
+                <span className="text-secondary">{p.priority}</span>
+              ),
+            },
+            {
+              cellAlign: 'left',
+              header: 'Targets',
+              headerAlign: 'left',
+              key: 'targets',
+              render: (p) => (
+                <span className="text-xs text-tertiary">
+                  {(p.targets ?? []).length === 0
+                    ? 'All types'
+                    : (p.targets ?? []).join(', ')}
+                </span>
+              ),
+            },
+            {
+              cellAlign: 'center',
+              header: 'Enabled',
+              headerAlign: 'center',
+              key: 'enabled',
+              render: (p) =>
+                p.enabled ? (
+                  <CheckCircle className="mx-auto h-4 w-4 text-success" />
+                ) : (
+                  <XCircle className="mx-auto h-4 w-4 text-tertiary" />
+                ),
+            },
+          ]}
+          emptyMessage={
+            searchQuery || enabledFilter
+              ? 'No policies match your filters.'
+              : 'No scoring policies defined yet.'
+          }
+          getDeleteLabel={(p) => p.name}
+          getRowKey={(p) => p.slug}
+          isDeleting={deleteMutation.isPending}
+          onDelete={(p) => deleteMutation.mutate(p.slug)}
+          onRowClick={(p) => goToEdit(p.slug)}
+          rows={filteredPolicies}
+        />
+      </AdminSection>
+
+      <ImportScoringPolicyDialog
+        apiError={createMutation.error}
+        isLoading={createMutation.isPending}
+        isOpen={importDialogOpen}
+        onClose={() => setImportDialogOpen(false)}
+        onImport={handleImport}
       />
-    </AdminSection>
+    </>
   )
 }

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -120,11 +120,15 @@ export function ScoringPolicyManagement() {
         : {}),
       weight: policy.weight,
     }
+    if (!navigator.clipboard?.writeText) return
     navigator.clipboard
       .writeText(JSON.stringify(exportObj, null, 2))
       .then(() => {
         setCopiedSlug(policy.slug)
         setTimeout(() => setCopiedSlug(null), 2000)
+      })
+      .catch(() => {
+        setCopiedSlug(null)
       })
   }
 

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -19,6 +19,12 @@ import {
 } from '@/api/endpoints'
 import { AdminTable } from '@/components/ui/admin-table'
 import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import { buildDiffPatch } from '@/lib/json-patch'
@@ -214,21 +220,30 @@ export function ScoringPolicyManagement() {
       >
         <AdminTable<ScoringPolicy>
           actions={(p) => (
-            <Button
-              aria-label={`Copy ${p.name}`}
-              onClick={(e) => {
-                e.stopPropagation()
-                handleCopy(p)
-              }}
-              size="sm"
-              variant="ghost"
-            >
-              {copiedSlug === p.slug ? (
-                <Check className="h-4 w-4 text-green-500" />
-              ) : (
-                <Copy className="h-4 w-4 text-secondary" />
-              )}
-            </Button>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    aria-label={`Copy ${p.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleCopy(p)
+                    }}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    {copiedSlug === p.slug ? (
+                      <Check className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <Copy className="h-4 w-4 text-secondary" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Copy Definition</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
           columns={[
             {

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -40,12 +40,14 @@ export function ImportScoringPolicyDialog({
     useState<null | ScoringPolicyCreate>(null)
   const [detectedFormat, setDetectedFormat] =
     useState<DetectedFormat>('unknown')
+  const [showApiError, setShowApiError] = useState(false)
 
   const reset = useCallback(() => {
     setRawInput('')
     setError(null)
     setParsedPreview(null)
     setDetectedFormat('unknown')
+    setShowApiError(false)
   }, [])
 
   useEffect(() => {
@@ -60,6 +62,7 @@ export function ImportScoringPolicyDialog({
   const handleInputChange = useCallback((value: string) => {
     setRawInput(value)
     setError(null)
+    setShowApiError(false)
     setParsedPreview(null)
 
     if (!value.trim()) {
@@ -72,19 +75,20 @@ export function ImportScoringPolicyDialog({
 
     try {
       let parsed: unknown
+      let jsonFailed = false
       if (fmt === 'json' || fmt === 'unknown') {
         try {
           parsed = JSON.parse(value)
         } catch {
-          if (fmt === 'json') return
-          try {
-            parsed = yaml.load(value)
-          } catch {
-            return
-          }
+          jsonFailed = true
         }
-      } else {
-        parsed = yaml.load(value)
+      }
+      if (jsonFailed || fmt === 'yaml') {
+        try {
+          parsed = yaml.load(value)
+        } catch {
+          return
+        }
       }
 
       const result = validatePolicyShape(parsed)
@@ -106,33 +110,29 @@ export function ImportScoringPolicyDialog({
 
     let parsed: unknown
     const fmt = detectFormat(trimmed)
+    let jsonParseError: Error | null = null
 
     if (fmt === 'json' || fmt === 'unknown') {
       try {
         parsed = JSON.parse(trimmed)
       } catch (e) {
-        if (fmt === 'json') {
-          setError(
-            `Invalid JSON: ${e instanceof Error ? e.message : 'parse error'}`,
-          )
-          return
-        }
-        try {
-          parsed = yaml.load(trimmed)
-        } catch (yamlErr) {
+        jsonParseError = e instanceof Error ? e : new Error('parse error')
+      }
+    }
+
+    if (jsonParseError !== null || fmt === 'yaml') {
+      try {
+        parsed = yaml.load(trimmed)
+      } catch (yamlErr) {
+        if (jsonParseError !== null) {
           setError(
             `Could not parse as JSON or YAML: ${yamlErr instanceof Error ? yamlErr.message : 'parse error'}`,
           )
-          return
+        } else {
+          setError(
+            `Invalid YAML: ${yamlErr instanceof Error ? yamlErr.message : 'parse error'}`,
+          )
         }
-      }
-    } else {
-      try {
-        parsed = yaml.load(trimmed)
-      } catch (e) {
-        setError(
-          `Invalid YAML: ${e instanceof Error ? e.message : 'parse error'}`,
-        )
         return
       }
     }
@@ -143,6 +143,7 @@ export function ImportScoringPolicyDialog({
       return
     }
 
+    setShowApiError(true)
     onImport(result.policy)
   }, [rawInput, onImport])
 
@@ -227,7 +228,7 @@ export function ImportScoringPolicyDialog({
             </div>
           )}
 
-          {apiError && !error && (
+          {apiError && showApiError && !error && (
             <div className="flex items-start gap-2.5 rounded-lg border border-danger bg-danger px-3 py-2.5 text-danger">
               <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
               <div className="text-sm">

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -353,13 +353,18 @@ function validatePolicyShape(
     }
   }
 
-  const weight = Number(obj.weight)
-  if (isNaN(weight) || weight < 0 || weight > 100) {
+  if (
+    typeof obj.weight !== 'number' ||
+    !Number.isFinite(obj.weight) ||
+    obj.weight < 0 ||
+    obj.weight > 100
+  ) {
     return {
       error: '"weight" must be a number between 0 and 100.',
       valid: false,
     }
   }
+  const weight = obj.weight
 
   const hasValueMap =
     obj.value_score_map !== null &&
@@ -395,7 +400,10 @@ function validatePolicyShape(
     return { error: '"enabled" must be a boolean.', valid: false }
   }
 
-  if (obj.priority !== undefined && typeof obj.priority !== 'number') {
+  if (
+    obj.priority !== undefined &&
+    (typeof obj.priority !== 'number' || !Number.isFinite(obj.priority))
+  ) {
     return { error: '"priority" must be a number.', valid: false }
   }
 

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -391,15 +391,45 @@ function validatePolicyShape(
     return { error: '"targets" must be an array of strings.', valid: false }
   }
 
+  if (obj.enabled !== undefined && typeof obj.enabled !== 'boolean') {
+    return { error: '"enabled" must be a boolean.', valid: false }
+  }
+
+  if (obj.priority !== undefined && typeof obj.priority !== 'number') {
+    return { error: '"priority" must be a number.', valid: false }
+  }
+
+  const hasOnlyNumericValues = (map: unknown): map is Record<string, number> =>
+    !!map &&
+    typeof map === 'object' &&
+    !Array.isArray(map) &&
+    Object.values(map as Record<string, unknown>).every(
+      (v) => typeof v === 'number' && Number.isFinite(v),
+    )
+
+  if (hasValueMap && !hasOnlyNumericValues(obj.value_score_map)) {
+    return {
+      error: '"value_score_map" values must be numbers.',
+      valid: false,
+    }
+  }
+
+  if (hasRangeMap && !hasOnlyNumericValues(obj.range_score_map)) {
+    return {
+      error: '"range_score_map" values must be numbers.',
+      valid: false,
+    }
+  }
+
   const policy: ScoringPolicyCreate = {
     attribute_name: (obj.attribute_name as string).trim(),
     description:
       typeof obj.description === 'string'
         ? obj.description.trim() || null
         : null,
-    enabled: typeof obj.enabled === 'boolean' ? obj.enabled : true,
+    enabled: obj.enabled === undefined ? true : obj.enabled,
     name: (obj.name as string).trim(),
-    priority: typeof obj.priority === 'number' ? obj.priority : 0,
+    priority: obj.priority === undefined ? 0 : obj.priority,
     range_score_map: hasRangeMap
       ? (obj.range_score_map as Record<string, number>)
       : null,

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import yaml from 'js-yaml'
+import { AlertCircle, FileJson, FileText, Upload } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { ScoringPolicyCreate } from '@/types'
+
+type DetectedFormat = 'json' | 'unknown' | 'yaml'
+
+interface ImportScoringPolicyDialogProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  apiError?: any
+  isLoading?: boolean
+  isOpen: boolean
+  onClose: () => void
+  onImport: (policy: ScoringPolicyCreate) => void
+}
+
+const REQUIRED_FIELDS = ['name', 'slug', 'attribute_name', 'weight'] as const
+
+export function ImportScoringPolicyDialog({
+  apiError,
+  isLoading = false,
+  isOpen,
+  onClose,
+  onImport,
+}: ImportScoringPolicyDialogProps) {
+  const [rawInput, setRawInput] = useState('')
+  const [error, setError] = useState<null | string>(null)
+  const [parsedPreview, setParsedPreview] =
+    useState<null | ScoringPolicyCreate>(null)
+  const [detectedFormat, setDetectedFormat] =
+    useState<DetectedFormat>('unknown')
+
+  const reset = useCallback(() => {
+    setRawInput('')
+    setError(null)
+    setParsedPreview(null)
+    setDetectedFormat('unknown')
+  }, [])
+
+  useEffect(() => {
+    if (isOpen) reset()
+  }, [isOpen, reset])
+
+  const handleClose = useCallback(() => {
+    reset()
+    onClose()
+  }, [reset, onClose])
+
+  const handleInputChange = useCallback((value: string) => {
+    setRawInput(value)
+    setError(null)
+    setParsedPreview(null)
+
+    if (!value.trim()) {
+      setDetectedFormat('unknown')
+      return
+    }
+
+    const fmt = detectFormat(value)
+    setDetectedFormat(fmt)
+
+    try {
+      let parsed: unknown
+      if (fmt === 'json' || fmt === 'unknown') {
+        try {
+          parsed = JSON.parse(value)
+        } catch {
+          if (fmt === 'json') return
+          try {
+            parsed = yaml.load(value)
+          } catch {
+            return
+          }
+        }
+      } else {
+        parsed = yaml.load(value)
+      }
+
+      const result = validatePolicyShape(parsed)
+      if (result.valid) {
+        setParsedPreview(result.policy)
+        setError(null)
+      }
+    } catch {
+      // ignore parse errors while typing
+    }
+  }, [])
+
+  const handleValidateAndImport = useCallback(() => {
+    const trimmed = rawInput.trim()
+    if (!trimmed) {
+      setError('Please paste a JSON or YAML scoring policy definition.')
+      return
+    }
+
+    let parsed: unknown
+    const fmt = detectFormat(trimmed)
+
+    if (fmt === 'json' || fmt === 'unknown') {
+      try {
+        parsed = JSON.parse(trimmed)
+      } catch (e) {
+        if (fmt === 'json') {
+          setError(
+            `Invalid JSON: ${e instanceof Error ? e.message : 'parse error'}`,
+          )
+          return
+        }
+        try {
+          parsed = yaml.load(trimmed)
+        } catch (yamlErr) {
+          setError(
+            `Could not parse as JSON or YAML: ${yamlErr instanceof Error ? yamlErr.message : 'parse error'}`,
+          )
+          return
+        }
+      }
+    } else {
+      try {
+        parsed = yaml.load(trimmed)
+      } catch (e) {
+        setError(
+          `Invalid YAML: ${e instanceof Error ? e.message : 'parse error'}`,
+        )
+        return
+      }
+    }
+
+    const result = validatePolicyShape(parsed)
+    if (!result.valid) {
+      setError(result.error)
+      return
+    }
+
+    onImport(result.policy)
+  }, [rawInput, onImport])
+
+  const formatIcon =
+    detectedFormat === 'json' ? (
+      <FileJson className="h-3.5 w-3.5" />
+    ) : detectedFormat === 'yaml' ? (
+      <FileText className="h-3.5 w-3.5" />
+    ) : null
+
+  return (
+    <Dialog onOpenChange={(open) => !open && handleClose()} open={isOpen}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-primary">
+            Import Scoring Policy
+          </DialogTitle>
+          <DialogDescription>
+            Paste a JSON or YAML scoring policy definition below. Required
+            fields:{' '}
+            {REQUIRED_FIELDS.map((f, i) => (
+              <span key={f}>
+                <code className="rounded bg-secondary px-1 py-0.5 text-xs">
+                  {f}
+                </code>
+                {i < REQUIRED_FIELDS.length - 1 ? ', ' : ''}
+              </span>
+            ))}{' '}
+            and at least one of{' '}
+            <code className="rounded bg-secondary px-1 py-0.5 text-xs">
+              value_score_map
+            </code>{' '}
+            or{' '}
+            <code className="rounded bg-secondary px-1 py-0.5 text-xs">
+              range_score_map
+            </code>
+            .
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {detectedFormat !== 'unknown' && rawInput.trim() && (
+            <div className="flex items-center gap-1.5">
+              {formatIcon}
+              <span className="text-xs text-tertiary">
+                Detected format: {detectedFormat.toUpperCase()}
+              </span>
+              {parsedPreview && (
+                <span className="ml-2 inline-flex items-center gap-1 text-xs text-green-600">
+                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500" />
+                  Valid
+                </span>
+              )}
+            </div>
+          )}
+
+          <textarea
+            className={`w-full resize-y rounded-md border border-input bg-secondary px-4 py-3 font-mono text-sm leading-relaxed text-primary placeholder:text-muted-foreground ${error ? 'border-danger' : ''}`}
+            onChange={(e) => handleInputChange(e.target.value)}
+            placeholder={`{
+  "name": "Test Coverage",
+  "slug": "test-coverage",
+  "attribute_name": "test_coverage",
+  "weight": 50,
+  "priority": 0,
+  "enabled": true,
+  "targets": [],
+  "value_score_map": {
+    "passing": 100,
+    "failing": 0
+  }
+}`}
+            rows={14}
+            spellCheck={false}
+            value={rawInput}
+          />
+
+          {error && (
+            <div className="flex items-start gap-2.5 rounded-lg border border-danger bg-danger px-3 py-2.5 text-danger">
+              <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+              <span className="text-sm">{error}</span>
+            </div>
+          )}
+
+          {apiError && !error && (
+            <div className="flex items-start gap-2.5 rounded-lg border border-danger bg-danger px-3 py-2.5 text-danger">
+              <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+              <div className="text-sm">
+                <div className="font-medium">
+                  Failed to import scoring policy
+                </div>
+                <div className="mt-1">
+                  {apiError?.response?.data?.detail ||
+                    apiError?.response?.data?.message ||
+                    apiError?.message ||
+                    `Server error (${apiError?.response?.status || 'unknown'})`}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {parsedPreview && (
+            <div className="rounded-lg border border-input bg-secondary px-3 py-2.5">
+              <div className="mb-1.5 text-xs font-medium text-tertiary">
+                Preview
+              </div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                <div>
+                  <span className="text-tertiary">Name: </span>
+                  <span className="text-primary">{parsedPreview.name}</span>
+                </div>
+                <div>
+                  <span className="text-tertiary">Slug: </span>
+                  <span className="font-mono text-primary">
+                    {parsedPreview.slug}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-tertiary">Attribute: </span>
+                  <code className="rounded bg-card px-1 py-0.5 text-xs text-primary">
+                    {parsedPreview.attribute_name}
+                  </code>
+                </div>
+                <div>
+                  <span className="text-tertiary">Weight: </span>
+                  <span className="text-primary">{parsedPreview.weight}</span>
+                </div>
+                <div>
+                  <span className="text-tertiary">Map type: </span>
+                  <span className="text-primary">
+                    {parsedPreview.range_score_map ? 'Range' : 'Value'}
+                  </span>
+                </div>
+                {(parsedPreview.targets ?? []).length > 0 && (
+                  <div className="col-span-2">
+                    <span className="text-tertiary">Targets: </span>
+                    <span className="text-primary">
+                      {parsedPreview.targets.join(', ')}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button disabled={isLoading} onClick={handleClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            className="bg-action text-action-foreground hover:bg-action-hover"
+            disabled={isLoading || !rawInput.trim()}
+            onClick={handleValidateAndImport}
+          >
+            <Upload className="mr-2 h-4 w-4" />
+            {isLoading ? 'Importing...' : 'Import'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function detectFormat(input: string): DetectedFormat {
+  const trimmed = input.trim()
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json'
+  if (
+    trimmed.includes(': ') ||
+    trimmed.includes(':\n') ||
+    trimmed.startsWith('---')
+  )
+    return 'yaml'
+  return 'unknown'
+}
+
+function validatePolicyShape(
+  data: unknown,
+):
+  | { error: string; valid: false }
+  | { policy: ScoringPolicyCreate; valid: true } {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { error: 'Input must be a JSON/YAML object.', valid: false }
+  }
+
+  const obj = data as Record<string, unknown>
+
+  for (const field of REQUIRED_FIELDS) {
+    if (obj[field] === undefined || obj[field] === null) {
+      return { error: `Missing required field: "${field}".`, valid: false }
+    }
+  }
+
+  if (typeof obj.name !== 'string' || !obj.name.trim()) {
+    return { error: '"name" must be a non-empty string.', valid: false }
+  }
+  if (typeof obj.slug !== 'string' || !/^[a-z0-9_-]+$/.test(obj.slug)) {
+    return {
+      error:
+        '"slug" must be lowercase letters, numbers, hyphens, or underscores.',
+      valid: false,
+    }
+  }
+  if (typeof obj.attribute_name !== 'string' || !obj.attribute_name.trim()) {
+    return {
+      error: '"attribute_name" must be a non-empty string.',
+      valid: false,
+    }
+  }
+
+  const weight = Number(obj.weight)
+  if (isNaN(weight) || weight < 0 || weight > 100) {
+    return {
+      error: '"weight" must be a number between 0 and 100.',
+      valid: false,
+    }
+  }
+
+  const hasValueMap =
+    obj.value_score_map !== null &&
+    obj.value_score_map !== undefined &&
+    typeof obj.value_score_map === 'object' &&
+    !Array.isArray(obj.value_score_map) &&
+    Object.keys(obj.value_score_map as object).length > 0
+  const hasRangeMap =
+    obj.range_score_map !== null &&
+    obj.range_score_map !== undefined &&
+    typeof obj.range_score_map === 'object' &&
+    !Array.isArray(obj.range_score_map) &&
+    Object.keys(obj.range_score_map as object).length > 0
+
+  if (!hasValueMap && !hasRangeMap) {
+    return {
+      error:
+        'At least one of "value_score_map" or "range_score_map" must have entries.',
+      valid: false,
+    }
+  }
+
+  if (
+    obj.targets !== undefined &&
+    obj.targets !== null &&
+    (!Array.isArray(obj.targets) ||
+      !(obj.targets as unknown[]).every((v) => typeof v === 'string'))
+  ) {
+    return { error: '"targets" must be an array of strings.', valid: false }
+  }
+
+  const policy: ScoringPolicyCreate = {
+    attribute_name: (obj.attribute_name as string).trim(),
+    description:
+      typeof obj.description === 'string'
+        ? obj.description.trim() || null
+        : null,
+    enabled: typeof obj.enabled === 'boolean' ? obj.enabled : true,
+    name: (obj.name as string).trim(),
+    priority: typeof obj.priority === 'number' ? obj.priority : 0,
+    range_score_map: hasRangeMap
+      ? (obj.range_score_map as Record<string, number>)
+      : null,
+    slug: obj.slug as string,
+    targets: Array.isArray(obj.targets) ? (obj.targets as string[]) : [],
+    value_score_map: hasValueMap
+      ? (obj.value_score_map as Record<string, number>)
+      : null,
+    weight,
+  }
+
+  return { policy, valid: true }
+}

--- a/src/components/reports/MonthlyImprovementReport.tsx
+++ b/src/components/reports/MonthlyImprovementReport.tsx
@@ -57,18 +57,26 @@ export function MonthlyImprovementReport() {
 
   const [selected, setSelected] = useState<MonthOption>(monthOptions[0])
 
-  const { data: rawRows, isLoading: rowsLoading } = useQuery({
+  const {
+    data: rawRows,
+    error: rowsError,
+    isLoading: rowsLoading,
+  } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) =>
       getMonthlyImprovement(
         { month: selected.month, year: selected.year },
         signal,
       ),
-    queryKey: ['monthlyImprovement', selected.year, selected.month],
+    queryKey: ['monthlyImprovement', orgSlug, selected.year, selected.month],
     staleTime: 120_000,
   })
 
-  const { data: teams, isLoading: teamsLoading } = useQuery({
+  const {
+    data: teams,
+    error: teamsError,
+    isLoading: teamsLoading,
+  } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listTeams(orgSlug, signal),
     queryKey: ['teams', orgSlug],
@@ -76,6 +84,7 @@ export function MonthlyImprovementReport() {
   })
 
   const isLoading = rowsLoading || teamsLoading
+  const hasError = !!(rowsError || teamsError)
 
   const rows: TeamRow[] = useMemo(() => {
     if (!rawRows) return []
@@ -100,19 +109,28 @@ export function MonthlyImprovementReport() {
     [rows],
   )
 
-  // Org-wide aggregates
+  // Org-wide aggregates (project_count-weighted)
   const orgWide = useMemo(() => {
-    const withCur = rows.filter((r) => r.current_avg_score != null)
-    const withImp = rows.filter((r) => r.improvement != null)
+    const withCur = rows.filter(
+      (r) => r.current_avg_score != null && r.project_count > 0,
+    )
+    const withImp = rows.filter(
+      (r) => r.improvement != null && r.project_count > 0,
+    )
+    const totalCurWeight = withCur.reduce((s, r) => s + r.project_count, 0)
+    const totalImpWeight = withImp.reduce((s, r) => s + r.project_count, 0)
     return {
       avg_score:
-        withCur.length > 0
-          ? withCur.reduce((s, r) => s + r.current_avg_score!, 0) /
-            withCur.length
+        totalCurWeight > 0
+          ? withCur.reduce(
+              (s, r) => s + r.current_avg_score! * r.project_count,
+              0,
+            ) / totalCurWeight
           : null,
       improvement:
-        withImp.length > 0
-          ? withImp.reduce((s, r) => s + r.improvement!, 0) / withImp.length
+        totalImpWeight > 0
+          ? withImp.reduce((s, r) => s + r.improvement! * r.project_count, 0) /
+            totalImpWeight
           : null,
     }
   }, [rows])
@@ -162,6 +180,10 @@ export function MonthlyImprovementReport() {
         {isLoading ? (
           <div className="py-16 text-center text-sm text-tertiary">
             Loading…
+          </div>
+        ) : hasError ? (
+          <div className="py-16 text-center text-sm text-danger">
+            Failed to load report data. Please try again.
           </div>
         ) : sorted.length === 0 ? (
           <div className="py-16 text-center text-sm text-tertiary">

--- a/src/components/reports/MonthlyImprovementReport.tsx
+++ b/src/components/reports/MonthlyImprovementReport.tsx
@@ -1,0 +1,255 @@
+import { useMemo, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { ChevronDown } from 'lucide-react'
+
+import {
+  getMonthlyImprovement,
+  listTeams,
+  MonthlyImprovementRow,
+} from '@/api/endpoints'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { Team } from '@/types'
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+interface MonthOption {
+  label: string
+  month: number
+  year: number
+}
+
+interface TeamRow extends MonthlyImprovementRow {
+  name: string
+}
+
+export function MonthlyImprovementReport() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
+  const orgName = selectedOrganization?.name ?? 'Org'
+
+  const monthOptions = useMemo<MonthOption[]>(() => {
+    const opts: MonthOption[] = []
+    const now = new Date()
+    for (let i = 0; i < 12; i++) {
+      const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+      opts.push({
+        label: `${MONTH_NAMES[d.getMonth()]} ${d.getFullYear()}`,
+        month: d.getMonth() + 1,
+        year: d.getFullYear(),
+      })
+    }
+    return opts
+  }, [])
+
+  const [selected, setSelected] = useState<MonthOption>(monthOptions[0])
+
+  const { data: rawRows, isLoading: rowsLoading } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) =>
+      getMonthlyImprovement(
+        { month: selected.month, year: selected.year },
+        signal,
+      ),
+    queryKey: ['monthlyImprovement', selected.year, selected.month],
+    staleTime: 120_000,
+  })
+
+  const { data: teams, isLoading: teamsLoading } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => listTeams(orgSlug, signal),
+    queryKey: ['teams', orgSlug],
+    staleTime: 120_000,
+  })
+
+  const isLoading = rowsLoading || teamsLoading
+
+  const rows: TeamRow[] = useMemo(() => {
+    if (!rawRows) return []
+    const teamBySlug = new Map<string, Team>(
+      (teams ?? []).map((t) => [t.slug, t]),
+    )
+    return rawRows.map((r) => ({
+      ...r,
+      name: teamBySlug.get(r.key)?.name ?? r.key,
+    }))
+  }, [rawRows, teams])
+
+  // Sort: descending improvement, nulls last
+  const sorted = useMemo(
+    () =>
+      [...rows].sort((a, b) => {
+        if (a.improvement == null && b.improvement == null) return 0
+        if (a.improvement == null) return 1
+        if (b.improvement == null) return -1
+        return b.improvement - a.improvement
+      }),
+    [rows],
+  )
+
+  // Org-wide aggregates
+  const orgWide = useMemo(() => {
+    const withCur = rows.filter((r) => r.current_avg_score != null)
+    const withImp = rows.filter((r) => r.improvement != null)
+    return {
+      avg_score:
+        withCur.length > 0
+          ? withCur.reduce((s, r) => s + r.current_avg_score!, 0) /
+            withCur.length
+          : null,
+      improvement:
+        withImp.length > 0
+          ? withImp.reduce((s, r) => s + r.improvement!, 0) / withImp.length
+          : null,
+    }
+  }, [rows])
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Month selector */}
+      <div className="flex items-center gap-3">
+        <span className="text-sm text-secondary">Month</span>
+        <div className="relative">
+          <select
+            className="h-8 appearance-none rounded border border-tertiary bg-primary py-0 pl-3 pr-8 text-sm text-primary transition-colors hover:border-secondary focus:outline-none focus:ring-0"
+            onChange={(e) => {
+              const opt = monthOptions[Number(e.target.value)]
+              if (opt) setSelected(opt)
+            }}
+            value={monthOptions.indexOf(selected)}
+          >
+            {monthOptions.map((opt, i) => (
+              <option key={`${opt.year}-${opt.month}`} value={i}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-tertiary" />
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-lg border border-tertiary bg-primary">
+        {/* Table header */}
+        <div
+          className="grid border-b border-tertiary bg-secondary"
+          style={COL_GRID}
+        >
+          <div className="px-5 py-3 text-[13px] font-medium text-primary">
+            Team
+          </div>
+          <div className="px-5 py-3 text-right text-[13px] font-medium text-primary">
+            Monthly improvement
+          </div>
+          <div className="px-5 py-3 text-right text-[13px] font-medium text-primary">
+            Stack health score
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="py-16 text-center text-sm text-tertiary">
+            Loading…
+          </div>
+        ) : sorted.length === 0 ? (
+          <div className="py-16 text-center text-sm text-tertiary">
+            No score data for {selected.label}.
+          </div>
+        ) : (
+          <>
+            {sorted.map((row, i) => (
+              <div
+                className="grid items-center border-b border-tertiary transition-colors last:border-0 hover:bg-secondary"
+                key={row.key}
+                style={COL_GRID}
+              >
+                <div className="px-5 py-3.5 text-[13px] text-primary">
+                  <span className="mr-2 tabular-nums text-tertiary">
+                    {i + 1}.
+                  </span>
+                  {row.name}
+                </div>
+                <div className="px-5 py-3.5 text-right">
+                  <ImprovementValue value={row.improvement} />
+                </div>
+                <div className="px-5 py-3.5 text-right font-mono text-[13px] tabular-nums text-primary">
+                  {row.current_avg_score != null
+                    ? `${row.current_avg_score.toFixed(2)}%`
+                    : '—'}
+                </div>
+              </div>
+            ))}
+
+            {/* Org-wide summary row */}
+            <div
+              className="grid items-center border-t border-tertiary bg-secondary"
+              style={COL_GRID}
+            >
+              <div className="px-5 py-4 text-[13px] font-medium uppercase tracking-wide text-primary">
+                {orgName} wide
+              </div>
+              <div className="px-5 py-4 text-right">
+                <ImprovementValue bold value={orgWide.improvement} />
+              </div>
+              <div className="px-5 py-4 text-right font-mono text-[13px] font-medium tabular-nums text-primary">
+                {orgWide.avg_score != null
+                  ? `${orgWide.avg_score.toFixed(2)}%`
+                  : '—'}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const COL_GRID = {
+  gridTemplateColumns: '1fr 220px 220px',
+}
+
+function ImprovementValue({
+  bold = false,
+  value,
+}: {
+  bold?: boolean
+  value: null | number
+}) {
+  if (value == null) {
+    return (
+      <span className="font-mono text-[13px] tabular-nums text-tertiary">
+        —
+      </span>
+    )
+  }
+
+  const positive = value > 0
+  const zero = value === 0
+  const color = zero
+    ? 'var(--color-text-secondary)'
+    : positive
+      ? 'var(--color-text-success)'
+      : 'var(--color-text-danger)'
+
+  return (
+    <span
+      className={`font-mono text-[13px] tabular-nums ${bold ? 'font-medium' : ''}`}
+      style={{ color }}
+    >
+      {positive ? '+' : ''}
+      {value.toFixed(2)}
+    </span>
+  )
+}

--- a/src/components/reports/TeamKPIReport.tsx
+++ b/src/components/reports/TeamKPIReport.tsx
@@ -1,0 +1,382 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { RefreshCw } from 'lucide-react'
+
+import { getScoreRollup, listTeams, ScoreRollupRow } from '@/api/endpoints'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { Team } from '@/types'
+
+interface BarChartProps {
+  rows: TeamRow[]
+}
+
+interface TeamRow extends ScoreRollupRow {
+  name: string
+  project_count?: number
+}
+
+export function TeamKPIReport() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
+
+  const {
+    data: rollup,
+    isLoading: rollupLoading,
+    refetch,
+  } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => getScoreRollup('team', signal),
+    queryKey: ['scoreRollup', 'team'],
+    staleTime: 60_000,
+  })
+
+  const { data: teams, isLoading: teamsLoading } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => listTeams(orgSlug, signal),
+    queryKey: ['teams', orgSlug],
+    staleTime: 120_000,
+  })
+
+  const isLoading = rollupLoading || teamsLoading
+
+  const rows: TeamRow[] = (() => {
+    if (!rollup) return []
+    const teamBySlug = new Map<string, Team>(
+      (teams ?? []).map((t) => [t.slug, t]),
+    )
+    return rollup.map((r) => ({
+      ...r,
+      name: teamBySlug.get(r.key)?.name ?? r.key,
+    }))
+  })()
+
+  const sorted = [...rows].sort((a, b) => b.avg_score - a.avg_score)
+
+  const avgOfAvgs =
+    rows.length > 0
+      ? rows.reduce((s, r) => s + r.avg_score, 0) / rows.length
+      : null
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Summary stat row */}
+      <div className="grid grid-cols-3 gap-4">
+        <StatCard
+          label="Teams tracked"
+          value={isLoading ? '—' : String(rows.length)}
+        />
+        <StatCard
+          label="Org avg score"
+          value={isLoading || avgOfAvgs == null ? '—' : fmtScore(avgOfAvgs)}
+          valueColor={avgOfAvgs != null ? scoreColor(avgOfAvgs) : undefined}
+        />
+        <StatCard
+          label="Top team score"
+          value={
+            isLoading || sorted.length === 0
+              ? '—'
+              : fmtScore(sorted[0].avg_score)
+          }
+          valueColor={
+            sorted.length > 0 ? scoreColor(sorted[0].avg_score) : undefined
+          }
+        />
+      </div>
+
+      {/* Bar chart card */}
+      <div className="rounded-lg border border-tertiary bg-primary p-[18px]">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <div className="text-overline uppercase tracking-wide text-tertiary">
+              Avg score by team
+            </div>
+            <div className="mt-0.5 text-xs text-tertiary">
+              Bar = avg across all projects · tick = best project score
+            </div>
+          </div>
+          <button
+            className="inline-flex h-7 items-center gap-1.5 rounded border border-tertiary px-2.5 text-xs text-primary transition-colors hover:bg-secondary"
+            onClick={() => refetch()}
+          >
+            <RefreshCw size={11} />
+            Refresh
+          </button>
+        </div>
+
+        {isLoading ? (
+          <div className="flex h-40 items-center justify-center text-sm text-tertiary">
+            Loading…
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="flex h-40 items-center justify-center text-sm text-tertiary">
+            No score data yet. Projects need to be scored first.
+          </div>
+        ) : (
+          <TeamBarChart rows={rows} />
+        )}
+      </div>
+
+      {/* Table card */}
+      <div className="rounded-lg border border-tertiary bg-primary">
+        <div className="border-b border-tertiary px-[18px] py-3.5">
+          <div className="text-overline uppercase tracking-wide text-tertiary">
+            Team details
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="py-10 text-center text-sm text-tertiary">
+            Loading…
+          </div>
+        ) : sorted.length === 0 ? (
+          <div className="py-10 text-center text-sm text-tertiary">
+            No data available.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-tertiary">
+                <th className="px-[18px] py-2.5 text-left text-overline font-normal uppercase tracking-wide text-tertiary">
+                  Team
+                </th>
+                <th className="px-4 py-2.5 text-right text-overline font-normal uppercase tracking-wide text-tertiary">
+                  Avg score
+                </th>
+                <th className="px-4 py-2.5 text-right text-overline font-normal uppercase tracking-wide text-tertiary">
+                  Best project
+                </th>
+                <th className="px-[18px] py-2.5 text-right text-overline font-normal uppercase tracking-wide text-tertiary">
+                  Last scored
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row, i) => (
+                <tr
+                  className={`border-b border-tertiary transition-colors hover:bg-secondary ${
+                    i === sorted.length - 1 ? 'border-0' : ''
+                  }`}
+                  key={row.key}
+                >
+                  <td className="px-[18px] py-3 font-medium text-primary">
+                    {row.name}
+                    <span className="ml-2 font-mono text-[11px] text-tertiary">
+                      {row.key}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <ScorePill score={row.avg_score} />
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <ScorePill score={row.latest_score} />
+                  </td>
+                  <td className="px-[18px] py-3 text-right font-mono text-xs text-tertiary">
+                    {fmtRelative(row.last_updated)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function fmtRelative(iso: null | string): string {
+  if (!iso) return '—'
+  const ms =
+    Date.now() - new Date(iso.endsWith('Z') ? iso : iso + 'Z').getTime()
+  const min = Math.round(ms / 60000)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  return `${Math.round(hr / 24)}d ago`
+}
+
+function fmtScore(n: number): string {
+  return n.toFixed(1)
+}
+
+function scoreBgColor(score: number): string {
+  if (score >= 85) return 'var(--color-background-success)'
+  if (score >= 70) return 'var(--color-background-warning)'
+  return 'var(--color-background-danger)'
+}
+
+function scoreColor(score: number): string {
+  if (score >= 85) return 'var(--color-text-success)'
+  if (score >= 70) return 'var(--color-text-warning)'
+  return 'var(--color-text-danger)'
+}
+
+function ScorePill({ score }: { score: number }) {
+  return (
+    <span
+      className="inline-flex h-6 items-center rounded px-2 font-mono text-xs font-medium tabular-nums"
+      style={{
+        background: scoreBgColor(score),
+        color: scoreColor(score),
+      }}
+    >
+      {fmtScore(score)}
+    </span>
+  )
+}
+
+function StatCard({
+  label,
+  value,
+  valueColor,
+}: {
+  label: string
+  value: string
+  valueColor?: string
+}) {
+  return (
+    <div className="rounded-lg border border-tertiary bg-primary p-[18px]">
+      <div className="text-overline uppercase tracking-wide text-tertiary">
+        {label}
+      </div>
+      <div
+        className="mt-2 font-mono text-[28px] tabular-nums leading-none"
+        style={{ color: valueColor ?? 'var(--color-text-primary)' }}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function TeamBarChart({ rows }: BarChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [W, setW] = useState(640)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const obs = new ResizeObserver(([entry]) => {
+      const w = entry.contentRect.width
+      if (w > 0) setW(Math.round(w))
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+
+  if (rows.length === 0) return null
+
+  const BAR_H = 22
+  const GAP = 10
+  const PAD_TOP = 20
+  const PAD_LEFT = 140
+  const PAD_RIGHT = 60
+  const PAD_BOTTOM = 32
+  const innerW = W - PAD_LEFT - PAD_RIGHT
+
+  const sorted = [...rows].sort((a, b) => b.avg_score - a.avg_score)
+  const H = PAD_TOP + sorted.length * (BAR_H + GAP) - GAP + PAD_BOTTOM
+
+  const xFor = (score: number) => (score / 100) * innerW
+
+  const xTicks = [0, 25, 50, 75, 100]
+
+  return (
+    <div ref={containerRef} style={{ width: '100%' }}>
+      <svg
+        height={H}
+        style={{ display: 'block', overflow: 'visible' }}
+        width={W}
+      >
+        {/* x-axis grid lines */}
+        {xTicks.map((t) => (
+          <g key={t}>
+            <line
+              stroke="var(--color-border-tertiary)"
+              strokeWidth="1"
+              x1={PAD_LEFT + xFor(t)}
+              x2={PAD_LEFT + xFor(t)}
+              y1={PAD_TOP}
+              y2={H - PAD_BOTTOM}
+            />
+            <text
+              fill="var(--color-text-tertiary)"
+              fontFamily="var(--font-sans)"
+              fontSize="10"
+              textAnchor="middle"
+              x={PAD_LEFT + xFor(t)}
+              y={H - PAD_BOTTOM + 14}
+            >
+              {t}
+            </text>
+          </g>
+        ))}
+
+        {sorted.map((row, i) => {
+          const y = PAD_TOP + i * (BAR_H + GAP)
+          const barW = Math.max(2, xFor(row.avg_score))
+          const latestX = PAD_LEFT + xFor(row.latest_score)
+
+          return (
+            <g key={row.key}>
+              {/* Team label */}
+              <text
+                fill="var(--color-text-primary)"
+                fontFamily="var(--font-sans)"
+                fontSize="12"
+                textAnchor="end"
+                x={PAD_LEFT - 8}
+                y={y + BAR_H / 2 + 4}
+              >
+                {row.name.length > 18 ? row.name.slice(0, 17) + '…' : row.name}
+              </text>
+
+              {/* Avg score bar background */}
+              <rect
+                fill="var(--color-background-secondary)"
+                height={BAR_H}
+                rx="3"
+                width={innerW}
+                x={PAD_LEFT}
+                y={y}
+              />
+
+              {/* Avg score bar fill */}
+              <rect
+                fill={scoreBgColor(row.avg_score)}
+                height={BAR_H}
+                rx="3"
+                width={barW}
+                x={PAD_LEFT}
+                y={y}
+              />
+
+              {/* Latest score tick (max) */}
+              <line
+                stroke={scoreColor(row.latest_score)}
+                strokeWidth="2"
+                x1={latestX}
+                x2={latestX}
+                y1={y + 3}
+                y2={y + BAR_H - 3}
+              />
+
+              {/* Score label */}
+              <text
+                fill={scoreColor(row.avg_score)}
+                fontFamily="var(--font-mono)"
+                fontSize="11"
+                fontWeight="500"
+                textAnchor="start"
+                x={PAD_LEFT + barW + 6}
+                y={y + BAR_H / 2 + 4}
+              >
+                {fmtScore(row.avg_score)}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}

--- a/src/components/reports/TeamKPIReport.tsx
+++ b/src/components/reports/TeamKPIReport.tsx
@@ -24,7 +24,7 @@ export function TeamKPIReport() {
     data: rollup,
     error: rollupError,
     isLoading: rollupLoading,
-    refetch,
+    refetch: refetchRollup,
   } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => getScoreRollup('team', signal),
@@ -36,6 +36,7 @@ export function TeamKPIReport() {
     data: teams,
     error: teamsError,
     isLoading: teamsLoading,
+    refetch: refetchTeams,
   } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listTeams(orgSlug, signal),
@@ -45,6 +46,11 @@ export function TeamKPIReport() {
 
   const isLoading = rollupLoading || teamsLoading
   const hasError = !!(rollupError || teamsError)
+
+  function refetchAll() {
+    void refetchRollup()
+    void refetchTeams()
+  }
 
   const rows: TeamRow[] = (() => {
     if (!rollup) return []
@@ -70,17 +76,21 @@ export function TeamKPIReport() {
       <div className="grid grid-cols-3 gap-4">
         <StatCard
           label="Teams tracked"
-          value={isLoading ? '—' : String(rows.length)}
+          value={isLoading || hasError ? '—' : String(rows.length)}
         />
         <StatCard
           label="Org avg score"
-          value={isLoading || avgOfAvgs == null ? '—' : fmtScore(avgOfAvgs)}
+          value={
+            isLoading || hasError || avgOfAvgs == null
+              ? '—'
+              : fmtScore(avgOfAvgs)
+          }
           valueColor={avgOfAvgs != null ? scoreColor(avgOfAvgs) : undefined}
         />
         <StatCard
           label="Top team score"
           value={
-            isLoading || sorted.length === 0
+            isLoading || hasError || sorted.length === 0
               ? '—'
               : fmtScore(sorted[0].avg_score)
           }
@@ -103,7 +113,7 @@ export function TeamKPIReport() {
           </div>
           <button
             className="inline-flex h-7 items-center gap-1.5 rounded border border-tertiary px-2.5 text-xs text-primary transition-colors hover:bg-secondary"
-            onClick={() => refetch()}
+            onClick={refetchAll}
           >
             <RefreshCw size={11} />
             Refresh
@@ -142,7 +152,7 @@ export function TeamKPIReport() {
         ) : hasError ? (
           <div className="py-10 text-center text-sm text-danger">
             Failed to load report data.{' '}
-            <button className="underline" onClick={() => refetch()}>
+            <button className="underline" onClick={refetchAll}>
               Retry
             </button>
           </div>

--- a/src/components/reports/TeamKPIReport.tsx
+++ b/src/components/reports/TeamKPIReport.tsx
@@ -22,16 +22,21 @@ export function TeamKPIReport() {
 
   const {
     data: rollup,
+    error: rollupError,
     isLoading: rollupLoading,
     refetch,
   } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => getScoreRollup('team', signal),
-    queryKey: ['scoreRollup', 'team'],
+    queryKey: ['scoreRollup', 'team', orgSlug],
     staleTime: 60_000,
   })
 
-  const { data: teams, isLoading: teamsLoading } = useQuery({
+  const {
+    data: teams,
+    error: teamsError,
+    isLoading: teamsLoading,
+  } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listTeams(orgSlug, signal),
     queryKey: ['teams', orgSlug],
@@ -39,6 +44,7 @@ export function TeamKPIReport() {
   })
 
   const isLoading = rollupLoading || teamsLoading
+  const hasError = !!(rollupError || teamsError)
 
   const rows: TeamRow[] = (() => {
     if (!rollup) return []
@@ -108,6 +114,10 @@ export function TeamKPIReport() {
           <div className="flex h-40 items-center justify-center text-sm text-tertiary">
             Loading…
           </div>
+        ) : hasError ? (
+          <div className="flex h-40 items-center justify-center text-sm text-danger">
+            Failed to load report data. Please try again.
+          </div>
         ) : rows.length === 0 ? (
           <div className="flex h-40 items-center justify-center text-sm text-tertiary">
             No score data yet. Projects need to be scored first.
@@ -128,6 +138,13 @@ export function TeamKPIReport() {
         {isLoading ? (
           <div className="py-10 text-center text-sm text-tertiary">
             Loading…
+          </div>
+        ) : hasError ? (
+          <div className="py-10 text-center text-sm text-danger">
+            Failed to load report data.{' '}
+            <button className="underline" onClick={() => refetch()}>
+              Retry
+            </button>
           </div>
         ) : sorted.length === 0 ? (
           <div className="py-10 text-center text-sm text-tertiary">

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -354,11 +354,9 @@ export function AdminTable<T>({
                                       </Button>
                                     </span>
                                   </TooltipTrigger>
-                                  {deleteReason && (
-                                    <TooltipContent>
-                                      <p>{deleteReason}</p>
-                                    </TooltipContent>
-                                  )}
+                                  <TooltipContent>
+                                    <p>{deleteReason ?? 'Delete'}</p>
+                                  </TooltipContent>
                                 </Tooltip>
                               </TooltipProvider>
                             )}

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+
+import { BarChart3, TrendingUp } from 'lucide-react'
+
+import { CommandBar } from '@/components/CommandBar'
+import { Navigation } from '@/components/Navigation'
+import { MonthlyImprovementReport } from '@/components/reports/MonthlyImprovementReport'
+import { TeamKPIReport } from '@/components/reports/TeamKPIReport'
+import { usePageTitle } from '@/hooks/usePageTitle'
+
+interface Report {
+  description: string
+  id: string
+  label: string
+  subtitle: string
+}
+
+const REPORTS: Report[] = [
+  {
+    description: 'Avg quality score per team',
+    id: 'team-kpi',
+    label: 'Team KPI',
+    subtitle: 'Quality score rollup by team',
+  },
+  {
+    description: 'Month-over-month score delta',
+    id: 'monthly-improvement',
+    label: 'Monthly improvement',
+    subtitle: 'Score improvement by team for a selected month',
+  },
+]
+
+export function ReportsPage() {
+  usePageTitle('Reports')
+  const [activeId, setActiveId] = useState<string>(REPORTS[0].id)
+  const active = REPORTS.find((r) => r.id === activeId) ?? REPORTS[0]
+
+  return (
+    <div className="min-h-screen bg-tertiary text-primary">
+      <Navigation />
+      <main
+        className="mx-auto max-w-[1400px] px-6 pt-24"
+        style={{ paddingBottom: 'var(--assistant-height, 64px)' }}
+      >
+        <div className="flex gap-6">
+          {/* Left sidebar — report list */}
+          <aside className="w-56 flex-shrink-0">
+            <div className="rounded-lg border border-tertiary bg-primary">
+              <div className="border-b border-tertiary px-4 py-3">
+                <div className="text-overline uppercase tracking-wide text-tertiary">
+                  Reports
+                </div>
+              </div>
+              <div className="p-1">
+                {REPORTS.map((r) => {
+                  const isActive = r.id === activeId
+                  return (
+                    <button
+                      className={`flex w-full items-start gap-2.5 rounded-md px-3 py-2.5 text-left transition-colors ${
+                        isActive
+                          ? 'bg-amber-bg text-amber-text'
+                          : 'text-secondary hover:bg-secondary hover:text-primary'
+                      }`}
+                      key={r.id}
+                      onClick={() => setActiveId(r.id)}
+                    >
+                      {r.id === 'team-kpi' ? (
+                        <BarChart3 className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                      ) : (
+                        <TrendingUp className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                      )}
+                      <div>
+                        <div className="text-[13px] font-medium">{r.label}</div>
+                        <div className="mt-0.5 text-[11px] opacity-70">
+                          {r.description}
+                        </div>
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          </aside>
+
+          {/* Main content */}
+          <div className="min-w-0 flex-1">
+            <div className="mb-5 flex items-baseline gap-3">
+              <h1 className="text-[18px] font-medium text-primary">
+                {active.label}
+              </h1>
+              <span className="text-sm text-tertiary">{active.subtitle}</span>
+            </div>
+            {activeId === 'team-kpi' && <TeamKPIReport />}
+            {activeId === 'monthly-improvement' && <MonthlyImprovementReport />}
+          </div>
+        </div>
+      </main>
+      <CommandBar />
+    </div>
+  )
+}

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -17,16 +17,16 @@ interface Report {
 
 const REPORTS: Report[] = [
   {
-    description: 'Avg quality score per team',
-    id: 'team-kpi',
-    label: 'Team KPI',
-    subtitle: 'Quality score rollup by team',
-  },
-  {
     description: 'Month-over-month score delta',
     id: 'monthly-improvement',
     label: 'Monthly improvement',
     subtitle: 'Score improvement by team for a selected month',
+  },
+  {
+    description: 'Avg quality score per team',
+    id: 'team-kpi',
+    label: 'Team KPI',
+    subtitle: 'Quality score rollup by team',
   },
 ]
 


### PR DESCRIPTION
## Summary

Implements the Reports section of the UI (the nav item already existed but had no route). Adds two reports accessible from a sidebar:

- **Monthly improvement** (default, shown first): month selector (current + 11 prior months) showing each team's score improvement — last project score at end of selected month minus last project score at end of prior month — plus their current avg health score. Org-wide summary row at the bottom uses the selected organization's name.
- **Team KPI**: SVG bar chart and ranked table of avg/best-project scores per team from the existing `/scores/rollup` endpoint.

## Problem

The Reports nav item linked to `/reports` but no page existed. There was no way to see score trends across teams without drilling into individual projects.

## Solution

- New `ReportsPage` with a clickable sidebar listing reports alphabetically.
- `TeamKPIReport` component uses `GET /scores/rollup?dimension=team` (existing endpoint).
- `MonthlyImprovementReport` component uses the new `GET /scores/monthly-improvement` endpoint (see companion imbi-api PR). Month selector defaults to the current month. Team names are resolved by slug from `GET /organizations/{org}/teams/`.
- Both reports color-code scores: ≥85 green, 70–84 amber, <70 red.

## Impact

New read-only UI page. No changes to existing routes or components. Requires the imbi-api `feature/reports-tab` branch to be deployed for the Monthly Improvement report to return data.