### PR TITLE
Add Settings → Connections page for identity plugins

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -24,6 +24,9 @@ import type {
   CurrentReleaseEnvironment,
   Environment,
   EnvironmentCreate,
+  IdentityConnectionResponse,
+  IdentityConnectionStartRequest,
+  IdentityConnectionStartResponse,
   InstalledPlugin,
   LinkDefinition,
   LinkDefinitionCreate,
@@ -1870,6 +1873,32 @@ export const getMonthlyImprovement = (
     },
     signal,
   )
+
+// Identity connections (per-user)
+export const getMyIdentities = (signal?: AbortSignal) =>
+  apiClient.get<IdentityConnectionResponse[]>(
+    '/me/identities',
+    undefined,
+    signal,
+  )
+
+export const startMyIdentity = (
+  pluginId: string,
+  body: IdentityConnectionStartRequest = {},
+) =>
+  apiClient.post<IdentityConnectionStartResponse>(
+    `/me/identities/${encodeURIComponent(pluginId)}/start`,
+    body,
+  )
+
+export const refreshMyIdentity = (pluginId: string) =>
+  apiClient.post<{ status: string }>(
+    `/me/identities/${encodeURIComponent(pluginId)}/refresh`,
+    {},
+  )
+
+export const disconnectMyIdentity = (pluginId: string) =>
+  apiClient.delete<void>(`/me/identities/${encodeURIComponent(pluginId)}`)
 
 // Admin Plugins
 export const getAdminPlugins = (signal?: AbortSignal) =>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -2,10 +2,11 @@ import { useEffect } from 'react'
 
 import { useNavigate, useParams } from 'react-router-dom'
 
-import { ArrowLeft, Bell, Key, Link2, Shield, User } from 'lucide-react'
+import { ArrowLeft, Bell, Key, Link2, Plug, Shield, User } from 'lucide-react'
 
 import { SettingsAccount } from './settings/SettingsAccount'
 import { SettingsApiKeys } from './settings/SettingsApiKeys'
+import { SettingsConnections } from './settings/SettingsConnections'
 import { SettingsIntegrations } from './settings/SettingsIntegrations'
 import { SettingsNotifications } from './settings/SettingsNotifications'
 import { SettingsSecurity } from './settings/SettingsSecurity'
@@ -15,12 +16,14 @@ import { Card } from './ui/card'
 type SettingsTab =
   | 'account'
   | 'api-keys'
+  | 'connections'
   | 'integrations'
   | 'notifications'
   | 'security'
 
 const tabs: { icon: typeof User; id: SettingsTab; label: string }[] = [
   { icon: User, id: 'account', label: 'Account' },
+  { icon: Plug, id: 'connections', label: 'Connections' },
   { icon: Link2, id: 'integrations', label: 'Integrations' },
   { icon: Bell, id: 'notifications', label: 'Notifications' },
   { icon: Key, id: 'api-keys', label: 'API Keys' },
@@ -94,6 +97,7 @@ export function Settings() {
         {/* Content area */}
         <div className="lg:col-span-3">
           {activeTab === 'account' && <SettingsAccount />}
+          {activeTab === 'connections' && <SettingsConnections />}
           {activeTab === 'integrations' && <SettingsIntegrations />}
           {activeTab === 'notifications' && <SettingsNotifications />}
           {activeTab === 'api-keys' && <SettingsApiKeys />}

--- a/src/components/admin/PluginsManagement.tsx
+++ b/src/components/admin/PluginsManagement.tsx
@@ -139,8 +139,8 @@ function DisabledList({ parentLoading, plugins }: DisabledListProps) {
       <CardHeader className="px-6 py-4">
         <CardTitle>Disabled Plugins</CardTitle>
         <CardDescription>
-          Installed plugins that are not yet enabled. Enable a plugin to make
-          it available for project type and service assignments.
+          Installed plugins that are not yet enabled. Enable a plugin to make it
+          available for project type and service assignments.
         </CardDescription>
       </CardHeader>
       <CardContent className="p-0">
@@ -192,12 +192,7 @@ function DisabledList({ parentLoading, plugins }: DisabledListProps) {
   )
 }
 
-function EnabledList({
-  error,
-  isError,
-  isLoading,
-  plugins,
-}: EnabledListProps) {
+function EnabledList({ error, isError, isLoading, plugins }: EnabledListProps) {
   if (isLoading) {
     return <LoadingState label="Loading..." />
   }
@@ -234,6 +229,7 @@ function EnabledList({
           <TableHeader>
             <TableRow>
               <TableHead>Plugin</TableHead>
+              <TableHead>Type</TableHead>
               <TableHead>Package</TableHead>
               <TableHead>Version</TableHead>
               <TableHead>Auth</TableHead>
@@ -248,6 +244,16 @@ function EnabledList({
                   <div className="text-xs text-secondary">
                     {plugin.description}
                   </div>
+                  {plugin.login_capable && (
+                    <div className="mt-1">
+                      <Badge variant="outline">Login provider</Badge>
+                    </div>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="secondary">
+                    {plugin.plugin_type ?? plugin.supported_tabs[0] ?? '—'}
+                  </Badge>
                 </TableCell>
                 <TableCell>
                   <code className="rounded bg-secondary px-1.5 py-0.5 text-xs">

--- a/src/components/settings/SettingsConnections.tsx
+++ b/src/components/settings/SettingsConnections.tsx
@@ -1,0 +1,348 @@
+import { useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link2, Loader2, RefreshCw, Unplug } from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  disconnectMyIdentity,
+  getAdminPlugins,
+  getMyIdentities,
+  refreshMyIdentity,
+  startMyIdentity,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type {
+  AdminPluginsResponse,
+  IdentityConnectionResponse,
+  IdentityConnectionStatus,
+  InstalledPlugin,
+} from '@/types'
+
+interface ConnectionActionsProps {
+  connection: IdentityConnectionResponse | null
+  onConnect: () => void
+  onDisconnect: () => void
+  onRefresh: () => void
+  pending: boolean
+}
+
+interface ConnectionRow {
+  connection: IdentityConnectionResponse | null
+  plugin: InstalledPlugin
+}
+
+const STATUS_LABEL: Record<'not_connected' | IdentityConnectionStatus, string> =
+  {
+    active: 'Connected',
+    expired: 'Expired',
+    not_connected: 'Not connected',
+    revoked: 'Revoked',
+  }
+
+const STATUS_VARIANT: Record<
+  'not_connected' | IdentityConnectionStatus,
+  'default' | 'destructive' | 'outline' | 'secondary'
+> = {
+  active: 'default',
+  expired: 'destructive',
+  not_connected: 'outline',
+  revoked: 'secondary',
+}
+
+export function SettingsConnections() {
+  const queryClient = useQueryClient()
+  const [pendingDisconnectId, setPendingDisconnectId] = useState<null | string>(
+    null,
+  )
+
+  const pluginsQuery = useQuery<AdminPluginsResponse>({
+    queryFn: ({ signal }) => getAdminPlugins(signal),
+    queryKey: ['admin-plugins'],
+    staleTime: 60 * 1000,
+  })
+
+  const connectionsQuery = useQuery<IdentityConnectionResponse[]>({
+    queryFn: ({ signal }) => getMyIdentities(signal),
+    queryKey: ['me-identities'],
+    staleTime: 30 * 1000,
+  })
+
+  const startMutation = useMutation({
+    mutationFn: (pluginId: string) =>
+      startMyIdentity(pluginId, {
+        return_to: '/settings/connections',
+      }),
+    onError: (err) => {
+      toast.error(
+        extractApiErrorDetail(err) ?? 'Failed to start the connect flow',
+      )
+    },
+    onSuccess: (data) => {
+      // Device-flow plugins (AWS IAM IC) return a polling descriptor
+      // alongside the URL.  Phase 1 just opens the URL in a new tab and
+      // tells the user to complete the flow there; the polling
+      // descriptor will be wired into a modal in a follow-up.
+      if (data.polling) {
+        toast.info(`Enter code ${data.polling.user_code} on the AWS page`)
+      }
+      window.open(data.authorization_url, '_blank', 'noopener,noreferrer')
+    },
+  })
+
+  const refreshMutation = useMutation({
+    mutationFn: (pluginId: string) => refreshMyIdentity(pluginId),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to refresh connection')
+    },
+    onSuccess: () => {
+      toast.success('Connection refreshed')
+      void queryClient.invalidateQueries({
+        queryKey: ['me-identities'],
+      })
+    },
+  })
+
+  const disconnectMutation = useMutation({
+    mutationFn: (pluginId: string) => disconnectMyIdentity(pluginId),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to disconnect')
+    },
+    onSuccess: () => {
+      toast.success('Disconnected')
+      setPendingDisconnectId(null)
+      void queryClient.invalidateQueries({
+        queryKey: ['me-identities'],
+      })
+    },
+  })
+
+  if (pluginsQuery.isLoading || connectionsQuery.isLoading) {
+    return <LoadingState label="Loading connections..." />
+  }
+
+  if (pluginsQuery.isError) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-destructive">
+          {extractApiErrorDetail(pluginsQuery.error) ??
+            'Failed to load plugins'}
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const identityPlugins = (pluginsQuery.data?.installed ?? []).filter(
+    (p) => p.enabled && p.plugin_type === 'identity',
+  )
+
+  if (identityPlugins.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <Link2 className="mx-auto mb-3 h-8 w-8 text-secondary" />
+          <h2 className="mb-1 text-base font-medium text-primary">
+            No identity providers
+          </h2>
+          <p className="text-sm text-secondary">
+            Ask your administrator to enable an identity plugin (OIDC, GitHub,
+            AWS IAM Identity Center) to connect your accounts.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const connectionsByPluginId = new Map<string, IdentityConnectionResponse>()
+  for (const c of connectionsQuery.data ?? []) {
+    connectionsByPluginId.set(c.plugin_id, c)
+  }
+
+  // Phase 1: a Plugin row's id isn't surfaced on the admin/plugins
+  // catalog (which is keyed on slug), so the table dispatches connect by
+  // *slug* as a stand-in.  The host's start endpoint accepts either the
+  // node id or the slug; the latter is unambiguous when only one Plugin
+  // exists per slug, which matches the Phase-1 catalog.
+  const rows: ConnectionRow[] = identityPlugins.map((plugin) => ({
+    connection: connectionsByPluginId.get(plugin.slug) ?? null,
+    plugin,
+  }))
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-base font-medium text-primary">
+          Third-party connections
+        </h2>
+        <p className="mt-1 text-sm text-secondary">
+          Connect your account to identity providers so Imbi can run AWS,
+          GitHub, and OIDC operations as you instead of a shared service
+          principal.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Provider</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Last used</TableHead>
+                <TableHead>Scopes</TableHead>
+                <TableHead className="w-48 text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map(({ connection, plugin }) => {
+                const status: 'not_connected' | IdentityConnectionStatus =
+                  connection?.status ?? 'not_connected'
+                return (
+                  <TableRow key={plugin.slug}>
+                    <TableCell>
+                      <div className="font-medium">{plugin.name}</div>
+                      {plugin.description && (
+                        <div className="text-xs text-secondary">
+                          {plugin.description}
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={STATUS_VARIANT[status]}>
+                        {STATUS_LABEL[status]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-secondary">
+                      {formatRelative(connection?.last_used_at ?? null)}
+                    </TableCell>
+                    <TableCell className="max-w-[260px] truncate text-xs text-secondary">
+                      {connection?.scopes?.length
+                        ? connection.scopes.join(', ')
+                        : '—'}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <ConnectionActions
+                        connection={connection}
+                        onConnect={() => startMutation.mutate(plugin.slug)}
+                        onDisconnect={() => setPendingDisconnectId(plugin.slug)}
+                        onRefresh={() => refreshMutation.mutate(plugin.slug)}
+                        pending={
+                          startMutation.isPending ||
+                          refreshMutation.isPending ||
+                          disconnectMutation.isPending
+                        }
+                      />
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        confirmLabel="Disconnect"
+        description="Disconnecting revokes the connection at the provider when possible and removes it from Imbi. You'll need to reconnect to use this provider again."
+        onCancel={() => setPendingDisconnectId(null)}
+        onConfirm={() => {
+          if (pendingDisconnectId) {
+            disconnectMutation.mutate(pendingDisconnectId)
+          }
+        }}
+        open={pendingDisconnectId !== null}
+        title="Disconnect provider?"
+      />
+    </div>
+  )
+}
+
+function ConnectionActions({
+  connection,
+  onConnect,
+  onDisconnect,
+  onRefresh,
+  pending,
+}: ConnectionActionsProps) {
+  if (!connection) {
+    return (
+      <Button
+        disabled={pending}
+        onClick={onConnect}
+        size="sm"
+        variant="outline"
+      >
+        {pending ? (
+          <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+        ) : (
+          <Link2 className="mr-1 h-3 w-3" />
+        )}
+        Connect
+      </Button>
+    )
+  }
+  if (connection.status === 'active') {
+    return (
+      <div className="flex justify-end gap-2">
+        <Button
+          disabled={pending}
+          onClick={onRefresh}
+          size="sm"
+          variant="ghost"
+        >
+          <RefreshCw className="mr-1 h-3 w-3" />
+          Refresh
+        </Button>
+        <Button
+          disabled={pending}
+          onClick={onDisconnect}
+          size="sm"
+          variant="outline"
+        >
+          <Unplug className="mr-1 h-3 w-3" />
+          Disconnect
+        </Button>
+      </div>
+    )
+  }
+  return (
+    <div className="flex justify-end gap-2">
+      <Button
+        disabled={pending}
+        onClick={onConnect}
+        size="sm"
+        variant="outline"
+      >
+        Reconnect
+      </Button>
+      <Button
+        disabled={pending}
+        onClick={onDisconnect}
+        size="sm"
+        variant="ghost"
+      >
+        Forget
+      </Button>
+    </div>
+  )
+}
+
+function formatRelative(value: null | string): string {
+  if (!value) return '—'
+  const ts = new Date(value)
+  if (Number.isNaN(ts.getTime())) return '—'
+  return ts.toLocaleString()
+}

--- a/src/components/settings/SettingsConnections.tsx
+++ b/src/components/settings/SettingsConnections.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link2, Loader2, RefreshCw, Unplug } from 'lucide-react'
@@ -65,6 +65,10 @@ const STATUS_VARIANT: Record<
 
 export function SettingsConnections() {
   const queryClient = useQueryClient()
+  // Pre-opened during the click handler so the popup-blocker accepts it as
+  // a user-gesture window; the URL is assigned once the start mutation
+  // resolves.  See the comment on `onConnect` below.
+  const pendingAuthWindowRef = useRef<null | Window>(null)
   const [pendingDisconnectId, setPendingDisconnectId] = useState<null | string>(
     null,
   )
@@ -87,6 +91,8 @@ export function SettingsConnections() {
         return_to: '/settings/connections',
       }),
     onError: (err) => {
+      pendingAuthWindowRef.current?.close()
+      pendingAuthWindowRef.current = null
       toast.error(
         extractApiErrorDetail(err) ?? 'Failed to start the connect flow',
       )
@@ -99,7 +105,13 @@ export function SettingsConnections() {
       if (data.polling) {
         toast.info(`Enter code ${data.polling.user_code} on the AWS page`)
       }
-      window.open(data.authorization_url, '_blank', 'noopener,noreferrer')
+      const authWindow = pendingAuthWindowRef.current
+      pendingAuthWindowRef.current = null
+      if (authWindow) {
+        authWindow.location.assign(data.authorization_url)
+      } else {
+        toast.error('Popup blocked. Please allow popups and try again.')
+      }
     },
   })
 
@@ -247,7 +259,18 @@ export function SettingsConnections() {
                     <TableCell className="text-right">
                       <ConnectionActions
                         connection={connection}
-                        onConnect={() => startMutation.mutate(plugin.slug)}
+                        onConnect={() => {
+                          // Open the auth tab synchronously inside the
+                          // click handler so the browser treats it as a
+                          // user-initiated popup; the URL is filled in
+                          // once startMutation.onSuccess fires.
+                          pendingAuthWindowRef.current = window.open(
+                            '',
+                            '_blank',
+                            'noopener,noreferrer',
+                          )
+                          startMutation.mutate(plugin.slug)
+                        }}
                         onDisconnect={() => setPendingDisconnectId(plugin.slug)}
                         onRefresh={() => refreshMutation.mutate(plugin.slug)}
                         pending={

--- a/src/components/settings/SettingsConnections.tsx
+++ b/src/components/settings/SettingsConnections.tsx
@@ -145,6 +145,17 @@ export function SettingsConnections() {
     )
   }
 
+  if (connectionsQuery.isError) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-destructive">
+          {extractApiErrorDetail(connectionsQuery.error) ??
+            'Failed to load connections'}
+        </CardContent>
+      </Card>
+    )
+  }
+
   const identityPlugins = (pluginsQuery.data?.installed ?? []).filter(
     (p) => p.enabled && p.plugin_type === 'identity',
   )
@@ -166,18 +177,18 @@ export function SettingsConnections() {
     )
   }
 
-  const connectionsByPluginId = new Map<string, IdentityConnectionResponse>()
+  // Phase 1: a Plugin row's id isn't surfaced on the admin/plugins
+  // catalog (which is keyed on slug), so we join connections to plugins
+  // by slug.  The host's start endpoint accepts either the node id or
+  // the slug; the latter is unambiguous when only one Plugin exists per
+  // slug, which matches the Phase-1 catalog.
+  const connectionsByPluginSlug = new Map<string, IdentityConnectionResponse>()
   for (const c of connectionsQuery.data ?? []) {
-    connectionsByPluginId.set(c.plugin_id, c)
+    connectionsByPluginSlug.set(c.plugin_slug, c)
   }
 
-  // Phase 1: a Plugin row's id isn't surfaced on the admin/plugins
-  // catalog (which is keyed on slug), so the table dispatches connect by
-  // *slug* as a stand-in.  The host's start endpoint accepts either the
-  // node id or the slug; the latter is unambiguous when only one Plugin
-  // exists per slug, which matches the Phase-1 catalog.
   const rows: ConnectionRow[] = identityPlugins.map((plugin) => ({
-    connection: connectionsByPluginId.get(plugin.slug) ?? null,
+    connection: connectionsByPluginSlug.get(plugin.slug) ?? null,
     plugin,
   }))
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -337,18 +337,60 @@ export type DeploymentStatus =
   | 'pending'
   | 'rolled_back'
   | 'success'
+export interface IdentityConnectionResponse {
+  connects_users_to: null | string
+  expires_at: null | string
+  id: string
+  last_used_at: null | string
+  metadata: Record<string, unknown>
+  plugin_id: string
+  plugin_label: null | string
+  plugin_slug: string
+  scopes: string[]
+  status: IdentityConnectionStatus
+  subject: string
+}
+
+export interface IdentityConnectionStartRequest {
+  return_to?: null | string
+  scopes?: null | string[]
+}
+
+export interface IdentityConnectionStartResponse {
+  authorization_url: string
+  polling: IdentityPollingDescriptor | null
+  state: string
+}
+
+export type IdentityConnectionStatus = 'active' | 'expired' | 'revoked'
+
+export interface IdentityPollingDescriptor {
+  expires_in: number
+  interval: number
+  user_code: string
+  verification_uri: string
+  verification_uri_complete: null | string
+}
+
 export interface InstalledPlugin {
   api_version: number
-  auth_type: 'api_token' | 'oauth2'
+  auth_type: 'api_token' | 'aws-iam-ic' | 'oauth2' | 'oidc'
   cacheable: boolean
   credentials: PluginCredentialField[]
   description: string
   docs_url: null | string
   enabled: boolean
+  // login_capable / requires_identity ride along on the manifest. The
+  // legacy Phase-1 catalog plugins (ssm, logzio) leave them at false;
+  // the Phase-2 identity plugins (oidc, github*, aws-iam-ic) set
+  // login_capable=true.
+  login_capable?: boolean
   name: string
   options: PluginOptionDef[]
   package_name: string
   package_version: string
+  plugin_type?: 'identity' | PluginTab
+  requires_identity?: boolean
   slug: string
   supported_tabs: PluginTab[]
 }


### PR DESCRIPTION
## Summary

User-facing slice of [docs/identity-plugin-implementation-plan.md §10](https://github.com/AWeber-Imbi/imbi/blob/main/docs/identity-plugin-implementation-plan.md). Adds a new **Connections** tab to \`/settings\` backed by the \`/me/identities/*\` endpoints landed in AWeber-Imbi/imbi-api#265.

### What ships

- New types: \`IdentityConnectionResponse\`, \`IdentityConnectionStartRequest\`, \`IdentityConnectionStartResponse\`, \`IdentityPollingDescriptor\`, \`IdentityConnectionStatus\` matching the backend contract.
- API endpoints in \`src/api\`: \`getMyIdentities\`, \`startMyIdentity\`, \`refreshMyIdentity\`, \`disconnectMyIdentity\`.
- \`InstalledPlugin\` widened with optional \`plugin_type\` / \`login_capable\` / \`requires_identity\` and the new \`auth_type\` literals (\`oidc\`, \`aws-iam-ic\`).
- New \`SettingsConnections\` component:
  - Filters \`/admin/plugins\` to identity plugins that are enabled.
  - Joins per-plugin against \`/me/identities\` so each row shows status (Connected / Expired / Revoked / Not connected), last-used, scopes, and a per-row action.
  - **Connect** opens the authorization URL in a new tab. Device-flow plugins (AWS IAM IC) get a toast with the user code; the polling descriptor will be wired into a modal in a follow-up.
  - **Refresh** and **Disconnect** call the corresponding endpoints; mutations invalidate the connections query.
  - Disconnect routes through \`ConfirmDialog\`.
- \`Settings.tsx\` grows a **Connections** sidebar entry between Account and Integrations.
- **Admin → Plugins** gains a **Type** column (\`configuration\` / \`logs\` / \`identity\`) and renders a \"Login provider\" badge under the plugin name when the manifest sets \`login_capable=true\`.

### Deferred

- Inline 401 \`identity_required\` handling on the project Logs / Configuration tabs (those tabs aren't in this codebase yet).
- Merged Login Providers admin source view — needs admin endpoints work.
- Auto-CRUD \`AwsAccount\` admin page — the host's auto-mounted \`/admin/plugins/{plugin_id}/entities/{vlabel}\` router doesn't exist yet either.

### Test plan

- [ ] \`npm run lint\` clean
- [ ] \`npm run format:check\` clean
- [ ] \`npx tsc --noEmit\` clean
- [ ] \`npm run build\` succeeds
- [ ] Smoke: bring up the API with the imbi-plugin-oidc identity plugin enabled, navigate to \`/settings/connections\`, click Connect, verify the authorization URL opens. After completing the flow on the IdP, return to the page and confirm the row reads \`Connected\`.