### PR TITLE
Surface user_subject_selector and identity_plugin_slug

### DIFF
--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -110,6 +110,30 @@ export function WebhookDetail({ onBack, onEdit, webhook }: WebhookDetailProps) {
                 </div>
               </div>
             )}
+            {webhook.user_subject_selector && (
+              <div>
+                <div className="text-sm text-secondary">
+                  User Subject Selector
+                </div>
+                <div className="mt-1">
+                  <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
+                    {webhook.user_subject_selector}
+                  </code>
+                </div>
+              </div>
+            )}
+            {webhook.identity_plugin_slug && (
+              <div>
+                <div className="text-sm text-secondary">
+                  Identity Plugin Slug
+                </div>
+                <div className="mt-1">
+                  <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
+                    {webhook.identity_plugin_slug}
+                  </code>
+                </div>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -57,6 +57,12 @@ export function WebhookForm({
   const [identifierSelector, setIdentifierSelector] = useState(
     webhook?.identifier_selector || '',
   )
+  const [userSubjectSelector, setUserSubjectSelector] = useState(
+    webhook?.user_subject_selector || '',
+  )
+  const [identityPluginSlug, setIdentityPluginSlug] = useState(
+    webhook?.identity_plugin_slug || '',
+  )
   const [rules, setRules] = useState<RuleDraft[]>(() =>
     (webhook?.rules || []).map((r) => ({ ...r, _clientId: makeClientId() })),
   )
@@ -90,6 +96,14 @@ export function WebhookForm({
       newErrors.identifier_selector =
         'Identifier selector requires a third-party service'
     }
+    if (userSubjectSelector && !tpsSlug) {
+      newErrors.user_subject_selector =
+        'User subject selector requires a third-party service'
+    }
+    if (identityPluginSlug && !tpsSlug) {
+      newErrors.identity_plugin_slug =
+        'Identity plugin slug requires a third-party service'
+    }
     for (let i = 0; i < rules.length; i++) {
       if (!rules[i].filter_expression.trim()) {
         newErrors[`rule_${i}_filter`] = 'Filter expression is required'
@@ -109,6 +123,7 @@ export function WebhookForm({
       description: description.trim() || null,
       icon: icon.trim() || null,
       identifier_selector: identifierSelector.trim() || null,
+      identity_plugin_slug: identityPluginSlug.trim() || null,
       name: name.trim(),
       rules: rules.map((r) => ({
         filter_expression: r.filter_expression.trim(),
@@ -117,6 +132,7 @@ export function WebhookForm({
       })),
       secret: secret.trim() || null,
       third_party_service_slug: tpsSlug || null,
+      user_subject_selector: userSubjectSelector.trim() || null,
       // Include slug only when editing so the PATCH can update it.
       ...(isEditing ? { slug: slug.trim() } : {}),
     }
@@ -138,7 +154,11 @@ export function WebhookForm({
 
   const handleServiceChange = (newTps: string) => {
     setTpsSlug(newTps)
-    if (!newTps) setIdentifierSelector('')
+    if (!newTps) {
+      setIdentifierSelector('')
+      setUserSubjectSelector('')
+      setIdentityPluginSlug('')
+    }
     // In edit mode, auto-update the displayed slug to the computed value
     // so the user can see what will be saved if they don't override it.
     if (isEditing) {
@@ -416,34 +436,97 @@ export function WebhookForm({
               </div>
 
               {tpsSlug && (
-                <div>
-                  <label className="mb-1.5 block text-sm text-secondary">
-                    Identifier Selector (JSON Path)
-                  </label>
-                  <Input
-                    className={`font-mono text-sm ${
-                      errors.identifier_selector ? 'border-red-500' : ''
-                    }`}
-                    disabled={isLoading}
-                    onChange={(e) => setIdentifierSelector(e.target.value)}
-                    placeholder="e.g., $.repository.full_name"
-                    value={identifierSelector}
-                  />
-                  {errors.identifier_selector && (
-                    <div
-                      className={
-                        'mt-1 flex items-center gap-1 text-xs text-danger'
-                      }
-                    >
-                      <AlertCircle className="h-3 w-3" />
-                      {errors.identifier_selector}
-                    </div>
-                  )}
-                  <p className="mt-1 text-xs text-tertiary">
-                    JSON Path expression to extract the project identifier from
-                    the webhook payload.
-                  </p>
-                </div>
+                <>
+                  <div>
+                    <label className="mb-1.5 block text-sm text-secondary">
+                      Identifier Selector (JSON Path)
+                    </label>
+                    <Input
+                      className={`font-mono text-sm ${
+                        errors.identifier_selector ? 'border-red-500' : ''
+                      }`}
+                      disabled={isLoading}
+                      onChange={(e) => setIdentifierSelector(e.target.value)}
+                      placeholder="e.g., $.repository.full_name"
+                      value={identifierSelector}
+                    />
+                    {errors.identifier_selector && (
+                      <div
+                        className={
+                          'mt-1 flex items-center gap-1 text-xs text-danger'
+                        }
+                      >
+                        <AlertCircle className="h-3 w-3" />
+                        {errors.identifier_selector}
+                      </div>
+                    )}
+                    <p className="mt-1 text-xs text-tertiary">
+                      JSON Path expression to extract the project identifier
+                      from the webhook payload.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="mb-1.5 block text-sm text-secondary">
+                      User Subject Selector (JSON Pointer)
+                    </label>
+                    <Input
+                      className={`font-mono text-sm ${
+                        errors.user_subject_selector ? 'border-red-500' : ''
+                      }`}
+                      disabled={isLoading}
+                      onChange={(e) => setUserSubjectSelector(e.target.value)}
+                      placeholder="e.g., /deployment/creator/id"
+                      value={userSubjectSelector}
+                    />
+                    {errors.user_subject_selector && (
+                      <div
+                        className={
+                          'mt-1 flex items-center gap-1 text-xs text-danger'
+                        }
+                      >
+                        <AlertCircle className="h-3 w-3" />
+                        {errors.user_subject_selector}
+                      </div>
+                    )}
+                    <p className="mt-1 text-xs text-tertiary">
+                      JSON Pointer to the external identity subject in the
+                      payload. Used to resolve the Imbi user attributed to
+                      handler events.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="mb-1.5 block text-sm text-secondary">
+                      Identity Plugin Slug{' '}
+                      <span className="text-xs text-tertiary">(optional)</span>
+                    </label>
+                    <Input
+                      className={`font-mono text-sm ${
+                        errors.identity_plugin_slug ? 'border-red-500' : ''
+                      }`}
+                      disabled={isLoading}
+                      onChange={(e) => setIdentityPluginSlug(e.target.value)}
+                      placeholder="e.g., github"
+                      value={identityPluginSlug}
+                    />
+                    {errors.identity_plugin_slug && (
+                      <div
+                        className={
+                          'mt-1 flex items-center gap-1 text-xs text-danger'
+                        }
+                      >
+                        <AlertCircle className="h-3 w-3" />
+                        {errors.identity_plugin_slug}
+                      </div>
+                    )}
+                    <p className="mt-1 text-xs text-tertiary">
+                      Override which identity plugin resolves the user. Leave
+                      blank to fall back to identity plugins attached to the
+                      third-party service.
+                    </p>
+                  </div>
+                </>
               )}
             </div>
           </CardContent>

--- a/src/types/api-generated.ts
+++ b/src/types/api-generated.ts
@@ -4900,6 +4900,16 @@ export interface components {
              * @description JSON Path expression to extract project identifier
              */
             identifier_selector?: string | null;
+            /**
+             * User Subject Selector
+             * @description JSON Pointer that locates the external identity subject (e.g. /deployment/creator/id) used to resolve the Imbi user.
+             */
+            user_subject_selector?: string | null;
+            /**
+             * Identity Plugin Slug
+             * @description Optional override for the identity plugin slug used to resolve the Imbi user; falls back to identity plugins attached to the third-party service when unset.
+             */
+            identity_plugin_slug?: string | null;
             /** Rules */
             rules?: components["schemas"]["WebhookRuleCreate"][];
         };
@@ -4926,6 +4936,10 @@ export interface components {
             } | null;
             /** Identifier Selector */
             identifier_selector?: string | null;
+            /** User Subject Selector */
+            user_subject_selector?: string | null;
+            /** Identity Plugin Slug */
+            identity_plugin_slug?: string | null;
             /**
              * Rules
              * @default []
@@ -4992,6 +5006,16 @@ export interface components {
              * @description JSON Path expression to extract project identifier
              */
             identifier_selector?: string | null;
+            /**
+             * User Subject Selector
+             * @description JSON Pointer that locates the external identity subject (e.g. /deployment/creator/id) used to resolve the Imbi user.
+             */
+            user_subject_selector?: string | null;
+            /**
+             * Identity Plugin Slug
+             * @description Optional override for the identity plugin slug used to resolve the Imbi user; falls back to identity plugins attached to the third-party service when unset.
+             */
+            identity_plugin_slug?: string | null;
             /** Rules */
             rules?: components["schemas"]["WebhookRuleCreate"][];
         };


### PR DESCRIPTION
## Summary

Expose the two new webhook `IMPLEMENTED_BY`-edge fields
(`user_subject_selector`, `identity_plugin_slug`) in the webhook
create/edit form and detail view, and update the generated OpenAPI
types to match.

## Problem

The companion API change adds two optional properties to the
`Webhook -> ThirdPartyService IMPLEMENTED_BY` edge so the gateway can
resolve external actors (e.g. GitHub `deployment.creator.id`) onto
Imbi users. Without UI controls, operators have no way to configure
those properties when creating or editing a webhook.

## Solution

* `WebhookForm.tsx`: text inputs for both new fields rendered next to
  the existing `identifier_selector`. Validation rejects either field
  without a third-party service; clearing the service clears all
  three selectors. Both go into the save payload alongside
  `identifier_selector`.
* `WebhookDetail.tsx`: shows the new fields (when set) in the
  Configuration card.
* `src/types/api-generated.ts`: hand-patched to add
  `user_subject_selector` and `identity_plugin_slug` to
  `WebhookCreate`, `WebhookUpdate`, and `WebhookResponse`. Once the
  API PR merges, regenerate via `npm run codegen:fetch` to refresh
  the snapshot from the live spec.

This is part of a feature set tracked in
[`plans/deployment-webhook.md`](https://github.com/AWeber-Imbi/imbi-development/blob/main/plans/deployment-webhook.md).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint .` and `npx oxfmt --check` clean
- [x] `npx vitest run` — 155 tests pass
- [ ] Manual smoke test: create a webhook with `tps_slug=github`,
      `identifier_selector=/repository/full_name`,
      `user_subject_selector=/deployment/creator/id`,
      `identity_plugin_slug=github`. GET it back and confirm all
      three round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Companion PRs

- API: https://github.com/AWeber-Imbi/imbi-api/pull/272 — adds `/users/by-identity` and the new IMPLEMENTED_BY-edge fields
- Gateway: https://github.com/AWeber-Imbi/imbi-gateway/pull/10 — implements the deployment-event handlers and consumes the new fields
