### PR TITLE
Rename Notes → Documents (components, types, API, copy)

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -22,6 +22,11 @@ import type {
   ConfigKeyResponse,
   ConfigKeyValueResponse,
   CurrentReleaseEnvironment,
+  Document,
+  DocumentCreate,
+  DocumentListResponse,
+  DocumentTemplate,
+  DocumentTemplateCreate,
   Environment,
   EnvironmentCreate,
   IdentityConnectionPollResponse,
@@ -38,11 +43,6 @@ import type {
   LoginProviderUpdate,
   LoginRequest,
   LogResultResponse,
-  Note,
-  NoteCreate,
-  NoteListResponse,
-  NoteTemplate,
-  NoteTemplateCreate,
   OperationsLogFilters,
   OperationsLogRecord,
   Organization,
@@ -314,49 +314,52 @@ export const deleteLinkDefinition = (orgSlug: string, slug: string) =>
     `/organizations/${encodeURIComponent(orgSlug)}/link-definitions/${encodeURIComponent(slug)}`,
   )
 
-// Note Templates (org-scoped)
-export const listNoteTemplates = async (
+// Document Templates (org-scoped)
+export const listDocumentTemplates = async (
   orgSlug: string,
   signal?: AbortSignal,
-): Promise<NoteTemplate[]> => {
-  const response = await apiClient.get<NoteTemplate[]>(
-    `/organizations/${encodeURIComponent(orgSlug)}/note-templates/`,
+): Promise<DocumentTemplate[]> => {
+  const response = await apiClient.get<DocumentTemplate[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/document-templates/`,
     undefined,
     signal,
   )
   return Array.isArray(response) ? response : []
 }
 
-export const getNoteTemplate = (
+export const getDocumentTemplate = (
   orgSlug: string,
   slug: string,
   signal?: AbortSignal,
 ) =>
-  apiClient.get<NoteTemplate>(
-    `/organizations/${encodeURIComponent(orgSlug)}/note-templates/${encodeURIComponent(slug)}`,
+  apiClient.get<DocumentTemplate>(
+    `/organizations/${encodeURIComponent(orgSlug)}/document-templates/${encodeURIComponent(slug)}`,
     undefined,
     signal,
   )
 
-export const createNoteTemplate = (orgSlug: string, data: NoteTemplateCreate) =>
-  apiClient.post<NoteTemplate>(
-    `/organizations/${encodeURIComponent(orgSlug)}/note-templates/`,
+export const createDocumentTemplate = (
+  orgSlug: string,
+  data: DocumentTemplateCreate,
+) =>
+  apiClient.post<DocumentTemplate>(
+    `/organizations/${encodeURIComponent(orgSlug)}/document-templates/`,
     data,
   )
 
-export const updateNoteTemplate = (
+export const updateDocumentTemplate = (
   orgSlug: string,
   slug: string,
   operations: PatchOperation[],
 ) =>
-  apiClient.patch<NoteTemplate>(
-    `/organizations/${encodeURIComponent(orgSlug)}/note-templates/${encodeURIComponent(slug)}`,
+  apiClient.patch<DocumentTemplate>(
+    `/organizations/${encodeURIComponent(orgSlug)}/document-templates/${encodeURIComponent(slug)}`,
     operations,
   )
 
-export const deleteNoteTemplate = (orgSlug: string, slug: string) =>
+export const deleteDocumentTemplate = (orgSlug: string, slug: string) =>
   apiClient.delete<void>(
-    `/organizations/${encodeURIComponent(orgSlug)}/note-templates/${encodeURIComponent(slug)}`,
+    `/organizations/${encodeURIComponent(orgSlug)}/document-templates/${encodeURIComponent(slug)}`,
   )
 
 // Activity Feed
@@ -1489,61 +1492,61 @@ export const deleteProjectService = (
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectSlug)}/services/${encodeURIComponent(serviceSlug)}`,
   )
 
-// Notes (project-scoped)
-export const listProjectNotes = async (
+// Documents (project-scoped)
+export const listProjectDocuments = async (
   orgSlug: string,
   projectId: string,
   params?: { cursor?: string; limit?: number; tag?: string },
   signal?: AbortSignal,
-): Promise<Note[]> => {
-  const response = await apiClient.get<NoteListResponse>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/`,
+): Promise<Document[]> => {
+  const response = await apiClient.get<DocumentListResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/`,
     params,
     signal,
   )
   return response?.data ?? []
 }
 
-export const getProjectNote = (
+export const getProjectDocument = (
   orgSlug: string,
   projectId: string,
-  noteId: string,
+  documentId: string,
   signal?: AbortSignal,
 ) =>
-  apiClient.get<Note>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/${encodeURIComponent(noteId)}`,
+  apiClient.get<Document>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}`,
     undefined,
     signal,
   )
 
-export const createProjectNote = (
+export const createProjectDocument = (
   orgSlug: string,
   projectId: string,
-  data: NoteCreate,
+  data: DocumentCreate,
 ) =>
-  apiClient.post<Note>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/`,
+  apiClient.post<Document>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/`,
     data,
   )
 
-export const patchProjectNote = (
+export const patchProjectDocument = (
   orgSlug: string,
   projectId: string,
-  noteId: string,
+  documentId: string,
   operations: PatchOperation[],
 ) =>
-  apiClient.patch<Note>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/${encodeURIComponent(noteId)}`,
+  apiClient.patch<Document>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}`,
     operations,
   )
 
-export const deleteProjectNote = (
+export const deleteProjectDocument = (
   orgSlug: string,
   projectId: string,
-  noteId: string,
+  documentId: string,
 ) =>
   apiClient.delete<void>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/notes/${encodeURIComponent(noteId)}`,
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}`,
   )
 
 // Tags (org-scoped)

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -28,9 +28,9 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 
 import { AuthProvidersManagement } from './admin/AuthProvidersManagement'
 import { BlueprintManagement } from './admin/BlueprintManagement'
+import { DocumentTemplateManagement } from './admin/DocumentTemplateManagement'
 import { EnvironmentManagement } from './admin/EnvironmentManagement'
 import { LinkDefinitionManagement } from './admin/LinkDefinitionManagement'
-import { NoteTemplateManagement } from './admin/NoteTemplateManagement'
 import { OrganizationManagement } from './admin/OrganizationManagement'
 import { PluginPackageDetail } from './admin/PluginPackageDetail'
 import { PluginsManagement } from './admin/PluginsManagement'
@@ -45,9 +45,9 @@ import { WebhookManagement } from './admin/WebhookManagement'
 
 type AdminSection =
   | 'blueprints'
+  | 'document-templates'
   | 'environments'
   | 'link-definitions'
-  | 'note-templates'
   | 'oauth'
   | 'organizations'
   | 'plugins'
@@ -64,7 +64,7 @@ const VALID_SECTIONS: AdminSection[] = [
   'blueprints',
   'environments',
   'link-definitions',
-  'note-templates',
+  'document-templates',
   'oauth',
   'organizations',
   'plugins',
@@ -127,10 +127,10 @@ export function Admin() {
       scope: 'org',
     },
     {
-      description: 'Manage reusable note templates',
+      description: 'Manage reusable document templates',
       icon: StickyNote,
-      id: 'note-templates',
-      label: 'Note Templates',
+      id: 'document-templates',
+      label: 'Document Templates',
       scope: 'org',
     },
     {
@@ -349,7 +349,9 @@ export function Admin() {
             {currentSection === 'link-definitions' && (
               <LinkDefinitionManagement />
             )}
-            {currentSection === 'note-templates' && <NoteTemplateManagement />}
+            {currentSection === 'document-templates' && (
+              <DocumentTemplateManagement />
+            )}
             {currentSection === 'blueprints' && <BlueprintManagement />}
             {currentSection === 'organizations' && <OrganizationManagement />}
             {currentSection === 'users' && <UserManagement />}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -21,14 +21,14 @@ import {
   getScoreTrend,
   listCurrentReleases,
   listLinkDefinitions,
-  listProjectNotes,
+  listProjectDocuments,
   listProjectPlugins,
   listProjectTypes,
   listScoringPolicies,
   listTeams,
   type ScoreTrend,
 } from '@/api/endpoints'
-import { ProjectNotesTab } from '@/components/notes/ProjectNotesTab'
+import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
 import { ConfigurationTab } from '@/components/project/ConfigurationTab'
 import { LogsTab } from '@/components/project/LogsTab'
@@ -80,7 +80,7 @@ const VALID_TABS = [
   'dependencies',
   'relationships',
   'logs',
-  'notes',
+  'documents',
   'operations-log',
   'score-history',
   'settings',
@@ -203,11 +203,11 @@ export function ProjectDetail({
     queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
     queryKey: ['projectTypes', orgSlug],
   })
-  const { data: projectNotes = [] } = useQuery({
+  const { data: projectDocuments = [] } = useQuery({
     enabled: !!orgSlug && !!project.id,
     queryFn: ({ signal }) =>
-      listProjectNotes(orgSlug, project.id, undefined, signal),
-    queryKey: ['projectNotes', orgSlug, project.id],
+      listProjectDocuments(orgSlug, project.id, undefined, signal),
+    queryKey: ['projectDocuments', orgSlug, project.id],
   })
   // Drives whether the Configuration / Logs tabs are surfaced. Only
   // treat the absence of a plugin as authoritative once the assignments
@@ -338,9 +338,11 @@ export function ProjectDetail({
     { id: 'dependencies', label: 'Dependencies' },
     ...(hasLogsPlugin ? [{ id: 'logs' as const, label: 'Logs' }] : []),
     {
-      id: 'notes',
+      id: 'documents',
       label:
-        projectNotes.length > 0 ? `Notes (${projectNotes.length})` : 'Notes',
+        projectDocuments.length > 0
+          ? `Documents (${projectDocuments.length})`
+          : 'Documents',
     },
     { id: 'operations-log', label: 'Operations Log' },
     {
@@ -668,10 +670,14 @@ export function ProjectDetail({
             />
           </TabsContent>
         )}
-        <TabsContent value="notes">
-          <ProjectNotesTab
-            initialAction={activeTab === 'notes' ? initialSubAction : undefined}
-            initialNoteId={activeTab === 'notes' ? initialSubId : undefined}
+        <TabsContent value="documents">
+          <ProjectDocumentsTab
+            initialAction={
+              activeTab === 'documents' ? initialSubAction : undefined
+            }
+            initialDocumentId={
+              activeTab === 'documents' ? initialSubId : undefined
+            }
             orgSlug={project.team.organization.slug}
             projectId={project.id}
             projectTypeSlugs={

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -191,7 +191,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
               {project.slug}
             </code>{' '}
             immediately, removing the project and all associated data, including
-            facts, operation logs, and notes. Are you absolutely sure?
+            facts, operation logs, and documents. Are you absolutely sure?
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/components/admin/DocumentTemplateManagement.tsx
+++ b/src/components/admin/DocumentTemplateManagement.tsx
@@ -3,10 +3,10 @@ import { useMemo, useState } from 'react'
 import { StickyNote } from 'lucide-react'
 
 import {
-  createNoteTemplate,
-  deleteNoteTemplate,
-  listNoteTemplates,
-  updateNoteTemplate,
+  createDocumentTemplate,
+  deleteDocumentTemplate,
+  listDocumentTemplates,
+  updateDocumentTemplate,
 } from '@/api/endpoints'
 import { AdminTable } from '@/components/ui/admin-table'
 import { EntityIcon } from '@/components/ui/entity-icon'
@@ -15,12 +15,16 @@ import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { buildDiffPatch } from '@/lib/json-patch'
-import type { NoteTemplate, NoteTemplateCreate, PatchOperation } from '@/types'
+import type {
+  DocumentTemplate,
+  DocumentTemplateCreate,
+  PatchOperation,
+} from '@/types'
 
 import { AdminSection } from './AdminSection'
-import { NoteTemplateForm } from './note-templates/NoteTemplateForm'
+import { DocumentTemplateForm } from './document-templates/DocumentTemplateForm'
 
-export function NoteTemplateManagement() {
+export function DocumentTemplateManagement() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug
   const {
@@ -37,25 +41,25 @@ export function NoteTemplateManagement() {
     deleteMutation,
     error,
     isLoading,
-    items: noteTemplates,
+    items: documentTemplates,
     updateMutation,
   } = useAdminCrud<
-    NoteTemplate,
-    { data: NoteTemplateCreate; orgSlug: string },
+    DocumentTemplate,
+    { data: DocumentTemplateCreate; orgSlug: string },
     { operations: PatchOperation[]; orgSlug: string; slug: string },
     { orgSlug: string; slug: string }
   >({
-    createFn: ({ data, orgSlug }) => createNoteTemplate(orgSlug, data),
-    deleteErrorLabel: 'note template',
-    deleteFn: ({ orgSlug, slug }) => deleteNoteTemplate(orgSlug, slug),
-    listFn: orgSlug ? (signal) => listNoteTemplates(orgSlug, signal) : null,
+    createFn: ({ data, orgSlug }) => createDocumentTemplate(orgSlug, data),
+    deleteErrorLabel: 'document template',
+    deleteFn: ({ orgSlug, slug }) => deleteDocumentTemplate(orgSlug, slug),
+    listFn: orgSlug ? (signal) => listDocumentTemplates(orgSlug, signal) : null,
     onMutationSuccess: goToList,
-    queryKey: ['noteTemplates', orgSlug],
+    queryKey: ['documentTemplates', orgSlug],
     updateFn: ({ operations, orgSlug, slug }) =>
-      updateNoteTemplate(orgSlug, slug, operations),
+      updateDocumentTemplate(orgSlug, slug, operations),
   })
 
-  const filteredNoteTemplates = noteTemplates.filter((nt) => {
+  const filteredDocumentTemplates = documentTemplates.filter((nt) => {
     if (searchQuery) {
       const query = searchQuery.toLowerCase()
       return (
@@ -67,29 +71,29 @@ export function NoteTemplateManagement() {
     return true
   })
 
-  const selectedNoteTemplate = useMemo(
-    () => noteTemplates.find((nt) => nt.slug === selectedSlug) || null,
-    [noteTemplates, selectedSlug],
+  const selectedDocumentTemplate = useMemo(
+    () => documentTemplates.find((nt) => nt.slug === selectedSlug) || null,
+    [documentTemplates, selectedSlug],
   )
 
-  const handleDelete = (nt: NoteTemplate) => {
+  const handleDelete = (nt: DocumentTemplate) => {
     deleteMutation.mutate({ orgSlug: nt.organization.slug, slug: nt.slug })
   }
 
-  const handleSave = (formOrgSlug: string, data: NoteTemplateCreate) => {
+  const handleSave = (formOrgSlug: string, data: DocumentTemplateCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate({ data, orgSlug: formOrgSlug })
-    } else if (selectedSlug && selectedNoteTemplate) {
+    } else if (selectedSlug && selectedDocumentTemplate) {
       const beforeFields: Record<string, unknown> = {
-        content: selectedNoteTemplate.content ?? '',
-        description: selectedNoteTemplate.description ?? null,
-        icon: selectedNoteTemplate.icon ?? null,
-        name: selectedNoteTemplate.name,
-        project_type_slugs: selectedNoteTemplate.project_type_slugs ?? [],
-        slug: selectedNoteTemplate.slug,
-        sort_order: selectedNoteTemplate.sort_order ?? 0,
-        tags: (selectedNoteTemplate.tags ?? []).map((t) => t.slug),
-        title: selectedNoteTemplate.title ?? null,
+        content: selectedDocumentTemplate.content ?? '',
+        description: selectedDocumentTemplate.description ?? null,
+        icon: selectedDocumentTemplate.icon ?? null,
+        name: selectedDocumentTemplate.name,
+        project_type_slugs: selectedDocumentTemplate.project_type_slugs ?? [],
+        slug: selectedDocumentTemplate.slug,
+        sort_order: selectedDocumentTemplate.sort_order ?? 0,
+        tags: (selectedDocumentTemplate.tags ?? []).map((t) => t.slug),
+        title: selectedDocumentTemplate.title ?? null,
       }
       const operations = buildDiffPatch(
         beforeFields,
@@ -102,7 +106,7 @@ export function NoteTemplateManagement() {
       }
       updateMutation.mutate({
         operations,
-        orgSlug: selectedNoteTemplate.organization.slug || formOrgSlug,
+        orgSlug: selectedDocumentTemplate.organization.slug || formOrgSlug,
         slug: selectedSlug,
       })
     }
@@ -115,38 +119,40 @@ export function NoteTemplateManagement() {
   if (!orgSlug && !isLoading && !error) {
     return (
       <div className="py-12 text-center text-tertiary">
-        Select an organization to manage note templates.
+        Select an organization to manage document templates.
       </div>
     )
   }
 
-  if (viewMode === 'edit' && !selectedNoteTemplate) {
+  if (viewMode === 'edit' && !selectedDocumentTemplate) {
     return (
       <div className="py-12 text-center text-tertiary">
-        {isLoading ? 'Loading note template...' : 'Note template not found.'}
+        {isLoading
+          ? 'Loading document template...'
+          : 'Document template not found.'}
       </div>
     )
   }
 
   if (viewMode === 'create' || viewMode === 'edit') {
     return (
-      <NoteTemplateForm
+      <DocumentTemplateForm
+        documentTemplate={selectedDocumentTemplate}
         error={createMutation.error || updateMutation.error}
         isLoading={createMutation.isPending || updateMutation.isPending}
         key={selectedSlug ?? 'create'}
-        noteTemplate={selectedNoteTemplate}
         onCancel={handleCancel}
         onSave={handleSave}
       />
     )
   }
 
-  if (viewMode === 'detail' && selectedNoteTemplate) {
+  if (viewMode === 'detail' && selectedDocumentTemplate) {
     return (
-      <NoteTemplateForm
+      <DocumentTemplateForm
+        documentTemplate={selectedDocumentTemplate}
         error={updateMutation.error}
         isLoading={updateMutation.isPending}
-        noteTemplate={selectedNoteTemplate}
         onCancel={handleCancel}
         onSave={handleSave}
       />
@@ -155,15 +161,15 @@ export function NoteTemplateManagement() {
 
   return (
     <AdminSection
-      createLabel="New Note Template"
+      createLabel="New Document Template"
       error={error}
-      errorTitle="Failed to load note templates"
+      errorTitle="Failed to load document templates"
       isLoading={isLoading}
-      loadingLabel="Loading note templates..."
+      loadingLabel="Loading document templates..."
       onCreate={goToCreate}
       onSearchChange={setSearchQuery}
       search={searchQuery}
-      searchPlaceholder="Search note templates..."
+      searchPlaceholder="Search document templates..."
     >
       <AdminTable
         columns={[
@@ -257,17 +263,17 @@ export function NoteTemplateManagement() {
         ]}
         emptyMessage={
           searchQuery
-            ? 'No note templates found matching your search.'
+            ? 'No document templates found matching your search.'
             : selectedOrganization
-              ? `No note templates in ${selectedOrganization.name} yet.`
-              : 'No note templates created yet.'
+              ? `No document templates in ${selectedOrganization.name} yet.`
+              : 'No document templates created yet.'
         }
         getDeleteLabel={(nt) => nt.name}
         getRowKey={(nt) => nt.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
         onRowClick={(nt) => goToEdit(nt.slug)}
-        rows={filteredNoteTemplates}
+        rows={filteredDocumentTemplates}
       />
     </AdminSection>
   )

--- a/src/components/admin/document-templates/DocumentTemplateForm.tsx
+++ b/src/components/admin/document-templates/DocumentTemplateForm.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { AlertCircle, Save, X } from 'lucide-react'
 
 import { listProjectTypes } from '@/api/endpoints'
-import { TagCombobox } from '@/components/notes/TagCombobox'
+import { TagCombobox } from '@/components/documents/TagCombobox'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { ErrorBanner } from '@/components/ui/error-banner'
@@ -15,47 +15,47 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
 import type {
-  NoteTemplate,
-  NoteTemplateCreate,
+  DocumentTemplate,
+  DocumentTemplateCreate,
   ProjectType,
   TagRef,
 } from '@/types'
 
-interface NoteTemplateFormProps {
+interface DocumentTemplateFormProps {
+  documentTemplate: DocumentTemplate | null
   error?: unknown
   isLoading?: boolean
-  noteTemplate: NoteTemplate | null
   onCancel: () => void
-  onSave: (orgSlug: string, data: NoteTemplateCreate) => void
+  onSave: (orgSlug: string, data: DocumentTemplateCreate) => void
 }
 
-export function NoteTemplateForm({
+export function DocumentTemplateForm({
+  documentTemplate,
   error,
   isLoading = false,
-  noteTemplate,
   onCancel,
   onSave,
-}: NoteTemplateFormProps) {
-  const isEditing = !!noteTemplate
+}: DocumentTemplateFormProps) {
+  const isEditing = !!documentTemplate
   const { selectedOrganization } = useOrganization()
   const orgSlug =
-    noteTemplate?.organization?.slug || selectedOrganization?.slug || ''
+    documentTemplate?.organization?.slug || selectedOrganization?.slug || ''
 
-  const [name, setName] = useState(noteTemplate?.name || '')
-  const [slug, setSlug] = useState(noteTemplate?.slug || '')
+  const [name, setName] = useState(documentTemplate?.name || '')
+  const [slug, setSlug] = useState(documentTemplate?.slug || '')
   const [description, setDescription] = useState(
-    noteTemplate?.description || '',
+    documentTemplate?.description || '',
   )
-  const [icon, setIcon] = useState(noteTemplate?.icon || '')
+  const [icon, setIcon] = useState(documentTemplate?.icon || '')
   const handleIconChange = useIconWithCleanup(icon, setIcon)
-  const [title, setTitle] = useState(noteTemplate?.title || '')
-  const [content, setContent] = useState(noteTemplate?.content || '')
-  const [tags, setTags] = useState<TagRef[]>(noteTemplate?.tags || [])
+  const [title, setTitle] = useState(documentTemplate?.title || '')
+  const [content, setContent] = useState(documentTemplate?.content || '')
+  const [tags, setTags] = useState<TagRef[]>(documentTemplate?.tags || [])
   const [projectTypeSlugs, setProjectTypeSlugs] = useState<string[]>(
-    noteTemplate?.project_type_slugs || [],
+    documentTemplate?.project_type_slugs || [],
   )
   const [sortOrder, setSortOrder] = useState<string>(
-    String(noteTemplate?.sort_order ?? 0),
+    String(documentTemplate?.sort_order ?? 0),
   )
   const [errors, setErrors] = useState<Record<string, string>>({})
 
@@ -118,10 +118,10 @@ export function NoteTemplateForm({
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-base font-medium text-primary">
-            {isEditing ? 'Edit Note Template' : 'Create Note Template'}
+            {isEditing ? 'Edit Document Template' : 'Create Document Template'}
           </h2>
           <p className="mt-1 text-secondary">
-            Reusable note skeleton offered when authoring project notes.
+            Reusable document skeleton offered when authoring project documents.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -148,7 +148,7 @@ export function NoteTemplateForm({
 
       {/* API Error */}
       {!!error && (
-        <ErrorBanner error={error} title="Failed to save note template" />
+        <ErrorBanner error={error} title="Failed to save document template" />
       )}
 
       <form className="space-y-6" onSubmit={handleSubmit}>
@@ -160,14 +160,14 @@ export function NoteTemplateForm({
               <div>
                 <label
                   className="mb-1.5 block text-sm text-secondary"
-                  htmlFor="note-tpl-name"
+                  htmlFor="document-tpl-name"
                 >
                   Name <span className="text-red-500">*</span>
                 </label>
                 <Input
                   className={errors.name ? 'border-red-500' : ''}
                   disabled={isLoading}
-                  id="note-tpl-name"
+                  id="document-tpl-name"
                   onChange={(e) => handleNameChange(e.target.value)}
                   placeholder="e.g., Architecture Decision Record"
                   value={name}
@@ -184,14 +184,14 @@ export function NoteTemplateForm({
                 <div>
                   <label
                     className="mb-1.5 block text-sm text-secondary"
-                    htmlFor="note-tpl-slug"
+                    htmlFor="document-tpl-slug"
                   >
                     Slug <span className="text-red-500">*</span>
                   </label>
                   <Input
                     className={errors.slug ? 'border-red-500' : ''}
                     disabled={isLoading}
-                    id="note-tpl-slug"
+                    id="document-tpl-slug"
                     onChange={(e) => setSlug(e.target.value)}
                     placeholder="e.g., adr"
                     value={slug}
@@ -209,14 +209,14 @@ export function NoteTemplateForm({
             <div>
               <label
                 className="mb-1.5 block text-sm text-secondary"
-                htmlFor="note-tpl-description"
+                htmlFor="document-tpl-description"
               >
                 Description
               </label>
               <textarea
                 className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground"
                 disabled={isLoading}
-                id="note-tpl-description"
+                id="document-tpl-description"
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Brief description shown when picking a template"
                 rows={2}
@@ -259,15 +259,15 @@ export function NoteTemplateForm({
             <div>
               <label
                 className="mb-1.5 block text-sm text-secondary"
-                htmlFor="note-tpl-title"
+                htmlFor="document-tpl-title"
               >
-                Default Note Title
+                Default Document Title
               </label>
               <Input
                 disabled={isLoading}
-                id="note-tpl-title"
+                id="document-tpl-title"
                 onChange={(e) => setTitle(e.target.value)}
-                placeholder="Pre-fills the title field of new notes"
+                placeholder="Pre-fills the title field of new documents"
                 value={title}
               />
             </div>
@@ -275,16 +275,16 @@ export function NoteTemplateForm({
             <div>
               <label
                 className="mb-1.5 block text-sm text-secondary"
-                htmlFor="note-tpl-content"
+                htmlFor="document-tpl-content"
               >
                 Content
               </label>
               <textarea
                 className="w-full resize-y rounded-lg border border-input bg-background px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground"
                 disabled={isLoading}
-                id="note-tpl-content"
+                id="document-tpl-content"
                 onChange={(e) => setContent(e.target.value)}
-                placeholder="Markdown body that pre-fills new notes"
+                placeholder="Markdown body that pre-fills new documents"
                 rows={10}
                 value={content}
               />
@@ -295,7 +295,7 @@ export function NoteTemplateForm({
                 Default Tags
               </label>
               <p className="mb-2 text-xs text-tertiary">
-                Tags applied to notes created from this template.
+                Tags applied to documents created from this template.
               </p>
               {orgSlug && (
                 <TagCombobox
@@ -360,14 +360,14 @@ export function NoteTemplateForm({
             <div>
               <label
                 className="mb-1.5 block text-sm text-secondary"
-                htmlFor="note-tpl-sort-order"
+                htmlFor="document-tpl-sort-order"
               >
                 Sort Order
               </label>
               <Input
                 className={errors.sort_order ? 'border-red-500' : ''}
                 disabled={isLoading}
-                id="note-tpl-sort-order"
+                id="document-tpl-sort-order"
                 onChange={(e) => setSortOrder(e.target.value)}
                 placeholder="0"
                 type="number"

--- a/src/components/documents/DocumentTagChip.tsx
+++ b/src/components/documents/DocumentTagChip.tsx
@@ -2,7 +2,7 @@ import { LabelChip } from '@/components/ui/label-chip'
 import { cn } from '@/lib/utils'
 import type { TagRef } from '@/types'
 
-import { colorForTag } from './notesHelpers'
+import { colorForTag } from './documentsHelpers'
 
 interface Props {
   className?: string
@@ -11,7 +11,12 @@ interface Props {
   tag: TagRef
 }
 
-export function NoteTagChip({ className, onClick, size = 'md', tag }: Props) {
+export function DocumentTagChip({
+  className,
+  onClick,
+  size = 'md',
+  tag,
+}: Props) {
   const hex = colorForTag(tag.slug)
   return (
     <LabelChip

--- a/src/components/documents/DocumentsFilterRail.tsx
+++ b/src/components/documents/DocumentsFilterRail.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 import type { TagRef } from '@/types'
 
-import { colorForTag } from './notesHelpers'
+import { colorForTag } from './documentsHelpers'
 
 interface Props {
   active: ReadonlySet<string>
@@ -19,7 +19,7 @@ interface Props {
   totalFiltered: number
 }
 
-export function NotesFilterRail({
+export function DocumentsFilterRail({
   active,
   counts,
   disabled = false,
@@ -46,7 +46,7 @@ export function NotesFilterRail({
           className="h-8 pl-8 text-xs"
           disabled={disabled}
           onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search notes"
+          placeholder="Search documents"
           tabIndex={disabled ? -1 : undefined}
           value={search}
         />
@@ -56,7 +56,7 @@ export function NotesFilterRail({
         <div className="mb-3 flex items-center justify-between gap-2 rounded-md border border-warning bg-warning px-2.5 py-1.5">
           <span className="text-[11.5px] text-warning">
             {activeCount} filter{activeCount > 1 ? 's' : ''} · {totalFiltered}{' '}
-            notes
+            documents
           </span>
           <button
             className="cursor-pointer border-0 bg-transparent p-0 text-[11.5px] text-warning hover:underline"

--- a/src/components/documents/DocumentsPinboard.tsx
+++ b/src/components/documents/DocumentsPinboard.tsx
@@ -12,29 +12,29 @@ import {
 } from '@/components/ui/card'
 import { UserDisplay } from '@/components/ui/user-display'
 import { cn } from '@/lib/utils'
-import type { Note } from '@/types'
+import type { Document } from '@/types'
 
-import { NotesFilterRail } from './NotesFilterRail'
+import { DocumentsFilterRail } from './DocumentsFilterRail'
 import {
   deriveExcerpt,
+  documentTitle,
   formatUpdated,
-  noteTitle,
   tagCounts,
-  uniqueTagsFromNotes,
-} from './notesHelpers'
-import { NoteTagChip } from './NoteTagChip'
+  uniqueTagsFromDocuments,
+} from './documentsHelpers'
+import { DocumentTagChip } from './DocumentTagChip'
 
 interface Props {
   displayNames?: Map<string, string>
-  notes: Note[]
+  documents: Document[]
   onCreate: () => void
-  onOpen: (noteId: string) => void
-  onTogglePin: (note: Note) => void
+  onOpen: (documentId: string) => void
+  onTogglePin: (document: Document) => void
 }
 
-export function NotesPinboard({
+export function DocumentsPinboard({
   displayNames,
-  notes,
+  documents,
   onCreate,
   onOpen,
   onTogglePin,
@@ -42,21 +42,21 @@ export function NotesPinboard({
   const [active, setActive] = useState<Set<string>>(new Set())
   const [search, setSearch] = useState('')
 
-  const tags = useMemo(() => uniqueTagsFromNotes(notes), [notes])
-  const counts = useMemo(() => tagCounts(notes), [notes])
+  const tags = useMemo(() => uniqueTagsFromDocuments(documents), [documents])
+  const counts = useMemo(() => tagCounts(documents), [documents])
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase()
-    return notes.filter((n) => {
+    return documents.filter((n) => {
       for (const slug of active) {
         if (!n.tags.some((t) => t.slug === slug)) return false
       }
       if (!q) return true
-      const title = noteTitle(n).toLowerCase()
+      const title = documentTitle(n).toLowerCase()
       const content = n.content.toLowerCase()
       return title.includes(q) || content.includes(q)
     })
-  }, [notes, active, search])
+  }, [documents, active, search])
 
   const pinned = useMemo(() => filtered.filter((n) => n.is_pinned), [filtered])
   const rest = useMemo(() => filtered.filter((n) => !n.is_pinned), [filtered])
@@ -72,7 +72,7 @@ export function NotesPinboard({
 
   return (
     <div className="grid grid-cols-[220px_1fr] gap-5">
-      <NotesFilterRail
+      <DocumentsFilterRail
         active={active}
         counts={counts}
         onClear={() => setActive(new Set())}
@@ -90,8 +90,8 @@ export function NotesPinboard({
               {pinned.map((n) => (
                 <HeroCard
                   displayNames={displayNames}
+                  document={n}
                   key={n.id}
-                  note={n}
                   onOpen={onOpen}
                 />
               ))}
@@ -103,7 +103,7 @@ export function NotesPinboard({
             size="sm"
           >
             <Plus className="h-3 w-3" />
-            New note
+            New document
           </Button>
         </section>
 
@@ -116,7 +116,7 @@ export function NotesPinboard({
                   'minmax(0, 1.6fr) minmax(0, 1fr) 100px 60px 60px',
               }}
             >
-              <span>Note</span>
+              <span>Document</span>
               <span>Tags</span>
               <span>Author</span>
               <span className="text-right">Updated</span>
@@ -125,8 +125,8 @@ export function NotesPinboard({
             {rest.map((n) => (
               <IndexRow
                 displayNames={displayNames}
+                document={n}
                 key={n.id}
-                note={n}
                 onOpen={onOpen}
                 onTogglePin={onTogglePin}
               />
@@ -134,8 +134,8 @@ export function NotesPinboard({
             {rest.length === 0 && (
               <div className="px-8 py-7 text-center text-sm text-tertiary">
                 {filtered.length === 0
-                  ? 'No notes match the current filters.'
-                  : 'All remaining notes are pinned.'}
+                  ? 'No documents match the current filters.'
+                  : 'All remaining documents are pinned.'}
               </div>
             )}
           </div>
@@ -147,19 +147,19 @@ export function NotesPinboard({
 
 function HeroCard({
   displayNames,
-  note,
+  document,
   onOpen,
 }: {
   displayNames?: Map<string, string>
-  note: Note
-  onOpen: (noteId: string) => void
+  document: Document
+  onOpen: (documentId: string) => void
 }) {
-  const title = noteTitle(note)
-  const excerpt = deriveExcerpt(note.content)
+  const title = documentTitle(document)
+  const excerpt = deriveExcerpt(document.content)
   return (
     <Card
       className="flex cursor-pointer flex-col transition-colors hover:border-secondary hover:shadow-md"
-      onClick={() => onOpen(note.id)}
+      onClick={() => onOpen(document.id)}
     >
       <CardHeader className="space-y-2">
         <div className="flex items-start justify-between gap-2">
@@ -176,10 +176,10 @@ function HeroCard({
         <p className="m-0 line-clamp-3 text-[13px] leading-[1.55] text-secondary">
           {excerpt}
         </p>
-        {note.tags.length > 0 && (
+        {document.tags.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            {note.tags.map((t) => (
-              <NoteTagChip key={t.slug} size="sm" tag={t} />
+            {document.tags.map((t) => (
+              <DocumentTagChip key={t.slug} size="sm" tag={t} />
             ))}
           </div>
         )}
@@ -188,12 +188,12 @@ function HeroCard({
         <UserDisplay
           className="text-secondary"
           displayNames={displayNames}
-          email={note.created_by}
+          email={document.created_by}
           size={16}
           textClassName="font-medium"
         />
         <span className="text-tertiary">·</span>
-        <span>Updated {formatUpdated(note)}</span>
+        <span>Updated {formatUpdated(document)}</span>
       </CardFooter>
     </Card>
   )
@@ -201,23 +201,23 @@ function HeroCard({
 
 function IndexRow({
   displayNames,
-  note,
+  document,
   onOpen,
   onTogglePin,
 }: {
   displayNames?: Map<string, string>
-  note: Note
-  onOpen: (noteId: string) => void
-  onTogglePin: (note: Note) => void
+  document: Document
+  onOpen: (documentId: string) => void
+  onTogglePin: (document: Document) => void
 }) {
-  const pinned = note.is_pinned
-  const title = noteTitle(note)
-  const excerpt = deriveExcerpt(note.content)
-  const author = note.created_by
+  const pinned = document.is_pinned
+  const title = documentTitle(document)
+  const excerpt = deriveExcerpt(document.content)
+  const author = document.created_by
   return (
     <div
       className="grid cursor-pointer items-center gap-3.5 border-b border-tertiary px-3.5 py-2.5 last:border-b-0 hover:bg-secondary"
-      onClick={() => onOpen(note.id)}
+      onClick={() => onOpen(document.id)}
       style={{
         gridTemplateColumns: 'minmax(0, 1.6fr) minmax(0, 1fr) 100px 60px 60px',
       }}
@@ -229,8 +229,8 @@ function IndexRow({
         <div className="mt-0.5 truncate text-xs text-tertiary">{excerpt}</div>
       </div>
       <div className="flex flex-wrap gap-1">
-        {note.tags.slice(0, 3).map((t) => (
-          <NoteTagChip key={t.slug} tag={t} />
+        {document.tags.slice(0, 3).map((t) => (
+          <DocumentTagChip key={t.slug} tag={t} />
         ))}
       </div>
       <UserDisplay
@@ -240,15 +240,15 @@ function IndexRow({
         size={18}
       />
       <div className="text-right font-mono text-[11.5px] text-tertiary">
-        {formatUpdated(note)}
+        {formatUpdated(document)}
       </div>
       <div className="flex justify-end gap-0.5">
         <RowIconButton
           onClick={(e) => {
             e.stopPropagation()
-            onTogglePin(note)
+            onTogglePin(document)
           }}
-          title={pinned ? 'Unpin note' : 'Pin note'}
+          title={pinned ? 'Unpin document' : 'Pin document'}
         >
           <Pin
             className={cn('h-3 w-3', pinned ? 'text-warning' : 'text-tertiary')}
@@ -257,9 +257,9 @@ function IndexRow({
         <RowIconButton
           onClick={(e) => {
             e.stopPropagation()
-            onOpen(note.id)
+            onOpen(document.id)
           }}
-          title="Open note"
+          title="Open document"
         >
           <ArrowUpRight className="h-3 w-3 text-tertiary" />
         </RowIconButton>

--- a/src/components/documents/DocumentsPinboardEmpty.tsx
+++ b/src/components/documents/DocumentsPinboardEmpty.tsx
@@ -1,20 +1,20 @@
 import { useQuery } from '@tanstack/react-query'
 import { Plus, StickyNote } from 'lucide-react'
 
-import { listNoteTemplates } from '@/api/endpoints'
+import { listDocumentTemplates } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { EntityIcon } from '@/components/ui/entity-icon'
-import type { NoteTemplate } from '@/types'
+import type { DocumentTemplate } from '@/types'
 
-import { NoteTagChip } from './NoteTagChip'
+import { DocumentTagChip } from './DocumentTagChip'
 
 interface Props {
-  onCreate: (template?: NoteTemplate) => void
+  onCreate: (template?: DocumentTemplate) => void
   orgSlug: string
   projectTypeSlugs?: string[]
 }
 
-export function NotesPinboardEmpty({
+export function DocumentsPinboardEmpty({
   onCreate,
   orgSlug,
   projectTypeSlugs,
@@ -23,10 +23,10 @@ export function NotesPinboardEmpty({
     data: templates = [],
     error: templatesError,
     isLoading: templatesLoading,
-  } = useQuery<NoteTemplate[]>({
+  } = useQuery<DocumentTemplate[]>({
     enabled: !!orgSlug,
-    queryFn: ({ signal }) => listNoteTemplates(orgSlug, signal),
-    queryKey: ['noteTemplates', orgSlug],
+    queryFn: ({ signal }) => listDocumentTemplates(orgSlug, signal),
+    queryKey: ['documentTemplates', orgSlug],
   })
 
   const projectTypeSet =
@@ -51,18 +51,19 @@ export function NotesPinboardEmpty({
       </div>
 
       <h2 className="m-0 text-h2 font-medium tracking-[-0.015em]">
-        No notes yet for this project
+        No documents yet for this project
       </h2>
       <p className="m-0 max-w-[720px] text-sm leading-[1.6] text-secondary">
-        Notes capture decisions, reviews, and patterns that outlive any one
+        Documents capture decisions, reviews, and patterns that outlive any one
         deploy. They render as Markdown, carry tags you can filter, and can be
-        pinned to stay at the top of this tab. Notes are also exposed to agents
-        in the graph, providing project-level context across your workflows.
+        pinned to stay at the top of this tab. Documents are also exposed to
+        agents in the graph, providing project-level context across your
+        workflows.
       </p>
 
       <Button className="mt-1 gap-1.5" onClick={() => onCreate()}>
         <Plus className="h-3 w-3" />
-        New note
+        New document
       </Button>
 
       {templatesLoading && (
@@ -99,7 +100,7 @@ export function NotesPinboardEmpty({
                   </span>
                   {t.tags && t.tags.length > 0 && (
                     <span className="ml-auto">
-                      <NoteTagChip size="sm" tag={t.tags[0]} />
+                      <DocumentTagChip size="sm" tag={t.tags[0]} />
                     </span>
                   )}
                 </div>

--- a/src/components/documents/DocumentsPinboardNew.tsx
+++ b/src/components/documents/DocumentsPinboardNew.tsx
@@ -6,51 +6,60 @@ import remarkGfm from 'remark-gfm'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import type { Note, NoteTemplate, TagRef } from '@/types'
+import type { Document, DocumentTemplate, TagRef } from '@/types'
 
-import { NotesFilterRail } from './NotesFilterRail'
-import { EMPTY_ACTIVE, tagCounts, uniqueTagsFromNotes } from './notesHelpers'
+import { DocumentsFilterRail } from './DocumentsFilterRail'
+import {
+  EMPTY_ACTIVE,
+  tagCounts,
+  uniqueTagsFromDocuments,
+} from './documentsHelpers'
 import { TagCombobox } from './TagCombobox'
 
 type EditorMode = 'preview' | 'split' | 'write'
 
 interface Props {
-  allNotes?: Note[]
-  initialNote?: Note | null
+  allDocuments?: Document[]
+  initialDocument?: Document | null
   onDiscard: () => void
   onSave: (draft: { content: string; tags: string[]; title: string }) => void
   orgSlug: string
   saving?: boolean
   /**
-   * When creating a new note, pre-seed the form (title, content, tags) from
-   * the chosen template. Ignored when `initialNote` is provided.
+   * When creating a new document, pre-seed the form (title, content, tags) from
+   * the chosen template. Ignored when `initialDocument` is provided.
    */
-  template?: NoteTemplate | null
+  template?: DocumentTemplate | null
 }
 
 const NOOP = () => {}
 
-export function NotesPinboardNew({
-  allNotes = [],
-  initialNote,
+export function DocumentsPinboardNew({
+  allDocuments = [],
+  initialDocument,
   onDiscard,
   onSave,
   orgSlug,
   saving = false,
   template,
 }: Props) {
-  const railTags = useMemo(() => uniqueTagsFromNotes(allNotes), [allNotes])
-  const railCounts = useMemo(() => tagCounts(allNotes), [allNotes])
-  const isEditing = !!initialNote
-  const seed = !initialNote ? template : null
+  const railTags = useMemo(
+    () => uniqueTagsFromDocuments(allDocuments),
+    [allDocuments],
+  )
+  const railCounts = useMemo(() => tagCounts(allDocuments), [allDocuments])
+  const isEditing = !!initialDocument
+  const seed = !initialDocument ? template : null
   const [mode, setMode] = useState<EditorMode>('split')
-  const [title, setTitle] = useState(initialNote?.title ?? seed?.title ?? '')
+  const [title, setTitle] = useState(
+    initialDocument?.title ?? seed?.title ?? '',
+  )
   const [content, setContent] = useState(
-    initialNote?.content ?? seed?.content ?? '',
+    initialDocument?.content ?? seed?.content ?? '',
   )
   const [tags, setTags] = useState<TagRef[]>(
-    initialNote
-      ? initialNote.tags.map((t) => ({ name: t.name, slug: t.slug }))
+    initialDocument
+      ? initialDocument.tags.map((t) => ({ name: t.name, slug: t.slug }))
       : seed?.tags
         ? seed.tags.map((t) => ({ name: t.name, slug: t.slug }))
         : [],
@@ -67,13 +76,13 @@ export function NotesPinboardNew({
   const trimmedTitle = title.trim()
   const isValid = trimmedTitle.length > 0 && content.trim().length > 0
   const dirty = useMemo(() => {
-    if (!initialNote)
+    if (!initialDocument)
       return trimmedTitle.length > 0 || content.length > 0 || tags.length > 0
     // Compare against the trimmed save value so trailing-space-only edits
     // don't masquerade as dirty.
-    if (trimmedTitle !== initialNote.title.trim()) return true
-    if (content !== initialNote.content) return true
-    const initialSlugs = initialNote.tags
+    if (trimmedTitle !== initialDocument.title.trim()) return true
+    if (content !== initialDocument.content) return true
+    const initialSlugs = initialDocument.tags
       .map((t) => t.slug)
       .sort()
       .join(',')
@@ -82,7 +91,7 @@ export function NotesPinboardNew({
       .sort()
       .join(',')
     return initialSlugs !== currentSlugs
-  }, [initialNote, trimmedTitle, content, tags])
+  }, [initialDocument, trimmedTitle, content, tags])
   const canSave = isValid && dirty
 
   const handleSave = () => {
@@ -100,7 +109,7 @@ export function NotesPinboardNew({
   return (
     <div className="grid grid-cols-[220px_1fr] gap-5">
       {/* Rail stays visible but disabled while composing — preserves spatial continuity. */}
-      <NotesFilterRail
+      <DocumentsFilterRail
         active={EMPTY_ACTIVE}
         counts={railCounts}
         disabled
@@ -109,7 +118,7 @@ export function NotesPinboardNew({
         onToggle={NOOP}
         search=""
         tags={railTags}
-        totalFiltered={allNotes.length}
+        totalFiltered={allDocuments.length}
       />
 
       <div>
@@ -121,11 +130,11 @@ export function NotesPinboardNew({
             type="button"
           >
             <ArrowLeft className="h-3 w-3" />
-            All notes
+            All documents
           </button>
           <span className="text-tertiary">/</span>
           <span className="text-xs font-medium text-primary">
-            {isEditing ? 'Edit note' : 'New note'}
+            {isEditing ? 'Edit document' : 'New document'}
           </span>
 
           <div className="ml-auto inline-flex gap-0.5 rounded-md border border-secondary bg-primary p-0.5">
@@ -260,7 +269,7 @@ function PreviewPane({ content }: { content: string }) {
     )
   }
   return (
-    <div className="note-markdown">
+    <div className="document-markdown">
       <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
     </div>
   )

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -8,18 +8,18 @@ import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { UserDisplay } from '@/components/ui/user-display'
 import { cn } from '@/lib/utils'
-import type { Note } from '@/types'
+import type { Document } from '@/types'
 
-import { NotesFilterRail } from './NotesFilterRail'
+import { DocumentsFilterRail } from './DocumentsFilterRail'
 import {
+  documentTitle,
   EMPTY_ACTIVE,
   formatFull,
   formatUpdated,
-  noteTitle,
   tagCounts,
-  uniqueTagsFromNotes,
-} from './notesHelpers'
-import { NoteTagChip } from './NoteTagChip'
+  uniqueTagsFromDocuments,
+} from './documentsHelpers'
+import { DocumentTagChip } from './DocumentTagChip'
 
 interface Heading {
   level: 2 | 3
@@ -28,22 +28,22 @@ interface Heading {
 }
 
 interface Props {
-  allNotes: Note[]
+  allDocuments: Document[]
   deleting?: boolean
   displayNames?: Map<string, string>
-  note: Note
+  document: Document
   onBack: () => void
   onDelete?: () => void
   onEdit?: () => void
-  onOpen: (noteId: string) => void
+  onOpen: (documentId: string) => void
   onTogglePin: () => void
 }
 
-export function NotesPinboardReader({
-  allNotes,
+export function DocumentsPinboardReader({
+  allDocuments,
   deleting = false,
   displayNames,
-  note,
+  document,
   onBack,
   onDelete,
   onEdit,
@@ -52,33 +52,40 @@ export function NotesPinboardReader({
 }: Props) {
   const [search, setSearch] = useState('')
   const [confirmDelete, setConfirmDelete] = useState(false)
-  const pinned = note.is_pinned
-  const title = noteTitle(note)
+  const pinned = document.is_pinned
+  const title = documentTitle(document)
 
-  const tags = useMemo(() => uniqueTagsFromNotes(allNotes), [allNotes])
-  const counts = useMemo(() => tagCounts(allNotes), [allNotes])
+  const tags = useMemo(
+    () => uniqueTagsFromDocuments(allDocuments),
+    [allDocuments],
+  )
+  const counts = useMemo(() => tagCounts(allDocuments), [allDocuments])
   const highlightedSlugs = useMemo(
-    () => new Set(note.tags.map((t) => t.slug)),
-    [note.tags],
+    () => new Set(document.tags.map((t) => t.slug)),
+    [document.tags],
   )
 
   const related = useMemo(() => {
-    const noteTags = new Set(note.tags.map((t) => t.slug))
-    return allNotes
+    const documentTags = new Set(document.tags.map((t) => t.slug))
+    return allDocuments
       .filter(
-        (n) => n.id !== note.id && n.tags.some((t) => noteTags.has(t.slug)),
+        (n) =>
+          n.id !== document.id && n.tags.some((t) => documentTags.has(t.slug)),
       )
       .slice(0, 4)
-  }, [allNotes, note])
+  }, [allDocuments, document])
 
-  const headings = useMemo(() => extractHeadings(note.content), [note.content])
+  const headings = useMemo(
+    () => extractHeadings(document.content),
+    [document.content],
+  )
   const headingSlugs = useMemo(() => headings.map((h) => h.slug), [headings])
   const activeSlug = useActiveHeading(headingSlugs)
 
   // Reader is navigable from the same tab; filter rail keeps rail semantics.
   return (
     <div className="grid grid-cols-[220px_1fr] gap-5">
-      <NotesFilterRail
+      <DocumentsFilterRail
         active={EMPTY_ACTIVE}
         counts={counts}
         highlightedSlugs={highlightedSlugs}
@@ -87,7 +94,7 @@ export function NotesPinboardReader({
         onToggle={() => onBack()}
         search={search}
         tags={tags}
-        totalFiltered={allNotes.length}
+        totalFiltered={allDocuments.length}
       />
 
       <div>
@@ -99,7 +106,7 @@ export function NotesPinboardReader({
               type="button"
             >
               <ArrowLeft className="h-3 w-3" />
-              All notes
+              All documents
             </button>
             <div className="ml-auto flex items-center gap-1">
               <Button
@@ -134,7 +141,7 @@ export function NotesPinboardReader({
                 disabled={!onDelete || deleting}
                 onClick={() => setConfirmDelete(true)}
                 size="sm"
-                title="Delete note"
+                title="Delete document"
                 variant="ghost"
               >
                 <Trash2 className="h-3 w-3" />
@@ -154,22 +161,22 @@ export function NotesPinboardReader({
                 <UserDisplay
                   className="text-secondary"
                   displayNames={displayNames}
-                  email={note.created_by}
+                  email={document.created_by}
                   size={22}
                   textClassName="text-[12.5px] text-secondary"
                 />
                 <span className="text-tertiary">·</span>
-                <span>Updated {formatUpdated(note)}</span>
+                <span>Updated {formatUpdated(document)}</span>
               </div>
               <div className="h-3.5 w-px bg-tertiary" />
               <div className="flex flex-wrap gap-1">
-                {note.tags.map((t) => (
-                  <NoteTagChip key={t.slug} tag={t} />
+                {document.tags.map((t) => (
+                  <DocumentTagChip key={t.slug} tag={t} />
                 ))}
               </div>
             </div>
 
-            <div className="note-markdown mt-6">
+            <div className="document-markdown mt-6">
               <Markdown
                 components={{
                   h2: ({ children, ...props }) => (
@@ -193,17 +200,17 @@ export function NotesPinboardReader({
                 }}
                 remarkPlugins={[remarkGfm]}
               >
-                {note.content}
+                {document.content}
               </Markdown>
             </div>
 
             <div className="mt-7 flex flex-wrap items-center gap-2.5 border-t border-tertiary pt-4 text-[11.5px] text-tertiary">
               <Clock className="h-3 w-3" />
-              <span>Created {formatFull(note.created_at)}</span>
-              {note.updated_at && (
+              <span>Created {formatFull(document.created_at)}</span>
+              {document.updated_at && (
                 <>
                   <span className="text-tertiary">·</span>
-                  <span>Last updated {formatFull(note.updated_at)}</span>
+                  <span>Last updated {formatFull(document.updated_at)}</span>
                 </>
               )}
             </div>
@@ -248,7 +255,7 @@ export function NotesPinboardReader({
             {related.length > 0 && (
               <div>
                 <div className="mb-2 text-overline uppercase text-tertiary">
-                  Related notes
+                  Related documents
                 </div>
                 <div className="flex flex-col gap-2">
                   {related.map((r) => (
@@ -259,7 +266,7 @@ export function NotesPinboardReader({
                       type="button"
                     >
                       <div className="line-clamp-2 text-[12.5px] font-medium leading-[1.35] text-primary">
-                        {noteTitle(r)}
+                        {documentTitle(r)}
                       </div>
                       <div className="mt-1 flex items-center gap-1.5 text-[11px] text-tertiary">
                         <UserDisplay
@@ -286,7 +293,7 @@ export function NotesPinboardReader({
           onDelete?.()
         }}
         open={confirmDelete}
-        title="Delete note?"
+        title="Delete document?"
       />
     </div>
   )

--- a/src/components/documents/ProjectDocumentsTab.tsx
+++ b/src/components/documents/ProjectDocumentsTab.tsx
@@ -6,59 +6,59 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import {
-  createProjectNote,
-  deleteProjectNote,
+  createProjectDocument,
+  deleteProjectDocument,
   listAdminUsers,
-  listProjectNotes,
-  patchProjectNote,
+  listProjectDocuments,
+  patchProjectDocument,
 } from '@/api/endpoints'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { LoadingState } from '@/components/ui/loading-state'
 import { extractApiErrorDetail } from '@/lib/apiError'
-import type { Note, NoteTemplate } from '@/types'
+import type { Document, DocumentTemplate } from '@/types'
 
-import { NotesPinboard } from './NotesPinboard'
-import { NotesPinboardEmpty } from './NotesPinboardEmpty'
-import { NotesPinboardNew } from './NotesPinboardNew'
-import { NotesPinboardReader } from './NotesPinboardReader'
+import { DocumentsPinboard } from './DocumentsPinboard'
+import { DocumentsPinboardEmpty } from './DocumentsPinboardEmpty'
+import { DocumentsPinboardNew } from './DocumentsPinboardNew'
+import { DocumentsPinboardReader } from './DocumentsPinboardReader'
 
 interface Props {
   initialAction?: string
-  initialNoteId?: string
+  initialDocumentId?: string
   orgSlug: string
   projectId: string
   projectTypeSlugs?: string[]
 }
 
 type View =
-  | { kind: 'creating'; template?: NoteTemplate | null }
-  | { kind: 'editing'; noteId: string }
+  | { documentId: string; kind: 'editing' }
+  | { documentId: string; kind: 'reading' }
+  | { kind: 'creating'; template?: DocumentTemplate | null }
   | { kind: 'list' }
-  | { kind: 'reading'; noteId: string }
 
-export function ProjectNotesTab({
+export function ProjectDocumentsTab({
   initialAction,
-  initialNoteId,
+  initialDocumentId,
   orgSlug,
   projectId,
   projectTypeSlugs,
 }: Props) {
   const navigate = useNavigate()
   const [view, setView] = useState<View>(() =>
-    viewFromUrl(initialNoteId, initialAction),
+    viewFromUrl(initialDocumentId, initialAction),
   )
   const qc = useQueryClient()
 
   const navigateToView = useCallback(
     (next: View) => {
       setView(next)
-      const base = `/projects/${projectId}/notes`
+      const base = `/projects/${projectId}/documents`
       if (next.kind === 'reading') {
-        navigate(`${base}/${encodeURIComponent(next.noteId)}`, {
+        navigate(`${base}/${encodeURIComponent(next.documentId)}`, {
           replace: true,
         })
       } else if (next.kind === 'editing') {
-        navigate(`${base}/${encodeURIComponent(next.noteId)}/edit`, {
+        navigate(`${base}/${encodeURIComponent(next.documentId)}/edit`, {
           replace: true,
         })
       } else if (next.kind === 'creating') {
@@ -72,30 +72,30 @@ export function ProjectNotesTab({
 
   // Reflect URL changes (e.g. browser back/forward) into local view state.
   useEffect(() => {
-    const next = viewFromUrl(initialNoteId, initialAction)
+    const next = viewFromUrl(initialDocumentId, initialAction)
     setView((prev) => {
       if (
         prev.kind === next.kind &&
-        ('noteId' in prev ? prev.noteId : null) ===
-          ('noteId' in next ? next.noteId : null)
+        ('documentId' in prev ? prev.documentId : null) ===
+          ('documentId' in next ? next.documentId : null)
       ) {
         return prev
       }
       return next
     })
-  }, [initialNoteId, initialAction])
+  }, [initialDocumentId, initialAction])
 
-  const notesKey = ['projectNotes', orgSlug, projectId] as const
+  const documentsKey = ['projectDocuments', orgSlug, projectId] as const
 
   const {
-    data: notes = [],
+    data: documents = [],
     error,
     isLoading,
   } = useQuery({
     enabled: !!orgSlug && !!projectId,
     queryFn: ({ signal }) =>
-      listProjectNotes(orgSlug, projectId, undefined, signal),
-    queryKey: notesKey,
+      listProjectDocuments(orgSlug, projectId, undefined, signal),
+    queryKey: documentsKey,
   })
 
   const { data: users = [], error: usersError } = useQuery({
@@ -109,7 +109,7 @@ export function ProjectNotesTab({
   useEffect(() => {
     if (usersError) {
       console.warn(
-        'Failed to load admin users for note display names',
+        'Failed to load admin users for document display names',
         usersError,
       )
     }
@@ -124,62 +124,68 @@ export function ProjectNotesTab({
   }, [users])
 
   const pinMutation = useMutation<
-    Note,
+    Document,
     unknown,
-    { noteId: string; pinned: boolean },
-    { previous?: Note[] }
+    { documentId: string; pinned: boolean },
+    { previous?: Document[] }
   >({
-    mutationFn: ({ noteId, pinned }: { noteId: string; pinned: boolean }) =>
-      patchProjectNote(orgSlug, projectId, noteId, [
+    mutationFn: ({
+      documentId,
+      pinned,
+    }: {
+      documentId: string
+      pinned: boolean
+    }) =>
+      patchProjectDocument(orgSlug, projectId, documentId, [
         { op: 'replace', path: '/is_pinned', value: pinned },
       ]),
     onError: (err, _vars, ctx) => {
-      if (ctx?.previous) qc.setQueryData(notesKey, ctx.previous)
+      if (ctx?.previous) qc.setQueryData(documentsKey, ctx.previous)
       toast.error(`Pin failed: ${extractApiErrorDetail(err)}`)
     },
-    onMutate: async ({ noteId, pinned }) => {
-      await qc.cancelQueries({ queryKey: notesKey })
-      const previous = qc.getQueryData<Note[]>(notesKey)
+    onMutate: async ({ documentId, pinned }) => {
+      await qc.cancelQueries({ queryKey: documentsKey })
+      const previous = qc.getQueryData<Document[]>(documentsKey)
       if (previous) {
-        qc.setQueryData<Note[]>(
-          notesKey,
+        qc.setQueryData<Document[]>(
+          documentsKey,
           previous.map((n) =>
-            n.id === noteId ? { ...n, is_pinned: pinned } : n,
+            n.id === documentId ? { ...n, is_pinned: pinned } : n,
           ),
         )
       }
       return { previous }
     },
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: notesKey })
+      qc.invalidateQueries({ queryKey: documentsKey })
     },
   })
 
   const createMutation = useMutation({
     mutationFn: (draft: { content: string; tags: string[]; title: string }) =>
-      createProjectNote(orgSlug, projectId, draft),
+      createProjectDocument(orgSlug, projectId, draft),
     onError: (err) => {
       toast.error(`Save failed: ${extractApiErrorDetail(err)}`)
     },
-    onSuccess: (note) => {
-      qc.setQueryData<Note[]>(notesKey, (prev) =>
-        prev ? [note, ...prev] : [note],
+    onSuccess: (document) => {
+      qc.setQueryData<Document[]>(documentsKey, (prev) =>
+        prev ? [document, ...prev] : [document],
       )
-      qc.invalidateQueries({ queryKey: notesKey })
-      toast.success('Note saved')
-      navigateToView({ kind: 'reading', noteId: note.id })
+      qc.invalidateQueries({ queryKey: documentsKey })
+      toast.success('Document saved')
+      navigateToView({ documentId: document.id, kind: 'reading' })
     },
   })
 
   const updateMutation = useMutation({
     mutationFn: ({
+      documentId,
       draft,
-      noteId,
     }: {
+      documentId: string
       draft: { content: string; tags: string[]; title: string }
-      noteId: string
     }) =>
-      patchProjectNote(orgSlug, projectId, noteId, [
+      patchProjectDocument(orgSlug, projectId, documentId, [
         { op: 'replace', path: '/title', value: draft.title },
         { op: 'replace', path: '/content', value: draft.content },
         { op: 'replace', path: '/tags', value: draft.tags },
@@ -187,70 +193,75 @@ export function ProjectNotesTab({
     onError: (err) => {
       toast.error(`Update failed: ${extractApiErrorDetail(err)}`)
     },
-    onSuccess: (note) => {
-      qc.setQueryData<Note[]>(notesKey, (prev) =>
-        prev ? prev.map((n) => (n.id === note.id ? note : n)) : [note],
+    onSuccess: (document) => {
+      qc.setQueryData<Document[]>(documentsKey, (prev) =>
+        prev
+          ? prev.map((n) => (n.id === document.id ? document : n))
+          : [document],
       )
-      qc.invalidateQueries({ queryKey: notesKey })
-      toast.success('Note updated')
-      navigateToView({ kind: 'reading', noteId: note.id })
+      qc.invalidateQueries({ queryKey: documentsKey })
+      toast.success('Document updated')
+      navigateToView({ documentId: document.id, kind: 'reading' })
     },
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (noteId: string) =>
-      deleteProjectNote(orgSlug, projectId, noteId),
+    mutationFn: (documentId: string) =>
+      deleteProjectDocument(orgSlug, projectId, documentId),
     onError: (err) => {
       toast.error(`Delete failed: ${extractApiErrorDetail(err)}`)
     },
-    onSuccess: (_data, noteId) => {
-      qc.setQueryData<Note[]>(notesKey, (prev) =>
-        prev ? prev.filter((n) => n.id !== noteId) : [],
+    onSuccess: (_data, documentId) => {
+      qc.setQueryData<Document[]>(documentsKey, (prev) =>
+        prev ? prev.filter((n) => n.id !== documentId) : [],
       )
-      qc.invalidateQueries({ queryKey: notesKey })
-      toast.success('Note deleted')
+      qc.invalidateQueries({ queryKey: documentsKey })
+      toast.success('Document deleted')
       navigateToView({ kind: 'list' })
     },
   })
 
   const togglePin = useCallback(
-    (note: Note) => {
-      pinMutation.mutate({ noteId: note.id, pinned: !note.is_pinned })
+    (document: Document) => {
+      pinMutation.mutate({
+        documentId: document.id,
+        pinned: !document.is_pinned,
+      })
     },
     [pinMutation],
   )
 
-  const selectedNote = useMemo(
+  const selectedDocument = useMemo(
     () =>
       view.kind === 'reading'
-        ? (notes.find((n) => n.id === view.noteId) ?? null)
+        ? (documents.find((n) => n.id === view.documentId) ?? null)
         : null,
-    [notes, view],
+    [documents, view],
   )
 
-  const editingNote = useMemo(
+  const editingDocument = useMemo(
     () =>
       view.kind === 'editing'
-        ? (notes.find((n) => n.id === view.noteId) ?? null)
+        ? (documents.find((n) => n.id === view.documentId) ?? null)
         : null,
-    [notes, view],
+    [documents, view],
   )
 
-  // If a deep-linked note id doesn't exist (deleted, wrong id), surface a
+  // If a deep-linked document id doesn't exist (deleted, wrong id), surface a
   // toast and bounce back to the list view rather than silently rendering
-  // the empty list. Skip while the notes query is loading or errored —
+  // the empty list. Skip while the documents query is loading or errored —
   // the error banner (rendered below) already covers fetch failures and
-  // an empty-on-error notes array shouldn't masquerade as a missing note.
+  // an empty-on-error documents array shouldn't masquerade as a missing document.
   useEffect(() => {
     if (isLoading || error) return
     if (view.kind !== 'reading' && view.kind !== 'editing') return
-    if (notes.some((n) => n.id === view.noteId)) return
-    toast.error('Note not found')
+    if (documents.some((n) => n.id === view.documentId)) return
+    toast.error('Document not found')
     navigateToView({ kind: 'list' })
-  }, [error, isLoading, navigateToView, notes, view])
+  }, [error, isLoading, navigateToView, documents, view])
 
   const handleCreate = useCallback(
-    (template?: NoteTemplate) => {
+    (template?: DocumentTemplate) => {
       navigateToView({ kind: 'creating', template: template ?? null })
     },
     [navigateToView],
@@ -258,7 +269,7 @@ export function ProjectNotesTab({
 
   const handleDiscard = useCallback(() => {
     if (view.kind === 'editing') {
-      navigateToView({ kind: 'reading', noteId: view.noteId })
+      navigateToView({ documentId: view.documentId, kind: 'reading' })
     } else {
       navigateToView({ kind: 'list' })
     }
@@ -267,7 +278,7 @@ export function ProjectNotesTab({
   const handleSave = useCallback(
     (draft: { content: string; tags: string[]; title: string }) => {
       if (view.kind === 'editing') {
-        updateMutation.mutate({ draft, noteId: view.noteId })
+        updateMutation.mutate({ documentId: view.documentId, draft })
       } else {
         createMutation.mutate(draft)
       }
@@ -275,13 +286,14 @@ export function ProjectNotesTab({
     [createMutation, updateMutation, view],
   )
 
-  if (isLoading) return <LoadingState label="Loading notes…" />
-  if (error) return <ErrorBanner error={error} title="Failed to load notes" />
+  if (isLoading) return <LoadingState label="Loading documents…" />
+  if (error)
+    return <ErrorBanner error={error} title="Failed to load documents" />
 
   if (view.kind === 'creating') {
     return (
-      <NotesPinboardNew
-        allNotes={notes}
+      <DocumentsPinboardNew
+        allDocuments={documents}
         onDiscard={handleDiscard}
         onSave={handleSave}
         orgSlug={orgSlug}
@@ -291,12 +303,12 @@ export function ProjectNotesTab({
     )
   }
 
-  if (editingNote) {
+  if (editingDocument) {
     return (
-      <NotesPinboardNew
-        allNotes={notes}
-        initialNote={editingNote}
-        key={editingNote.id}
+      <DocumentsPinboardNew
+        allDocuments={documents}
+        initialDocument={editingDocument}
+        key={editingDocument.id}
         onDiscard={handleDiscard}
         onSave={handleSave}
         orgSlug={orgSlug}
@@ -305,27 +317,27 @@ export function ProjectNotesTab({
     )
   }
 
-  if (selectedNote) {
+  if (selectedDocument) {
     return (
-      <NotesPinboardReader
-        allNotes={notes}
+      <DocumentsPinboardReader
+        allDocuments={documents}
         deleting={deleteMutation.isPending}
         displayNames={displayNames}
-        note={selectedNote}
+        document={selectedDocument}
         onBack={() => navigateToView({ kind: 'list' })}
-        onDelete={() => deleteMutation.mutate(selectedNote.id)}
+        onDelete={() => deleteMutation.mutate(selectedDocument.id)}
         onEdit={() =>
-          navigateToView({ kind: 'editing', noteId: selectedNote.id })
+          navigateToView({ documentId: selectedDocument.id, kind: 'editing' })
         }
-        onOpen={(id) => navigateToView({ kind: 'reading', noteId: id })}
-        onTogglePin={() => togglePin(selectedNote)}
+        onOpen={(id) => navigateToView({ documentId: id, kind: 'reading' })}
+        onTogglePin={() => togglePin(selectedDocument)}
       />
     )
   }
 
-  if (notes.length === 0) {
+  if (documents.length === 0) {
     return (
-      <NotesPinboardEmpty
+      <DocumentsPinboardEmpty
         onCreate={handleCreate}
         orgSlug={orgSlug}
         projectTypeSlugs={projectTypeSlugs}
@@ -334,24 +346,25 @@ export function ProjectNotesTab({
   }
 
   return (
-    <NotesPinboard
+    <DocumentsPinboard
       displayNames={displayNames}
-      notes={notes}
+      documents={documents}
       onCreate={handleCreate}
-      onOpen={(id) => navigateToView({ kind: 'reading', noteId: id })}
+      onOpen={(id) => navigateToView({ documentId: id, kind: 'reading' })}
       onTogglePin={togglePin}
     />
   )
 }
 
 function viewFromUrl(
-  initialNoteId: string | undefined,
+  initialDocumentId: string | undefined,
   initialAction: string | undefined,
 ): View {
-  if (initialNoteId === 'new') return { kind: 'creating' }
-  if (initialNoteId && initialAction === 'edit') {
-    return { kind: 'editing', noteId: initialNoteId }
+  if (initialDocumentId === 'new') return { kind: 'creating' }
+  if (initialDocumentId && initialAction === 'edit') {
+    return { documentId: initialDocumentId, kind: 'editing' }
   }
-  if (initialNoteId) return { kind: 'reading', noteId: initialNoteId }
+  if (initialDocumentId)
+    return { documentId: initialDocumentId, kind: 'reading' }
   return { kind: 'list' }
 }

--- a/src/components/documents/TagCombobox.tsx
+++ b/src/components/documents/TagCombobox.tsx
@@ -9,7 +9,7 @@ import { extractApiErrorDetail } from '@/lib/apiError'
 import { cn } from '@/lib/utils'
 import type { Tag, TagRef } from '@/types'
 
-import { NoteTagChip } from './NoteTagChip'
+import { DocumentTagChip } from './DocumentTagChip'
 
 interface Props {
   onChange: (tags: TagRef[]) => void
@@ -17,7 +17,7 @@ interface Props {
   selected: TagRef[]
   /**
    * Layout variant. `'compact'` (default) is the right-aligned inline pill
-   * used in the note composer header. `'full'` stretches to fill its
+   * used in the document composer header. `'full'` stretches to fill its
    * container and uses input-sized padding/text — for use inside forms.
    */
   variant?: 'compact' | 'full'
@@ -168,7 +168,7 @@ export function TagCombobox({
             key={t.slug}
             onClick={(e) => e.stopPropagation()}
           >
-            <NoteTagChip size="sm" tag={t} />
+            <DocumentTagChip size="sm" tag={t} />
             <button
               aria-label={`Remove tag ${t.name}`}
               className="rounded border-0 bg-transparent p-0 text-tertiary hover:text-primary"
@@ -222,7 +222,7 @@ export function TagCombobox({
                     onMouseEnter={() => setActiveIdx(i)}
                     type="button"
                   >
-                    <NoteTagChip size="sm" tag={t} />
+                    <DocumentTagChip size="sm" tag={t} />
                     <span className="ml-auto text-[11px] text-tertiary">
                       {isActive && (
                         <CornerDownLeft className="h-3 w-3 text-tertiary" />

--- a/src/components/documents/documentsHelpers.ts
+++ b/src/components/documents/documentsHelpers.ts
@@ -1,5 +1,5 @@
 import { LABEL_SWATCHES } from '@/lib/chip-colors'
-import type { Note, TagRef } from '@/types'
+import type { Document, TagRef } from '@/types'
 
 /**
  * Deterministic color for a tag slug. Stable hash keeps each tag on the same
@@ -49,6 +49,24 @@ export function deriveExcerpt(content: string): string {
   return truncate(text, EXCERPT_MAX)
 }
 
+/**
+ * Prefer the document's explicit title; fall back to the first heading or line
+ * of content for rows written before the title column existed.
+ */
+export function documentTitle(document: Document): string {
+  const explicit = (document.title ?? '').trim()
+  if (explicit) return truncate(explicit, TITLE_MAX)
+  const lines = document.content.split('\n')
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+    const heading = line.match(/^#{1,6}\s+(.+?)\s*#*$/)
+    if (heading) return truncate(heading[1], TITLE_MAX)
+    return truncate(line.replace(/^[*_>`~-]+\s*/, ''), TITLE_MAX)
+  }
+  return 'Untitled document'
+}
+
 export function formatFull(iso: null | string | undefined): string {
   if (!iso) return ''
   try {
@@ -61,8 +79,8 @@ export function formatFull(iso: null | string | undefined): string {
   }
 }
 
-export function formatUpdated(note: Note): string {
-  const iso = note.updated_at ?? note.created_at
+export function formatUpdated(document: Document): string {
+  const iso = document.updated_at ?? document.created_at
   return relativeShort(iso)
 }
 
@@ -72,24 +90,6 @@ export function initials(name: string): string {
   const parts = trimmed.split(/\s+/)
   if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
-}
-
-/**
- * Prefer the note's explicit title; fall back to the first heading or line
- * of content for rows written before the title column existed.
- */
-export function noteTitle(note: Note): string {
-  const explicit = (note.title ?? '').trim()
-  if (explicit) return truncate(explicit, TITLE_MAX)
-  const lines = note.content.split('\n')
-  for (const raw of lines) {
-    const line = raw.trim()
-    if (!line) continue
-    const heading = line.match(/^#{1,6}\s+(.+?)\s*#*$/)
-    if (heading) return truncate(heading[1], TITLE_MAX)
-    return truncate(line.replace(/^[*_>`~-]+\s*/, ''), TITLE_MAX)
-  }
-  return 'Untitled note'
 }
 
 function relativeShort(iso: null | string | undefined): string {
@@ -119,18 +119,18 @@ function truncate(s: string, max: number): string {
 
 export const EMPTY_ACTIVE: ReadonlySet<string> = new Set()
 
-export function tagCounts(notes: Note[]): Record<string, number> {
+export function tagCounts(documents: Document[]): Record<string, number> {
   const counts: Record<string, number> = {}
-  for (const n of notes) {
+  for (const n of documents) {
     for (const t of n.tags) counts[t.slug] = (counts[t.slug] ?? 0) + 1
   }
   return counts
 }
 
-/** Dedupe tags by slug across the whole note list. */
-export function uniqueTagsFromNotes(notes: Note[]): TagRef[] {
+/** Dedupe tags by slug across the whole document list. */
+export function uniqueTagsFromDocuments(documents: Document[]): TagRef[] {
   const seen = new Map<string, TagRef>()
-  for (const n of notes) {
+  for (const n of documents) {
     for (const t of n.tags) {
       if (!seen.has(t.slug)) seen.set(t.slug, t)
     }

--- a/src/components/ui/user-display.tsx
+++ b/src/components/ui/user-display.tsx
@@ -11,7 +11,7 @@ interface Props {
   hideName?: boolean
   /**
    * When true (default), wraps the chip in a link to /users/:email so the
-   * user's profile page is reachable from any opslog/note/release row.
+   * user's profile page is reachable from any opslog/document/release row.
    */
   linkToProfile?: boolean
   size?: number

--- a/src/index.css
+++ b/src/index.css
@@ -143,59 +143,59 @@
 }
 
 @layer components {
-  .note-markdown {
+  .document-markdown {
     font-size: 14.5px;
     line-height: 1.65;
     color: var(--color-text-primary);
   }
-  .note-markdown h1,
-  .note-markdown h2,
-  .note-markdown h3,
-  .note-markdown h4 {
+  .document-markdown h1,
+  .document-markdown h2,
+  .document-markdown h3,
+  .document-markdown h4 {
     font-weight: 600;
     letter-spacing: -0.01em;
     color: var(--color-text-primary);
     margin: 1em 0 0.4em;
   }
-  .note-markdown h1 {
+  .document-markdown h1 {
     font-size: 22px;
   }
-  .note-markdown h2 {
+  .document-markdown h2 {
     font-size: 17px;
   }
-  .note-markdown h3 {
+  .document-markdown h3 {
     font-size: 15px;
   }
-  .note-markdown h4 {
+  .document-markdown h4 {
     font-size: 13.5px;
   }
-  .note-markdown p,
-  .note-markdown ul,
-  .note-markdown ol {
+  .document-markdown p,
+  .document-markdown ul,
+  .document-markdown ol {
     margin: 0.5em 0;
   }
-  .note-markdown ul,
-  .note-markdown ol {
+  .document-markdown ul,
+  .document-markdown ol {
     padding-left: 1.2em;
   }
-  .note-markdown li {
+  .document-markdown li {
     margin: 0.25em 0;
   }
-  .note-markdown a {
+  .document-markdown a {
     color: var(--color-text-warning);
     text-decoration: none;
   }
-  .note-markdown a:hover {
+  .document-markdown a:hover {
     text-decoration: underline;
   }
-  .note-markdown code {
+  .document-markdown code {
     font-family: var(--font-mono);
     font-size: 12.5px;
     background: var(--color-background-secondary);
     padding: 0.1em 0.3em;
     border-radius: 3px;
   }
-  .note-markdown pre {
+  .document-markdown pre {
     margin: 0.75em 0;
     padding: 10px 12px;
     background: var(--color-background-secondary);
@@ -206,18 +206,18 @@
     line-height: 1.55;
     overflow: auto;
   }
-  .note-markdown pre code {
+  .document-markdown pre code {
     background: transparent;
     padding: 0;
     font-size: inherit;
   }
-  .note-markdown blockquote {
+  .document-markdown blockquote {
     margin: 0.5em 0;
     padding: 0.25em 0.75em;
     border-left: 2px solid var(--color-border-tertiary);
     color: var(--color-text-secondary);
   }
-  .note-markdown table {
+  .document-markdown table {
     width: 100%;
     border-collapse: collapse;
     font-size: 12.5px;
@@ -226,13 +226,13 @@
     overflow: hidden;
     margin: 0.75em 0;
   }
-  .note-markdown th,
-  .note-markdown td {
+  .document-markdown th,
+  .document-markdown td {
     padding: 8px 10px;
     text-align: left;
     border-top: 0.5px solid var(--color-border-tertiary);
   }
-  .note-markdown thead th {
+  .document-markdown thead th {
     background: var(--color-background-secondary);
     color: var(--color-text-tertiary);
     text-transform: uppercase;
@@ -241,7 +241,7 @@
     font-weight: 600;
     border-top: 0;
   }
-  .note-markdown input[type='checkbox'] {
+  .document-markdown input[type='checkbox'] {
     margin-right: 0.5em;
   }
 }

--- a/src/pages/UserProfile/ActivityRow.tsx
+++ b/src/pages/UserProfile/ActivityRow.tsx
@@ -64,10 +64,10 @@ function pickIcon(record: ActivityRecord) {
   switch (record.source) {
     case 'conversation':
       return <MessageSquare className="h-4 w-4" />
+    case 'document':
+      return <FileText className="h-4 w-4" />
     case 'events':
       return <Zap className="h-4 w-4" />
-    case 'note':
-      return <FileText className="h-4 w-4" />
     case 'release':
       return <Tag className="h-4 w-4" />
     case 'upload':

--- a/src/pages/UserProfile/api.ts
+++ b/src/pages/UserProfile/api.ts
@@ -18,8 +18,8 @@ export type ActivityResponse = {
 
 export type ActivitySource =
   | 'conversation'
+  | 'document'
   | 'events'
-  | 'note'
   | 'operations_log'
   | 'release'
   | 'upload'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -338,6 +338,58 @@ export type DeploymentStatus =
   | 'rolled_back'
   | 'success'
 
+export interface Document {
+  content: string
+  created_at: string
+  created_by: string
+  id: string
+  is_pinned: boolean
+  project_id: string
+  tags: TagRef[]
+  title: string
+  updated_at?: null | string
+  updated_by?: null | string
+}
+
+export interface DocumentCreate {
+  content: string
+  tags?: string[]
+  title: string
+}
+
+export type DocumentListResponse = CollectionResponse<Document>
+
+// Document Templates. Inlined for the same reason as Document/Tag — the
+// committed openapi.json snapshot predates these endpoints. Switch to
+// `Schemas['DocumentTemplateResponse']` etc. once the snapshot is refreshed.
+export interface DocumentTemplate {
+  content: string
+  created_at: string
+  description?: null | string
+  icon?: null | string
+  id: string
+  name: string
+  organization: { name: string; slug: string }
+  project_type_slugs: string[]
+  slug: string
+  sort_order: number
+  tags: TagRef[]
+  title?: null | string
+  updated_at?: null | string
+}
+
+export interface DocumentTemplateCreate {
+  content?: string
+  description?: null | string
+  icon?: null | string
+  name: string
+  project_type_slugs?: string[]
+  slug: string
+  sort_order?: number
+  tags?: string[]
+  title?: null | string
+}
+
 export interface IdentityConnectionPollResponse {
   return_to?: null | string
   status: 'complete' | 'pending'
@@ -498,58 +550,6 @@ export interface LogResultResponse {
   entries: LogEntryResponse[]
   next_cursor: null | string
   total: null | number
-}
-
-export interface Note {
-  content: string
-  created_at: string
-  created_by: string
-  id: string
-  is_pinned: boolean
-  project_id: string
-  tags: TagRef[]
-  title: string
-  updated_at?: null | string
-  updated_by?: null | string
-}
-
-export interface NoteCreate {
-  content: string
-  tags?: string[]
-  title: string
-}
-
-export type NoteListResponse = CollectionResponse<Note>
-
-// Note Templates. Inlined for the same reason as Note/Tag — the committed
-// openapi.json snapshot predates these endpoints. Switch to
-// `Schemas['NoteTemplateResponse']` etc. once the snapshot is refreshed.
-export interface NoteTemplate {
-  content: string
-  created_at: string
-  description?: null | string
-  icon?: null | string
-  id: string
-  name: string
-  organization: { name: string; slug: string }
-  project_type_slugs: string[]
-  slug: string
-  sort_order: number
-  tags: TagRef[]
-  title?: null | string
-  updated_at?: null | string
-}
-
-export interface NoteTemplateCreate {
-  content?: string
-  description?: null | string
-  icon?: null | string
-  name: string
-  project_type_slugs?: string[]
-  slug: string
-  sort_order?: number
-  tags?: string[]
-  title?: null | string
 }
 
 // Auth provider types — mirror the consolidated `ServiceApplication`-backed
@@ -874,10 +874,10 @@ export interface Tag {
   updated_at?: null | string
 }
 
-// Notes & tags. Inlined here (not from api-generated.ts) because the
-// committed openapi.json snapshot predates the notes endpoints.
+// Documents & tags. Inlined here (not from api-generated.ts) because the
+// committed openapi.json snapshot predates the documents endpoints.
 // Regenerate with `npm run codegen:fetch` once the snapshot is refreshed
-// and switch these to `Schemas['NoteResponse']` etc.
+// and switch these to `Schemas['DocumentResponse']` etc.
 export interface TagRef {
   name: string
   slug: string


### PR DESCRIPTION
## Summary

Phase 3 of the multi-repo `Note` → `Document` rename — see `docs/notes-to-documents-rename-plan.md` in the orchestrator. Phases 1 ([imbi-common#80](https://github.com/AWeber-Imbi/imbi-common/pull/80)) and 2 ([imbi-api#277](https://github.com/AWeber-Imbi/imbi-api/pull/277)) are both merged.

- Component dirs: `src/components/notes/` → `src/components/documents/`; component files renamed (NotesPinboard → DocumentsPinboard, ProjectNotesTab → ProjectDocumentsTab, NoteTagChip → DocumentTagChip, notesHelpers → documentsHelpers, …)
- Admin: `NoteTemplateManagement` → `DocumentTemplateManagement`; `components/admin/note-templates/` → `document-templates/`; `NoteTemplateForm` → `DocumentTemplateForm`
- Types (`src/types/index.ts`): hand-written `Note`, `NoteCreate`, `NoteListResponse`, `NoteTemplate`, `NoteTemplateCreate` → `Document*`. `api-generated.ts` kept as-is — regenerate via `npm run codegen:fetch` once the merged imbi-api OpenAPI snapshot is refreshed.
- API client (`src/api/endpoints.ts`): `listProjectNotes`/`getProjectNote`/`createProjectNote`/`patchProjectNote`/`deleteProjectNote` → `*ProjectDocument`; same for templates. Path strings flipped to `/documents/` and `/document-templates/`
- `ProjectDetail`: tab id `'notes'` → `'documents'`; visible label "Notes" → "Documents"; query keys (`projectNotes` → `projectDocuments`, `initialNoteId` → `initialDocumentId`)
- `index.css`: `.note-markdown` → `.document-markdown`
- UserProfile activity `source: 'note'` → `'document'`; visible copy ("New Note Template" → "New Document Template", empty-state, toasts)

Out of scope per the plan: `OperationLog.notes` (`record.notes` rendering / `api-generated.ts` types), Lucide `StickyNote` icon, `// NOTE: …` comments.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm run format:check` — all files use the correct format