### PR TITLE
Add log level param + auto-fill OAuth2 callback URL

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1740,6 +1740,7 @@ export interface LogSearchParams {
   end_time?: string
   environment?: string | string[]
   filter?: string[]
+  level?: string[]
   limit?: number
   source?: string
   start_time?: string
@@ -1790,6 +1791,7 @@ export const searchProjectLogs = (
     if (params.cursor) query.cursor = params.cursor
     if (params.limit != null) query.limit = String(params.limit)
     if (params.filter?.length) query.filter = params.filter
+    if (params.level?.length) query.level = params.level
   }
   return apiClient.get<LogResultResponse>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/logs/`,

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 
 import { AlertCircle } from 'lucide-react'
 
+import { API_BASE_URL } from '@/api/client'
 import { FormHeader } from '@/components/admin/form-header'
 import { Input } from '@/components/ui/input'
 import { useAuth } from '@/hooks/useAuth'
@@ -11,6 +12,9 @@ import type {
   ServiceApplicationCreate,
   ServiceApplicationUpdate,
 } from '@/types'
+
+const callbackUrlForSlug = (slug: string): string =>
+  slug ? `${API_BASE_URL}/me/identities/${slug}/callback` : ''
 
 interface OAuth2ApplicationFormProps {
   application: null | ServiceApplication
@@ -66,6 +70,10 @@ export function OAuth2ApplicationForm({
   const [callbackUrl, setCallbackUrl] = useState(
     application?.callback_url || '',
   )
+  // Tracks whether the user has typed into the callback URL field. Until
+  // they do, we keep it in lock-step with the slug so the value matches
+  // the imbi-api OAuth callback route the third party must redirect to.
+  const [callbackUrlTouched, setCallbackUrlTouched] = useState(isEdit)
   const [clientId, setClientId] = useState(application?.client_id || '')
   const [scopes, setScopes] = useState(application?.scopes?.join(', ') || '')
   const [status, setStatus] = useState<AppStatus>(
@@ -85,8 +93,24 @@ export function OAuth2ApplicationForm({
   const handleNameChange = (value: string) => {
     setName(value)
     if (!isEdit) {
-      setSlug(slugify(value))
+      const nextSlug = slugify(value)
+      setSlug(nextSlug)
+      if (!callbackUrlTouched) {
+        setCallbackUrl(callbackUrlForSlug(nextSlug))
+      }
     }
+  }
+
+  const handleSlugChange = (value: string) => {
+    setSlug(value)
+    if (!isEdit && !callbackUrlTouched) {
+      setCallbackUrl(callbackUrlForSlug(value))
+    }
+  }
+
+  const handleCallbackUrlChange = (value: string) => {
+    setCallbackUrl(value)
+    setCallbackUrlTouched(true)
   }
 
   const handleSubmit = () => {
@@ -210,7 +234,7 @@ export function OAuth2ApplicationForm({
             <Input
               className={inputClass}
               disabled={isEdit}
-              onChange={(e) => setSlug(e.target.value)}
+              onChange={(e) => handleSlugChange(e.target.value)}
               placeholder="my-github-app"
               value={slug}
             />
@@ -241,7 +265,7 @@ export function OAuth2ApplicationForm({
             <label className={labelClass}>Callback URL</label>
             <Input
               className={inputClass}
-              onChange={(e) => setCallbackUrl(e.target.value)}
+              onChange={(e) => handleCallbackUrlChange(e.target.value)}
               placeholder="https://app.example.com/auth/callback"
               value={callbackUrl}
             />


### PR DESCRIPTION
## Summary
Two unrelated UI updates batched into one PR per repo:

1. **Log level query param** — `LogSearchParams` gains an optional `level: string[]` field that `searchProjectLogs` serializes as repeated `?level=` query params so the API can push severity filtering down into the log plugin. Depends on the matching imbi-api change (AWeber-Imbi/imbi-api#275).
2. **OAuth2 callback URL auto-fill** — `OAuth2ApplicationForm` keeps the callback URL in lock-step with the slug until the operator types into it manually, removing the friction of copy-pasting `${API_BASE_URL}/me/identities/<slug>/callback` for every new OAuth2 third-party service.

## Test plan
- [ ] CI green
- [ ] Verify in dev: creating a new OAuth2 application populates callback URL as the slug changes; manual edits stick
- [ ] Verify the project Logs tab — when level chips are toggled the request includes `?level=...`