### PR TITLE
Add event_type_selector to webhook admin UI

### DIFF
--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -134,6 +134,18 @@ export function WebhookDetail({ onBack, onEdit, webhook }: WebhookDetailProps) {
                 </div>
               </div>
             )}
+            {webhook.event_type_selector && (
+              <div>
+                <div className="text-sm text-secondary">
+                  Event Type Selector
+                </div>
+                <div className="mt-1">
+                  <code className="rounded bg-secondary px-2 py-1 text-sm text-primary">
+                    {webhook.event_type_selector}
+                  </code>
+                </div>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -63,6 +63,9 @@ export function WebhookForm({
   const [identityPluginSlug, setIdentityPluginSlug] = useState(
     webhook?.identity_plugin_slug || '',
   )
+  const [eventTypeSelector, setEventTypeSelector] = useState(
+    webhook?.event_type_selector || '',
+  )
   const [rules, setRules] = useState<RuleDraft[]>(() =>
     (webhook?.rules || []).map((r) => ({ ...r, _clientId: makeClientId() })),
   )
@@ -104,6 +107,10 @@ export function WebhookForm({
       newErrors.identity_plugin_slug =
         'Identity plugin slug requires a third-party service'
     }
+    if (eventTypeSelector && !tpsSlug) {
+      newErrors.event_type_selector =
+        'Event type selector requires a third-party service'
+    }
     for (let i = 0; i < rules.length; i++) {
       if (!rules[i].filter_expression.trim()) {
         newErrors[`rule_${i}_filter`] = 'Filter expression is required'
@@ -121,6 +128,7 @@ export function WebhookForm({
 
     const payload: WebhookSaveData = {
       description: description.trim() || null,
+      event_type_selector: eventTypeSelector.trim() || null,
       icon: icon.trim() || null,
       identifier_selector: identifierSelector.trim() || null,
       identity_plugin_slug: identityPluginSlug.trim() || null,
@@ -158,6 +166,7 @@ export function WebhookForm({
       setIdentifierSelector('')
       setUserSubjectSelector('')
       setIdentityPluginSlug('')
+      setEventTypeSelector('')
     }
     // In edit mode, auto-update the displayed slug to the computed value
     // so the user can see what will be saved if they don't override it.
@@ -524,6 +533,40 @@ export function WebhookForm({
                       Override which identity plugin resolves the user. Leave
                       blank to fall back to identity plugins attached to the
                       third-party service.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="mb-1.5 block text-sm text-secondary">
+                      Event Type Selector{' '}
+                      <span className="text-xs text-tertiary">(optional)</span>
+                    </label>
+                    <Input
+                      className={`font-mono text-sm ${
+                        errors.event_type_selector ? 'border-red-500' : ''
+                      }`}
+                      disabled={isLoading}
+                      onChange={(e) => setEventTypeSelector(e.target.value)}
+                      placeholder="e.g., x-github-event or /action"
+                      value={eventTypeSelector}
+                    />
+                    {errors.event_type_selector && (
+                      <div
+                        className={
+                          'mt-1 flex items-center gap-1 text-xs text-danger'
+                        }
+                      >
+                        <AlertCircle className="h-3 w-3" />
+                        {errors.event_type_selector}
+                      </div>
+                    )}
+                    <p className="mt-1 text-xs text-tertiary">
+                      Resolves the activity-feed event type. Values starting
+                      with <code>/</code> are JSON pointers evaluated against
+                      the request body; otherwise the value is treated as an
+                      HTTP header name. When the header is absent, the selector
+                      itself is used as the literal label (e.g.,{' '}
+                      <code>SonarQube Notification</code>).
                     </p>
                   </div>
                 </>

--- a/src/types/api-generated.ts
+++ b/src/types/api-generated.ts
@@ -4910,6 +4910,11 @@ export interface components {
              * @description Optional override for the identity plugin slug used to resolve the Imbi user; falls back to identity plugins attached to the third-party service when unset.
              */
             identity_plugin_slug?: string | null;
+            /**
+             * Event Type Selector
+             * @description Resolves the activity-feed event type for each webhook. Values starting with "/" are JSON pointers evaluated against the request body; otherwise the value is treated as an HTTP header name (case-insensitive). When the header is absent, the literal selector value is used as the label.
+             */
+            event_type_selector?: string | null;
             /** Rules */
             rules?: components["schemas"]["WebhookRuleCreate"][];
         };
@@ -4940,6 +4945,8 @@ export interface components {
             user_subject_selector?: string | null;
             /** Identity Plugin Slug */
             identity_plugin_slug?: string | null;
+            /** Event Type Selector */
+            event_type_selector?: string | null;
             /**
              * Rules
              * @default []
@@ -5016,6 +5023,11 @@ export interface components {
              * @description Optional override for the identity plugin slug used to resolve the Imbi user; falls back to identity plugins attached to the third-party service when unset.
              */
             identity_plugin_slug?: string | null;
+            /**
+             * Event Type Selector
+             * @description Resolves the activity-feed event type for each webhook. Values starting with "/" are JSON pointers evaluated against the request body; otherwise the value is treated as an HTTP header name (case-insensitive). When the header is absent, the literal selector value is used as the label.
+             */
+            event_type_selector?: string | null;
             /** Rules */
             rules?: components["schemas"]["WebhookRuleCreate"][];
         };


### PR DESCRIPTION
## Summary
Surface the new `event_type_selector` field on the webhook admin form so operators can configure how the gateway populates `events.type` for each webhook source.

## Problem
The companion imbi-gateway PR populates a per-row `type` value when it inserts a webhook event into ClickHouse. That value drives the activity-feed row body in `ProjectActivityLog` (`entry.type.replace(/-/g, ' ')`), so without a configurable selector every event would render with an empty body.

The companion imbi-api PR adds `event_type_selector` to the webhook CRUD shape; this PR is the user-facing surface for setting it.

## Solution
- **`WebhookForm.tsx`**: new state, validation rule (selector requires a third-party service, mirroring the other selectors), payload field, reset on TPS removal, and an input with help text describing the three resolution modes.
- **`WebhookDetail.tsx`**: read-only display alongside the other selectors.
- **`api-generated.ts`**: hand-applied additions to `WebhookCreate`, `WebhookResponse`, and `WebhookUpdate`. These will be regenerated cleanly by `npm run codegen:fetch` once the imbi-api companion PR lands locally.

The selector resolves to a UI-friendly label per the resolution rule the gateway implements:
- Values starting with `/` are JSON pointers evaluated against the request body.
- Otherwise the value is treated as an HTTP header name (case-insensitive).
- If the header is absent (or the selector can't be a valid header, e.g. `SonarQube Notification`), the literal selector value is used as the label.

## Impact
- **Backwards compatible**: optional field, defaults to nothing. Existing webhooks without a selector continue to work — they just store an empty `type`.
- **Companion PRs (must merge in this order):**
  - imbi-common 0.7.1 ✅ released (new `Event` model fields)
  - imbi-api: webhook CRUD plumbing (in flight)
  - **this PR**
  - imbi-gateway: lifespan + ClickHouse insert (in flight)
- Plan of record: `imbi-development:plans/webhook-events-to-clickhouse.md`

## Testing
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run build` — builds successfully