### PR TITLE
Multi-env logs + Identity Plugin selector for assignments

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -258,7 +258,18 @@ function buildUrl(url: string, params?: Record<string, unknown>): string {
   if (params) {
     const searchParams = new URLSearchParams()
     for (const [key, value] of Object.entries(params)) {
-      if (value !== undefined && value !== null) {
+      if (value === undefined || value === null) continue
+      // Arrays serialize as repeated query params (?k=a&k=b) so they
+      // map cleanly to FastAPI ``list[str]`` query params.  String(arr)
+      // would join with commas and produce a single key=a,b entry that
+      // every list-based endpoint mis-parses as one element.
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (item !== undefined && item !== null) {
+            searchParams.append(key, String(item))
+          }
+        }
+      } else {
         searchParams.set(key, String(value))
       }
     }

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1589,10 +1589,7 @@ export interface IdentityPluginRef {
   plugin_slug: string
 }
 
-export const listIdentityPlugins = (
-  orgSlug: string,
-  signal?: AbortSignal,
-) =>
+export const listIdentityPlugins = (orgSlug: string, signal?: AbortSignal) =>
   apiClient.get<IdentityPluginRef[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/identity-plugins/`,
     undefined,

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1582,6 +1582,23 @@ export const listCurrentReleases = async (
   return Array.isArray(response) ? response : []
 }
 
+// Identity Plugins (org-scoped)
+export interface IdentityPluginRef {
+  label: string
+  plugin_id: string
+  plugin_slug: string
+}
+
+export const listIdentityPlugins = (
+  orgSlug: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<IdentityPluginRef[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/identity-plugins/`,
+    undefined,
+    signal,
+  )
+
 // Service Plugins
 export const listServicePlugins = (
   orgSlug: string,
@@ -1719,7 +1736,7 @@ export const deleteConfigurationKey = (
 export interface LogSearchParams {
   cursor?: string
   end_time?: string
-  environment?: string
+  environment?: string | string[]
   filter?: string[]
   limit?: number
   source?: string
@@ -1732,7 +1749,7 @@ export const getProjectLogsHistogram = (
   params?: {
     bucket_count?: number
     end_time?: string
-    environment?: string
+    environment?: string | string[]
     filter?: string[]
     source?: string
     start_time?: string

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1765,7 +1765,7 @@ export const getProjectLogsHistogram = (
   }
   return apiClient.get<LogHistogramBucket[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/logs/histogram`,
-    query as Record<string, string>,
+    query,
     signal,
   )
 }
@@ -1788,7 +1788,7 @@ export const searchProjectLogs = (
   }
   return apiClient.get<LogResultResponse>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/logs/`,
-    query as Record<string, string>,
+    query,
     signal,
   )
 }

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1589,12 +1589,17 @@ export interface IdentityPluginRef {
   plugin_slug: string
 }
 
-export const listIdentityPlugins = (orgSlug: string, signal?: AbortSignal) =>
-  apiClient.get<IdentityPluginRef[]>(
+export const listIdentityPlugins = async (
+  orgSlug: string,
+  signal?: AbortSignal,
+): Promise<IdentityPluginRef[]> => {
+  const response = await apiClient.get<IdentityPluginRef[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/identity-plugins/`,
     undefined,
     signal,
   )
+  return Array.isArray(response) ? response : []
+}
 
 // Service Plugins
 export const listServicePlugins = (

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -864,9 +864,7 @@ function IdentityPluginSelect({
     value && identityPlugins.find((ip) => ip.plugin_id === value)?.label
   return (
     <Select
-      onValueChange={(v) =>
-        onChange(v === IDENTITY_NONE_VALUE ? null : v)
-      }
+      onValueChange={(v) => onChange(v === IDENTITY_NONE_VALUE ? null : v)}
       value={value ?? IDENTITY_NONE_VALUE}
     >
       <SelectTrigger>

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -7,6 +7,8 @@ import { toast } from 'sonner'
 import {
   getAdminPlugin,
   getServicePluginConfiguration,
+  type IdentityPluginRef,
+  listIdentityPlugins,
   listProjectTypes,
   listServicePluginAssignments,
   patchServicePluginConfiguration,
@@ -72,6 +74,7 @@ interface DefaultOptionsCardProps {
 
 interface DraftAssignment {
   default: boolean
+  identity_plugin_id: null | string
   options: Record<string, unknown>
   project_type_slug: string
   tab: PluginTab
@@ -573,6 +576,12 @@ function ProjectTypesCard({
     staleTime: 60 * 1000,
   })
 
+  const { data: identityPlugins } = useQuery({
+    queryFn: ({ signal }) => listIdentityPlugins(orgSlug, signal),
+    queryKey: queryKeys.identityPlugins(orgSlug),
+    staleTime: 60 * 1000,
+  })
+
   // Re-seed drafts whenever the server-returned list actually changes.
   // Tracking by hash avoids stomping a user's in-progress edits on a
   // stale refetch and avoids the seeded/refetch race after save.
@@ -583,6 +592,7 @@ function ProjectTypesCard({
     setDrafts(
       existing.map((a: PluginAssignmentRow) => ({
         default: a.default,
+        identity_plugin_id: a.identity_plugin_id ?? null,
         options: a.options,
         project_type_slug: a.project_type_slug,
         tab: a.tab,
@@ -624,6 +634,7 @@ function ProjectTypesCard({
   const isDirty = useMemo(() => {
     const baseline = (existing ?? []).map((a: PluginAssignmentRow) => ({
       default: a.default,
+      identity_plugin_id: a.identity_plugin_id ?? null,
       options: a.options,
       project_type_slug: a.project_type_slug,
       tab: a.tab,
@@ -640,6 +651,7 @@ function ProjectTypesCard({
       ...prev,
       {
         default: false,
+        identity_plugin_id: null,
         options: {},
         project_type_slug: remainingPts[0].slug,
         tab: supportedTab,
@@ -719,6 +731,7 @@ function ProjectTypesCard({
                 <TableHead>Project Type</TableHead>
                 <TableHead>Tab</TableHead>
                 <TableHead>Default</TableHead>
+                <TableHead>Identity Plugin</TableHead>
                 <TableHead>Option Overrides</TableHead>
                 <TableHead className="w-12" />
               </TableRow>
@@ -769,6 +782,15 @@ function ProjectTypesCard({
                           updateDraft(idx, { default: e.target.checked })
                         }
                         type="checkbox"
+                      />
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <IdentityPluginSelect
+                        identityPlugins={identityPlugins ?? []}
+                        onChange={(next) =>
+                          updateDraft(idx, { identity_plugin_id: next })
+                        }
+                        value={draft.identity_plugin_id ?? null}
                       />
                     </TableCell>
                     <TableCell className="align-top">
@@ -824,5 +846,42 @@ function ProjectTypesCard({
         )}
       </CardContent>
     </Card>
+  )
+}
+
+const IDENTITY_NONE_VALUE = '__none__'
+
+function IdentityPluginSelect({
+  identityPlugins,
+  onChange,
+  value,
+}: {
+  identityPlugins: IdentityPluginRef[]
+  onChange: (next: null | string) => void
+  value: null | string
+}) {
+  const selectedLabel =
+    value && identityPlugins.find((ip) => ip.plugin_id === value)?.label
+  return (
+    <Select
+      onValueChange={(v) =>
+        onChange(v === IDENTITY_NONE_VALUE ? null : v)
+      }
+      value={value ?? IDENTITY_NONE_VALUE}
+    >
+      <SelectTrigger>
+        <SelectValue placeholder="None">
+          {value ? (selectedLabel ?? value) : 'None'}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={IDENTITY_NONE_VALUE}>None</SelectItem>
+        {identityPlugins.map((ip) => (
+          <SelectItem key={ip.plugin_id} value={ip.plugin_id}>
+            {ip.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   )
 }

--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -303,7 +303,7 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
         {
           cursor: cursor ?? undefined,
           end_time: datetimes.end,
-          environment: envs.length === 1 ? envs[0] : undefined,
+          environment: envs.length > 0 ? envs : undefined,
           filter: apiFilters,
           limit: 100,
           source: activeSource,
@@ -422,7 +422,7 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
         {
           bucket_count: 60,
           end_time: datetimes.end,
-          environment: envs.length === 1 ? envs[0] : undefined,
+          environment: envs.length > 0 ? envs : undefined,
           filter: apiFilters,
           source: activeSource,
           start_time: datetimes.start,

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -13,8 +13,7 @@ export const queryKeys = {
     anchorSlug: string,
     relType: string,
   ) => ['anchor-edges', kind, orgSlug, anchorSlug, relType] as const,
-  identityPlugins: (orgSlug: string) =>
-    ['identity-plugins', orgSlug] as const,
+  identityPlugins: (orgSlug: string) => ['identity-plugins', orgSlug] as const,
   pluginEdgesByOrg: (pluginSlug: string, relType: string, orgSlug: string) =>
     ['plugin-edges-by-org', pluginSlug, relType, orgSlug] as const,
   pluginEntities: (slug: string, label: string) =>

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -13,6 +13,8 @@ export const queryKeys = {
     anchorSlug: string,
     relType: string,
   ) => ['anchor-edges', kind, orgSlug, anchorSlug, relType] as const,
+  identityPlugins: (orgSlug: string) =>
+    ['identity-plugins', orgSlug] as const,
   pluginEdgesByOrg: (pluginSlug: string, relType: string, orgSlug: string) =>
     ['plugin-edges-by-org', pluginSlug, relType, orgSlug] as const,
   pluginEntities: (slug: string, label: string) =>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -595,18 +595,21 @@ export type Permission = Schemas['Permission']
 
 export interface PluginAssignmentCreate {
   default: boolean
+  identity_plugin_id?: null | string
   options?: Record<string, unknown>
   plugin_id: string
   tab: PluginTab
 }
 export interface PluginAssignmentInput {
   default: boolean
+  identity_plugin_id?: null | string
   options: Record<string, unknown>
   project_type_slug: string
   tab: PluginTab
 }
 export interface PluginAssignmentResponse {
   default: boolean
+  identity_plugin_id?: null | string
   label: string
   options: Record<string, unknown>
   plugin_id: string
@@ -617,6 +620,7 @@ export interface PluginAssignmentResponse {
 
 export interface PluginAssignmentRow {
   default: boolean
+  identity_plugin_id?: null | string
   options: Record<string, unknown>
   project_type_name: string
   project_type_slug: string


### PR DESCRIPTION
## Summary

- \`LogsTab\` now passes \`environment\` as the full selected set (\`string[]\`) instead of dropping it whenever \`envs.length !== 1\`, and the API client serializes array values as repeated query params (\`?environment=production&environment=staging\`) instead of the broken comma-joined \`String(arr)\`. This also retroactively fixes multi-\`filter\`, which had the same bug.
- \`searchProjectLogs\` / \`getProjectLogsHistogram\` param types widen \`environment\` to \`string | string[]\`.
- New \`IdentityPluginSelect\` component on the admin Project Types card: a None-or-pick-an-identity \`Select\` sourced from a new \`listIdentityPlugins(orgSlug)\` API call. Saves now persist \`identity_plugin_id\` on the \`USES_PLUGIN\` edge instead of silently dropping it.
- \`PluginAssignment*\` type interfaces gain \`identity_plugin_id\`.
- New \`queryKeys.identityPlugins(orgSlug)\` builder.

## Why

Two layered bugs surfaced while testing per-environment AWS credentials for cloudwatch log search:

1. The admin form had no control to bind an identity plugin to a data plugin's project-type assignment, and the API silently dropped the field anyway.
2. The Logs tab's env multi-select chips were never sent to the API when more than one env was selected — multi-env requests had no way to express which envs.

## Depends on

- imbi-api: AWeber-Imbi/imbi-api#271 (adds \`identity_plugin_id\` to assignment models + \`/identity-plugins/\` endpoint + multi-env log search).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run build\` (tsc)
- [ ] Manual: bind aws-iam-ic on the database project type's cloudwatch-logs assignment; save persists; reload shows the selection.
- [ ] Manual: select two envs on a project's Logs tab; results from both envs are merged.