### PR TITLE
Plugin abstraction follow-ups: bulk edges, query keys, paste UX

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -2079,3 +2079,15 @@ export const deleteEnvironmentEdge = (
   envSlug: string,
   relType: string,
 ) => apiClient.delete<void>(environmentEdgesPath(orgSlug, envSlug, relType))
+
+export const listPluginEdgesByOrg = (
+  pluginSlug: string,
+  relType: string,
+  orgSlug: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<Record<string, PluginEdge[]>>(
+    `/admin/plugins/${encodeURIComponent(pluginSlug)}/edges`,
+    { org_slug: orgSlug, rel_type: relType },
+    signal,
+  )

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -26,6 +26,7 @@ import { getAdminPlugins, getMyIdentities, getProjects } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useRecentDeployments } from '@/hooks/useRecentDeployments'
+import { queryKeys } from '@/lib/queryKeys'
 import type { AdminPluginsResponse, IdentityConnectionResponse } from '@/types'
 
 import { MyPullRequestsWidget } from './dashboard/widgets/MyPullRequestsWidget'
@@ -171,7 +172,7 @@ export function Dashboard({
   // becomes active.
   const pluginsQuery = useQuery<AdminPluginsResponse>({
     queryFn: ({ signal }) => getAdminPlugins(signal),
-    queryKey: ['admin-plugins'],
+    queryKey: queryKeys.adminPlugins(),
     staleTime: 60 * 1000,
   })
   const identitiesQuery = useQuery<IdentityConnectionResponse[]>({

--- a/src/components/admin/AnchorEdgesCard.tsx
+++ b/src/components/admin/AnchorEdgesCard.tsx
@@ -12,15 +12,19 @@ import {
 } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
 import { extractApiErrorDetail } from '@/lib/apiError'
-import type { PluginEdge, PluginEdgeLabel, PluginEntity } from '@/types'
+import {
+  findOrCreatePluginEntityByKey,
+  naturalKeyField,
+} from '@/lib/plugin-entities'
+import { queryKeys } from '@/lib/queryKeys'
+import type {
+  InstalledPlugin,
+  PluginEdge,
+  PluginEdgeLabel,
+  PluginEntity,
+} from '@/types'
 
 // Only ``environment`` anchors are wired up today; widen the union when
 // projects/project-types/orgs gain edge endpoints.
@@ -31,6 +35,7 @@ interface AnchorEdgesCardProps {
   anchorKind: AnchorKind
   edge: PluginEdgeLabel
   entityPluginSlug: string
+  manifest: InstalledPlugin
   title?: string
 }
 
@@ -55,17 +60,22 @@ export function AnchorEdgesCard({
   anchorKind,
   edge,
   entityPluginSlug,
+  manifest,
   title,
 }: AnchorEdgesCardProps) {
   const queryClient = useQueryClient()
   const targetLabel = edge.to_labels[0]
-  const edgesKey = [
-    'anchor-edges',
+  const targetVlabel = manifest.vertex_labels?.find(
+    (v) => v.name === targetLabel,
+  )
+  const targetDisplay = targetVlabel?.display_name || targetLabel
+  const naturalKey = naturalKeyField(targetVlabel)
+  const edgesKey = queryKeys.anchorEdges(
     anchorKind,
     anchor.orgSlug,
     anchor.slug,
     edge.name,
-  ]
+  )
 
   const edgesQuery = useQuery<PluginEdge[]>({
     queryFn: ({ signal }) =>
@@ -77,24 +87,41 @@ export function AnchorEdgesCard({
   const targetsQuery = useQuery<PluginEntity[]>({
     queryFn: ({ signal }) =>
       listPluginEntities(entityPluginSlug, targetLabel, signal),
-    queryKey: ['plugin-entities', entityPluginSlug, targetLabel],
+    queryKey: queryKeys.pluginEntities(entityPluginSlug, targetLabel),
     staleTime: 30 * 1000,
   })
 
-  const [pendingId, setPendingId] = useState<null | string>(null)
+  const [draft, setDraft] = useState<null | string>(null)
 
   const setMutation = useMutation({
-    mutationFn: (targetId: string) =>
-      setEnvironmentEdge(anchor.orgSlug, anchor.slug, edge.name, {
-        target_id: targetId,
+    mutationFn: async (pasted: string) => {
+      if (!naturalKey) {
+        throw new Error(
+          `Plugin ${manifest.slug} declared no unique key for ${targetLabel}; ` +
+            `cannot resolve "${pasted}".`,
+        )
+      }
+      const target = await findOrCreatePluginEntityByKey({
+        existing: targetsQuery.data,
+        keyField: naturalKey,
+        label: targetLabel,
+        pluginSlug: entityPluginSlug,
+        value: pasted,
+      })
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.pluginEntities(entityPluginSlug, targetLabel),
+      })
+      return setEnvironmentEdge(anchor.orgSlug, anchor.slug, edge.name, {
+        target_id: target.id,
         target_label: targetLabel,
-      }),
+      })
+    },
     onError: (err) => {
       toast.error(extractApiErrorDetail(err) ?? 'Failed to set mapping')
     },
     onSuccess: () => {
       toast.success(`${edge.name} edge saved`)
-      setPendingId(null)
+      setDraft(null)
       void queryClient.invalidateQueries({ queryKey: edgesKey })
     },
   })
@@ -111,16 +138,20 @@ export function AnchorEdgesCard({
     },
   })
 
-  const targets = targetsQuery.data ?? []
   const current = edgesQuery.data?.[0] ?? null
   const submitting = setMutation.isPending || deleteMutation.isPending
+  const currentTargetKey = naturalKey ? current?.target[naturalKey] : undefined
+  const currentKey =
+    typeof currentTargetKey === 'string' ? currentTargetKey : ''
+  const inputValue = draft ?? currentKey
+  const dirty = inputValue !== currentKey
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{title ?? `${edge.name} → ${targetLabel}`}</CardTitle>
+        <CardTitle>{title ?? `${edge.name} → ${targetDisplay}`}</CardTitle>
         <p className="mt-1 text-sm text-secondary">
-          Map this {anchorKind} to a {targetLabel} via the{' '}
+          Map this {anchorKind} to a {targetDisplay} via the{' '}
           <code className="text-xs">{edge.name}</code> edge.
         </p>
       </CardHeader>
@@ -151,49 +182,27 @@ export function AnchorEdgesCard({
           </div>
         ) : (
           <div className="text-sm text-secondary">
-            Not mapped to any {targetLabel} yet.
+            Not mapped to any {targetDisplay} yet.
           </div>
         )}
 
-        {targets.length === 0 ? (
-          <p className="text-sm text-tertiary">
-            No {targetLabel} records have been registered.
-          </p>
-        ) : (
-          <div className="flex items-center gap-3">
-            <Select
-              onValueChange={(value) => setPendingId(value)}
-              value={pendingId ?? current?.target.id ?? ''}
-            >
-              <SelectTrigger className="w-[300px]">
-                <SelectValue placeholder={`Choose a ${targetLabel}…`} />
-              </SelectTrigger>
-              <SelectContent>
-                {targets.map((target) => (
-                  <SelectItem key={target.id} value={target.id}>
-                    {labelEntityName(target)}
-                    {labelEntitySubtitle(target)
-                      ? ` (${labelEntitySubtitle(target)})`
-                      : ''}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button
-              disabled={
-                submitting ||
-                pendingId === null ||
-                pendingId === current?.target.id
-              }
-              onClick={() => {
-                if (pendingId) setMutation.mutate(pendingId)
-              }}
-              size="sm"
-            >
-              {current ? 'Change' : `Map ${targetLabel}`}
-            </Button>
-          </div>
-        )}
+        <div className="flex items-center gap-3">
+          <Input
+            className="w-[300px]"
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={
+              naturalKey ? `Paste ${naturalKey}` : `Paste ${targetDisplay}`
+            }
+            value={inputValue}
+          />
+          <Button
+            disabled={submitting || !dirty || inputValue.trim() === ''}
+            onClick={() => setMutation.mutate(inputValue.trim())}
+            size="sm"
+          >
+            {current ? 'Change' : `Map ${targetDisplay}`}
+          </Button>
+        </div>
       </CardContent>
     </Card>
   )

--- a/src/components/admin/PluginEntityManagement.tsx
+++ b/src/components/admin/PluginEntityManagement.tsx
@@ -94,7 +94,7 @@ export function PluginEntityManagement({
     [pluginSlug, label],
   )
   const schemaKey = useMemo(
-    () => ['plugin-entity-schema', pluginSlug, label],
+    () => queryKeys.pluginEntitySchema(pluginSlug, label),
     [pluginSlug, label],
   )
 

--- a/src/components/admin/PluginEntityManagement.tsx
+++ b/src/components/admin/PluginEntityManagement.tsx
@@ -36,6 +36,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { queryKeys } from '@/lib/queryKeys'
 import type {
   PluginEntity,
   PluginEntitySchema,
@@ -89,7 +90,7 @@ export function PluginEntityManagement({
   const queryClient = useQueryClient()
   const label = vertexLabel.name
   const queryKey = useMemo(
-    () => ['plugin-entities', pluginSlug, label],
+    () => queryKeys.pluginEntities(pluginSlug, label),
     [pluginSlug, label],
   )
   const schemaKey = useMemo(

--- a/src/components/admin/PluginPackageDetail.tsx
+++ b/src/components/admin/PluginPackageDetail.tsx
@@ -23,6 +23,7 @@ import { Input } from '@/components/ui/input'
 import { LoadingState } from '@/components/ui/loading-state'
 import { Textarea } from '@/components/ui/textarea'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { queryKeys } from '@/lib/queryKeys'
 import type { InstalledPlugin, PluginVertexLabel } from '@/types'
 
 import { PluginEntityManagement } from './PluginEntityManagement'
@@ -68,7 +69,7 @@ export function PluginPackageDetail({
 
   const pluginQuery = useQuery<InstalledPlugin>({
     queryFn: ({ signal }) => getAdminPlugin(slug, signal),
-    queryKey: ['admin-plugin', slug],
+    queryKey: queryKeys.adminPlugin(slug),
     staleTime: 30 * 1000,
   })
 
@@ -131,8 +132,10 @@ export function PluginPackageDetail({
     },
     onSuccess: (data) => {
       toast.success('Saved')
-      queryClient.setQueryData(['admin-plugin', slug], data)
-      void queryClient.invalidateQueries({ queryKey: ['admin-plugins'] })
+      queryClient.setQueryData(queryKeys.adminPlugin(slug), data)
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.adminPlugins(),
+      })
     },
   })
 

--- a/src/components/admin/PluginsManagement.tsx
+++ b/src/components/admin/PluginsManagement.tsx
@@ -26,6 +26,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { queryKeys } from '@/lib/queryKeys'
 import type { AdminPluginsResponse, InstalledPlugin } from '@/types'
 
 type ActiveTab = 'disabled' | 'enabled'
@@ -52,7 +53,7 @@ export function PluginsManagement() {
 
   const { data, error, isError, isLoading } = useQuery<AdminPluginsResponse>({
     queryFn: ({ signal }) => getAdminPlugins(signal),
-    queryKey: ['admin-plugins'],
+    queryKey: queryKeys.adminPlugins(),
     staleTime: 60 * 1000,
   })
 
@@ -114,7 +115,9 @@ function DisabledList({ parentLoading, plugins }: DisabledListProps) {
     },
     onSuccess: (_, slug) => {
       toast.success(`${slug} enabled`)
-      void queryClient.invalidateQueries({ queryKey: ['admin-plugins'] })
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.adminPlugins(),
+      })
     },
   })
 

--- a/src/components/admin/environments/EnvironmentDetail.tsx
+++ b/src/components/admin/environments/EnvironmentDetail.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
 import { EntityIcon } from '@/components/ui/entity-icon'
 import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
+import { queryKeys } from '@/lib/queryKeys'
 import { extractDynamicFields } from '@/lib/utils'
 import type { Environment, InstalledPlugin } from '@/types'
 
@@ -29,7 +30,7 @@ export function EnvironmentDetail({
   })
   const { data: pluginsResponse } = useQuery({
     queryFn: ({ signal }) => getAdminPlugins(signal),
-    queryKey: ['admin-plugins'],
+    queryKey: queryKeys.adminPlugins(),
     staleTime: 60 * 1000,
   })
 
@@ -143,6 +144,7 @@ export function EnvironmentDetail({
           edge={edge}
           entityPluginSlug={plugin.slug}
           key={`${plugin.slug}:${edge.name}`}
+          manifest={plugin}
           title={`${plugin.name}: ${edge.name}`}
         />
       ))}

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -41,6 +41,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { queryKeys } from '@/lib/queryKeys'
 import type {
   InstalledPlugin,
   PluginAssignmentInput,
@@ -122,7 +123,7 @@ export function ServicePluginConfiguration({
 
   const { data: manifest, isLoading: manifestLoading } = useQuery({
     queryFn: ({ signal }) => getAdminPlugin(plugin.plugin_slug, signal),
-    queryKey: ['admin-plugin', plugin.plugin_slug],
+    queryKey: queryKeys.adminPlugin(plugin.plugin_slug),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/admin/third-party-services/ServicePluginEdgesCard.tsx
+++ b/src/components/admin/third-party-services/ServicePluginEdgesCard.tsx
@@ -1,17 +1,11 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 
-import {
-  useMutation,
-  useQueries,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import {
-  createPluginEntity,
-  listEnvironmentEdges,
   listEnvironments,
+  listPluginEdgesByOrg,
   listPluginEntities,
   setEnvironmentEdge,
 } from '@/api/endpoints'
@@ -33,13 +27,17 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import {
+  findOrCreatePluginEntityByKey,
+  naturalKeyField,
+} from '@/lib/plugin-entities'
+import { queryKeys } from '@/lib/queryKeys'
 import type {
   Environment,
   InstalledPlugin,
   PluginEdge,
   PluginEdgeLabel,
   PluginEntity,
-  PluginVertexLabel,
 } from '@/types'
 
 interface EnvironmentEdgeTableProps {
@@ -112,31 +110,19 @@ function EnvironmentEdgeTable({
   const targetsQuery = useQuery<PluginEntity[]>({
     queryFn: ({ signal }) =>
       listPluginEntities(entityPluginSlug, targetLabel, signal),
-    queryKey: ['plugin-entities', entityPluginSlug, targetLabel],
+    queryKey: queryKeys.pluginEntities(entityPluginSlug, targetLabel),
     staleTime: 30 * 1000,
   })
 
   const environments = environmentsQuery.data ?? []
-  const edgeQueries = useQueries({
-    queries: environments.map((env) => ({
-      queryFn: ({ signal }: { signal?: AbortSignal }) =>
-        listEnvironmentEdges(orgSlug, env.slug, edge.name, signal),
-      queryKey: ['anchor-edges', 'environment', orgSlug, env.slug, edge.name],
-      staleTime: 30 * 1000,
-    })),
+  const edgesByEnvQuery = useQuery<Record<string, PluginEdge[]>>({
+    queryFn: ({ signal }) =>
+      listPluginEdgesByOrg(entityPluginSlug, edge.name, orgSlug, signal),
+    queryKey: queryKeys.pluginEdgesByOrg(entityPluginSlug, edge.name, orgSlug),
+    staleTime: 30 * 1000,
   })
 
   const [pendingValue, setPendingValue] = useState<Record<string, string>>({})
-
-  const targetsByKey = useMemo(() => {
-    const map = new Map<string, PluginEntity>()
-    if (!naturalKey) return map
-    for (const t of targetsQuery.data ?? []) {
-      const k = t[naturalKey]
-      if (typeof k === 'string') map.set(k, t)
-    }
-    return map
-  }, [naturalKey, targetsQuery.data])
 
   const mapMutation = useMutation({
     mutationFn: async ({
@@ -152,22 +138,16 @@ function EnvironmentEdgeTable({
             `cannot resolve "${pasted}".`,
         )
       }
-      let target = targetsByKey.get(pasted)
-      if (!target) {
-        const body: Record<string, unknown> = { name: pasted }
-        body[naturalKey] = pasted
-        try {
-          target = await createPluginEntity(entityPluginSlug, targetLabel, body)
-        } catch (err) {
-          // Race with a concurrent create; resolve via a fresh list.
-          const fresh = await listPluginEntities(entityPluginSlug, targetLabel)
-          target = fresh.find((t) => t[naturalKey] === pasted)
-          if (!target) throw err
-        }
-        await queryClient.invalidateQueries({
-          queryKey: ['plugin-entities', entityPluginSlug, targetLabel],
-        })
-      }
+      const target = await findOrCreatePluginEntityByKey({
+        existing: targetsQuery.data,
+        keyField: naturalKey,
+        label: targetLabel,
+        pluginSlug: entityPluginSlug,
+        value: pasted,
+      })
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.pluginEntities(entityPluginSlug, targetLabel),
+      })
       return setEnvironmentEdge(orgSlug, envSlug, edge.name, {
         target_id: target.id,
         target_label: targetLabel,
@@ -184,7 +164,19 @@ function EnvironmentEdgeTable({
         return next
       })
       void queryClient.invalidateQueries({
-        queryKey: ['anchor-edges', 'environment', orgSlug, envSlug, edge.name],
+        queryKey: queryKeys.pluginEdgesByOrg(
+          entityPluginSlug,
+          edge.name,
+          orgSlug,
+        ),
+      })
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.anchorEdges(
+          'environment',
+          orgSlug,
+          envSlug,
+          edge.name,
+        ),
       })
     },
   })
@@ -217,8 +209,8 @@ function EnvironmentEdgeTable({
                 </TableCell>
               </TableRow>
             ) : (
-              environments.map((env, i) => {
-                const edges: PluginEdge[] | undefined = edgeQueries[i]?.data
+              environments.map((env) => {
+                const edges = edgesByEnvQuery.data?.[env.slug]
                 const current = edges?.[0] ?? null
                 const currentTargetKey = naturalKey
                   ? current?.target[naturalKey]
@@ -275,12 +267,4 @@ function EnvironmentEdgeTable({
       </div>
     </div>
   )
-}
-
-// First single-field unique index is the operator-facing natural key.
-function naturalKeyField(vlabel: PluginVertexLabel | undefined): null | string {
-  for (const idx of vlabel?.indexes ?? []) {
-    if (idx.unique && idx.fields.length === 1) return idx.fields[0]
-  }
-  return null
 }

--- a/src/components/admin/third-party-services/ServicePluginList.tsx
+++ b/src/components/admin/third-party-services/ServicePluginList.tsx
@@ -39,6 +39,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { queryKeys } from '@/lib/queryKeys'
 
 import { ServicePluginConfiguration } from './ServicePluginConfiguration'
 
@@ -83,7 +84,7 @@ export function ServicePluginList({
     isError: isAdminPluginsError,
   } = useQuery({
     queryFn: ({ signal }) => getAdminPlugins(signal),
-    queryKey: ['admin-plugins'],
+    queryKey: queryKeys.adminPlugins(),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/settings/SettingsConnections.tsx
+++ b/src/components/settings/SettingsConnections.tsx
@@ -29,6 +29,7 @@ import {
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { getIcon, iconRegistry, useIconRegistryVersion } from '@/lib/icons'
 import type { IconComponent } from '@/lib/icons'
+import { queryKeys } from '@/lib/queryKeys'
 import type {
   AdminPluginsResponse,
   IdentityConnectionResponse,
@@ -178,7 +179,7 @@ export function SettingsConnections() {
 
   const pluginsQuery = useQuery<AdminPluginsResponse>({
     queryFn: ({ signal }) => getAdminPlugins(signal),
-    queryKey: ['admin-plugins'],
+    queryKey: queryKeys.adminPlugins(),
     staleTime: 60 * 1000,
   })
 

--- a/src/lib/plugin-entities.ts
+++ b/src/lib/plugin-entities.ts
@@ -1,0 +1,53 @@
+import { createPluginEntity, listPluginEntities } from '@/api/endpoints'
+import type { PluginEntity, PluginVertexLabel } from '@/types'
+
+/**
+ * The first single-field unique index on a vertex label is the
+ * operator-facing natural key — the value users paste to identify an
+ * entity (e.g. an AWS account id).  Returns ``null`` if the label has
+ * no such index.
+ */
+export const naturalKeyField = (
+  vlabel: PluginVertexLabel | undefined,
+): null | string => {
+  for (const idx of vlabel?.indexes ?? []) {
+    if (idx.unique && idx.fields.length === 1) return idx.fields[0]
+  }
+  return null
+}
+
+/**
+ * Resolve a ``PluginEntity`` by its natural key, creating one with just
+ * the key field populated if no match exists.
+ *
+ * The lookup-or-create dance is shared by every paste-style edge
+ * editor: the user pastes a value, we want a target entity to link to,
+ * and we don't want to force a full creation dialog when the missing
+ * fields can be backfilled later via the entity admin.
+ *
+ * Race-safe: if a concurrent request creates the entity between our
+ * miss and our POST, we re-list and return the freshly-created row
+ * rather than surfacing the duplicate-key error.
+ */
+export async function findOrCreatePluginEntityByKey(args: {
+  existing?: PluginEntity[]
+  keyField: string
+  label: string
+  pluginSlug: string
+  value: string
+}): Promise<PluginEntity> {
+  const { existing, keyField, label, pluginSlug, value } = args
+  const found = (existing ?? []).find((t) => t[keyField] === value)
+  if (found) return found
+
+  const body: Record<string, unknown> = { name: value }
+  body[keyField] = value
+  try {
+    return await createPluginEntity(pluginSlug, label, body)
+  } catch (err) {
+    const fresh = await listPluginEntities(pluginSlug, label)
+    const racedTo = fresh.find((t) => t[keyField] === value)
+    if (racedTo) return racedTo
+    throw err
+  }
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,4 +1,25 @@
 /**
+ * Centralized React Query keys for plugin-related queries.
+ *
+ * Inline construction drifts: a typo in one invalidate site silently
+ * breaks the other.  Use these builders instead of literals.
+ */
+export const queryKeys = {
+  adminPlugin: (slug: string) => ['admin-plugin', slug] as const,
+  adminPlugins: () => ['admin-plugins'] as const,
+  anchorEdges: (
+    kind: string,
+    orgSlug: string,
+    anchorSlug: string,
+    relType: string,
+  ) => ['anchor-edges', kind, orgSlug, anchorSlug, relType] as const,
+  pluginEdgesByOrg: (pluginSlug: string, relType: string, orgSlug: string) =>
+    ['plugin-edges-by-org', pluginSlug, relType, orgSlug] as const,
+  pluginEntities: (slug: string, label: string) =>
+    ['plugin-entities', slug, label] as const,
+} as const
+
+/**
  * Map resource names (from the assistant's refresh_data tool)
  * to React Query keys for cache invalidation.
  */

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -17,6 +17,8 @@ export const queryKeys = {
     ['plugin-edges-by-org', pluginSlug, relType, orgSlug] as const,
   pluginEntities: (slug: string, label: string) =>
     ['plugin-entities', slug, label] as const,
+  pluginEntitySchema: (slug: string, label: string) =>
+    ['plugin-entity-schema', slug, label] as const,
 } as const
 
 /**


### PR DESCRIPTION
## Summary

Three follow-ups from `docs/plugin-abstraction-followups.md`, all wired together because they touch the same paste-style edge-editor surface.

### Bulk edges endpoint (§1)

`ServicePluginEdgesCard` now fetches every env→target edge for an org in **one** HTTP request via the new `GET /admin/plugins/{slug}/edges` endpoint (see imbi-api PR), replacing the `useQueries`-per-environment fan-out. An org with 12 envs goes from 12 requests on card mount to 1.

### Centralized plugin query keys (§6)

Eight call sites were constructing `['plugin-entities', …]` / `['admin-plugins']` / `['admin-plugin', slug]` / `['anchor-edges', …]` inline. A typo in any one would silently break invalidation on the others. Centralized in `lib/queryKeys.ts`:

\`\`\`ts
queryKeys.adminPlugin(slug)
queryKeys.adminPlugins()
queryKeys.anchorEdges(kind, orgSlug, anchorSlug, relType)
queryKeys.pluginEdgesByOrg(pluginSlug, relType, orgSlug)
queryKeys.pluginEntities(slug, label)
\`\`\`

### Paste UX consistency (§7 + §11)

Extracted `naturalKeyField` and `findOrCreatePluginEntityByKey` into `lib/plugin-entities.ts` (race-safe lookup-or-create — re-lists on duplicate-key error to find the racing creator's row).

`AnchorEdgesCard` switches from a `<Select>` over pre-existing entities to the same paste-text + auto-create flow that `ServicePluginEdgesCard` uses. Now both surfaces behave the same way: paste a natural key (e.g. AWS account ID), and if no entity matches we silently create one with just that field populated and link the edge. Missing fields can be filled in later via the entity admin.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `oxlint src` clean
- [x] `npm run build` succeeds
- [ ] Smoke: from `/admin/third-party-services/<slug>` paste an AWS account ID, confirm a single network request fires for the bulk edges fetch and the mapping persists
- [ ] Smoke: from an environment detail page (with an `imbi-plugin-aws` `MAPS_TO` edge) paste a fresh account ID and verify auto-create + map works