### PR TITLE
Add user profile page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,11 @@ const ReportsPage = lazy(() =>
 const SettingsPage = lazy(() =>
   import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage })),
 )
+const UserProfilePage = lazy(() =>
+  import('./pages/UserProfile/UserProfilePage').then((m) => ({
+    default: m.UserProfilePage,
+  })),
+)
 const LoginPage = lazy(() =>
   import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })),
 )
@@ -134,6 +139,14 @@ function App() {
                     </AdminProtectedRoute>
                   }
                   path="/admin/:section?/:slug?/:action?"
+                />
+                <Route
+                  element={
+                    <ProtectedRoute>
+                      <UserProfilePage />
+                    </ProtectedRoute>
+                  }
+                  path="/users/:email"
                 />
                 <Route
                   element={<Navigate replace to="/operations-log" />}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -42,7 +42,6 @@ interface NavigationProps {
   onNewDeployment?: () => void
   onNewOpsEntry?: () => void
   onNewProject?: () => void
-  onViewChange?: (view: string) => void
 }
 
 export function Navigation({
@@ -50,7 +49,6 @@ export function Navigation({
   onNewDeployment,
   onNewOpsEntry,
   onNewProject,
-  onViewChange,
 }: NavigationProps) {
   const { isDarkMode, toggleTheme } = useTheme()
   const { logout, user } = useAuth()
@@ -268,7 +266,13 @@ export function Navigation({
                 </div>
               )}
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => onViewChange?.('user-profile')}>
+              <DropdownMenuItem
+                disabled={!user?.email}
+                onClick={() =>
+                  user?.email &&
+                  navigate(`/users/${encodeURIComponent(user.email)}`)
+                }
+              >
                 <UserCircle className="mr-2 h-4 w-4" />
                 <span>Profile</span>
               </DropdownMenuItem>

--- a/src/components/ui/user-display.tsx
+++ b/src/components/ui/user-display.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom'
+
 import { cn } from '@/lib/utils'
 
 import { Gravatar } from './gravatar'
@@ -7,6 +9,11 @@ interface Props {
   displayNames?: Map<string, string>
   email: string
   hideName?: boolean
+  /**
+   * When true (default), wraps the chip in a link to /users/:email so the
+   * user's profile page is reachable from any opslog/note/release row.
+   */
+  linkToProfile?: boolean
   size?: number
   textClassName?: string
   title?: string
@@ -21,16 +28,14 @@ export function UserDisplay({
   displayNames,
   email,
   hideName = false,
+  linkToProfile = true,
   size = 18,
   textClassName,
   title,
 }: Props) {
   const name = displayNames?.get(email) ?? email.split('@')[0] ?? email
-  return (
-    <span
-      className={cn('inline-flex items-center gap-1.5 truncate', className)}
-      title={title ?? name}
-    >
+  const body = (
+    <>
       <Gravatar
         className="flex-shrink-0 rounded-full"
         email={email}
@@ -39,6 +44,29 @@ export function UserDisplay({
       {!hideName && (
         <span className={cn('truncate', textClassName)}>{name}</span>
       )}
+    </>
+  )
+  if (linkToProfile && email) {
+    return (
+      <Link
+        className={cn(
+          'inline-flex items-center gap-1.5 truncate hover:underline',
+          className,
+        )}
+        onClick={(event) => event.stopPropagation()}
+        title={title ?? name}
+        to={`/users/${encodeURIComponent(email)}`}
+      >
+        {body}
+      </Link>
+    )
+  }
+  return (
+    <span
+      className={cn('inline-flex items-center gap-1.5 truncate', className)}
+      title={title ?? name}
+    >
+      {body}
     </span>
   )
 }

--- a/src/pages/UserProfile/ActivityRow.tsx
+++ b/src/pages/UserProfile/ActivityRow.tsx
@@ -1,0 +1,76 @@
+import { Link } from 'react-router-dom'
+
+import {
+  Activity as ActivityIcon,
+  FileText,
+  MessageSquare,
+  Paperclip,
+  Rocket,
+  RotateCcw,
+  Tag,
+  Zap,
+} from 'lucide-react'
+
+import { formatRelativeDate } from '@/lib/formatDate'
+
+import type { ActivityRecord } from './api'
+
+interface ActivityRowProps {
+  record: ActivityRecord
+}
+
+export function ActivityRow({ record }: ActivityRowProps) {
+  const body = (
+    <div className="flex items-start gap-3">
+      <span className="mt-0.5 flex-shrink-0 text-tertiary">
+        {pickIcon(record)}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm text-primary">{record.summary}</p>
+        <p className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-tertiary">
+          <span>{formatRelativeDate(record.occurred_at)}</span>
+          <span className="rounded-sm border border-tertiary px-1.5 py-0.5">
+            {record.type}
+          </span>
+          {record.environment_slug && (
+            <span className="rounded-sm border border-tertiary px-1.5 py-0.5">
+              {record.environment_slug}
+            </span>
+          )}
+        </p>
+      </div>
+    </div>
+  )
+
+  if (record.link) {
+    return (
+      <Link
+        className="block rounded-sm py-2 hover:bg-secondary"
+        to={record.link}
+      >
+        {body}
+      </Link>
+    )
+  }
+  return <div className="py-2">{body}</div>
+}
+
+function pickIcon(record: ActivityRecord) {
+  if (record.source === 'operations_log') {
+    if (record.type === 'Deployed') return <Rocket className="h-4 w-4" />
+    if (record.type === 'Rolled Back') return <RotateCcw className="h-4 w-4" />
+    return <ActivityIcon className="h-4 w-4" />
+  }
+  switch (record.source) {
+    case 'conversation':
+      return <MessageSquare className="h-4 w-4" />
+    case 'events':
+      return <Zap className="h-4 w-4" />
+    case 'note':
+      return <FileText className="h-4 w-4" />
+    case 'release':
+      return <Tag className="h-4 w-4" />
+    case 'upload':
+      return <Paperclip className="h-4 w-4" />
+  }
+}

--- a/src/pages/UserProfile/ContributionHeatmap.tsx
+++ b/src/pages/UserProfile/ContributionHeatmap.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from 'react'
+
+import type { ContributionsResponse } from './api'
+
+interface HeatmapProps {
+  data: ContributionsResponse | undefined
+  isLoading?: boolean
+}
+
+const CELL_SIZE = 11
+const CELL_GAP = 2
+const WEEKS = 53
+
+const BUCKET_COLORS = [
+  'fill-neutral-200 dark:fill-neutral-800',
+  'fill-green-200 dark:fill-green-900',
+  'fill-green-400 dark:fill-green-700',
+  'fill-green-600 dark:fill-green-500',
+  'fill-green-800 dark:fill-green-300',
+]
+
+export function ContributionHeatmap({ data, isLoading }: HeatmapProps) {
+  const cells = useMemo(() => {
+    const counts = new Map<string, number>()
+    if (data) {
+      for (const bucket of data.buckets) {
+        counts.set(bucket.date, bucket.count)
+      }
+    }
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const weekStart = startOfWeek(today)
+    const grid: { count: number; date: string; x: number; y: number }[] = []
+    for (let w = 0; w < WEEKS; w += 1) {
+      const weekIndex = WEEKS - 1 - w
+      for (let day = 0; day < 7; day += 1) {
+        const d = new Date(weekStart)
+        d.setDate(d.getDate() - 7 * w + day)
+        if (d > today) continue
+        const key = fmtDate(d)
+        grid.push({
+          count: counts.get(key) ?? 0,
+          date: key,
+          x: weekIndex,
+          y: day,
+        })
+      }
+    }
+    return grid
+  }, [data])
+
+  const total = data?.total ?? 0
+  const width = WEEKS * (CELL_SIZE + CELL_GAP)
+  const height = 7 * (CELL_SIZE + CELL_GAP)
+
+  return (
+    <section className="rounded-md border border-tertiary bg-primary p-4">
+      <header className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-sm font-medium text-primary">
+          {isLoading
+            ? 'Loading contributions…'
+            : `${total.toLocaleString()} contributions in the last year`}
+        </h2>
+        <Legend />
+      </header>
+      <div className="overflow-x-auto">
+        <svg
+          aria-label="Contribution heatmap"
+          height={height}
+          role="img"
+          width={width}
+        >
+          {cells.map((cell) => (
+            <rect
+              className={BUCKET_COLORS[bucketIndex(cell.count)]}
+              height={CELL_SIZE}
+              key={`${cell.x}-${cell.y}`}
+              rx={2}
+              ry={2}
+              width={CELL_SIZE}
+              x={cell.x * (CELL_SIZE + CELL_GAP)}
+              y={cell.y * (CELL_SIZE + CELL_GAP)}
+            >
+              <title>
+                {cell.count} contribution{cell.count === 1 ? '' : 's'} on{' '}
+                {cell.date}
+              </title>
+            </rect>
+          ))}
+        </svg>
+      </div>
+    </section>
+  )
+}
+
+function bucketIndex(count: number): number {
+  if (count <= 0) return 0
+  if (count < 2) return 1
+  if (count < 5) return 2
+  if (count < 10) return 3
+  return 4
+}
+
+function fmtDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+function Legend() {
+  return (
+    <div className="flex items-center gap-1 text-xs text-tertiary">
+      <span>Less</span>
+      {BUCKET_COLORS.map((cls, i) => (
+        <span
+          className={`inline-block h-2.5 w-2.5 rounded-sm ${cls.replace('fill-', 'bg-')}`}
+          key={i}
+        />
+      ))}
+      <span>More</span>
+    </div>
+  )
+}
+
+function startOfWeek(date: Date): Date {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  // Reduce to Monday (ISO start of week per design.md mockup)
+  const day = (d.getDay() + 6) % 7
+  d.setDate(d.getDate() - day)
+  return d
+}

--- a/src/pages/UserProfile/ContributionHeatmap.tsx
+++ b/src/pages/UserProfile/ContributionHeatmap.tsx
@@ -102,7 +102,10 @@ function bucketIndex(count: number): number {
 }
 
 function fmtDate(d: Date): string {
-  return d.toISOString().slice(0, 10)
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 function Legend() {
@@ -111,7 +114,7 @@ function Legend() {
       <span>Less</span>
       {BUCKET_COLORS.map((cls, i) => (
         <span
-          className={`inline-block h-2.5 w-2.5 rounded-sm ${cls.replace('fill-', 'bg-')}`}
+          className={`inline-block h-2.5 w-2.5 rounded-sm ${cls.replace(/fill-/g, 'bg-')}`}
           key={i}
         />
       ))}

--- a/src/pages/UserProfile/OrganizationMemberships.tsx
+++ b/src/pages/UserProfile/OrganizationMemberships.tsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom'
+
+import type { AdminUser } from '@/types'
+
+interface OrgMembershipsProps {
+  user: AdminUser
+}
+
+export function OrganizationMemberships({ user }: OrgMembershipsProps) {
+  const orgs = user.organizations ?? []
+  return (
+    <section className="rounded-md border border-tertiary bg-primary p-4">
+      <h2 className="mb-3 text-sm font-medium text-primary">Organizations</h2>
+      {orgs.length === 0 ? (
+        <p className="text-xs text-tertiary">No organization memberships.</p>
+      ) : (
+        <ul className="space-y-2">
+          {orgs.map((m) => (
+            <li
+              className="flex items-center justify-between text-sm"
+              key={m.organization_slug}
+            >
+              <Link
+                className="text-primary hover:text-info"
+                to={`/admin/organizations/${m.organization_slug}`}
+              >
+                {m.organization_name}
+              </Link>
+              <span className="rounded-sm border border-tertiary px-1.5 py-0.5 text-xs text-secondary">
+                {m.role}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/src/pages/UserProfile/ProfileHeader.tsx
+++ b/src/pages/UserProfile/ProfileHeader.tsx
@@ -1,0 +1,67 @@
+import { Gravatar } from '@/components/ui/gravatar'
+import { formatDate, formatRelativeDate } from '@/lib/formatDate'
+import type { AdminUser } from '@/types'
+
+import type { IdentitiesResponse } from './api'
+
+interface ProfileHeaderProps {
+  identities: IdentitiesResponse | undefined
+  user: AdminUser
+}
+
+export function ProfileHeader({ identities, user }: ProfileHeaderProps) {
+  const handle = user.email.split('@')[0]
+  const primary = identities?.primary
+  const externalSubject = primary
+    ? `${primary.provider}-${primary.provider_user_id}`
+    : null
+
+  return (
+    <header className="flex flex-col gap-4 border-b border-secondary pb-6 md:flex-row md:items-start md:gap-6">
+      <Gravatar
+        className="rounded-md border border-tertiary"
+        email={user.email}
+        size={96}
+      />
+      <div className="flex-1 space-y-1">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <h1 className="text-2xl font-semibold text-primary">
+            {user.display_name}
+          </h1>
+          {primary?.provider && (
+            <span className="rounded-sm border border-tertiary px-1.5 py-0.5 text-xs text-secondary">
+              {primary.provider}
+            </span>
+          )}
+          {user.is_service_account && (
+            <span className="rounded-sm border border-tertiary px-1.5 py-0.5 text-xs text-secondary">
+              service account
+            </span>
+          )}
+          {!user.is_active && (
+            <span className="rounded-sm border border-tertiary bg-danger px-1.5 py-0.5 text-xs text-danger">
+              deactivated
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-secondary">@{handle}</p>
+        <p className="text-sm text-secondary">{user.email}</p>
+        {externalSubject && (
+          <p className="font-mono text-xs text-tertiary">{externalSubject}</p>
+        )}
+        <dl className="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-xs text-secondary">
+          <div>
+            <dt className="inline text-tertiary">Joined </dt>
+            <dd className="inline">{formatDate(user.created_at)}</dd>
+          </div>
+          {user.last_login && (
+            <div>
+              <dt className="inline text-tertiary">Last active </dt>
+              <dd className="inline">{formatRelativeDate(user.last_login)}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+    </header>
+  )
+}

--- a/src/pages/UserProfile/RecentActivity.tsx
+++ b/src/pages/UserProfile/RecentActivity.tsx
@@ -1,0 +1,70 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+
+import { Button } from '@/components/ui/button'
+
+import { ActivityRow } from './ActivityRow'
+import { fetchActivity } from './api'
+import type { ActivityResponse } from './api'
+
+type ActivityPage = { data: ActivityResponse; nextCursor: null | string }
+
+interface RecentActivityProps {
+  email: string
+}
+
+export function RecentActivity({ email }: RecentActivityProps) {
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useInfiniteQuery<
+    ActivityPage,
+    Error,
+    { pageParams: unknown[]; pages: ActivityPage[] },
+    string[],
+    string | undefined
+  >({
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam, signal }) =>
+      fetchActivity(email, { cursor: pageParam, limit: 20 }, signal),
+    queryKey: ['user-activity', email],
+  })
+
+  const records = data?.pages.flatMap((p) => p.data.data) ?? []
+
+  return (
+    <section className="rounded-md border border-tertiary bg-primary p-4">
+      <h2 className="mb-3 text-sm font-medium text-primary">Recent activity</h2>
+      {isLoading && <p className="text-xs text-tertiary">Loading…</p>}
+      {error && (
+        <p className="text-xs text-danger">Failed to load activity feed.</p>
+      )}
+      {!isLoading && records.length === 0 && (
+        <p className="text-xs text-tertiary">No recent activity.</p>
+      )}
+      <ul className="divide-y divide-tertiary">
+        {records.map((record) => (
+          <li key={`${record.source}-${record.id}`}>
+            <ActivityRow record={record} />
+          </li>
+        ))}
+      </ul>
+      {hasNextPage && (
+        <div className="mt-3 flex justify-center">
+          <Button
+            disabled={isFetchingNextPage}
+            onClick={() => fetchNextPage()}
+            size="sm"
+            variant="outline"
+          >
+            {isFetchingNextPage ? 'Loading…' : 'Load more'}
+          </Button>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/pages/UserProfile/RecentActivity.tsx
+++ b/src/pages/UserProfile/RecentActivity.tsx
@@ -43,7 +43,7 @@ export function RecentActivity({ email }: RecentActivityProps) {
       {error && (
         <p className="text-xs text-danger">Failed to load activity feed.</p>
       )}
-      {!isLoading && records.length === 0 && (
+      {!isLoading && !error && records.length === 0 && (
         <p className="text-xs text-tertiary">No recent activity.</p>
       )}
       <ul className="divide-y divide-tertiary">

--- a/src/pages/UserProfile/StatisticsCard.tsx
+++ b/src/pages/UserProfile/StatisticsCard.tsx
@@ -1,0 +1,75 @@
+import { CheckCircle, Folder, Rocket } from 'lucide-react'
+
+import { Card } from '@/components/ui/card'
+
+import type { StatsResponse } from './api'
+
+interface StatsProps {
+  data: StatsResponse | undefined
+}
+
+interface TileProps {
+  icon: React.ReactNode
+  label: string
+  sub?: string
+  value: string
+}
+
+export function StatisticsCard({ data }: StatsProps) {
+  const deployments = data?.deployments
+  const successPct =
+    deployments && deployments.success_rate !== null
+      ? Math.round(deployments.success_rate * 100)
+      : null
+  const successDenominator = deployments?.total ?? 0
+  const successNumerator = deployments
+    ? deployments.total - deployments.rolled_back
+    : 0
+
+  return (
+    <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <Tile
+        icon={<Rocket className="h-4 w-4" />}
+        label="Total deployments"
+        sub={
+          deployments?.rolled_back
+            ? `${deployments.rolled_back.toLocaleString()} rolled back`
+            : undefined
+        }
+        value={deployments ? deployments.total.toLocaleString() : '—'}
+      />
+      <Tile
+        icon={<Folder className="h-4 w-4" />}
+        label="Projects touched"
+        value={
+          data?.projects_touched !== undefined
+            ? data.projects_touched.toLocaleString()
+            : '—'
+        }
+      />
+      <Tile
+        icon={<CheckCircle className="h-4 w-4" />}
+        label="Success rate"
+        sub={
+          successDenominator > 0
+            ? `${successNumerator} of ${successDenominator} deployments succeeded`
+            : undefined
+        }
+        value={successPct !== null ? `${successPct}%` : '—'}
+      />
+    </section>
+  )
+}
+
+function Tile({ icon, label, sub, value }: TileProps) {
+  return (
+    <Card className="rounded-md border border-tertiary p-4 shadow-none">
+      <div className="flex items-center gap-2 text-xs text-tertiary">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="mt-2 text-2xl font-semibold text-primary">{value}</div>
+      {sub && <div className="mt-1 text-xs text-secondary">{sub}</div>}
+    </Card>
+  )
+}

--- a/src/pages/UserProfile/UserProfilePage.tsx
+++ b/src/pages/UserProfile/UserProfilePage.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from 'react'
+
+import { useParams } from 'react-router-dom'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { getAdminUser } from '@/api/endpoints'
+import { CommandBar } from '@/components/CommandBar'
+import { Navigation } from '@/components/Navigation'
+import { usePageTitle } from '@/hooks/usePageTitle'
+
+import { fetchContributions, fetchIdentities, fetchStats } from './api'
+import { ContributionHeatmap } from './ContributionHeatmap'
+import { OrganizationMemberships } from './OrganizationMemberships'
+import { ProfileHeader } from './ProfileHeader'
+import { RecentActivity } from './RecentActivity'
+import { StatisticsCard } from './StatisticsCard'
+
+export function UserProfilePage() {
+  const { email: rawEmail } = useParams<{ email: string }>()
+  const email = useMemo(
+    () => (rawEmail ? decodeURIComponent(rawEmail) : ''),
+    [rawEmail],
+  )
+  usePageTitle(email ? `Profile · ${email}` : 'User profile')
+
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+  const userQuery = useQuery({
+    enabled: !!email,
+    queryFn: ({ signal }) => getAdminUser(email, signal),
+    queryKey: ['user', email],
+  })
+
+  const contributionsQuery = useQuery({
+    enabled: !!email,
+    queryFn: ({ signal }) => fetchContributions(email, { tz }, signal),
+    queryKey: ['user-contributions', email, tz],
+  })
+
+  const statsQuery = useQuery({
+    enabled: !!email,
+    queryFn: ({ signal }) => fetchStats(email, { tz }, signal),
+    queryKey: ['user-stats', email, tz],
+  })
+
+  const identitiesQuery = useQuery({
+    enabled: !!email,
+    queryFn: ({ signal }) => fetchIdentities(email, signal),
+    queryKey: ['user-identities', email],
+  })
+
+  return (
+    <div className="min-h-screen bg-tertiary text-primary">
+      <Navigation currentView="users" />
+      <main
+        className="px-6 pb-12 pt-20"
+        style={{ paddingBottom: 'var(--assistant-height, 64px)' }}
+      >
+        <div className="mx-auto max-w-5xl space-y-4">
+          {userQuery.error && (
+            <p className="rounded-md border border-danger bg-danger p-4 text-sm text-danger">
+              Could not load profile: {(userQuery.error as Error).message}
+            </p>
+          )}
+          {userQuery.data && (
+            <>
+              <ProfileHeader
+                identities={identitiesQuery.data}
+                user={userQuery.data}
+              />
+              <ContributionHeatmap
+                data={contributionsQuery.data}
+                isLoading={contributionsQuery.isLoading}
+              />
+              <StatisticsCard data={statsQuery.data} />
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+                <div className="lg:col-span-1">
+                  <OrganizationMemberships user={userQuery.data} />
+                </div>
+                <div className="lg:col-span-2">
+                  <RecentActivity email={email} />
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </main>
+      <CommandBar />
+    </div>
+  )
+}

--- a/src/pages/UserProfile/api.ts
+++ b/src/pages/UserProfile/api.ts
@@ -1,0 +1,127 @@
+import { apiClient } from '@/api/client'
+
+export type ActivityRecord = {
+  environment_slug: null | string
+  id: string
+  link: null | string
+  occurred_at: string
+  project_id: null | string
+  project_slug: null | string
+  source: ActivitySource
+  summary: string
+  type: string
+}
+
+export type ActivityResponse = {
+  data: ActivityRecord[]
+}
+
+export type ActivitySource =
+  | 'conversation'
+  | 'events'
+  | 'note'
+  | 'operations_log'
+  | 'release'
+  | 'upload'
+
+export type ContributionBucket = {
+  by_source: Record<string, number>
+  count: number
+  date: string
+}
+
+export type ContributionsResponse = {
+  buckets: ContributionBucket[]
+  since: string
+  total: number
+  tz: string
+  until: string
+}
+
+export type DeploymentStats = {
+  rolled_back: number
+  success_rate: null | number
+  total: number
+}
+
+export type IdentitiesResponse = {
+  all: IdentityRecord[]
+  primary: IdentityRecord | null
+}
+
+export type IdentityRecord = {
+  display_name: null | string
+  email: null | string
+  last_used: null | string
+  linked_at: null | string
+  provider: string
+  provider_user_id: string
+}
+
+export type StatsResponse = {
+  deployments: DeploymentStats
+  deployments_by_environment: Record<string, number>
+  projects_touched: number
+  since: string
+  until: string
+}
+
+const encode = (email: string) => encodeURIComponent(email)
+
+export const fetchContributions = (
+  email: string,
+  params?: { since?: string; tz?: string; until?: string },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<ContributionsResponse>(
+    `/users/${encode(email)}/contributions`,
+    params,
+    signal,
+  )
+
+export const fetchStats = (
+  email: string,
+  params?: { since?: string; tz?: string; until?: string },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<StatsResponse>(`/users/${encode(email)}/stats`, params, signal)
+
+export const fetchIdentities = (email: string, signal?: AbortSignal) =>
+  apiClient.get<IdentitiesResponse>(
+    `/users/${encode(email)}/identities`,
+    undefined,
+    signal,
+  )
+
+export const fetchActivity = (
+  email: string,
+  params?: { cursor?: string; limit?: number },
+  signal?: AbortSignal,
+): Promise<{ data: ActivityResponse; nextCursor: null | string }> =>
+  apiClient
+    .getWithHeaders<ActivityResponse>(
+      `/users/${encode(email)}/activity`,
+      params,
+      signal,
+    )
+    .then(({ data, headers }) => ({
+      data,
+      nextCursor: parseNextCursor(headers.get('link')),
+    }))
+
+function parseNextCursor(link: null | string): null | string {
+  if (!link) return null
+  // Parse `Link: <url>; rel="next", <url>; rel="first"`
+  const parts = link.split(',')
+  for (const part of parts) {
+    const match = /<([^>]+)>;\s*rel="next"/.exec(part.trim())
+    if (match) {
+      const url = match[1]
+      const queryIndex = url.indexOf('?')
+      if (queryIndex < 0) return null
+      const search = new URLSearchParams(url.slice(queryIndex + 1))
+      return search.get('cursor')
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 + 3 of `docs/user-profile-page-plan.md`: a v2 user profile page at `/users/:email` driven by the four new `imbi-api` endpoints (PR https://github.com/AWeber-Imbi/imbi-api/pull/276).

- `ProfileHeader` — Gravatar, display name, primary OAuth provider badge, @handle, email, external subject, joined / last-active timestamps.
- `ContributionHeatmap` — 53w × 7d SVG, 5-step green ramp (the documented amber-rule exception), week starts on Monday, daily tooltip.
- `StatisticsCard` — deployments / projects touched / success rate (with `X of Y deployments succeeded` sub-text).
- `OrganizationMemberships` — listed via `MEMBER_OF` with role chip and click-through to the org page.
- `RecentActivity` — TanStack `useInfiniteQuery` over the cursor-paginated `/users/:email/activity` feed. Each row uses a source-aware lucide icon and links to the source detail page.

Cross-linking: `UserDisplay` (the shared chip used in opslog rows, notes, releases, and dashboard widgets) now wraps in a `<Link to=/users/:email>` by default, so clicking any performer/author chip lands on the profile page. Click events stop propagation so embedding inside a parent click target (e.g. opslog rows) keeps existing behaviour.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 155/155 passing
- [x] `npm run build` — succeeds
- [ ] Smoke: visit `/users/<email>` once the API PR lands; confirm heatmap, stats, memberships, feed render, and that opslog/note/release chips deep-link to the profile