### PR TITLE
Configuration tab redesign + logs env column / histogram polish

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -6,10 +6,12 @@ import { useQuery } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
   ArrowRight,
+  Check,
   ChevronDown,
   Filter,
   Rocket,
   Settings2 as SettingsIcon,
+  TrendingDown,
 } from 'lucide-react'
 
 import {
@@ -22,6 +24,7 @@ import {
   listProjectNotes,
   listProjectPlugins,
   listProjectTypes,
+  listScoringPolicies,
   listTeams,
   type ScoreTrend,
 } from '@/api/endpoints'
@@ -62,7 +65,7 @@ import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { getIcon, useIconRegistryVersion } from '@/lib/icons'
 import { formatFieldKey } from '@/lib/project-field-formatting'
 import { sanitizeHttpUrl, sortEnvironments } from '@/lib/utils'
-import type { Project } from '@/types'
+import type { Project, ScoringPolicy } from '@/types'
 
 interface ProjectDetailProps {
   initialSubAction?: string
@@ -173,6 +176,13 @@ export function ProjectDetail({
   })
   const scoreBreakdown = projectWithBreakdown?.breakdown
   const [breakdownOpen, setBreakdownOpen] = useState(false)
+
+  const { data: scoringPolicies = [] } = useQuery({
+    enabled: breakdownOpen,
+    queryFn: ({ signal }) => listScoringPolicies(signal),
+    queryKey: ['scoringPolicies'],
+    staleTime: 5 * 60 * 1000,
+  })
   // Capture the score present at page load so intra-session changes are visible
   // even when the 30d baseline equals the current live score.
   const sessionBaseScore = useRef<null | number>(project.score ?? null)
@@ -199,11 +209,15 @@ export function ProjectDetail({
       listProjectNotes(orgSlug, project.id, undefined, signal),
     queryKey: ['projectNotes', orgSlug, project.id],
   })
-  // Drives whether the Configuration / Logs tabs are surfaced. We treat
-  // an unresolved query (loading / errored) as "no plugin" so a stale or
-  // failed lookup hides the tab rather than rendering a dead one.
+  // Drives whether the Configuration / Logs tabs are surfaced. Only
+  // treat the absence of a plugin as authoritative once the assignments
+  // lookup has actually succeeded — a still-loading or errored query
+  // must not render the tab as "no plugin", because that would silently
+  // strip an existing tab and leave a deep-link landing on a blank
+  // pane. While the query is unresolved or failed, we hold both flags
+  // back; the redirect effect already waits on success before rerouting.
   const {
-    data: projectPlugins = [],
+    data: projectPlugins,
     isFetched: projectPluginsFetched,
     isSuccess: projectPluginsSuccess,
   } = useQuery({
@@ -212,10 +226,12 @@ export function ProjectDetail({
     queryKey: ['project-plugins', orgSlug, project.id],
     staleTime: 5 * 60 * 1000,
   })
-  const hasConfigurationPlugin = projectPlugins.some(
-    (a) => a.tab === 'configuration',
-  )
-  const hasLogsPlugin = projectPlugins.some((a) => a.tab === 'logs')
+  const hasConfigurationPlugin =
+    projectPluginsSuccess &&
+    (projectPlugins ?? []).some((a) => a.tab === 'configuration')
+  const hasLogsPlugin =
+    projectPluginsSuccess &&
+    (projectPlugins ?? []).some((a) => a.tab === 'logs')
 
   // Redirect to overview when a deep-link points at a tab that no
   // longer surfaces (e.g. /configuration on a project type with no
@@ -595,6 +611,7 @@ export function ProjectDetail({
                       {breakdownOpen && (
                         <ScoreBreakdownDetail
                           contributions={scoreBreakdown.attribute_contributions}
+                          policies={scoringPolicies}
                         />
                       )}
                     </CardFooter>
@@ -685,6 +702,35 @@ export function ProjectDetail({
   )
 }
 
+function buildRecommendation(
+  c: AttributeContribution,
+  policy: ScoringPolicy,
+): null | string {
+  const current = c.mapped_score
+  if (policy.value_score_map) {
+    const better = Object.entries(policy.value_score_map)
+      .filter(([, score]) => score > current)
+      .sort(([, a], [, b]) => b - a)
+    if (better.length === 0) return null
+    const topScore = better[0][1]
+    const top = better
+      .filter(([, score]) => score === topScore)
+      .map(([name]) => name)
+    if (top.length === 1) return `Update to ${top[0]}`
+    if (top.length === 2) return `Update to ${top[0]} or ${top[1]}`
+    return `Update to ${top.slice(0, -1).join(', ')}, or ${top[top.length - 1]}`
+  }
+  if (policy.range_score_map) {
+    const better = Object.entries(policy.range_score_map)
+      .filter(([, score]) => score > current)
+      .sort(([, a], [, b]) => b - a)
+    if (better.length === 0) return null
+    const [target] = better[0]
+    return `Update to reach ${target}`
+  }
+  return null
+}
+
 function fmtAttributeValue(value: unknown): string {
   const n = Number(value)
   return isFinite(n) && String(value).trim() !== ''
@@ -707,73 +753,151 @@ function PlaceholderTab({ name }: { name: string }) {
 
 function ScoreBreakdownDetail({
   contributions,
+  policies,
 }: {
   contributions: AttributeContribution[]
+  policies: ScoringPolicy[]
 }) {
   const totalWeight = contributions.reduce((s, c) => s + c.weight, 0)
-  const sorted = [...contributions].sort(
-    (a, b) => b.weighted_contribution - a.weighted_contribution,
-  )
+  const policyBySlug = useMemo(() => {
+    const map = new Map<string, ScoringPolicy>()
+    for (const p of policies) map.set(p.slug, p)
+    return map
+  }, [policies])
+
+  const enriched = contributions.map((c) => {
+    const maxPts = totalWeight > 0 ? (c.weight / totalWeight) * 100 : 0
+    return {
+      contribution: c,
+      isPerfect: c.mapped_score >= 100,
+      maxPts,
+      policy: policyBySlug.get(c.policy_slug),
+    }
+  })
+  const improve = enriched
+    .filter((e) => !e.isPerfect)
+    .sort(
+      (a, b) =>
+        b.maxPts -
+        b.contribution.weighted_contribution -
+        (a.maxPts - a.contribution.weighted_contribution),
+    )
+  const perfect = enriched
+    .filter((e) => e.isPerfect)
+    .sort((a, b) => b.maxPts - a.maxPts)
+
   return (
-    <div className="w-full px-6 pb-4">
-      <p className="mb-3 text-[11px] text-tertiary">
+    <div className="flex w-full flex-col gap-5 px-6 pb-4">
+      <p className="text-[11px] text-tertiary">
         {contributions.length} policies
       </p>
-      {sorted.map((c) => {
-        const maxPts = totalWeight > 0 ? (c.weight / totalWeight) * 100 : 0
-        const fillPct =
-          maxPts > 0 ? (c.weighted_contribution / maxPts) * 100 : 0
-        const isDrag = c.mapped_score === 0
-        const isPartial = !isDrag && c.mapped_score < 100
-        const policyName = formatFieldKey(c.policy_slug.replace(/-/g, '_'))
-        return (
-          <div className="mb-3 last:mb-0" key={c.policy_slug}>
-            <div className="flex items-baseline justify-between gap-2">
-              <div className="flex min-w-0 items-baseline gap-1.5">
-                <span className="text-[13px] font-semibold text-primary">
-                  {policyName}
-                </span>
-                <span className="font-mono text-[11px] text-tertiary">
-                  w{c.weight}
-                </span>
-              </div>
-              <div className="shrink-0 font-mono text-[13px] tabular-nums">
-                <span
-                  className={
-                    isDrag
-                      ? 'font-semibold text-danger'
-                      : 'font-semibold text-primary'
-                  }
-                >
-                  {Math.round(c.weighted_contribution)}
-                </span>
-                <span className="text-tertiary"> / {Math.round(maxPts)}</span>
-              </div>
-            </div>
-            <div className="mt-1 flex items-center gap-2">
-              <span
-                className={`w-1/3 shrink-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11.5px] ${
-                  isDrag
-                    ? 'text-danger'
-                    : isPartial
-                      ? 'text-amber-text'
-                      : 'text-tertiary'
-                }`}
-              >
-                {c.value != null ? fmtAttributeValue(c.value) : 'Not set'}
-              </span>
-              <div className="relative h-1.5 flex-1 rounded-full bg-secondary">
-                {fillPct > 0 && (
-                  <div
-                    className="absolute inset-y-0 left-0 rounded-full bg-action"
-                    style={{ width: `${fillPct}%` }}
-                  />
-                )}
-              </div>
-            </div>
+      {improve.length > 0 && (
+        <section>
+          <div className="mb-2.5 flex items-center justify-between text-[11px] font-semibold uppercase tracking-wider text-tertiary">
+            <span>To improve</span>
+            <span className="font-mono">{improve.length}</span>
           </div>
-        )
-      })}
+          <div className="flex flex-col gap-3">
+            {improve.map(({ contribution: c, maxPts, policy }) => {
+              const fillPct =
+                maxPts > 0 ? (c.weighted_contribution / maxPts) * 100 : 0
+              const lost = Math.round(maxPts - c.weighted_contribution)
+              const policyName = formatFieldKey(
+                c.policy_slug.replace(/-/g, '_'),
+              )
+              const recommendation = policy
+                ? buildRecommendation(c, policy)
+                : null
+              return (
+                <div
+                  className="rounded-md border border-tertiary bg-primary p-3.5"
+                  key={c.policy_slug}
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <div className="flex min-w-0 items-baseline gap-1.5">
+                      <span className="text-[14px] font-semibold text-primary">
+                        {policyName}
+                      </span>
+                      <span className="font-mono text-[11px] text-tertiary">
+                        w{c.weight}
+                      </span>
+                    </div>
+                    <div className="shrink-0 font-mono text-[13px] tabular-nums">
+                      <span className="font-semibold text-primary">
+                        {Math.round(c.weighted_contribution)}
+                      </span>
+                      <span className="text-tertiary">
+                        {' '}
+                        / {Math.round(maxPts)}
+                      </span>
+                    </div>
+                  </div>
+                  <p className="mb-2.5 mt-1 text-[13px] text-secondary">
+                    Currently{' '}
+                    <span className="font-medium text-amber-text">
+                      {c.value != null ? fmtAttributeValue(c.value) : 'Not set'}
+                    </span>
+                  </p>
+                  <div className="relative h-1.5 rounded-full bg-secondary">
+                    {fillPct > 0 && (
+                      <div
+                        className="absolute inset-y-0 left-0 rounded-full bg-action"
+                        style={{ width: `${fillPct}%` }}
+                      />
+                    )}
+                  </div>
+                  <div className="mt-2 flex items-center gap-1.5 text-[12.5px] text-secondary">
+                    <TrendingDown className="h-3 w-3 shrink-0 text-tertiary" />
+                    <span>
+                      Losing{' '}
+                      <span className="font-mono font-medium text-danger">
+                        {lost} pts
+                      </span>
+                      {recommendation ? ` · ${recommendation}` : ''}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      )}
+      {perfect.length > 0 && (
+        <section>
+          <div className="mb-2.5 flex items-center justify-between text-[11px] font-semibold uppercase tracking-wider text-tertiary">
+            <span>At maximum</span>
+            <span className="font-mono">{perfect.length}</span>
+          </div>
+          <div className="overflow-hidden rounded-md border border-tertiary">
+            {perfect.map(({ contribution: c, maxPts }, idx) => {
+              const policyName = formatFieldKey(
+                c.policy_slug.replace(/-/g, '_'),
+              )
+              return (
+                <div
+                  className={`grid grid-cols-[auto_1fr_auto] items-center gap-2.5 bg-primary px-3 py-2.5 ${
+                    idx > 0 ? 'border-t border-tertiary' : ''
+                  }`}
+                  key={c.policy_slug}
+                >
+                  <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-success text-success">
+                    <Check className="h-2.5 w-2.5" strokeWidth={3} />
+                  </span>
+                  <span className="text-[13.5px] font-medium text-primary">
+                    {policyName}
+                    <span className="ml-1.5 font-normal text-tertiary">
+                      {c.value != null ? fmtAttributeValue(c.value) : 'Not set'}
+                    </span>
+                  </span>
+                  <span className="font-mono text-[12px] tabular-nums text-tertiary">
+                    {Math.round(c.weighted_contribution)}/{Math.round(maxPts)}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      )}
     </div>
   )
 }

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -20,6 +20,7 @@ import {
   listCurrentReleases,
   listLinkDefinitions,
   listProjectNotes,
+  listProjectPlugins,
   listProjectTypes,
   listTeams,
   type ScoreTrend,
@@ -198,6 +199,47 @@ export function ProjectDetail({
       listProjectNotes(orgSlug, project.id, undefined, signal),
     queryKey: ['projectNotes', orgSlug, project.id],
   })
+  // Drives whether the Configuration / Logs tabs are surfaced. We treat
+  // an unresolved query (loading / errored) as "no plugin" so a stale or
+  // failed lookup hides the tab rather than rendering a dead one.
+  const {
+    data: projectPlugins = [],
+    isFetched: projectPluginsFetched,
+    isSuccess: projectPluginsSuccess,
+  } = useQuery({
+    enabled: !!orgSlug && !!project.id,
+    queryFn: ({ signal }) => listProjectPlugins(orgSlug, project.id, signal),
+    queryKey: ['project-plugins', orgSlug, project.id],
+    staleTime: 5 * 60 * 1000,
+  })
+  const hasConfigurationPlugin = projectPlugins.some(
+    (a) => a.tab === 'configuration',
+  )
+  const hasLogsPlugin = projectPlugins.some((a) => a.tab === 'logs')
+
+  // Redirect to overview when a deep-link points at a tab that no
+  // longer surfaces (e.g. /configuration on a project type with no
+  // configuration plugin assigned). Wait for the assignments query to
+  // resolve successfully before deciding — otherwise the empty default
+  // during the initial fetch redirects every direct navigation to
+  // /logs or /configuration.
+  useEffect(() => {
+    if (!projectPluginsFetched || !projectPluginsSuccess) return
+    if (
+      (activeTab === 'configuration' && !hasConfigurationPlugin) ||
+      (activeTab === 'logs' && !hasLogsPlugin)
+    ) {
+      navigate(`/projects/${project.id}`, { replace: true })
+    }
+  }, [
+    activeTab,
+    hasConfigurationPlugin,
+    hasLogsPlugin,
+    navigate,
+    project.id,
+    projectPluginsFetched,
+    projectPluginsSuccess,
+  ])
 
   // Bumps when an icon-set chunk finishes loading; include in useMemo deps
   // where icons are resolved so they refresh once available.
@@ -274,9 +316,11 @@ export function ProjectDetail({
 
   const tabs: { id: TabType; label: string }[] = [
     { id: 'overview', label: 'Overview' },
-    { id: 'configuration', label: 'Configuration' },
+    ...(hasConfigurationPlugin
+      ? [{ id: 'configuration' as const, label: 'Configuration' }]
+      : []),
     { id: 'dependencies', label: 'Dependencies' },
-    { id: 'logs', label: 'Logs' },
+    ...(hasLogsPlugin ? [{ id: 'logs' as const, label: 'Logs' }] : []),
     {
       id: 'notes',
       label:
@@ -577,9 +621,17 @@ export function ProjectDetail({
           </div>
         </TabsContent>
 
-        <TabsContent value="configuration">
-          <ConfigurationTab orgSlug={orgSlug} projectId={project.id} />
-        </TabsContent>
+        {hasConfigurationPlugin && (
+          <TabsContent value="configuration">
+            <ConfigurationTab
+              environments={sortedEnvironments}
+              orgSlug={orgSlug}
+              projectId={project.id}
+              projectSlug={project.slug}
+              teamSlug={project.team.slug}
+            />
+          </TabsContent>
+        )}
         <TabsContent value="relationships">
           <ProjectRelationshipsTab
             orgSlug={project.team.organization.slug}
@@ -590,9 +642,15 @@ export function ProjectDetail({
         <TabsContent value="dependencies">
           <PlaceholderTab name="Dependencies" />
         </TabsContent>
-        <TabsContent value="logs">
-          <LogsTab orgSlug={orgSlug} projectId={project.id} />
-        </TabsContent>
+        {hasLogsPlugin && (
+          <TabsContent value="logs">
+            <LogsTab
+              environments={sortedEnvironments}
+              orgSlug={orgSlug}
+              projectId={project.id}
+            />
+          </TabsContent>
+        )}
         <TabsContent value="notes">
           <ProjectNotesTab
             initialAction={activeTab === 'notes' ? initialSubAction : undefined}

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -328,19 +328,34 @@ function DefaultOptionsCard({
   serviceSlug,
 }: DefaultOptionsCardProps) {
   const [draft, setDraft] = useState<Record<string, unknown>>(plugin.options)
+  const [identityDraft, setIdentityDraft] = useState<null | string>(
+    plugin.identity_plugin_id ?? null,
+  )
 
   useEffect(() => {
     setDraft(plugin.options)
-  }, [plugin.id, plugin.options])
+    setIdentityDraft(plugin.identity_plugin_id ?? null)
+  }, [plugin.id, plugin.options, plugin.identity_plugin_id])
+
+  const { data: identityPlugins } = useQuery({
+    queryFn: ({ signal }) => listIdentityPlugins(orgSlug, signal),
+    queryKey: queryKeys.identityPlugins(orgSlug),
+    staleTime: 60 * 1000,
+  })
 
   const dirty = useMemo(
-    () => JSON.stringify(draft) !== JSON.stringify(plugin.options),
-    [draft, plugin.options],
+    () =>
+      JSON.stringify(draft) !== JSON.stringify(plugin.options) ||
+      (identityDraft ?? null) !== (plugin.identity_plugin_id ?? null),
+    [draft, identityDraft, plugin.options, plugin.identity_plugin_id],
   )
 
   const saveMutation = useMutation({
     mutationFn: () =>
       updateServicePlugin(orgSlug, serviceSlug, plugin.id, {
+        // Empty string explicitly clears the binding on the backend;
+        // omitting it would leave the previous value in place.
+        identity_plugin_id: identityDraft ?? '',
         label: plugin.label,
         options: draft,
       }),
@@ -358,7 +373,10 @@ function DefaultOptionsCard({
   })
 
   if (!manifest) return null
-  if (manifest.options.length === 0) return null
+  // Even when the manifest has no plugin options, we still render the card
+  // when a default identity plugin can be configured.
+  const hasOptions = manifest.options.length > 0
+  if (!hasOptions && manifest.plugin_type === 'identity') return null
 
   return (
     <Card>
@@ -381,6 +399,24 @@ function DefaultOptionsCard({
         )}
       </CardHeader>
       <CardContent className="space-y-3 px-6 pb-6">
+        {manifest.plugin_type !== 'identity' && (
+          <div className="grid grid-cols-[160px_1fr] items-center gap-3">
+            <Label className="truncate text-xs" title="Identity Plugin">
+              Identity Plugin
+            </Label>
+            <div className="space-y-1">
+              <IdentityPluginSelect
+                identityPlugins={identityPlugins ?? []}
+                onChange={setIdentityDraft}
+                value={identityDraft}
+              />
+              <p className="text-xs text-secondary">
+                Default identity used for plugin calls when no project-type
+                assignment names one. Per-type bindings still take precedence.
+              </p>
+            </div>
+          </div>
+        )}
         {manifest.options.map((opt) => (
           <OptionRow
             description={opt.description ?? null}

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -1,9 +1,24 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Eye, EyeOff, Plus, Trash2 } from 'lucide-react'
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import {
+  Check,
+  Eye,
+  EyeOff,
+  Lock,
+  Plus,
+  Search,
+  Settings2,
+  Trash2,
+} from 'lucide-react'
 import { toast } from 'sonner'
 
+import { ApiError } from '@/api/client'
 import {
   deleteConfigurationKey,
   fetchConfigurationValues,
@@ -11,73 +26,140 @@ import {
   listProjectPlugins,
   setConfigurationValue,
 } from '@/api/endpoints'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardTitle } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { LoadingState } from '@/components/ui/loading-state'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
+import { useTheme } from '@/contexts/ThemeContext'
 import { extractApiErrorDetail } from '@/lib/apiError'
-import type { ConfigKeyResponse } from '@/types'
+import { deriveChipColors } from '@/lib/chip-colors'
+import { cn, sortEnvironments } from '@/lib/utils'
+import type { ConfigKeyResponse, Environment } from '@/types'
 
-interface ConfigurationTabProps {
-  environment?: string
-  orgSlug: string
-  projectId: string
+const DATA_TYPES = ['string', 'string_list', 'secret'] as const
+type DataType = (typeof DATA_TYPES)[number]
+const DATA_TYPE_LABELS: Record<DataType, string> = {
+  secret: 'Secret',
+  string: 'String',
+  string_list: 'String List',
 }
 
-const DATA_TYPES = ['String', 'StringList', 'SecureString'] as const
+const COMMON_PREFIX_MIN_DEPTH = 3
 
-type DataType = (typeof DATA_TYPES)[number]
+interface AggregatedKey {
+  data_type: DataType
+  envs: Record<string, PerEnvKey | undefined>
+  key: string
+  last_modified: null | string
+  secret: boolean
+}
 
-interface SetValueForm {
+interface ConfigurationTabProps {
+  environments: Environment[]
+  orgSlug: string
+  projectId: string
+  projectSlug: string
+  teamSlug: string
+}
+
+interface CreateDraft {
   data_type: DataType
   key: string
+  values: Record<string, string>
+}
+
+interface DetailPaneProps {
+  draft?: CreateDraft
+  environments: Environment[]
+  isCreate?: boolean
+  onAdd?: () => void
+  onCancel?: () => void
+  onCommitType?: (type: DataType) => void
+  onCommitValue?: (envSlug: string, value: string) => void
+  onCreate?: () => void
+  onDelete?: () => void
+  onDraftChange?: (next: CreateDraft) => void
+  onToggleReveal?: (envSlug: string, key: string) => void
+  prefix: string
+  revealed?: Record<string, boolean>
+  savedFlash: boolean
+  selected?: AggregatedKey
+  typeOverride?: DataType | null
+  valuesByEnv?: Record<string, Record<string, unknown>>
+}
+
+interface EnvRowProps {
+  dataType: DataType
+  env: Environment
+  isCreate: boolean
+  isSecret: boolean
+  isSet: boolean
+  onCommit: (value: string) => void
+  onToggleReveal: () => void
+  revealed: boolean
+  value: string | undefined
+}
+
+interface ParamListProps {
+  filter: string
+  items: AggregatedKey[]
+  onSelect: (key: string) => void
+  prefix: string
+  selectedKey: null | string
+}
+
+interface PerEnvKey {
+  data_type: DataType
+  last_modified: null | string
   secret: boolean
-  value: string
 }
 
 export function ConfigurationTab({
-  environment,
+  environments,
   orgSlug,
   projectId,
+  projectSlug,
+  teamSlug,
 }: ConfigurationTabProps) {
   const queryClient = useQueryClient()
-  const [source, setSource] = useState<string | undefined>()
-  const [revealedValues, setRevealedValues] = useState<Record<string, unknown>>(
-    {},
+  const sortedEnvironments = useMemo(
+    () => sortEnvironments(environments ?? []),
+    [environments],
   )
-  const [showSetDialog, setShowSetDialog] = useState(false)
-  const [confirmDeleteKey, setConfirmDeleteKey] = useState<null | string>(null)
-  const [editingKey, setEditingKey] = useState<ConfigKeyResponse | null>(null)
-  const [form, setForm] = useState<SetValueForm>({
-    data_type: 'String',
+  const envSlugs = useMemo(
+    () => sortedEnvironments.map((e) => e.slug),
+    [sortedEnvironments],
+  )
+
+  const [source, setSource] = useState<string | undefined>()
+  const [filter, setFilter] = useState('')
+  const [selectedKey, setSelectedKey] = useState<null | string>(null)
+  const [mode, setMode] = useState<'create' | 'view'>('view')
+  const [revealed, setRevealed] = useState<Record<string, boolean>>({})
+  const [confirmDelete, setConfirmDelete] = useState<null | string>(null)
+  const [savedFlash, setSavedFlash] = useState(false)
+  const [typeOverride, setTypeOverride] = useState<null | {
+    key: string
+    type: DataType
+  }>(null)
+  const [draft, setDraft] = useState<CreateDraft>({
+    data_type: 'string',
     key: '',
-    secret: false,
-    value: '',
+    values: {},
   })
+
+  const flashTimer = useRef<null | ReturnType<typeof setTimeout>>(null)
+  const flashSaved = () => {
+    setSavedFlash(true)
+    if (flashTimer.current) clearTimeout(flashTimer.current)
+    flashTimer.current = setTimeout(() => setSavedFlash(false), 1400)
+  }
+  useEffect(() => {
+    return () => {
+      if (flashTimer.current) clearTimeout(flashTimer.current)
+    }
+  }, [])
 
   const { data: assignments } = useQuery({
     queryFn: ({ signal }) => listProjectPlugins(orgSlug, projectId, signal),
@@ -94,132 +176,317 @@ export function ConfigurationTab({
   const activeSource = sources.some((s) => s.id === source)
     ? source
     : sources[0]?.id
+  const activeAssignment = configAssignments.find(
+    (a) => a.plugin_id === activeSource,
+  )
+  const configuredPrefix = (() => {
+    const raw = activeAssignment?.options?.path_prefix
+    if (typeof raw !== 'string' || !raw) return ''
+    // Expand the same variables the backend's plugin template expander
+    // supports, so users see a concrete prefix instead of `${...}`.
+    // ${environment} stays unexpanded — it varies per row, and rendering
+    // any single env's value would be misleading at the panel level.
+    const vars: Record<string, string> = {
+      org_slug: orgSlug,
+      project_id: projectId,
+      project_slug: projectSlug,
+      team_slug: teamSlug,
+    }
+    return raw.replace(/\$\{([^}]+)\}/g, (match, name: string) =>
+      name in vars ? vars[name] : match,
+    )
+  })()
 
+  // Reset reveals whenever the data scope changes.
   useEffect(() => {
-    setRevealedValues({})
-  }, [activeSource, environment])
+    setRevealed({})
+  }, [activeSource])
 
-  const {
-    data: keys,
-    error,
-    isLoading,
-  } = useQuery({
-    enabled: sources.length > 0,
-    queryFn: ({ signal }) =>
-      listConfigurationKeys(
+  // List keys for each environment in parallel; aggregate into a single list.
+  const listQueries = useQueries({
+    queries: sortedEnvironments.map((env) => ({
+      enabled: sources.length > 0,
+      queryFn: ({ signal }: { signal?: AbortSignal }) =>
+        listConfigurationKeys(
+          orgSlug,
+          projectId,
+          { environment: env.slug, source: activeSource },
+          signal,
+        ),
+      queryKey: [
+        'config-keys',
         orgSlug,
         projectId,
-        {
-          environment: environment ?? undefined,
-          source: activeSource,
-        },
-        signal,
-      ),
-    queryKey: ['config-keys', orgSlug, projectId, activeSource, environment],
-    staleTime: 60 * 1000,
+        activeSource,
+        env.slug,
+      ] as const,
+      staleTime: 60 * 1000,
+    })),
   })
 
-  const revealMutation = useMutation({
-    mutationFn: async (keyNames: string[]) => {
-      return fetchConfigurationValues(orgSlug, projectId, keyNames, {
-        environment: environment ?? undefined,
-        source: activeSource,
-      })
-    },
-    onError: (err) => {
-      toast.error(extractApiErrorDetail(err) ?? 'Failed to reveal values')
-    },
-    onSuccess: (values) => {
-      setRevealedValues((prev) => {
-        const next = { ...prev }
-        for (const v of values) next[v.key] = v.value
-        return next
-      })
-    },
+  const isLoading = listQueries.some((q) => q.isLoading)
+  const loadError = listQueries.find((q) => q.error)?.error
+
+  const aggregated = useMemo(
+    () =>
+      aggregate(
+        sortedEnvironments.map((env, idx) => ({
+          envSlug: env.slug,
+          keys: listQueries[idx]?.data ?? [],
+        })),
+      ),
+    // listQueries is recreated each render; depend on each query's data.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sortedEnvironments, ...listQueries.map((q) => q.data)],
+  )
+
+  // Fetch values for every key in each environment so the right pane can
+  // render them inline. Secrets are returned in plaintext when the caller
+  // has the `read_secrets` permission and are masked client-side.
+  const valueQueries = useQueries({
+    queries: sortedEnvironments.map((env, idx) => {
+      const keys = listQueries[idx]?.data ?? []
+      const keyNames = keys.map((k) => k.key)
+      return {
+        enabled: keyNames.length > 0,
+        queryFn: () =>
+          fetchConfigurationValues(orgSlug, projectId, keyNames, {
+            environment: env.slug,
+            source: activeSource,
+          }),
+        queryKey: [
+          'config-values',
+          orgSlug,
+          projectId,
+          activeSource,
+          env.slug,
+          keyNames,
+        ] as const,
+        staleTime: 60 * 1000,
+      }
+    }),
   })
+
+  const valuesByEnv = useMemo(() => {
+    const out: Record<string, Record<string, unknown>> = {}
+    sortedEnvironments.forEach((env, idx) => {
+      const data = valueQueries[idx]?.data
+      if (!data) return
+      const map: Record<string, unknown> = {}
+      for (const v of data) map[v.key] = v.value
+      out[env.slug] = map
+    })
+    return out
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sortedEnvironments, ...valueQueries.map((q) => q.data)])
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    if (!q) return aggregated
+    return aggregated.filter((p) => p.key.toLowerCase().includes(q))
+  }, [aggregated, filter])
+
+  // The configured `path_prefix` (with ${...} variables) is the canonical
+  // prefix declared on the assignment. The keys returned by the plugin have
+  // those variables already expanded — and they expand differently per
+  // environment (e.g. ${environment} → testing/staging/production), so the
+  // longest common prefix across the aggregated key set is shorter than the
+  // configured one. We display the configured value when present and only
+  // fall back to a derived prefix when the assignment doesn't declare one.
+  const derivedPrefix = useMemo(
+    () => commonPrefix(aggregated.map((a) => a.key)),
+    [aggregated],
+  )
+  // For list-row truncation we still need a prefix that actually matches the
+  // keys, so use the derived value there.
+  const prefix = derivedPrefix
+  const displayPrefix = configuredPrefix || derivedPrefix
+
+  const selected = useMemo(
+    () => aggregated.find((a) => a.key === selectedKey) ?? null,
+    [aggregated, selectedKey],
+  )
+
+  // When data first arrives, auto-select the first key.
+  useEffect(() => {
+    if (mode === 'view' && !selected && aggregated.length > 0) {
+      setSelectedKey(aggregated[0].key)
+    }
+  }, [aggregated, mode, selected])
+
+  // Reset draft entering create mode.
+  useEffect(() => {
+    if (mode === 'create') {
+      setDraft({
+        data_type: 'string',
+        key: prefix,
+        values: Object.fromEntries(envSlugs.map((s) => [s, ''])),
+      })
+    }
+  }, [mode, prefix, envSlugs])
 
   const setMutation = useMutation({
-    mutationFn: () =>
+    mutationFn: ({
+      data_type,
+      environment,
+      key,
+      secret,
+      value,
+    }: {
+      data_type: DataType
+      environment: string
+      key: string
+      secret: boolean
+      value: string
+    }) =>
       setConfigurationValue(
         orgSlug,
         projectId,
-        form.key,
-        {
-          data_type: form.data_type,
-          secret: form.secret,
-          value: form.value,
-        },
-        {
-          environment: environment ?? undefined,
-          source: activeSource,
-        },
+        key,
+        { data_type, secret, value },
+        { environment, source: activeSource },
       ),
     onError: (err) => {
       toast.error(extractApiErrorDetail(err) ?? 'Failed to save value')
     },
-    onSuccess: () => {
-      toast.success(`Key "${form.key}" saved`)
-      setShowSetDialog(false)
-      setEditingKey(null)
+    onSuccess: (_, vars) => {
+      flashSaved()
       void queryClient.invalidateQueries({
-        queryKey: ['config-keys', orgSlug, projectId],
+        queryKey: [
+          'config-keys',
+          orgSlug,
+          projectId,
+          activeSource,
+          vars.environment,
+        ],
       })
     },
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (key: string) =>
-      deleteConfigurationKey(orgSlug, projectId, key, {
-        environment: environment ?? undefined,
-        source: activeSource,
-      }),
+    mutationFn: async (key: string) => {
+      // Delete from every environment where the key is set.
+      const targets = envSlugs.filter(
+        (slug) => aggregated.find((a) => a.key === key)?.envs[slug],
+      )
+      await Promise.all(
+        targets.map((env) =>
+          deleteConfigurationKey(orgSlug, projectId, key, {
+            environment: env,
+            source: activeSource,
+          }),
+        ),
+      )
+    },
     onError: (err) => {
       toast.error(extractApiErrorDetail(err) ?? 'Failed to delete key')
     },
     onSuccess: (_, key) => {
       toast.success(`Key "${key}" deleted`)
-      setConfirmDeleteKey(null)
+      setConfirmDelete(null)
+      setSelectedKey(null)
       void queryClient.invalidateQueries({
         queryKey: ['config-keys', orgSlug, projectId],
       })
     },
   })
 
-  const openAdd = () => {
-    setEditingKey(null)
-    setForm({ data_type: 'String', key: '', secret: false, value: '' })
-    setShowSetDialog(true)
-  }
-
-  const openEdit = (keyEntry: ConfigKeyResponse) => {
-    setEditingKey(keyEntry)
-    setForm({
-      data_type: (keyEntry.data_type as DataType) ?? 'String',
-      key: keyEntry.key,
-      secret: keyEntry.secret,
-      value: '',
+  const toggleReveal = (envSlug: string, key: string) => {
+    const ref = `${envSlug}::${key}`
+    setRevealed((prev) => {
+      const next = { ...prev }
+      if (next[ref]) delete next[ref]
+      else next[ref] = true
+      return next
     })
-    setShowSetDialog(true)
   }
 
-  const toggleReveal = (key: string) => {
-    if (key in revealedValues) {
-      setRevealedValues((prev) => {
-        const next = { ...prev }
-        delete next[key]
-        return next
-      })
-    } else {
-      revealMutation.mutate([key])
+  const handleCommitValue = (envSlug: string, value: string) => {
+    if (!selected) return
+    setMutation.mutate({
+      data_type: selected.data_type,
+      environment: envSlug,
+      key: selected.key,
+      secret: selected.secret,
+      value,
+    })
+  }
+
+  const handleCommitType = (newType: DataType) => {
+    if (!selected) return
+    // Optimistic override so the segmented control reflects the click
+    // immediately, before the round-trip lands.
+    setTypeOverride({ key: selected.key, type: newType })
+    const targets = envSlugs.filter((slug) => selected.envs[slug])
+    if (targets.length === 0) {
+      flashSaved()
+      return
     }
+    Promise.all(
+      targets.map((env) => {
+        const cached =
+          (valuesByEnv[env]?.[selected.key] as string | undefined) ?? ''
+        return setConfigurationValue(
+          orgSlug,
+          projectId,
+          selected.key,
+          {
+            data_type: newType,
+            secret: newType === 'secret',
+            value: cached,
+          },
+          { environment: env, source: activeSource },
+        )
+      }),
+    )
+      .then(() => {
+        flashSaved()
+        void queryClient.invalidateQueries({
+          queryKey: ['config-keys', orgSlug, projectId],
+        })
+      })
+      .catch((err) => {
+        toast.error(extractApiErrorDetail(err) ?? 'Failed to change data type')
+      })
+      .finally(() => {
+        setTypeOverride(null)
+      })
   }
 
-  const revealAll = () => {
-    const secretKeys = (keys ?? [])
-      .filter((k) => k.secret && !(k.key in revealedValues))
-      .map((k) => k.key)
-    if (secretKeys.length > 0) {
-      revealMutation.mutate(secretKeys)
+  const handleCreate = async () => {
+    if (!draft.key.trim()) {
+      toast.error('Key is required')
+      return
+    }
+    const targets = envSlugs.filter((slug) => draft.values[slug]?.trim())
+    if (targets.length === 0) {
+      toast.error('Set a value for at least one environment')
+      return
+    }
+    try {
+      await Promise.all(
+        targets.map((env) =>
+          setConfigurationValue(
+            orgSlug,
+            projectId,
+            draft.key.trim(),
+            {
+              data_type: draft.data_type,
+              secret: draft.data_type === 'secret',
+              value: draft.values[env],
+            },
+            { environment: env, source: activeSource },
+          ),
+        ),
+      )
+      toast.success(`Key "${draft.key.trim()}" created`)
+      setMode('view')
+      setSelectedKey(draft.key.trim())
+      void queryClient.invalidateQueries({
+        queryKey: ['config-keys', orgSlug, projectId],
+      })
+    } catch (err) {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to create key')
     }
   }
 
@@ -238,8 +505,7 @@ export function ConfigurationTab({
   }
 
   return (
-    <div className="space-y-4">
-      {/* Source picker when multiple plugins assigned */}
+    <div className="space-y-3">
       {sources.length > 1 && (
         <div className="flex items-center gap-3">
           <span className="text-sm text-secondary">Source:</span>
@@ -263,193 +529,660 @@ export function ConfigurationTab({
         </div>
       )}
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between px-6 py-4">
-          <CardTitle>Configuration Keys</CardTitle>
-          <div className="flex gap-2">
-            {(keys ?? []).some((k) => k.secret) && (
-              <Button onClick={revealAll} size="sm" variant="outline">
-                <Eye className="mr-1 h-3 w-3" />
-                Reveal All Secrets
-              </Button>
-            )}
-            <Button onClick={openAdd} size="sm">
-              <Plus className="mr-1 h-3 w-3" />
-              Add Key
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <LoadingState label="Loading..." />
-          ) : error ? (
-            <div className="py-8 text-center text-sm text-destructive">
-              Failed to load configuration keys
-            </div>
-          ) : (keys ?? []).length === 0 ? (
-            <div className="py-8 text-center text-sm text-secondary">
-              No configuration keys found
-            </div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Key</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Last Modified</TableHead>
-                  <TableHead>Value</TableHead>
-                  <TableHead className="w-20" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {(keys ?? []).map((entry) => (
-                  <TableRow key={entry.key}>
-                    <TableCell className="font-mono text-sm">
-                      {entry.key}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant="secondary">{entry.data_type}</Badge>
-                    </TableCell>
-                    <TableCell className="text-sm text-secondary">
-                      {entry.last_modified
-                        ? new Date(entry.last_modified).toLocaleString()
-                        : '—'}
-                    </TableCell>
-                    <TableCell>
-                      {entry.secret ? (
-                        <div className="flex items-center gap-2">
-                          {entry.key in revealedValues ? (
-                            <span className="font-mono text-sm">
-                              {String(revealedValues[entry.key] ?? '')}
-                            </span>
-                          ) : (
-                            <span className="text-secondary">••••••••</span>
-                          )}
-                          <Button
-                            onClick={() => toggleReveal(entry.key)}
-                            size="icon"
-                            variant="ghost"
-                          >
-                            {entry.key in revealedValues ? (
-                              <EyeOff className="h-3 w-3" />
-                            ) : (
-                              <Eye className="h-3 w-3" />
-                            )}
-                          </Button>
-                        </div>
-                      ) : (
-                        <span className="text-secondary">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex justify-end gap-1">
-                        <Button
-                          onClick={() => openEdit(entry)}
-                          size="sm"
-                          variant="ghost"
-                        >
-                          Edit
-                        </Button>
-                        <Button
-                          onClick={() => setConfirmDeleteKey(entry.key)}
-                          size="icon"
-                          variant="ghost"
-                        >
-                          <Trash2 className="h-3 w-3 text-destructive" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
+      {displayPrefix && (
+        <div className="text-xs text-secondary">
+          <span className="text-tertiary">Prefix:</span>{' '}
+          <span className="font-mono text-primary">{displayPrefix}</span>
+        </div>
+      )}
 
-      <Dialog onOpenChange={setShowSetDialog} open={showSetDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {editingKey
-                ? `Edit Key: ${editingKey.key}`
-                : 'Add Configuration Key'}
-            </DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4 py-2">
-            {!editingKey && (
-              <div className="space-y-2">
-                <Label htmlFor="cfg-key">Key</Label>
-                <Input
-                  id="cfg-key"
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, key: e.target.value }))
-                  }
-                  placeholder="/myapp/parameter"
-                  value={form.key}
-                />
-              </div>
-            )}
-            <div className="space-y-2">
-              <Label htmlFor="cfg-type">Data Type</Label>
-              <Select
-                onValueChange={(v) =>
-                  setForm((f) => ({
-                    ...f,
-                    data_type: v as DataType,
-                    secret: v === 'SecureString',
-                  }))
-                }
-                value={form.data_type}
-              >
-                <SelectTrigger id="cfg-type">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {DATA_TYPES.map((t) => (
-                    <SelectItem key={t} value={t}>
-                      {t}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="cfg-value">Value</Label>
+      <div className="grid h-[calc(100dvh-460px)] min-h-[320px] grid-cols-[420px_1fr] overflow-hidden rounded-lg border border-primary bg-primary">
+        {/* LEFT pane: filter + key list */}
+        <div className="flex min-h-0 flex-col border-r border-primary bg-secondary">
+          <div className="flex h-14 shrink-0 items-center border-b border-primary px-3.5">
+            <div className="relative flex w-full items-center">
+              <Search
+                aria-hidden
+                className="pointer-events-none absolute left-3 h-3.5 w-3.5 text-tertiary"
+              />
               <Input
-                id="cfg-value"
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, value: e.target.value }))
-                }
-                placeholder={form.secret ? '••••••••' : 'value'}
-                type={form.secret ? 'password' : 'text'}
-                value={form.value}
+                className="h-8 pl-9 font-mono text-xs"
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Filter"
+                value={filter}
               />
             </div>
-            <div className="flex justify-end gap-2 pt-2">
-              <Button onClick={() => setShowSetDialog(false)} variant="outline">
-                Cancel
-              </Button>
-              <Button
-                disabled={setMutation.isPending || !form.key || !form.value}
-                onClick={() => setMutation.mutate()}
-              >
-                {setMutation.isPending ? 'Saving...' : 'Save'}
-              </Button>
-            </div>
           </div>
-        </DialogContent>
-      </Dialog>
+          {isLoading ? (
+            <LoadingState label="Loading..." />
+          ) : loadError ? (
+            <ConfigLoadError error={loadError} />
+          ) : filtered.length === 0 ? (
+            <div className="px-5 py-10 text-center text-sm text-tertiary">
+              {filter
+                ? `No parameters match "${filter}"`
+                : 'No configuration keys yet.'}
+            </div>
+          ) : (
+            <ParamList
+              filter={filter}
+              items={filtered}
+              onSelect={(k) => {
+                setSelectedKey(k)
+                setMode('view')
+              }}
+              prefix={prefix}
+              selectedKey={mode === 'create' ? null : selectedKey}
+            />
+          )}
+        </div>
+
+        {/* RIGHT pane */}
+        <div className="flex min-h-0 flex-col bg-primary">
+          {mode === 'create' ? (
+            <DetailPane
+              draft={draft}
+              environments={sortedEnvironments}
+              isCreate
+              onCancel={() => setMode('view')}
+              onCreate={handleCreate}
+              onDraftChange={setDraft}
+              prefix={prefix}
+              savedFlash={false}
+            />
+          ) : selected ? (
+            <DetailPane
+              environments={sortedEnvironments}
+              onAdd={() => setMode('create')}
+              onCommitType={handleCommitType}
+              onCommitValue={handleCommitValue}
+              onDelete={() => setConfirmDelete(selected.key)}
+              onToggleReveal={toggleReveal}
+              prefix={prefix}
+              revealed={revealed}
+              savedFlash={savedFlash}
+              selected={selected}
+              typeOverride={
+                typeOverride && typeOverride.key === selected.key
+                  ? typeOverride.type
+                  : null
+              }
+              valuesByEnv={valuesByEnv}
+            />
+          ) : (
+            <EmptyState onAdd={() => setMode('create')} />
+          )}
+        </div>
+      </div>
 
       <ConfirmDialog
-        description={`Delete key "${confirmDeleteKey ?? ''}"? This cannot be undone.`}
-        onCancel={() => setConfirmDeleteKey(null)}
+        description={`Delete key "${confirmDelete ?? ''}" from every environment? This cannot be undone.`}
+        onCancel={() => setConfirmDelete(null)}
         onConfirm={() => {
-          if (confirmDeleteKey) deleteMutation.mutate(confirmDeleteKey)
+          if (confirmDelete) deleteMutation.mutate(confirmDelete)
         }}
-        open={confirmDeleteKey !== null}
+        open={confirmDelete !== null}
         title="Delete Configuration Key"
       />
+    </div>
+  )
+}
+
+function aggregate(
+  perEnv: Array<{ envSlug: string; keys: ConfigKeyResponse[] }>,
+): AggregatedKey[] {
+  const map = new Map<string, AggregatedKey>()
+  for (const { envSlug, keys } of perEnv) {
+    for (const k of keys) {
+      const dt: DataType = DATA_TYPES.includes(k.data_type as DataType)
+        ? (k.data_type as DataType)
+        : 'string'
+      let entry = map.get(k.key)
+      if (!entry) {
+        entry = {
+          data_type: dt,
+          envs: {},
+          key: k.key,
+          last_modified: k.last_modified,
+          secret: k.secret,
+        }
+        map.set(k.key, entry)
+      }
+      entry.envs[envSlug] = {
+        data_type: dt,
+        last_modified: k.last_modified,
+        secret: k.secret,
+      }
+      // Promote the most recent last_modified across envs for the key card.
+      if (
+        k.last_modified &&
+        (!entry.last_modified || k.last_modified > entry.last_modified)
+      ) {
+        entry.last_modified = k.last_modified
+      }
+      entry.secret = entry.secret || k.secret
+      entry.data_type = dt
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.key.localeCompare(b.key))
+}
+
+function commonPrefix(keys: string[]): string {
+  if (keys.length === 0) return ''
+  const segs = keys[0].split('/')
+  let prefix = ''
+  for (let i = 0; i < segs.length; i++) {
+    const candidate = (prefix ? prefix + '/' : '') + segs[i]
+    if (keys.every((k) => k === candidate || k.startsWith(candidate + '/'))) {
+      prefix = candidate
+    } else {
+      break
+    }
+  }
+  // Only collapse a prefix if it's at least 3 segments deep — otherwise the
+  // collapsed view hides too little to be worth the indirection.
+  if (prefix.split('/').filter(Boolean).length < COMMON_PREFIX_MIN_DEPTH) {
+    return ''
+  }
+  return prefix.endsWith('/') ? prefix : prefix + '/'
+}
+
+function ConfigLoadError({ error }: { error: unknown }) {
+  // FastAPI's identity_required 401 has detail = {error, plugin_id, start_url}
+  const detail =
+    error instanceof ApiError
+      ? (
+          error.data as
+            | undefined
+            | {
+                detail?:
+                  | string
+                  | { error?: string; plugin_id?: string; start_url?: string }
+              }
+        )?.detail
+      : undefined
+  const isIdentityRequired =
+    error instanceof ApiError &&
+    error.status === 401 &&
+    typeof detail === 'object' &&
+    detail?.error === 'identity_required'
+  const startUrl =
+    isIdentityRequired && typeof detail === 'object'
+      ? detail.start_url
+      : undefined
+
+  if (isIdentityRequired) {
+    return (
+      <div className="space-y-2 px-5 py-10 text-center text-sm">
+        <div className="text-primary">Connect your account to continue</div>
+        <div className="text-xs text-tertiary">
+          The configuration plugin needs an authenticated identity for your
+          user.
+        </div>
+        {startUrl && (
+          <a
+            className="inline-flex items-center text-xs font-medium text-amber-text hover:underline"
+            href={startUrl}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Connect now →
+          </a>
+        )}
+      </div>
+    )
+  }
+
+  const isUnavailable = error instanceof ApiError && error.status === 503
+  return (
+    <div className="space-y-1 px-5 py-10 text-center text-sm">
+      <div className="text-danger">
+        {isUnavailable
+          ? 'Configuration plugin is not available'
+          : 'Failed to load configuration keys'}
+      </div>
+      <div className="text-xs text-tertiary">
+        {extractApiErrorDetail(error)}
+      </div>
+    </div>
+  )
+}
+
+// True when the value (or any comma-separated segment of it) embeds a
+// URL credential pair like `scheme://user:password@host`. Used to mask
+// non-secret keys whose values still carry sensitive material.
+function containsCredentials(value: string): boolean {
+  if (!value) return false
+  const re = /[a-z][a-z0-9+\-.]*:\/\/[^:@/\s]+:[^@/\s]+@/i
+  return value.split(',').some((part) => re.test(part.trim()))
+}
+
+function DetailPane({
+  draft,
+  environments,
+  isCreate,
+  onAdd,
+  onCancel,
+  onCommitType,
+  onCommitValue,
+  onCreate,
+  onDelete,
+  onDraftChange,
+  onToggleReveal,
+  prefix,
+  revealed,
+  savedFlash,
+  selected,
+  typeOverride,
+  valuesByEnv,
+}: DetailPaneProps) {
+  // Defensively force `secret` to win over `data_type` so the picker
+  // reflects what the lock icon already conveys in the list.
+  const liveType: DataType = isCreate
+    ? draft!.data_type
+    : selected?.secret
+      ? 'secret'
+      : (selected?.data_type ?? 'string')
+  const currentType: DataType =
+    !isCreate && typeOverride ? typeOverride : liveType
+
+  const currentKey = isCreate ? draft!.key : (selected?.key ?? '')
+  const showsPrefix = prefix && currentKey.startsWith(prefix)
+  const keyTail = showsPrefix ? currentKey.slice(prefix.length) : currentKey
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header: type segmented + saved + add */}
+      <div className="flex h-14 shrink-0 items-center gap-2 border-b border-primary px-6">
+        <div className="inline-flex rounded-md border border-secondary bg-primary p-0.5">
+          {DATA_TYPES.map((t) => (
+            <button
+              className={cn(
+                'inline-flex h-7 items-center gap-1.5 rounded-[5px] px-2.5 text-xs font-medium transition-colors',
+                currentType === t
+                  ? 'bg-amber-bg text-amber-text shadow-sm'
+                  : 'text-secondary hover:bg-tertiary hover:text-primary',
+              )}
+              key={t}
+              onClick={() => {
+                if (isCreate) {
+                  onDraftChange?.({ ...draft!, data_type: t })
+                } else {
+                  onCommitType?.(t)
+                }
+              }}
+              type="button"
+            >
+              {t === 'secret' && <Lock className="h-2.5 w-2.5" />}
+              {DATA_TYPE_LABELS[t]}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1" />
+        {savedFlash && (
+          <span className="inline-flex items-center gap-1 text-xs text-success">
+            <Check className="h-3 w-3" /> Saved
+          </span>
+        )}
+        {!isCreate && onAdd && (
+          <Button onClick={onAdd} size="sm">
+            <Plus className="h-3 w-3" /> Add parameter
+          </Button>
+        )}
+      </div>
+
+      {/* Name */}
+      <div className="border-b border-primary px-6 py-4">
+        <div className="mb-1.5 text-overline uppercase text-tertiary">Name</div>
+        <div className="flex items-stretch overflow-hidden rounded-md border border-secondary bg-primary">
+          {prefix && (
+            <span className="inline-flex items-center whitespace-nowrap border-r border-primary bg-secondary px-2.5 font-mono text-xs text-tertiary">
+              {prefix}
+            </span>
+          )}
+          {isCreate ? (
+            <input
+              autoFocus
+              className="h-9 flex-1 bg-transparent px-3 font-mono text-xs text-primary outline-none placeholder:text-tertiary"
+              onChange={(e) =>
+                onDraftChange?.({
+                  ...draft!,
+                  key: (showsPrefix ? prefix : '') + e.target.value,
+                })
+              }
+              placeholder="component/setting/name"
+              value={keyTail}
+            />
+          ) : (
+            <span className="flex-1 px-3 py-2 font-mono text-xs text-primary">
+              {keyTail || currentKey}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Body: env rows. The grid lives on the parent so the env-label
+          column auto-sizes to the widest label across all rows. */}
+      <div className="flex-1 overflow-y-auto px-6 py-5">
+        <div className="grid grid-cols-[max-content_1fr] items-start gap-x-4 gap-y-3.5">
+          {environments.map((env) => {
+            const envValue = isCreate
+              ? (draft!.values[env.slug] ?? '')
+              : ((valuesByEnv?.[env.slug]?.[currentKey] as
+                  | string
+                  | undefined) ?? undefined)
+            const isSet = !isCreate && Boolean(selected?.envs[env.slug])
+            return (
+              <EnvRow
+                dataType={currentType}
+                env={env}
+                isCreate={Boolean(isCreate)}
+                isSecret={
+                  isCreate
+                    ? currentType === 'secret'
+                    : Boolean(
+                        selected?.envs[env.slug]?.secret ?? selected?.secret,
+                      )
+                }
+                isSet={isSet}
+                key={env.slug}
+                onCommit={(v) => {
+                  if (isCreate) {
+                    onDraftChange?.({
+                      ...draft!,
+                      values: { ...draft!.values, [env.slug]: v },
+                    })
+                  } else {
+                    onCommitValue?.(env.slug, v)
+                  }
+                }}
+                onToggleReveal={() => onToggleReveal?.(env.slug, currentKey)}
+                revealed={
+                  !isCreate && Boolean(revealed?.[`${env.slug}::${currentKey}`])
+                }
+                value={envValue}
+              />
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex shrink-0 items-center gap-2 border-t border-primary px-6 py-3">
+        {isCreate ? (
+          <>
+            <div className="flex-1" />
+            <Button onClick={onCancel} size="sm" variant="outline">
+              Cancel
+            </Button>
+            <Button onClick={onCreate} size="sm">
+              <Plus className="h-3 w-3" /> Save
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              className="text-danger hover:text-danger"
+              onClick={onDelete}
+              size="sm"
+              variant="ghost"
+            >
+              <Trash2 className="h-3 w-3" /> Delete parameter
+            </Button>
+            <div className="flex-1" />
+            {selected?.last_modified && (
+              <span className="text-xs text-tertiary">
+                Last modified{' '}
+                {new Date(selected.last_modified).toLocaleString()}
+              </span>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 p-10 text-center">
+      <Settings2 aria-hidden className="h-7 w-7 text-tertiary" />
+      <div className="text-sm text-secondary">
+        Select a parameter to view its values.
+      </div>
+      <Button onClick={onAdd} size="sm" variant="outline">
+        <Plus className="h-3 w-3" /> Add parameter
+      </Button>
+    </div>
+  )
+}
+
+function EnvRow({
+  dataType,
+  env,
+  isCreate,
+  isSecret,
+  isSet,
+  onCommit,
+  onToggleReveal,
+  revealed,
+  value,
+}: EnvRowProps) {
+  const { isDarkMode } = useTheme()
+  const chip = env.label_color
+    ? deriveChipColors(env.label_color, isDarkMode)
+    : null
+
+  const [local, setLocal] = useState(value ?? '')
+  const [focused, setFocused] = useState(false)
+  const initialRef = useRef(value ?? '')
+
+  useEffect(() => {
+    if (!focused) {
+      setLocal(value ?? '')
+      initialRef.current = value ?? ''
+    }
+  }, [value, focused])
+
+  const handleBlur = () => {
+    setFocused(false)
+    if (local !== initialRef.current) {
+      onCommit(local)
+      initialRef.current = local
+    }
+  }
+
+  // Mask whenever the param is flagged secret OR the value embeds URL
+  // credentials — non-secret string_list params often hold connection
+  // strings (rabbitmq, postgres) whose passwords still shouldn't be shown
+  // in plain text. The eye toggle reveals on demand either way.
+  const looksSensitive = !isCreate && containsCredentials(local)
+  const shouldMask =
+    !isCreate &&
+    (isSecret || looksSensitive) &&
+    !revealed &&
+    !focused &&
+    (isSet || Boolean(local))
+  const placeholder = isCreate ? 'Optional' : isSet ? '' : 'Not set'
+  const display = shouldMask
+    ? maskSecret(local)
+    : focused || revealed || isCreate
+      ? local
+      : (local ?? '')
+
+  const showRevealButton =
+    !isCreate && (isSecret || looksSensitive) && (isSet || Boolean(local))
+
+  return (
+    <>
+      <div className="pt-2">
+        <span
+          className="inline-flex h-6 items-center whitespace-nowrap rounded-md px-2 text-xs font-medium"
+          style={
+            chip
+              ? {
+                  backgroundColor: chip.bg,
+                  color: chip.fg,
+                }
+              : undefined
+          }
+        >
+          {env.name}
+        </span>
+      </div>
+      <div className="flex items-start gap-1.5">
+        {dataType === 'string_list' ? (
+          <textarea
+            className={cn(
+              'block w-full resize-y rounded-md border bg-transparent px-3 py-2 font-mono text-xs leading-relaxed text-primary outline-none transition-colors placeholder:text-tertiary',
+              focused
+                ? 'border-amber-border bg-primary ring-2 ring-amber-border/30'
+                : 'border-transparent hover:bg-tertiary',
+            )}
+            onBlur={handleBlur}
+            onChange={(e) => {
+              if (!shouldMask) setLocal(e.target.value)
+            }}
+            onFocus={() => setFocused(true)}
+            placeholder={placeholder}
+            rows={2}
+            value={display}
+          />
+        ) : (
+          <input
+            className={cn(
+              'block h-9 w-full rounded-md border bg-transparent px-3 font-mono text-xs text-primary outline-none transition-colors placeholder:text-tertiary',
+              focused
+                ? 'border-amber-border bg-primary ring-2 ring-amber-border/30'
+                : 'border-transparent hover:bg-tertiary',
+            )}
+            onBlur={handleBlur}
+            onChange={(e) => {
+              if (!shouldMask) setLocal(e.target.value)
+            }}
+            onFocus={() => setFocused(true)}
+            placeholder={placeholder}
+            type="text"
+            value={display}
+          />
+        )}
+        {showRevealButton && (
+          <Button
+            aria-label={revealed ? 'Hide value' : 'Reveal value'}
+            className="mt-0.5 h-7 px-1.5"
+            onClick={onToggleReveal}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            {revealed ? (
+              <EyeOff className="h-3 w-3" />
+            ) : (
+              <Eye className="h-3 w-3" />
+            )}
+          </Button>
+        )}
+      </div>
+    </>
+  )
+}
+
+function Highlight({ q, text }: { q: string; text: string }) {
+  if (!q) return <>{text}</>
+  const idx = text.toLowerCase().indexOf(q.toLowerCase())
+  if (idx < 0) return <>{text}</>
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="rounded-sm bg-amber-bg px-0 text-inherit">
+        {text.slice(idx, idx + q.length)}
+      </mark>
+      {text.slice(idx + q.length)}
+    </>
+  )
+}
+
+// If the value looks like a connection URL with embedded credentials
+// (scheme://user:password@host…), mask only the password segment.
+// Otherwise mask the whole value with bullets capped at a sensible length.
+// For string_list values (comma-separated), each entry is masked
+// independently so a list of URLs only hides each URL's password.
+function maskSecret(value: string): string {
+  if (!value) return ''
+  if (value.includes(',')) {
+    return value
+      .split(',')
+      .map((part) => {
+        // Preserve surrounding whitespace so the rendered list doesn't
+        // shift when toggling reveal.
+        const leading = part.match(/^\s*/)?.[0] ?? ''
+        const trailing = part.match(/\s*$/)?.[0] ?? ''
+        const inner = part.slice(leading.length, part.length - trailing.length)
+        return leading + maskSecretSingle(inner) + trailing
+      })
+      .join(',')
+  }
+  return maskSecretSingle(value)
+}
+
+function maskSecretSingle(value: string): string {
+  if (!value) return ''
+  const url = /^([a-z][a-z0-9+\-.]*:\/\/)([^:@/\s]+):([^@/\s]+)(@.*)$/i.exec(
+    value,
+  )
+  if (url) {
+    return `${url[1]}${url[2]}:${'•'.repeat(8)}${url[4]}`
+  }
+  return '•'.repeat(Math.min(40, value.length || 8))
+}
+
+function ParamList({
+  filter,
+  items,
+  onSelect,
+  prefix,
+  selectedKey,
+}: ParamListProps) {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      {items.map((p) => {
+        const isSelected = p.key === selectedKey
+        const display =
+          prefix && p.key.startsWith(prefix)
+            ? p.key.slice(prefix.length)
+            : p.key
+        return (
+          <button
+            className={cn(
+              'flex w-full items-center gap-2.5 border-b border-primary px-3.5 py-2.5 text-left transition-colors',
+              isSelected ? 'bg-amber-bg' : 'hover:bg-tertiary',
+            )}
+            key={p.key}
+            onClick={() => onSelect(p.key)}
+            style={{
+              borderLeft: isSelected
+                ? '2px solid var(--color-action-bg)'
+                : '2px solid transparent',
+            }}
+            type="button"
+          >
+            <span
+              className={cn(
+                'flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-xs',
+                isSelected ? 'text-amber-text' : 'text-primary',
+                isSelected && 'font-medium',
+              )}
+              style={{ direction: 'rtl', textAlign: 'left' }}
+              title={p.key}
+            >
+              <span style={{ direction: 'ltr', unicodeBidi: 'bidi-override' }}>
+                <Highlight q={filter} text={display} />
+              </span>
+            </span>
+            {p.secret && <Lock aria-hidden className="h-3 w-3 text-tertiary" />}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -86,6 +86,7 @@ interface DetailPaneProps {
   savedFlash: boolean
   selected?: AggregatedKey
   typeOverride?: DataType | null
+  valueLoadingByEnv?: Record<string, boolean>
   valuesByEnv?: Record<string, Record<string, unknown>>
 }
 
@@ -93,6 +94,7 @@ interface EnvRowProps {
   dataType: DataType
   env: Environment
   isCreate: boolean
+  isLoadingValue?: boolean
   isSecret: boolean
   isSet: boolean
   onCommit: (value: string) => void
@@ -280,6 +282,26 @@ export function ConfigurationTab({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortedEnvironments, ...valueQueries.map((q) => q.data)])
 
+  // Per-env load state for the values query. The keys list can resolve
+  // before its matching value fetch, so we surface this to EnvRow to
+  // gate edit/reveal until each env's values are actually present —
+  // otherwise an existing key briefly looks empty and a stray keystroke
+  // could overwrite a value the user never saw.
+  // ``q.fetchStatus === 'idle'`` is the disabled-query state (no keys
+  // for this env yet) — treat that as "not loading" so empty envs
+  // don't render a permanent skeleton.
+  const valueLoadingFlags = valueQueries.map(
+    (q) => q.fetchStatus !== 'idle' && (q.isLoading || q.data === undefined),
+  )
+  const valueLoadingByEnv = useMemo(() => {
+    const out: Record<string, boolean> = {}
+    sortedEnvironments.forEach((env, idx) => {
+      out[env.slug] = Boolean(valueLoadingFlags[idx])
+    })
+    return out
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sortedEnvironments, ...valueLoadingFlags])
+
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase()
     if (!q) return aggregated
@@ -351,15 +373,29 @@ export function ConfigurationTab({
     },
     onSuccess: (_, vars) => {
       flashSaved()
-      void queryClient.invalidateQueries({
-        queryKey: [
-          'config-keys',
-          orgSlug,
-          projectId,
-          activeSource,
-          vars.environment,
-        ],
-      })
+      // Invalidate both the keys list (in case data_type/secret flipped)
+      // *and* the per-env values so EnvRow rehydrates from fresh data on
+      // blur instead of snapping back to a stale cached value.
+      void Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [
+            'config-keys',
+            orgSlug,
+            projectId,
+            activeSource,
+            vars.environment,
+          ],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [
+            'config-values',
+            orgSlug,
+            projectId,
+            activeSource,
+            vars.environment,
+          ],
+        }),
+      ])
     },
   })
 
@@ -607,6 +643,7 @@ export function ConfigurationTab({
                   ? typeOverride.type
                   : null
               }
+              valueLoadingByEnv={valueLoadingByEnv}
               valuesByEnv={valuesByEnv}
             />
           ) : (
@@ -774,6 +811,7 @@ function DetailPane({
   savedFlash,
   selected,
   typeOverride,
+  valueLoadingByEnv,
   valuesByEnv,
 }: DetailPaneProps) {
   // Defensively force `secret` to win over `data_type` so the picker
@@ -872,11 +910,18 @@ function DetailPane({
                   | string
                   | undefined) ?? undefined)
             const isSet = !isCreate && Boolean(selected?.envs[env.slug])
+            // Treat the row as loading when the env claims this key is
+            // set but its value query hasn't landed yet — that's the
+            // window where an editable input could overwrite a value
+            // the user never saw.
+            const isLoadingValue =
+              !isCreate && isSet && Boolean(valueLoadingByEnv?.[env.slug])
             return (
               <EnvRow
                 dataType={currentType}
                 env={env}
                 isCreate={Boolean(isCreate)}
+                isLoadingValue={isLoadingValue}
                 isSecret={
                   isCreate
                     ? currentType === 'secret'
@@ -961,6 +1006,7 @@ function EnvRow({
   dataType,
   env,
   isCreate,
+  isLoadingValue,
   isSecret,
   isSet,
   onCommit,
@@ -1003,15 +1049,26 @@ function EnvRow({
     !revealed &&
     !focused &&
     (isSet || Boolean(local))
-  const placeholder = isCreate ? 'Optional' : isSet ? '' : 'Not set'
-  const display = shouldMask
-    ? maskSecret(local)
-    : focused || revealed || isCreate
-      ? local
-      : (local ?? '')
+  const placeholder = isLoadingValue
+    ? 'Loading…'
+    : isCreate
+      ? 'Optional'
+      : isSet
+        ? ''
+        : 'Not set'
+  const display = isLoadingValue
+    ? ''
+    : shouldMask
+      ? maskSecret(local)
+      : focused || revealed || isCreate
+        ? local
+        : (local ?? '')
 
   const showRevealButton =
-    !isCreate && (isSecret || looksSensitive) && (isSet || Boolean(local))
+    !isCreate &&
+    !isLoadingValue &&
+    (isSecret || looksSensitive) &&
+    (isSet || Boolean(local))
 
   return (
     <>
@@ -1038,10 +1095,12 @@ function EnvRow({
               focused
                 ? 'border-amber-border bg-primary ring-2 ring-amber-border/30'
                 : 'border-transparent hover:bg-tertiary',
+              isLoadingValue && 'animate-pulse cursor-wait',
             )}
+            disabled={isLoadingValue}
             onBlur={handleBlur}
             onChange={(e) => {
-              if (!shouldMask) setLocal(e.target.value)
+              if (!shouldMask && !isLoadingValue) setLocal(e.target.value)
             }}
             onFocus={() => setFocused(true)}
             placeholder={placeholder}
@@ -1055,10 +1114,12 @@ function EnvRow({
               focused
                 ? 'border-amber-border bg-primary ring-2 ring-amber-border/30'
                 : 'border-transparent hover:bg-tertiary',
+              isLoadingValue && 'animate-pulse cursor-wait',
             )}
+            disabled={isLoadingValue}
             onBlur={handleBlur}
             onChange={(e) => {
-              if (!shouldMask) setLocal(e.target.value)
+              if (!shouldMask && !isLoadingValue) setLocal(e.target.value)
             }}
             onFocus={() => setFocused(true)}
             placeholder={placeholder}

--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -1110,16 +1110,14 @@ function Histogram({
   const n = buckets.length
   // ``activeSum`` is the height-driving total for each bucket. Prefer the
   // sum of the level toggles the user has on; fall back to ``b.count``
-  // when the source plugin can't break down by level (e.g. Postgres
-  // logs in CloudWatch have no structured ``level`` field, so the
-  // per-level Insights query returns nothing — but the totals query
-  // still populates ``b.count``). Without this fallback the bars would
-  // all be zero-height.
-  const hasAnyLevelData = buckets.some((b) =>
-    (['ERROR', 'WARN', 'INFO', 'DEBUG'] as const).some((lv) => b[lv] > 0),
-  )
+  // when this bucket has no per-level breakdown (e.g. Postgres logs in
+  // CloudWatch have no structured ``level`` field, so the per-level
+  // Insights query returns nothing — but the totals query still
+  // populates ``b.count``). The fallback is evaluated per bucket so a
+  // mixed response (some buckets with level data, others count-only)
+  // still renders every bar at the right height.
   const activeSum = (b: HistogramBucket) =>
-    hasAnyLevelData
+    (['ERROR', 'WARN', 'INFO', 'DEBUG'] as const).some((lv) => b[lv] > 0)
       ? (['ERROR', 'WARN', 'INFO', 'DEBUG'] as const).reduce(
           (s, lv) => s + (levels[lv] ? b[lv] : 0),
           0,

--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -36,7 +36,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import type { LogEntryResponse } from '@/types'
+import { useTheme } from '@/contexts/ThemeContext'
+import { deriveChipColors } from '@/lib/chip-colors'
+import { sortEnvironments } from '@/lib/utils'
+import type { Environment, LogEntryResponse } from '@/types'
 
 // ── Types & Interfaces (alphabetical) ─────────────────────────────────────
 type DetailTab = 'json' | 'stack' | 'table'
@@ -67,6 +70,7 @@ interface LogsConfig {
 }
 
 interface LogsTabProps {
+  environments?: Environment[]
   orgSlug: string
   projectId: string
 }
@@ -133,12 +137,45 @@ const SEV_BAR_COLORS: Record<string, string> = {
   WARN: 'var(--color-action-bg)',
 }
 
-const CONTAINER_H = 600 // px — must match the scroll container height
+const CONTAINER_H_DEFAULT = 600 // px — initial scroll-container height
 const ROW_H_COLLAPSED = 36 // px — estimated height for a collapsed log row
 const VIRTUAL_OVERSCAN = 8 // rows pre-rendered above and below the viewport
 
 // ── Export ─────────────────────────────────────────────────────────────────
-export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
+export function LogsTab({
+  environments = [],
+  orgSlug,
+  projectId,
+}: LogsTabProps) {
+  const { isDarkMode } = useTheme()
+  const sortedEnvironments = useMemo(
+    () => sortEnvironments(environments),
+    [environments],
+  )
+  const envChipColors = useMemo(() => {
+    const out: Record<string, ReturnType<typeof deriveChipColors>> = {}
+    for (const e of sortedEnvironments) {
+      if (e.label_color)
+        out[e.slug] = deriveChipColors(e.label_color, isDarkMode)
+    }
+    return out
+  }, [sortedEnvironments, isDarkMode])
+  const envOptions = useMemo(
+    () =>
+      sortedEnvironments.length > 0
+        ? sortedEnvironments.map((e) => ({
+            color: envChipColors[e.slug],
+            name: e.name,
+            slug: e.slug,
+          }))
+        : ENVS.map((slug) => ({ color: null, name: slug, slug })),
+    [sortedEnvironments, envChipColors],
+  )
+  const envSlugToName = useMemo(() => {
+    const out: Record<string, string> = {}
+    for (const e of sortedEnvironments) out[e.slug] = e.name
+    return out
+  }, [sortedEnvironments])
   const storageKey = `imbi.logs.config.${projectId}`
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -191,7 +228,6 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
     searchParams.getAll('filter'),
   )
   const [datePickerOpen, setDatePickerOpen] = useState(false)
-  const [envDropOpen, setEnvDropOpen] = useState(false)
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
   const [selectedBucket, setSelectedBucket] = useState<null | number>(null)
   const [cursor, setCursor] = useState<null | string>(null)
@@ -202,6 +238,19 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
 
   // Virtual scroll
   const listRef = useRef<HTMLDivElement>(null)
+  // Tracks the actual rendered height of the scroll container so the
+  // virtual-scroll math (visStart/visEnd) stays in sync when the panel
+  // is sized via CSS calc against the viewport rather than a fixed px.
+  const [containerH, setContainerH] = useState(CONTAINER_H_DEFAULT)
+  useEffect(() => {
+    const el = listRef.current
+    if (!el) return
+    const update = () => setContainerH(el.clientHeight || CONTAINER_H_DEFAULT)
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
   const loadTriggerRef = useRef<HTMLDivElement>(null)
   const rowHeightCache = useRef<Map<string, number>>(new Map())
   const [listScrollTop, setListScrollTop] = useState(0)
@@ -414,7 +463,10 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
   // bucket counts. Independent of the table pagination state so scrolling
   // never causes the histogram to flicker or reset.
   const { data: histData } = useQuery({
-    enabled: config.showHistogram && !!activeSource,
+    enabled:
+      config.showHistogram &&
+      !!activeSource &&
+      Boolean(activeAssignment?.supports_histogram),
     queryFn: ({ signal }) =>
       getProjectLogsHistogram(
         orgSlug,
@@ -500,7 +552,7 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
   const { visEnd, visStart } = useMemo(() => {
     if (!offsets.length) return { visEnd: 0, visStart: 0 }
     const viewTop = listScrollTop
-    const viewBot = listScrollTop + CONTAINER_H
+    const viewBot = listScrollTop + containerH
 
     // Lower bound: first row whose bottom edge is below viewTop
     let hi = offsets.length,
@@ -525,7 +577,7 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
       visEnd: Math.min(offsets.length, lo + VIRTUAL_OVERSCAN),
       visStart: Math.max(0, first - VIRTUAL_OVERSCAN),
     }
-  }, [offsets, listScrollTop])
+  }, [offsets, listScrollTop, containerH])
 
   const topPad = offsets[visStart]?.top ?? 0
   const botPad = Math.max(
@@ -694,62 +746,51 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
           )}
         </div>
 
-        {/* Env filter */}
-        <div className="relative">
-          <button
-            className="flex items-center gap-1.5 rounded border bg-primary px-2 py-1.5 text-xs text-tertiary hover:border-primary"
-            onClick={() => setEnvDropOpen(!envDropOpen)}
-          >
-            <span className="text-tertiary">env:</span>
-            {envs.map((e) => (
-              <span
-                className={`rounded px-1.5 py-0.5 font-mono text-[10px] ${envChipClass(e)}`}
-                key={e}
+        {/* Visual gap between date and env groups */}
+        <div aria-hidden className="ml-3 h-5 w-px bg-tertiary opacity-50" />
+
+        {/* Env toggles — same pattern as the level toggles below, ordered
+            by sort_order and colored from each Environment's label_color. */}
+        <div className="flex items-center gap-1">
+          {envOptions.map((opt) => {
+            const active = envs.includes(opt.slug)
+            const c = opt.color
+            const activeStyle: React.CSSProperties | undefined =
+              active && c
+                ? {
+                    backgroundColor: c.bg,
+                    borderColor: c.border,
+                    color: c.fg,
+                  }
+                : undefined
+            return (
+              <button
+                className={`rounded border px-2 py-1 font-mono text-[10px] transition-colors ${
+                  active && !c
+                    ? 'border-secondary bg-secondary text-primary'
+                    : !active
+                      ? 'border-tertiary text-tertiary opacity-50'
+                      : ''
+                }`}
+                key={opt.slug}
+                onClick={() =>
+                  setEnvs(
+                    envs.includes(opt.slug)
+                      ? envs.filter((x) => x !== opt.slug)
+                      : [...envs, opt.slug],
+                  )
+                }
+                style={activeStyle}
+                type="button"
               >
-                {e}
-              </span>
-            ))}
-          </button>
-          {envDropOpen && (
-            <div className="absolute right-0 top-full z-30 mt-1 min-w-48 rounded-lg border bg-primary p-3 shadow-lg">
-              <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-tertiary">
-                Environments
-              </div>
-              {ENVS.map((e) => (
-                <label
-                  className="flex cursor-pointer items-center gap-2 py-1.5 text-xs"
-                  key={e}
-                >
-                  <input
-                    checked={envs.includes(e)}
-                    className="rounded border-secondary"
-                    onChange={() =>
-                      setEnvs(
-                        envs.includes(e)
-                          ? envs.filter((x) => x !== e)
-                          : [...envs, e],
-                      )
-                    }
-                    type="checkbox"
-                  />
-                  <span
-                    className={`rounded px-1.5 py-0.5 font-mono text-[11px] ${envChipClass(e)}`}
-                  >
-                    {e}
-                  </span>
-                </label>
-              ))}
-              <div className="mt-2 border-t pt-2 text-right">
-                <button
-                  className="rounded bg-action px-2.5 py-1 text-xs font-medium text-action-foreground"
-                  onClick={() => setEnvDropOpen(false)}
-                >
-                  Done
-                </button>
-              </div>
-            </div>
-          )}
+                {opt.name}
+              </button>
+            )
+          })}
         </div>
+
+        {/* Visual gap between env and severity groups */}
+        <div aria-hidden className="ml-3 h-5 w-px bg-tertiary opacity-50" />
 
         {/* Level toggles */}
         <div className="flex items-center gap-1">
@@ -773,6 +814,9 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
             </button>
           ))}
         </div>
+
+        {/* Visual gap between level toggles and the action icons */}
+        <div aria-hidden className="ml-3 h-5 w-px bg-tertiary opacity-50" />
 
         <TooltipProvider>
           <Tooltip>
@@ -846,8 +890,12 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
         </div>
       )}
 
-      {/* Histogram */}
-      {config.showHistogram && (
+      {/* Histogram — only render when the active log plugin advertises
+          time-bucket aggregation. CloudWatch Logs Insights, for example,
+          can do it via `stats count(*) by bin(...)` but the AWS plugin
+          doesn't yet implement it, so we hide the strip rather than
+          showing an empty chart. */}
+      {config.showHistogram && activeAssignment?.supports_histogram && (
         <Histogram
           buckets={buckets}
           levels={levels}
@@ -861,18 +909,26 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
       <div className="overflow-hidden rounded-lg border bg-primary">
         <div
           className="grid gap-2.5 border-b bg-secondary px-3 py-2 font-mono text-[11px] uppercase tracking-widest text-tertiary"
-          style={{ gridTemplateColumns: '16px 164px 58px minmax(0,1fr)' }}
+          style={{ gridTemplateColumns: '16px 164px 96px 58px minmax(0,1fr)' }}
         >
           <div />
           <div>Time (UTC)</div>
-          <div>Level</div>
+          <div className="text-center">Environment</div>
+          <div className="text-center">Level</div>
           <div>Message</div>
         </div>
 
         <div
-          className="h-[600px] overflow-y-auto"
+          className="overflow-y-auto"
           onScroll={(e) => setListScrollTop(e.currentTarget.scrollTop)}
           ref={listRef}
+          style={{
+            height:
+              config.showHistogram && activeAssignment?.supports_histogram
+                ? 'calc(100dvh - 660px)'
+                : 'calc(100dvh - 500px)',
+            minHeight: '320px',
+          }}
         >
           {isFetching && failureCount > 0 && displayEntries.length === 0 ? (
             <div className="py-10 text-center">
@@ -917,6 +973,8 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
                 return (
                   <LogRow
                     entry={entry}
+                    envChipColors={envChipColors}
+                    envNames={envSlugToName}
                     expanded={expandedRows.has(rowId)}
                     key={rowId}
                     onAddFilter={handleAddFilter}
@@ -951,12 +1009,6 @@ export function LogsTab({ orgSlug, projectId }: LogsTabProps) {
 }
 
 // ── Internal helpers & components ──────────────────────────────────────────
-
-function envChipClass(env: string): string {
-  if (env === 'production') return 'bg-amber-bg text-amber-text'
-  if (env === 'staging') return 'bg-info text-info'
-  return 'bg-success text-success'
-}
 
 function extractEnv(entry: LogEntryResponse): string {
   const r = entry.raw
@@ -1056,11 +1108,23 @@ function Histogram({
 }) {
   const BAR_H = 60
   const n = buckets.length
+  // ``activeSum`` is the height-driving total for each bucket. Prefer the
+  // sum of the level toggles the user has on; fall back to ``b.count``
+  // when the source plugin can't break down by level (e.g. Postgres
+  // logs in CloudWatch have no structured ``level`` field, so the
+  // per-level Insights query returns nothing — but the totals query
+  // still populates ``b.count``). Without this fallback the bars would
+  // all be zero-height.
+  const hasAnyLevelData = buckets.some((b) =>
+    (['ERROR', 'WARN', 'INFO', 'DEBUG'] as const).some((lv) => b[lv] > 0),
+  )
   const activeSum = (b: HistogramBucket) =>
-    (['ERROR', 'WARN', 'INFO', 'DEBUG'] as const).reduce(
-      (s, lv) => s + (levels[lv] ? b[lv] : 0),
-      0,
-    )
+    hasAnyLevelData
+      ? (['ERROR', 'WARN', 'INFO', 'DEBUG'] as const).reduce(
+          (s, lv) => s + (levels[lv] ? b[lv] : 0),
+          0,
+        )
+      : b.count
   const max = Math.max(1, ...buckets.map(activeSum))
 
   // 5 evenly-spaced axis ticks that work for any bucket count
@@ -1250,6 +1314,8 @@ function JsonPretty({ value }: { value: unknown }) {
 
 function LogRow({
   entry,
+  envChipColors,
+  envNames,
   expanded,
   onAddFilter,
   onHeightChange,
@@ -1258,6 +1324,8 @@ function LogRow({
   wrap,
 }: {
   entry: LogEntryResponse
+  envChipColors: Record<string, ReturnType<typeof deriveChipColors>>
+  envNames: Record<string, string>
   expanded: boolean
   onAddFilter: (field: string, value: string) => void
   onHeightChange?: (h: number) => void
@@ -1304,7 +1372,7 @@ function LogRow({
     >
       <div
         className="grid items-start gap-2.5 px-3 py-2"
-        style={{ gridTemplateColumns: '16px 164px 58px minmax(0,1fr)' }}
+        style={{ gridTemplateColumns: '16px 164px 96px 58px minmax(0,1fr)' }}
       >
         <ChevronRight
           className={`mt-0.5 text-tertiary transition-transform duration-100 ${expanded ? 'rotate-90 text-primary' : ''}`}
@@ -1314,7 +1382,30 @@ function LogRow({
           {t.date} {t.hms}
           <span className="text-tertiary">.{t.ms}</span>
         </div>
-        <div>
+        <div className="flex min-w-0 justify-center">
+          {(() => {
+            const slug = extractEnv(entry)
+            if (!slug) return null
+            const c = envChipColors[slug]
+            return (
+              <span
+                className="inline-flex h-5 max-w-full items-center overflow-hidden text-ellipsis whitespace-nowrap rounded px-1.5 font-mono text-[10px] font-medium"
+                style={
+                  c
+                    ? {
+                        backgroundColor: c.bg,
+                        color: c.fg,
+                      }
+                    : undefined
+                }
+                title={envNames[slug] ?? slug}
+              >
+                {envNames[slug] ?? slug}
+              </span>
+            )
+          })()}
+        </div>
+        <div className="flex justify-center">
           <SevBadge level={entry.level} />
         </div>
         <div
@@ -1498,7 +1589,7 @@ function SevBadge({ level }: { level: null | string }) {
           : 'bg-info text-info'
   return (
     <span
-      className={`inline-block rounded px-1.5 py-px font-mono text-[10px] font-semibold uppercase leading-none tracking-wide ${cls}`}
+      className={`inline-flex h-5 max-w-full items-center overflow-hidden text-ellipsis whitespace-nowrap rounded px-1.5 font-mono text-[10px] font-medium ${cls}`}
     >
       {lv === 'WARNING' ? 'WARN' : lv === 'FATAL' ? 'ERROR' : lv}
     </span>

--- a/src/lib/apiError.ts
+++ b/src/lib/apiError.ts
@@ -4,14 +4,35 @@ import { ApiError } from '@/api/client'
  * Extract a human-readable message from an error produced by ApiClient.
  * Handles ApiError instances, generic Error instances, string errors, and
  * anything else with the provided fallback.
+ *
+ * FastAPI's HTTPException can carry a non-string ``detail`` (e.g. the
+ * ``identity_required`` 401 returns ``{error, plugin_id, start_url}``).
+ * Callers expect a string here, so we coerce shaped objects rather than
+ * returning them unchanged — otherwise React renders crash with
+ * "Objects are not valid as a React child".
  */
 export function extractApiErrorDetail(
   error: unknown,
   fallback = 'Unknown error',
 ): string {
   if (error instanceof ApiError) {
-    const data = error.data as undefined | { detail?: string; message?: string }
-    return data?.detail || data?.message || error.message
+    const data = error.data as
+      | undefined
+      | {
+          detail?: string | { [k: string]: unknown; error?: string }
+          message?: string
+        }
+    const detail = data?.detail
+    if (typeof detail === 'string' && detail) return detail
+    if (detail && typeof detail === 'object') {
+      if (typeof detail.error === 'string' && detail.error) return detail.error
+      try {
+        return JSON.stringify(detail)
+      } catch {
+        return error.message
+      }
+    }
+    return data?.message || error.message
   }
   if (error instanceof Error) return error.message
   if (typeof error === 'string') return error

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -615,6 +615,7 @@ export interface PluginAssignmentResponse {
   plugin_id: string
   plugin_slug: string
   source: 'merged' | 'project' | 'project_type'
+  supports_histogram?: boolean
   tab: PluginTab
 }
 
@@ -694,15 +695,22 @@ export interface PluginOptionDef {
 // Plugin types (hand-written until api-generated.ts snapshot is refreshed)
 export interface PluginResponse {
   api_version: number
+  connects_users_to?: null | string
   id: string
+  identity_plugin_id?: null | string
   label: string
+  login_capable?: boolean
   options: Record<string, unknown>
   plugin_slug: string
   service_slug: null | string
   status: 'active' | 'unavailable'
+  used_as_login?: boolean
 }
 export type PluginTab = 'configuration' | 'logs'
 export interface PluginUpdate {
+  // Pass an explicit empty string to clear; omitting the field leaves
+  // the existing value untouched on the backend.
+  identity_plugin_id?: null | string
   label: string
   options?: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary

Two larger reworks plus a stack of polish across the project Logs / Configuration tabs and the service-plugin admin.

### Configuration tab — full redesign

- **Two-pane layout** (replaces the modal-based table). Left: filter + key list with longest-common-prefix collapse. Right: inline-editable form — type segmented control (`string` / `string_list` / `secret`), name field, per-env value rows.
- **Inline editing**: text inputs for `string` / `secret`, 2-row textarea for `string_list`. Commit on blur with a brief "Saved" flash; optimistic type-override so the segmented control reflects clicks immediately.
- **Secure-string masking** masks URL-credential passwords (`scheme://user:password@host`) by default even on non-secret keys, including each comma-separated entry of a `string_list`. Reveal-on-click.
- **Path prefix display** above the panel renders the configured `path_prefix` from the active assignment's options with `${project_slug}`, `${org_slug}`, `${team_slug}`, `${project_id}` expanded client-side. `${environment}` is intentionally left as-is (varies per row).
- **Common env-label column** auto-sizes via parent CSS grid — long env names like "Infrastructure Testing" no longer wrap.

### Tab visibility + assignment admin

- Configuration / Logs tabs hide when no plugin is assigned for that tab on the project. Deep-link redirects to overview only after the assignments query resolves, so direct navigation to `/logs` works during the loading state.
- New **Default Identity Plugin** selector in the service-plugin Default Options card. Frontend types updated for `identity_plugin_id` on `PluginUpdate` / `PluginResponse` and `supports_histogram` on `PluginAssignmentResponse`.

### Logs tab

- **Env toggles** restyled to match the level toggles, ordered by `sort_order` and colored from each Environment's `label_color` via the shared `sortEnvironments` / `deriveChipColors` helpers.
- **New Environment column** on each log row, centered and chip-colored.
- **Histogram** render gated on the active assignment's `supports_histogram`. When no per-bucket level breakdown is available, bars fall back to total counts in a single neutral color so plain logs still produce a visible chart.
- Scroll container height responsive (`calc(100dvh - …)`) and branches between two offsets depending on whether the histogram is shown. `ResizeObserver` keeps virtual-scroll math in sync.

### Misc

- `extractApiErrorDetail` coerces non-string FastAPI detail (the `identity_required` 401 carries a dict) so React renders no longer crash with "Objects are not valid as a React child".
- `ConfigLoadError` surfaces a "Connect your account" empty state with a Connect-now link when the configuration query returns `identity_required`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint` (oxlint — 0 errors)
- [x] `npm run format:check` (oxfmt)
- [x] `npx vitest run` — 155 passed
- [ ] Manual: configuration tab on a project with an SSM-backed plugin; create / edit / delete params, secure string masking + reveal
- [ ] Manual: logs tab on a project with the AWS CloudWatch plugin; env toggles + env column reflect environment metadata; histogram bars render
- [ ] Manual: project type with no configuration plugin → tab hidden; direct navigation to `?tab=configuration` redirects to overview

## Depends on

- imbi-api: AWeber-Imbi/imbi-api#273 (`PluginAssignmentResponse.supports_histogram`, `PluginUpdate.identity_plugin_id`, env stamping on log entries, identity_required 401 handler)
- imbi-plugin-aws: AWeber-Imbi/imbi-plugin-aws#8 (cloudwatch histogram + manifest's `supports_histogram=True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)