### PR TITLE
Add Deploy modal + Promote popover for the release train

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -19,6 +19,11 @@ import type {
   ConfigKeyResponse,
   ConfigKeyValueResponse,
   CurrentReleaseEnvironment,
+  DeploymentCommit,
+  DeploymentCompareResult,
+  DeploymentRef,
+  DeploymentTriggerRequest,
+  DeploymentTriggerResponse,
   Document,
   DocumentCreate,
   DocumentListResponse,
@@ -1349,6 +1354,97 @@ export const listCurrentReleases = async (
     signal,
   )
   return Array.isArray(response) ? response : []
+}
+
+// Deployments
+const deploymentsBase = (orgSlug: string, projectId: string): string =>
+  `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/deployments`
+
+export const listDeploymentRefs = async (
+  orgSlug: string,
+  projectId: string,
+  params: {
+    kind?: 'all' | 'branch' | 'default' | 'tag'
+    q?: string
+    source?: string
+  } = {},
+  signal?: AbortSignal,
+): Promise<DeploymentRef[]> => {
+  const search = new URLSearchParams()
+  if (params.kind) search.set('kind', params.kind)
+  if (params.q) search.set('q', params.q)
+  if (params.source) search.set('source', params.source)
+  const query = search.toString()
+  const response = await apiClient.get<DeploymentRef[]>(
+    `${deploymentsBase(orgSlug, projectId)}/refs${query ? `?${query}` : ''}`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const listRefCommits = async (
+  orgSlug: string,
+  projectId: string,
+  ref: string,
+  params: { limit?: number; source?: string } = {},
+  signal?: AbortSignal,
+): Promise<DeploymentCommit[]> => {
+  const search = new URLSearchParams()
+  if (params.limit != null) search.set('limit', String(params.limit))
+  if (params.source) search.set('source', params.source)
+  const query = search.toString()
+  const response = await apiClient.get<DeploymentCommit[]>(
+    `${deploymentsBase(orgSlug, projectId)}/refs/${encodeURIComponent(ref)}/commits${query ? `?${query}` : ''}`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const resolveCommit = (
+  orgSlug: string,
+  projectId: string,
+  committish: string,
+  source?: string,
+  signal?: AbortSignal,
+): Promise<DeploymentCommit> => {
+  const search = source ? `?source=${encodeURIComponent(source)}` : ''
+  return apiClient.get<DeploymentCommit>(
+    `${deploymentsBase(orgSlug, projectId)}/commits/${encodeURIComponent(committish)}${search}`,
+    undefined,
+    signal,
+  )
+}
+
+export const compareDeploymentRefs = (
+  orgSlug: string,
+  projectId: string,
+  base: string,
+  head: string,
+  source?: string,
+  signal?: AbortSignal,
+): Promise<DeploymentCompareResult> => {
+  const search = new URLSearchParams({ base, head })
+  if (source) search.set('source', source)
+  return apiClient.get<DeploymentCompareResult>(
+    `${deploymentsBase(orgSlug, projectId)}/compare?${search.toString()}`,
+    undefined,
+    signal,
+  )
+}
+
+export const triggerDeployment = (
+  orgSlug: string,
+  projectId: string,
+  body: DeploymentTriggerRequest,
+  source?: string,
+): Promise<DeploymentTriggerResponse> => {
+  const search = source ? `?source=${encodeURIComponent(source)}` : ''
+  return apiClient.post<DeploymentTriggerResponse>(
+    `${deploymentsBase(orgSlug, projectId)}${search}`,
+    body,
+  )
 }
 
 // Identity Plugins (org-scoped)

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -21,6 +21,7 @@ import type {
   CurrentReleaseEnvironment,
   DeploymentCommit,
   DeploymentCompareResult,
+  DeploymentPromoteRequest,
   DeploymentRef,
   DeploymentTriggerRequest,
   DeploymentTriggerResponse,
@@ -29,6 +30,8 @@ import type {
   DocumentListResponse,
   DocumentTemplate,
   DocumentTemplateCreate,
+  DraftReleaseNotesRequest,
+  DraftReleaseNotesResponse,
   Environment,
   EnvironmentCreate,
   IdentityConnectionPollResponse,
@@ -68,6 +71,7 @@ import type {
   ProjectRelationshipsResponse,
   ProjectType,
   ProjectTypeCreate,
+  PromotionOption,
   Role,
   RoleCreate,
   RoleDetail,
@@ -1445,6 +1449,47 @@ export const triggerDeployment = (
     `${deploymentsBase(orgSlug, projectId)}${search}`,
     body,
   )
+}
+
+export const promoteDeployment = (
+  orgSlug: string,
+  projectId: string,
+  body: DeploymentPromoteRequest,
+  source?: string,
+): Promise<DeploymentTriggerResponse> => {
+  const search = source ? `?source=${encodeURIComponent(source)}` : ''
+  return apiClient.post<DeploymentTriggerResponse>(
+    `${deploymentsBase(orgSlug, projectId)}${search}`,
+    body,
+  )
+}
+
+export const draftReleaseNotes = (
+  orgSlug: string,
+  projectId: string,
+  body: DraftReleaseNotesRequest,
+  source?: string,
+): Promise<DraftReleaseNotesResponse> => {
+  const search = source ? `?source=${encodeURIComponent(source)}` : ''
+  return apiClient.post<DraftReleaseNotesResponse>(
+    `${deploymentsBase(orgSlug, projectId)}/draft-release-notes${search}`,
+    body,
+  )
+}
+
+export const listPromotionOptions = async (
+  orgSlug: string,
+  projectId: string,
+  source?: string,
+  signal?: AbortSignal,
+): Promise<PromotionOption[]> => {
+  const search = source ? `?source=${encodeURIComponent(source)}` : ''
+  const response = await apiClient.get<PromotionOption[]>(
+    `${deploymentsBase(orgSlug, projectId)}/promotion-options${search}`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
 }
 
 // Identity Plugins (org-scoped)

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -9,6 +9,7 @@ import {
   Check,
   ChevronDown,
   Filter,
+  GitMerge,
   Rocket,
   Settings2 as SettingsIcon,
   TrendingDown,
@@ -28,7 +29,11 @@ import {
   listTeams,
   type ScoreTrend,
 } from '@/api/endpoints'
-import { DeploymentModal } from '@/components/deploy/DeploymentModal'
+import {
+  DeploymentModal,
+  type DeployModalTab,
+} from '@/components/deploy/DeploymentModal'
+import { PromoteDialog } from '@/components/deploy/PromoteDialog'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
 import { ConfigurationTab } from '@/components/project/ConfigurationTab'
@@ -189,11 +194,28 @@ export function ProjectDetail({
   const [deployModal, setDeployModal] = useState<{
     envSlug?: string
     open: boolean
-  }>({ open: false })
+    promoteFrom?: string
+    promoteFromCommittish?: string
+    promoteTo?: string
+    tab: DeployModalTab
+  }>({ open: false, tab: 'deploy' })
   const openDeploy = useCallback(
-    (envSlug?: string) => setDeployModal({ envSlug, open: true }),
+    (envSlug?: string) =>
+      setDeployModal({ envSlug, open: true, tab: 'deploy' }),
     [],
   )
+  const openPromote = useCallback(
+    (promoteFrom: string, promoteTo: string, promoteFromCommittish?: string) =>
+      setDeployModal({
+        open: true,
+        promoteFrom,
+        promoteFromCommittish,
+        promoteTo,
+        tab: 'promote',
+      }),
+    [],
+  )
+  const [promotePopoverOpen, setPromotePopoverOpen] = useState(false)
 
   const { data: projectSchema } = useQuery({
     enabled: !!orgSlug,
@@ -426,6 +448,25 @@ export function ProjectDetail({
                 <Rocket className="mr-1 h-4 w-4" />
                 Deploy
               </Button>
+              <PromoteDialog
+                onOpenChange={setPromotePopoverOpen}
+                onPromote={(opt) => {
+                  setPromotePopoverOpen(false)
+                  openPromote(
+                    opt.from_environment,
+                    opt.to_environment,
+                    opt.from_sha ?? opt.from_version ?? undefined,
+                  )
+                }}
+                open={promotePopoverOpen}
+                orgSlug={orgSlug}
+                projectId={project.id}
+              >
+                <Button size="sm" variant="outline">
+                  <GitMerge className="mr-1 h-4 w-4" />
+                  Promote
+                </Button>
+              </PromoteDialog>
             </div>
           )}
         </div>
@@ -721,11 +762,15 @@ export function ProjectDetail({
       <DeploymentModal
         environments={sortedEnvironments}
         initialEnvSlug={deployModal.envSlug}
+        initialTab={deployModal.tab}
         onOpenChange={(open) => setDeployModal((prev) => ({ ...prev, open }))}
         open={deployModal.open}
         orgSlug={orgSlug}
         projectId={project.id}
         projectName={project.name}
+        promoteFrom={deployModal.promoteFrom}
+        promoteFromCommittish={deployModal.promoteFromCommittish}
+        promoteTo={deployModal.promoteTo}
       />
     </div>
   )

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -404,10 +404,12 @@ export function ProjectDetail({
             </div>
           </div>
 
-          {/* Deployment Pipeline */}
-          {Object.keys(deploymentStatus).length > 0 && (
-            <div className="flex items-center gap-2">
-              {sortedEnvironments
+          {/* Deployment Pipeline — chips render only when there's
+               release history; the Deploy/Promote controls render
+               unconditionally so first-time deployments are reachable. */}
+          <div className="flex items-center gap-2">
+            {Object.keys(deploymentStatus).length > 0 &&
+              sortedEnvironments
                 .filter((env) => !!deploymentStatus[env.slug])
                 .map((env, idx) => {
                   const deployment = deploymentStatus[env.slug]
@@ -439,36 +441,35 @@ export function ProjectDetail({
                     </span>
                   )
                 })}
-              <Button
-                className="ml-4 border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100"
-                onClick={() => openDeploy()}
-                size="sm"
-                variant="outline"
-              >
-                <Rocket className="mr-1 h-4 w-4" />
-                Deploy
+            <Button
+              className="ml-4 border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100"
+              onClick={() => openDeploy()}
+              size="sm"
+              variant="outline"
+            >
+              <Rocket className="mr-1 h-4 w-4" />
+              Deploy
+            </Button>
+            <PromoteDialog
+              onOpenChange={setPromotePopoverOpen}
+              onPromote={(opt) => {
+                setPromotePopoverOpen(false)
+                openPromote(
+                  opt.from_environment,
+                  opt.to_environment,
+                  opt.from_sha ?? opt.from_version ?? undefined,
+                )
+              }}
+              open={promotePopoverOpen}
+              orgSlug={orgSlug}
+              projectId={project.id}
+            >
+              <Button size="sm" variant="outline">
+                <GitMerge className="mr-1 h-4 w-4" />
+                Promote
               </Button>
-              <PromoteDialog
-                onOpenChange={setPromotePopoverOpen}
-                onPromote={(opt) => {
-                  setPromotePopoverOpen(false)
-                  openPromote(
-                    opt.from_environment,
-                    opt.to_environment,
-                    opt.from_sha ?? opt.from_version ?? undefined,
-                  )
-                }}
-                open={promotePopoverOpen}
-                orgSlug={orgSlug}
-                projectId={project.id}
-              >
-                <Button size="sm" variant="outline">
-                  <GitMerge className="mr-1 h-4 w-4" />
-                  Promote
-                </Button>
-              </PromoteDialog>
-            </div>
-          )}
+            </PromoteDialog>
+          </div>
         </div>
 
         <div className="-ml-[18px] mt-3 text-secondary">

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -28,10 +28,7 @@ import {
   listTeams,
   type ScoreTrend,
 } from '@/api/endpoints'
-import {
-  DeploymentModal,
-  type DeployModalTab,
-} from '@/components/deploy/DeploymentModal'
+import { DeploymentModal } from '@/components/deploy/DeploymentModal'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
 import { ConfigurationTab } from '@/components/project/ConfigurationTab'
@@ -192,11 +189,9 @@ export function ProjectDetail({
   const [deployModal, setDeployModal] = useState<{
     envSlug?: string
     open: boolean
-    tab: DeployModalTab
-  }>({ open: false, tab: 'deploy' })
+  }>({ open: false })
   const openDeploy = useCallback(
-    (envSlug?: string, tab: DeployModalTab = 'deploy') =>
-      setDeployModal({ envSlug, open: true, tab }),
+    (envSlug?: string) => setDeployModal({ envSlug, open: true }),
     [],
   )
 
@@ -726,7 +721,6 @@ export function ProjectDetail({
       <DeploymentModal
         environments={sortedEnvironments}
         initialEnvSlug={deployModal.envSlug}
-        initialTab={deployModal.tab}
         onOpenChange={(open) => setDeployModal((prev) => ({ ...prev, open }))}
         open={deployModal.open}
         orgSlug={orgSlug}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -28,6 +28,10 @@ import {
   listTeams,
   type ScoreTrend,
 } from '@/api/endpoints'
+import {
+  DeploymentModal,
+  type DeployModalTab,
+} from '@/components/deploy/DeploymentModal'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
 import { ConfigurationTab } from '@/components/project/ConfigurationTab'
@@ -148,8 +152,6 @@ export function ProjectDetail({
     return out
   }, [currentReleases])
 
-  const isDev = import.meta.env.DEV
-
   const sortedEnvironments = useMemo(
     () => sortEnvironments(project.environments || []),
     [project.environments],
@@ -186,6 +188,17 @@ export function ProjectDetail({
   // Capture the score present at page load so intra-session changes are visible
   // even when the 30d baseline equals the current live score.
   const sessionBaseScore = useRef<null | number>(project.score ?? null)
+
+  const [deployModal, setDeployModal] = useState<{
+    envSlug?: string
+    open: boolean
+    tab: DeployModalTab
+  }>({ open: false, tab: 'deploy' })
+  const openDeploy = useCallback(
+    (envSlug?: string, tab: DeployModalTab = 'deploy') =>
+      setDeployModal({ envSlug, open: true, tab }),
+    [],
+  )
 
   const { data: projectSchema } = useQuery({
     enabled: !!orgSlug,
@@ -387,31 +400,37 @@ export function ProjectDetail({
                       {idx > 0 && (
                         <ArrowRight className="h-4 w-4 text-tertiary" />
                       )}
-                      {color ? (
-                        <LabelChip
-                          className="rounded-md px-3 py-1.5 text-sm"
-                          hex={color}
-                        >
-                          {env.name}: {deployment.version}
-                        </LabelChip>
-                      ) : (
-                        <span className="inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium">
-                          {env.name}: {deployment.version}
-                        </span>
-                      )}
+                      <button
+                        aria-label={`Deploy to ${env.name}`}
+                        className="cursor-pointer rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={() => openDeploy(env.slug)}
+                        type="button"
+                      >
+                        {color ? (
+                          <LabelChip
+                            className="rounded-md px-3 py-1.5 text-sm"
+                            hex={color}
+                          >
+                            {env.name}: {deployment.version}
+                          </LabelChip>
+                        ) : (
+                          <span className="inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium">
+                            {env.name}: {deployment.version}
+                          </span>
+                        )}
+                      </button>
                     </span>
                   )
                 })}
-              {isDev && (
-                <Button
-                  className="ml-4 border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100"
-                  size="sm"
-                  variant="outline"
-                >
-                  <Rocket className="mr-1 h-4 w-4" />
-                  Deploy
-                </Button>
-              )}
+              <Button
+                className="ml-4 border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100"
+                onClick={() => openDeploy()}
+                size="sm"
+                variant="outline"
+              >
+                <Rocket className="mr-1 h-4 w-4" />
+                Deploy
+              </Button>
             </div>
           )}
         </div>
@@ -704,6 +723,16 @@ export function ProjectDetail({
           <ProjectSettingsTab project={project} />
         </TabsContent>
       </Tabs>
+      <DeploymentModal
+        environments={sortedEnvironments}
+        initialEnvSlug={deployModal.envSlug}
+        initialTab={deployModal.tab}
+        onOpenChange={(open) => setDeployModal((prev) => ({ ...prev, open }))}
+        open={deployModal.open}
+        orgSlug={orgSlug}
+        projectId={project.id}
+        projectName={project.name}
+      />
     </div>
   )
 }

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -1,0 +1,438 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { formatDistanceToNow } from 'date-fns'
+import { Check, ExternalLink, Loader2, Rocket } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { ApiError } from '@/api/client'
+import {
+  compareDeploymentRefs,
+  listCurrentReleases,
+  listDeploymentRefs,
+  listRefCommits,
+  triggerDeployment,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { LoadingState } from '@/components/ui/loading-state'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import { cn, sortEnvironments } from '@/lib/utils'
+import type {
+  CurrentReleaseEnvironment,
+  DeploymentCommit,
+  DeploymentRef,
+  Environment,
+} from '@/types'
+
+interface DeployTabProps {
+  environments: Environment[]
+  initialEnvSlug?: string
+  onClose: () => void
+  orgSlug: string
+  projectId: string
+}
+
+const CI_DOT: Record<string, string> = {
+  fail: 'bg-danger',
+  pass: 'bg-success',
+  unknown: 'bg-tertiary',
+  warn: 'bg-warning',
+}
+
+export function DeployTab({
+  environments,
+  initialEnvSlug,
+  onClose,
+  orgSlug,
+  projectId,
+}: DeployTabProps) {
+  const sorted = useMemo(() => sortEnvironments(environments), [environments])
+  const [envSlug, setEnvSlug] = useState<string>(
+    initialEnvSlug ?? sorted[sorted.length - 1]?.slug ?? '',
+  )
+  useEffect(() => {
+    if (initialEnvSlug && initialEnvSlug !== envSlug) setEnvSlug(initialEnvSlug)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialEnvSlug])
+
+  const env = sorted.find((e) => e.slug === envSlug) ?? sorted[0]
+
+  const { data: currentReleases = [] } = useQuery<CurrentReleaseEnvironment[]>({
+    enabled: !!orgSlug && !!projectId,
+    queryFn: ({ signal }) => listCurrentReleases(orgSlug, projectId, signal),
+    queryKey: ['currentReleases', orgSlug, projectId],
+  })
+  const currentByEnv = useMemo(() => {
+    const map = new Map<string, CurrentReleaseEnvironment>()
+    for (const row of currentReleases) map.set(row.environment.slug, row)
+    return map
+  }, [currentReleases])
+  const current = env ? currentByEnv.get(env.slug) : undefined
+
+  // For testing-like envs (the leftmost in sort order) we list commits on
+  // the default branch.  For staging/production we list tags.
+  const isFirstEnv = env?.slug === sorted[0]?.slug
+  const refKind: 'branch' | 'tag' = isFirstEnv ? 'branch' : 'tag'
+
+  const { data: refs = [] } = useQuery<DeploymentRef[]>({
+    enabled: !!env,
+    queryFn: ({ signal }) =>
+      listDeploymentRefs(
+        orgSlug,
+        projectId,
+        { kind: isFirstEnv ? 'default' : 'tag' },
+        signal,
+      ),
+    queryKey: ['deploymentRefs', orgSlug, projectId, refKind],
+  })
+
+  const defaultBranchName = useMemo(() => {
+    const def = refs.find((r) => r.is_default)
+    return def?.name ?? 'main'
+  }, [refs])
+
+  const { data: branchCommits = [], isLoading: commitsLoading } = useQuery<
+    DeploymentCommit[]
+  >({
+    enabled: !!env && isFirstEnv,
+    queryFn: ({ signal }) =>
+      listRefCommits(
+        orgSlug,
+        projectId,
+        defaultBranchName,
+        { limit: 25 },
+        signal,
+      ),
+    queryKey: ['refCommits', orgSlug, projectId, defaultBranchName],
+  })
+
+  const tagOptions = useMemo<DeploymentRef[]>(
+    () => (isFirstEnv ? [] : refs.filter((r) => r.kind === 'tag')),
+    [isFirstEnv, refs],
+  )
+
+  const [selectedSha, setSelectedSha] = useState<null | string>(null)
+  const [selectedLabel, setSelectedLabel] = useState<null | string>(null)
+  useEffect(() => {
+    setSelectedSha(null)
+    setSelectedLabel(null)
+  }, [envSlug])
+
+  const queryClient = useQueryClient()
+  const mutation = useMutation({
+    mutationFn: ({
+      committish,
+      ref_label,
+    }: {
+      committish: string
+      ref_label: null | string
+    }) =>
+      triggerDeployment(orgSlug, projectId, {
+        action: current ? 'redeploy' : 'deploy',
+        committish,
+        environment: envSlug,
+        ref_label,
+      }),
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError
+          ? (extractApiErrorDetail(err) ?? err.message)
+          : (err as Error).message,
+      )
+    },
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['currentReleases', orgSlug, projectId],
+      })
+      const url = data.run.run_url
+      toast.success(
+        `Workflow dispatched to ${env?.name ?? envSlug}`,
+        url
+          ? {
+              action: {
+                label: 'View run',
+                onClick: () => window.open(url, '_blank', 'noopener'),
+              },
+            }
+          : undefined,
+      )
+      onClose()
+    },
+  })
+
+  const onDeploy = () => {
+    if (!selectedSha) return
+    mutation.mutate({
+      committish: selectedSha,
+      ref_label: selectedLabel,
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Step 1 — environment pickers */}
+      <section>
+        <p className="mb-2 text-xs uppercase tracking-wider text-tertiary">
+          Step 1 — Environment
+        </p>
+        <div className="grid grid-cols-3 gap-2">
+          {sorted.map((e) => {
+            const row = currentByEnv.get(e.slug)
+            const active = e.slug === envSlug
+            return (
+              <button
+                className={cn(
+                  'rounded-md border p-3 text-left transition-colors',
+                  active
+                    ? 'border-action bg-action/5'
+                    : 'border-secondary hover:bg-tertiary/30',
+                )}
+                key={e.slug}
+                onClick={() => setEnvSlug(e.slug)}
+                type="button"
+              >
+                <div className="text-sm font-medium">{e.name}</div>
+                <div className="mt-1 text-xs text-tertiary">
+                  {row?.release ? (
+                    <>
+                      <span className="font-mono">{row.release.version}</span>
+                      {row.last_event_at ? (
+                        <>
+                          {' · '}
+                          {formatDistanceToNow(new Date(row.last_event_at), {
+                            addSuffix: true,
+                          })}
+                        </>
+                      ) : null}
+                    </>
+                  ) : (
+                    'not deployed'
+                  )}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* Step 2 — version picker */}
+      <section className="min-h-[180px]">
+        <p className="mb-2 text-xs uppercase tracking-wider text-tertiary">
+          Step 2 — {isFirstEnv ? 'Commit on ' + defaultBranchName : 'Tag'}
+        </p>
+        {isFirstEnv ? (
+          <CommitList
+            commits={branchCommits}
+            current={current?.release?.version ?? null}
+            isLoading={commitsLoading}
+            onSelect={(c) => {
+              setSelectedSha(c.sha)
+              setSelectedLabel(defaultBranchName)
+            }}
+            selectedSha={selectedSha}
+          />
+        ) : (
+          <TagList
+            current={current?.release?.version ?? null}
+            onSelect={(r) => {
+              setSelectedSha(r.sha)
+              setSelectedLabel(r.name)
+            }}
+            selectedSha={selectedSha}
+            tags={tagOptions}
+          />
+        )}
+      </section>
+
+      {/* Diff summary */}
+      {selectedSha && current?.release ? (
+        <DiffSummary
+          base={current.release.version}
+          head={selectedLabel ?? selectedSha}
+          orgSlug={orgSlug}
+          projectId={projectId}
+        />
+      ) : null}
+
+      {/* Footer */}
+      <div className="bg-secondary/30 -mx-6 -mb-6 mt-2 flex items-center justify-end gap-2 border-t border-tertiary px-6 py-3">
+        <Button onClick={onClose} type="button" variant="ghost">
+          Cancel
+        </Button>
+        <Button
+          disabled={!selectedSha || mutation.isPending}
+          onClick={onDeploy}
+          type="button"
+        >
+          {mutation.isPending ? (
+            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+          ) : (
+            <Rocket className="mr-1 h-4 w-4" />
+          )}
+          {current ? 'Redeploy' : 'Deploy'}{' '}
+          {selectedLabel ?? selectedSha?.slice(0, 7) ?? ''} to{' '}
+          {env?.name ?? envSlug}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function CommitList({
+  commits,
+  current,
+  isLoading,
+  onSelect,
+  selectedSha,
+}: {
+  commits: DeploymentCommit[]
+  current: null | string
+  isLoading: boolean
+  onSelect: (commit: DeploymentCommit) => void
+  selectedSha: null | string
+}) {
+  if (isLoading) return <LoadingState label="Loading commits…" />
+  if (commits.length === 0)
+    return (
+      <p className="rounded-md border border-secondary p-3 text-sm text-tertiary">
+        No commits available.
+      </p>
+    )
+  return (
+    <ul className="max-h-[260px] overflow-y-auto rounded-md border border-secondary">
+      {commits.map((c) => {
+        const active = c.sha === selectedSha
+        const isCurrent = current ? c.sha.startsWith(current) : false
+        return (
+          <li
+            className={cn(
+              'flex items-center gap-3 border-b border-tertiary px-3 py-2 last:border-b-0',
+              active && 'bg-action/5',
+            )}
+            key={c.sha}
+          >
+            <button
+              className="flex flex-1 items-center gap-3 text-left"
+              onClick={() => onSelect(c)}
+              type="button"
+            >
+              <span
+                aria-label={`CI ${c.ci_status}`}
+                className={cn(
+                  'inline-block h-2 w-2 rounded-full',
+                  CI_DOT[c.ci_status] ?? CI_DOT.unknown,
+                )}
+              />
+              <span className="font-mono text-xs">{c.short_sha}</span>
+              <span className="flex-1 truncate text-sm">{c.message}</span>
+              <span className="shrink-0 text-xs text-tertiary">{c.author}</span>
+              {c.is_head ? <Badge variant="outline">HEAD</Badge> : null}
+              {isCurrent ? <Badge variant="neutral">current</Badge> : null}
+              {active ? <Check className="text-action h-4 w-4" /> : null}
+            </button>
+            {c.url ? (
+              <a
+                aria-label="View commit on GitHub"
+                className="text-tertiary hover:text-primary"
+                href={c.url}
+                rel="noopener"
+                target="_blank"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            ) : null}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+function DiffSummary({
+  base,
+  head,
+  orgSlug,
+  projectId,
+}: {
+  base: string
+  head: string
+  orgSlug: string
+  projectId: string
+}) {
+  const { data, isLoading } = useQuery({
+    enabled: base !== head,
+    queryFn: ({ signal }) =>
+      compareDeploymentRefs(orgSlug, projectId, base, head, undefined, signal),
+    queryKey: ['compare', orgSlug, projectId, base, head],
+  })
+  if (base === head)
+    return (
+      <p className="text-xs text-tertiary">
+        Re-deploying — no commit delta to summarize.
+      </p>
+    )
+  if (isLoading || !data) return null
+  return (
+    <div className="bg-tertiary/20 rounded-md border border-secondary p-3 text-xs">
+      <div className="font-mono text-tertiary">
+        {base} → {head}
+      </div>
+      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+        <span>{data.commits.length} commits</span>
+        <span>{data.files_changed} files changed</span>
+        <span className="text-success">+{data.additions}</span>
+        <span className="text-danger">−{data.deletions}</span>
+      </div>
+    </div>
+  )
+}
+
+function TagList({
+  current,
+  onSelect,
+  selectedSha,
+  tags,
+}: {
+  current: null | string
+  onSelect: (tag: DeploymentRef) => void
+  selectedSha: null | string
+  tags: DeploymentRef[]
+}) {
+  if (tags.length === 0)
+    return (
+      <p className="rounded-md border border-secondary p-3 text-sm text-tertiary">
+        No tags available.
+      </p>
+    )
+  return (
+    <ul className="max-h-[260px] overflow-y-auto rounded-md border border-secondary">
+      {tags.map((t) => {
+        const active = t.sha === selectedSha
+        const isCurrent = t.name === current
+        return (
+          <li
+            className={cn(
+              'flex items-center justify-between border-b border-tertiary px-3 py-2 last:border-b-0',
+              active && 'bg-action/5',
+            )}
+            key={t.sha}
+          >
+            <button
+              className="flex flex-1 items-center gap-3 text-left"
+              onClick={() => onSelect(t)}
+              type="button"
+            >
+              <span className="font-mono text-sm">{t.name}</span>
+              <span className="font-mono text-xs text-tertiary">
+                {t.sha.slice(0, 7)}
+              </span>
+              {isCurrent ? <Badge variant="neutral">current</Badge> : null}
+              {active ? <Check className="text-action h-4 w-4" /> : null}
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -128,8 +128,18 @@ export function DeployTab({
     setSelected(null)
   }, [envSlug])
 
+  // For first-env (commit-based) deployments, ``selected.label`` is the
+  // branch name (e.g. ``main``), so compare against ``selected.sha``.
+  // For tag-based envs ``selected.label`` is the tag and matches
+  // ``current.release.version``.
   const isRedeploy =
-    !!current?.release && current.release.version === selected?.label
+    !!current?.release &&
+    !!selected &&
+    (isFirstEnv
+      ? current.release.version === selected.sha ||
+        selected.sha.startsWith(current.release.version) ||
+        current.release.version.startsWith(selected.sha)
+      : current.release.version === selected.label)
 
   const queryClient = useQueryClient()
   const mutation = useMutation({

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -17,6 +17,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { LoadingState } from '@/components/ui/loading-state'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { ciStatusDotClass } from '@/lib/status-colors'
 import { cn, sortEnvironments } from '@/lib/utils'
 import type {
   CurrentReleaseEnvironment,
@@ -29,21 +30,23 @@ interface DeployTabProps {
   environments: Environment[]
   initialEnvSlug?: string
   onClose: () => void
+  // Modal-open gate: queries only fire while the modal is open so the
+  // hidden DeployTab doesn't issue GitHub round-trips on every page load.
+  open: boolean
   orgSlug: string
   projectId: string
 }
 
-const CI_DOT: Record<string, string> = {
-  fail: 'bg-danger',
-  pass: 'bg-success',
-  unknown: 'bg-tertiary',
-  warn: 'bg-warning',
+interface SelectedVersion {
+  label: null | string
+  sha: string
 }
 
 export function DeployTab({
   environments,
   initialEnvSlug,
   onClose,
+  open,
   orgSlug,
   projectId,
 }: DeployTabProps) {
@@ -52,6 +55,10 @@ export function DeployTab({
     initialEnvSlug ?? sorted[sorted.length - 1]?.slug ?? '',
   )
   useEffect(() => {
+    // Reset to the requested env whenever the modal is reopened with
+    // a different chip.  ``envSlug`` is intentionally excluded — listing
+    // it would re-snap to ``initialEnvSlug`` after the user picks
+    // another env card.
     if (initialEnvSlug && initialEnvSlug !== envSlug) setEnvSlug(initialEnvSlug)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialEnvSlug])
@@ -59,7 +66,7 @@ export function DeployTab({
   const env = sorted.find((e) => e.slug === envSlug) ?? sorted[0]
 
   const { data: currentReleases = [] } = useQuery<CurrentReleaseEnvironment[]>({
-    enabled: !!orgSlug && !!projectId,
+    enabled: open && !!orgSlug && !!projectId,
     queryFn: ({ signal }) => listCurrentReleases(orgSlug, projectId, signal),
     queryKey: ['currentReleases', orgSlug, projectId],
   })
@@ -70,13 +77,12 @@ export function DeployTab({
   }, [currentReleases])
   const current = env ? currentByEnv.get(env.slug) : undefined
 
-  // For testing-like envs (the leftmost in sort order) we list commits on
-  // the default branch.  For staging/production we list tags.
+  // For the first env (e.g. Testing) we list commits on the default
+  // branch.  For staging / production we list tags.
   const isFirstEnv = env?.slug === sorted[0]?.slug
-  const refKind: 'branch' | 'tag' = isFirstEnv ? 'branch' : 'tag'
 
   const { data: refs = [] } = useQuery<DeploymentRef[]>({
-    enabled: !!env,
+    enabled: open && !!env,
     queryFn: ({ signal }) =>
       listDeploymentRefs(
         orgSlug,
@@ -84,7 +90,12 @@ export function DeployTab({
         { kind: isFirstEnv ? 'default' : 'tag' },
         signal,
       ),
-    queryKey: ['deploymentRefs', orgSlug, projectId, refKind],
+    queryKey: [
+      'deploymentRefs',
+      orgSlug,
+      projectId,
+      isFirstEnv ? 'branch' : 'tag',
+    ],
   })
 
   const defaultBranchName = useMemo(() => {
@@ -95,7 +106,7 @@ export function DeployTab({
   const { data: branchCommits = [], isLoading: commitsLoading } = useQuery<
     DeploymentCommit[]
   >({
-    enabled: !!env && isFirstEnv,
+    enabled: open && !!env && isFirstEnv,
     queryFn: ({ signal }) =>
       listRefCommits(
         orgSlug,
@@ -112,27 +123,22 @@ export function DeployTab({
     [isFirstEnv, refs],
   )
 
-  const [selectedSha, setSelectedSha] = useState<null | string>(null)
-  const [selectedLabel, setSelectedLabel] = useState<null | string>(null)
+  const [selected, setSelected] = useState<null | SelectedVersion>(null)
   useEffect(() => {
-    setSelectedSha(null)
-    setSelectedLabel(null)
+    setSelected(null)
   }, [envSlug])
+
+  const isRedeploy =
+    !!current?.release && current.release.version === selected?.label
 
   const queryClient = useQueryClient()
   const mutation = useMutation({
-    mutationFn: ({
-      committish,
-      ref_label,
-    }: {
-      committish: string
-      ref_label: null | string
-    }) =>
+    mutationFn: (payload: SelectedVersion) =>
       triggerDeployment(orgSlug, projectId, {
-        action: current ? 'redeploy' : 'deploy',
-        committish,
+        action: isRedeploy ? 'redeploy' : 'deploy',
+        committish: payload.sha,
         environment: envSlug,
-        ref_label,
+        ref_label: payload.label,
       }),
     onError: (err) => {
       toast.error(
@@ -162,11 +168,8 @@ export function DeployTab({
   })
 
   const onDeploy = () => {
-    if (!selectedSha) return
-    mutation.mutate({
-      committish: selectedSha,
-      ref_label: selectedLabel,
-    })
+    if (!selected) return
+    mutation.mutate(selected)
   }
 
   return (
@@ -219,37 +222,33 @@ export function DeployTab({
       {/* Step 2 — version picker */}
       <section className="min-h-[180px]">
         <p className="mb-2 text-xs uppercase tracking-wider text-tertiary">
-          Step 2 — {isFirstEnv ? 'Commit on ' + defaultBranchName : 'Tag'}
+          {`Step 2 — ${isFirstEnv ? `Commit on ${defaultBranchName}` : 'Tag'}`}
         </p>
         {isFirstEnv ? (
           <CommitList
             commits={branchCommits}
             current={current?.release?.version ?? null}
             isLoading={commitsLoading}
-            onSelect={(c) => {
-              setSelectedSha(c.sha)
-              setSelectedLabel(defaultBranchName)
-            }}
-            selectedSha={selectedSha}
+            onSelect={(c) =>
+              setSelected({ label: defaultBranchName, sha: c.sha })
+            }
+            selectedSha={selected?.sha ?? null}
           />
         ) : (
           <TagList
             current={current?.release?.version ?? null}
-            onSelect={(r) => {
-              setSelectedSha(r.sha)
-              setSelectedLabel(r.name)
-            }}
-            selectedSha={selectedSha}
+            onSelect={(r) => setSelected({ label: r.name, sha: r.sha })}
+            selectedSha={selected?.sha ?? null}
             tags={tagOptions}
           />
         )}
       </section>
 
       {/* Diff summary */}
-      {selectedSha && current?.release ? (
+      {selected && current?.release ? (
         <DiffSummary
           base={current.release.version}
-          head={selectedLabel ?? selectedSha}
+          head={selected.label ?? selected.sha}
           orgSlug={orgSlug}
           projectId={projectId}
         />
@@ -261,7 +260,7 @@ export function DeployTab({
           Cancel
         </Button>
         <Button
-          disabled={!selectedSha || mutation.isPending}
+          disabled={!selected || mutation.isPending}
           onClick={onDeploy}
           type="button"
         >
@@ -270,9 +269,9 @@ export function DeployTab({
           ) : (
             <Rocket className="mr-1 h-4 w-4" />
           )}
-          {current ? 'Redeploy' : 'Deploy'}{' '}
-          {selectedLabel ?? selectedSha?.slice(0, 7) ?? ''} to{' '}
-          {env?.name ?? envSlug}
+          {`${isRedeploy ? 'Redeploy' : 'Deploy'} ${
+            selected?.label ?? selected?.sha.slice(0, 7) ?? ''
+          } to ${env?.name ?? envSlug}`}
         </Button>
       </div>
     </div>
@@ -321,7 +320,7 @@ function CommitList({
                 aria-label={`CI ${c.ci_status}`}
                 className={cn(
                   'inline-block h-2 w-2 rounded-full',
-                  CI_DOT[c.ci_status] ?? CI_DOT.unknown,
+                  ciStatusDotClass(c.ci_status),
                 )}
               />
               <span className="font-mono text-xs">{c.short_sha}</span>

--- a/src/components/deploy/DeploymentModal.tsx
+++ b/src/components/deploy/DeploymentModal.tsx
@@ -1,50 +1,116 @@
-import { Rocket } from 'lucide-react'
+import { GitMerge, Rocket } from 'lucide-react'
 
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
 import type { Environment } from '@/types'
 
 import { DeployTab } from './DeployTab'
+import { PromoteTab } from './PromoteTab'
+
+export type DeployModalTab = 'deploy' | 'promote'
 
 interface DeploymentModalProps {
   environments: Environment[]
   initialEnvSlug?: string
+  initialTab?: DeployModalTab
   onOpenChange: (open: boolean) => void
   open: boolean
   orgSlug: string
   projectId: string
   projectName: string
+  // Promote-tab inputs.  When set together with initialTab='promote'
+  // the modal opens directly into the Promote flow with the gap
+  // pre-selected (via the popover hand-off) or the testing → next-env
+  // gap inferred from the chip click.
+  promoteFrom?: null | string
+  promoteFromCommittish?: null | string
+  promoteTo?: null | string
 }
 
 export function DeploymentModal({
   environments,
   initialEnvSlug,
+  initialTab = 'deploy',
   onOpenChange,
   open,
   orgSlug,
   projectId,
   projectName,
+  promoteFrom,
+  promoteFromCommittish,
+  promoteTo,
 }: DeploymentModalProps) {
+  const isPromote = initialTab === 'promote' && !!promoteFrom && !!promoteTo
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-[680px] gap-0 p-0 sm:max-w-[680px]">
-        <header className="flex items-center gap-2 border-b border-secondary px-6 py-4">
-          <Rocket className="text-action h-4 w-4" />
-          <DialogTitle className="text-sm font-medium">
-            Deploy {projectName}
+        <header className="flex items-stretch border-b border-secondary px-6">
+          <DialogTitle className="sr-only">
+            {isPromote ? `Promote ${projectName}` : `Deploy ${projectName}`}
           </DialogTitle>
-          <span className="text-xs text-tertiary">— existing version</span>
+          <TabHeader
+            active={!isPromote}
+            icon={<Rocket className="h-4 w-4" />}
+            subtitle="existing version"
+            title="Deploy"
+          />
+          <TabHeader
+            active={isPromote}
+            icon={<GitMerge className="h-4 w-4" />}
+            subtitle="tag & release notes"
+            title="Promote"
+          />
         </header>
         <div className="px-6 py-4">
-          <DeployTab
-            environments={environments}
-            initialEnvSlug={initialEnvSlug}
-            onClose={() => onOpenChange(false)}
-            open={open}
-            orgSlug={orgSlug}
-            projectId={projectId}
-          />
+          {isPromote ? (
+            <PromoteTab
+              fromCommittish={promoteFromCommittish}
+              fromEnvironment={promoteFrom}
+              onClose={() => onOpenChange(false)}
+              open={open}
+              orgSlug={orgSlug}
+              projectId={projectId}
+              toEnvironment={promoteTo}
+            />
+          ) : (
+            <DeployTab
+              environments={environments}
+              initialEnvSlug={initialEnvSlug}
+              onClose={() => onOpenChange(false)}
+              open={open}
+              orgSlug={orgSlug}
+              projectId={projectId}
+            />
+          )}
         </div>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function TabHeader({
+  active,
+  icon,
+  subtitle,
+  title,
+}: {
+  active: boolean
+  icon: React.ReactNode
+  subtitle: string
+  title: string
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col py-4 pr-6 text-sm',
+        active ? '-mb-px border-b-2 border-action' : 'text-tertiary',
+      )}
+    >
+      <span className="flex items-center gap-1.5 font-medium">
+        {icon}
+        {title}
+      </span>
+      <span className="mt-0.5 text-xs">{subtitle}</span>
+    </div>
   )
 }

--- a/src/components/deploy/DeploymentModal.tsx
+++ b/src/components/deploy/DeploymentModal.tsx
@@ -1,0 +1,94 @@
+import { GitMerge, Rocket } from 'lucide-react'
+
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import type { Environment } from '@/types'
+
+import { DeployTab } from './DeployTab'
+
+export type DeployModalTab = 'deploy' | 'promote'
+
+interface DeploymentModalProps {
+  environments: Environment[]
+  initialEnvSlug?: string
+  initialTab?: DeployModalTab
+  onOpenChange: (open: boolean) => void
+  open: boolean
+  orgSlug: string
+  projectId: string
+  projectName: string
+}
+
+export function DeploymentModal({
+  environments,
+  initialEnvSlug,
+  initialTab = 'deploy',
+  onOpenChange,
+  open,
+  orgSlug,
+  projectId,
+  projectName,
+}: DeploymentModalProps) {
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-[680px] gap-0 p-0 sm:max-w-[680px]">
+        <header className="flex items-stretch border-b border-secondary px-6">
+          <DialogTitle className="sr-only">Deploy {projectName}</DialogTitle>
+          <TabHeader
+            active={initialTab === 'deploy'}
+            icon={<Rocket className="h-4 w-4" />}
+            subtitle="existing version"
+            title="Deploy"
+          />
+          <TabHeader
+            active={initialTab === 'promote'}
+            disabled
+            icon={<GitMerge className="h-4 w-4" />}
+            subtitle="tag & release notes (Phase 2)"
+            title="Promote"
+          />
+        </header>
+        <div className="px-6 py-4">
+          <DeployTab
+            environments={environments}
+            initialEnvSlug={initialEnvSlug}
+            onClose={() => onOpenChange(false)}
+            orgSlug={orgSlug}
+            projectId={projectId}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function TabHeader({
+  active,
+  disabled,
+  icon,
+  subtitle,
+  title,
+}: {
+  active: boolean
+  disabled?: boolean
+  icon: React.ReactNode
+  subtitle: string
+  title: string
+}) {
+  return (
+    <div
+      aria-disabled={disabled}
+      className={cn(
+        'flex flex-col py-4 pr-6 text-sm',
+        active ? 'border-b-2 border-action -mb-px' : 'text-tertiary',
+        disabled && 'opacity-50',
+      )}
+    >
+      <span className="flex items-center gap-1.5 font-medium">
+        {icon}
+        {title}
+      </span>
+      <span className="mt-0.5 text-xs">{subtitle}</span>
+    </div>
+  )
+}

--- a/src/components/deploy/DeploymentModal.tsx
+++ b/src/components/deploy/DeploymentModal.tsx
@@ -1,17 +1,13 @@
-import { GitMerge, Rocket } from 'lucide-react'
+import { Rocket } from 'lucide-react'
 
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { cn } from '@/lib/utils'
 import type { Environment } from '@/types'
 
 import { DeployTab } from './DeployTab'
 
-export type DeployModalTab = 'deploy' | 'promote'
-
 interface DeploymentModalProps {
   environments: Environment[]
   initialEnvSlug?: string
-  initialTab?: DeployModalTab
   onOpenChange: (open: boolean) => void
   open: boolean
   orgSlug: string
@@ -22,7 +18,6 @@ interface DeploymentModalProps {
 export function DeploymentModal({
   environments,
   initialEnvSlug,
-  initialTab = 'deploy',
   onOpenChange,
   open,
   orgSlug,
@@ -32,63 +27,24 @@ export function DeploymentModal({
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-[680px] gap-0 p-0 sm:max-w-[680px]">
-        <header className="flex items-stretch border-b border-secondary px-6">
-          <DialogTitle className="sr-only">Deploy {projectName}</DialogTitle>
-          <TabHeader
-            active={initialTab === 'deploy'}
-            icon={<Rocket className="h-4 w-4" />}
-            subtitle="existing version"
-            title="Deploy"
-          />
-          <TabHeader
-            active={initialTab === 'promote'}
-            disabled
-            icon={<GitMerge className="h-4 w-4" />}
-            subtitle="tag & release notes (Phase 2)"
-            title="Promote"
-          />
+        <header className="flex items-center gap-2 border-b border-secondary px-6 py-4">
+          <Rocket className="text-action h-4 w-4" />
+          <DialogTitle className="text-sm font-medium">
+            Deploy {projectName}
+          </DialogTitle>
+          <span className="text-xs text-tertiary">— existing version</span>
         </header>
         <div className="px-6 py-4">
           <DeployTab
             environments={environments}
             initialEnvSlug={initialEnvSlug}
             onClose={() => onOpenChange(false)}
+            open={open}
             orgSlug={orgSlug}
             projectId={projectId}
           />
         </div>
       </DialogContent>
     </Dialog>
-  )
-}
-
-function TabHeader({
-  active,
-  disabled,
-  icon,
-  subtitle,
-  title,
-}: {
-  active: boolean
-  disabled?: boolean
-  icon: React.ReactNode
-  subtitle: string
-  title: string
-}) {
-  return (
-    <div
-      aria-disabled={disabled}
-      className={cn(
-        'flex flex-col py-4 pr-6 text-sm',
-        active ? 'border-b-2 border-action -mb-px' : 'text-tertiary',
-        disabled && 'opacity-50',
-      )}
-    >
-      <span className="flex items-center gap-1.5 font-medium">
-        {icon}
-        {title}
-      </span>
-      <span className="mt-0.5 text-xs">{subtitle}</span>
-    </div>
   )
 }

--- a/src/components/deploy/DeploymentModal.tsx
+++ b/src/components/deploy/DeploymentModal.tsx
@@ -99,12 +99,18 @@ function TabHeader({
   subtitle: string
   title: string
 }) {
+  // Headers are presentational — the modal mode is fixed by props at
+  // mount time, so mark non-active headers as disabled to make that
+  // unambiguous to assistive tech and keyboard users.
   return (
     <div
+      aria-current={active ? 'page' : undefined}
+      aria-disabled={!active}
       className={cn(
         'flex flex-col py-4 pr-6 text-sm',
-        active ? '-mb-px border-b-2 border-action' : 'text-tertiary',
+        active ? '-mb-px border-b-2 border-action' : 'text-tertiary opacity-60',
       )}
+      role="presentation"
     >
       <span className="flex items-center gap-1.5 font-medium">
         {icon}

--- a/src/components/deploy/PromoteDialog.tsx
+++ b/src/components/deploy/PromoteDialog.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { GitMerge, Loader2 } from 'lucide-react'
+
+import { listPromotionOptions } from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import type { PromotionOption } from '@/types'
+
+interface PromoteDialogProps {
+  // The Promote button rendered as the trigger.
+  children: React.ReactNode
+  onOpenChange: (open: boolean) => void
+  onPromote: (option: PromotionOption) => void
+  open: boolean
+  orgSlug: string
+  projectId: string
+}
+
+export function PromoteDialog({
+  children,
+  onOpenChange,
+  onPromote,
+  open,
+  orgSlug,
+  projectId,
+}: PromoteDialogProps) {
+  const { data: options = [], isLoading } = useQuery<PromotionOption[]>({
+    enabled: open && !!orgSlug && !!projectId,
+    queryFn: ({ signal }) =>
+      listPromotionOptions(orgSlug, projectId, undefined, signal),
+    queryKey: ['promotionOptions', orgSlug, projectId],
+  })
+
+  const [selectedSlug, setSelectedSlug] = useState<null | string>(null)
+  const selected = useMemo<null | PromotionOption>(() => {
+    if (!options.length) return null
+    if (!selectedSlug) return options[0]
+    return (
+      options.find(
+        (opt) =>
+          `${opt.from_environment}->${opt.to_environment}` === selectedSlug,
+      ) ?? options[0]
+    )
+  }, [options, selectedSlug])
+
+  return (
+    <Popover onOpenChange={onOpenChange} open={open}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent align="end" className="w-[360px] p-0">
+        <header className="flex items-center gap-2 border-b border-secondary px-4 py-3">
+          <GitMerge className="text-action h-4 w-4" />
+          <span className="text-sm font-medium">Promote a build</span>
+        </header>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8 text-tertiary">
+            <Loader2 className="h-4 w-4 animate-spin" />
+          </div>
+        ) : options.length === 0 ? (
+          <p className="px-4 py-4 text-xs text-tertiary">
+            No promotion paths available — at least one environment must have a
+            release deployed.
+          </p>
+        ) : (
+          <ul className="px-2 py-2">
+            {options.map((opt) => {
+              const slug = `${opt.from_environment}->${opt.to_environment}`
+              const active =
+                slug ===
+                (selectedSlug ??
+                  `${options[0]?.from_environment}->${options[0]?.to_environment}`)
+              return (
+                <li key={slug}>
+                  <button
+                    className={cn(
+                      'flex w-full flex-col rounded-md px-2 py-2 text-left text-xs transition-colors',
+                      active
+                        ? 'border border-action bg-action/5'
+                        : 'border border-transparent hover:bg-tertiary/30',
+                    )}
+                    onClick={() => setSelectedSlug(slug)}
+                    type="button"
+                  >
+                    <span className="text-sm font-medium">
+                      {opt.from_environment} → {opt.to_environment}
+                    </span>
+                    <span className="mt-0.5 text-tertiary">
+                      {opt.from_version ? (
+                        <>
+                          <span className="font-mono">{opt.from_version}</span>
+                          {' from '}
+                          {opt.from_environment}
+                        </>
+                      ) : (
+                        <>nothing on {opt.from_environment} to promote</>
+                      )}
+                    </span>
+                    <span className="text-tertiary">
+                      currently{' '}
+                      <span className="font-mono">{opt.to_version ?? '—'}</span>{' '}
+                      on {opt.to_environment}
+                      {opt.commits_pending != null
+                        ? ` · ${opt.commits_pending} commits ahead`
+                        : ''}
+                    </span>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+        <footer className="flex justify-end gap-2 border-t border-secondary px-4 py-3">
+          <Button
+            onClick={() => onOpenChange(false)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!selected}
+            onClick={() => {
+              if (selected) onPromote(selected)
+            }}
+            size="sm"
+            type="button"
+          >
+            Promote
+          </Button>
+        </footer>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -59,8 +59,10 @@ export function PromoteTab({
   const fromTipSha = fromCommittish ?? fromCurrent?.release?.version ?? null
 
   // Compare last_tag → fromTipSha to enumerate the commits in flight.
-  const { data: compare } = useQuery({
-    enabled: open && !!lastTag && !!fromTipSha && lastTag !== fromTipSha,
+  const compareEnabled =
+    open && !!lastTag && !!fromTipSha && lastTag !== fromTipSha
+  const { data: compare, isLoading: compareLoading } = useQuery({
+    enabled: compareEnabled,
     queryFn: ({ signal }) =>
       compareDeploymentRefs(
         orgSlug,
@@ -186,8 +188,14 @@ export function PromoteTab({
         <p className="mb-2 text-xs uppercase tracking-wider text-tertiary">
           Step 1 — Build to promote
         </p>
-        {!compare ? (
+        {compareEnabled && compareLoading ? (
           <LoadingState label="Loading commits…" />
+        ) : !compareEnabled ? (
+          <p className="rounded-md border border-secondary p-3 text-sm text-tertiary">
+            {!lastTag
+              ? 'No prior release to compare against.'
+              : 'No commit delta to compare for this selection.'}
+          </p>
         ) : commits.length === 0 ? (
           <p className="rounded-md border border-secondary p-3 text-sm text-tertiary">
             No new commits between <span className="font-mono">{lastTag}</span>{' '}
@@ -322,7 +330,7 @@ export function PromoteTab({
 
       {/* Footer */}
       <p className="text-xs text-tertiary">
-        On deploy, a release{' '}
+        On promote, a release{' '}
         <span className="font-mono">{tag || 'vX.Y.Z'}</span> will be created at{' '}
         <span className="font-mono">{selectedSha?.slice(0, 7) ?? '—'}</span> and
         rolled out to {toEnvironment}.

--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2, RefreshCw, Rocket, Sparkles } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { ApiError } from '@/api/client'
+import {
+  compareDeploymentRefs,
+  draftReleaseNotes,
+  listCurrentReleases,
+  promoteDeployment,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { LoadingState } from '@/components/ui/loading-state'
+import { Textarea } from '@/components/ui/textarea'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import { ciStatusDotClass } from '@/lib/status-colors'
+import { cn } from '@/lib/utils'
+import type { DraftReleaseNotesResponse } from '@/types'
+
+interface PromoteTabProps {
+  fromCommittish?: null | string
+  fromEnvironment: string
+  onClose: () => void
+  open: boolean
+  orgSlug: string
+  projectId: string
+  toEnvironment: string
+}
+
+const SEMVER_RE = /^v?\d+\.\d+\.\d+(?:[-+].+)?$/
+
+export function PromoteTab({
+  fromCommittish,
+  fromEnvironment,
+  onClose,
+  open,
+  orgSlug,
+  projectId,
+  toEnvironment,
+}: PromoteTabProps) {
+  const { data: currentReleases = [] } = useQuery({
+    enabled: open && !!orgSlug && !!projectId,
+    queryFn: ({ signal }) => listCurrentReleases(orgSlug, projectId, signal),
+    queryKey: ['currentReleases', orgSlug, projectId],
+  })
+
+  const fromCurrent = useMemo(() => {
+    return currentReleases.find((r) => r.environment.slug === fromEnvironment)
+  }, [currentReleases, fromEnvironment])
+  const toCurrent = useMemo(() => {
+    return currentReleases.find((r) => r.environment.slug === toEnvironment)
+  }, [currentReleases, toEnvironment])
+
+  const lastTag = toCurrent?.release?.version ?? null
+  const fromTipSha = fromCommittish ?? fromCurrent?.release?.version ?? null
+
+  // Compare last_tag → fromTipSha to enumerate the commits in flight.
+  const { data: compare } = useQuery({
+    enabled: open && !!lastTag && !!fromTipSha && lastTag !== fromTipSha,
+    queryFn: ({ signal }) =>
+      compareDeploymentRefs(
+        orgSlug,
+        projectId,
+        lastTag ?? '',
+        fromTipSha ?? '',
+        undefined,
+        signal,
+      ),
+    queryKey: ['compare', orgSlug, projectId, lastTag, fromTipSha],
+  })
+  const commits = compare?.commits ?? []
+
+  // The selected build is the SHA we'll cut the tag at.  Default to
+  // the tip; user can pick an earlier commit in the list.
+  const [selectedSha, setSelectedSha] = useState<null | string>(null)
+  useEffect(() => {
+    if (commits.length > 0) {
+      const tip = commits[commits.length - 1]
+      setSelectedSha(tip.sha)
+    } else {
+      setSelectedSha(fromTipSha)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [compare, fromTipSha])
+
+  // AI suggestion + draft notes — fetched on demand and on regenerate.
+  const draftMutation = useMutation({
+    mutationFn: ({ headSha }: { headSha: string }) =>
+      draftReleaseNotes(orgSlug, projectId, {
+        base_sha: lastTag ?? '',
+        head_sha: headSha,
+        last_tag: lastTag,
+      }),
+  })
+  const [draft, setDraft] = useState<DraftReleaseNotesResponse | null>(null)
+
+  // Auto-draft on first open when we have a base + head.
+  useEffect(() => {
+    if (!open || draft || !lastTag || !selectedSha) return
+    draftMutation.mutate({ headSha: selectedSha }, { onSuccess: setDraft })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, lastTag, selectedSha])
+
+  const [tag, setTag] = useState<string>('')
+  const [notes, setNotes] = useState<string>('')
+  const [tagDirty, setTagDirty] = useState(false)
+  const [notesDirty, setNotesDirty] = useState(false)
+
+  // When a draft arrives, seed tag + notes from it (unless the user
+  // has already edited them).
+  useEffect(() => {
+    if (!draft) return
+    if (!tagDirty) setTag(draft.version)
+    if (!notesDirty) setNotes(draft.notes_markdown)
+  }, [draft, tagDirty, notesDirty])
+
+  const queryClient = useQueryClient()
+  const promoteMutation = useMutation({
+    mutationFn: () =>
+      promoteDeployment(orgSlug, projectId, {
+        action: 'promote',
+        from_committish: selectedSha ?? '',
+        from_environment: fromEnvironment,
+        prerelease: false,
+        release_name: tag,
+        release_notes_markdown: notes,
+        tag,
+        to_environment: toEnvironment,
+      }),
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError
+          ? (extractApiErrorDetail(err) ?? err.message)
+          : (err as Error).message,
+      )
+    },
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['currentReleases', orgSlug, projectId],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: ['promotionOptions', orgSlug, projectId],
+      })
+      const url = data.release_url ?? data.run.run_url
+      toast.success(
+        `Promoted ${data.tag ?? tag} to ${toEnvironment}`,
+        url
+          ? {
+              action: {
+                label: 'View',
+                onClick: () => window.open(url, '_blank', 'noopener'),
+              },
+            }
+          : undefined,
+      )
+      onClose()
+    },
+  })
+
+  const tagValid = SEMVER_RE.test(tag)
+  const canPromote = tagValid && !!selectedSha && !promoteMutation.isPending
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="bg-tertiary/20 rounded-md border border-secondary px-3 py-2 text-xs">
+        <span className="text-tertiary">Promoting </span>
+        <span className="font-medium">{fromEnvironment}</span>
+        <span className="text-tertiary"> → </span>
+        <span className="font-medium">{toEnvironment}</span>
+        {lastTag ? (
+          <>
+            <span className="text-tertiary"> · last tag </span>
+            <span className="font-mono">{lastTag}</span>
+          </>
+        ) : (
+          <span className="text-tertiary"> · no prior release</span>
+        )}
+      </header>
+
+      {/* Step 1 — pick the build */}
+      <section>
+        <p className="mb-2 text-xs uppercase tracking-wider text-tertiary">
+          Step 1 — Build to promote
+        </p>
+        {!compare ? (
+          <LoadingState label="Loading commits…" />
+        ) : commits.length === 0 ? (
+          <p className="rounded-md border border-secondary p-3 text-sm text-tertiary">
+            No new commits between <span className="font-mono">{lastTag}</span>{' '}
+            and <span className="font-mono">{fromEnvironment}</span>.
+          </p>
+        ) : (
+          <ul className="max-h-[200px] overflow-y-auto rounded-md border border-secondary">
+            {[...commits].reverse().map((c, idx) => {
+              const tipIndex = idx === 0 ? 'tip' : `−${idx}`
+              const active = c.sha === selectedSha
+              return (
+                <li
+                  className={cn(
+                    'flex items-center gap-3 border-b border-tertiary px-3 py-2 last:border-b-0',
+                    active && 'bg-action/5',
+                  )}
+                  key={c.sha}
+                >
+                  <button
+                    className="flex flex-1 items-center gap-3 text-left"
+                    onClick={() => setSelectedSha(c.sha)}
+                    type="button"
+                  >
+                    <span
+                      aria-label={`CI ${c.ci_status}`}
+                      className={cn(
+                        'inline-block h-2 w-2 rounded-full',
+                        ciStatusDotClass(c.ci_status),
+                      )}
+                    />
+                    <span className="font-mono text-xs">{c.short_sha}</span>
+                    <span className="flex-1 truncate text-sm">{c.message}</span>
+                    <Badge variant="neutral">{tipIndex}</Badge>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </section>
+
+      {/* Step 2 — version + notes */}
+      <section>
+        <p className="mb-2 text-xs uppercase tracking-wider text-tertiary">
+          Step 2 — Tag & release notes
+        </p>
+        <div className="grid grid-cols-[160px_160px_1fr] gap-3">
+          <label className="flex flex-col gap-1 text-xs text-tertiary">
+            Current
+            <Input className="font-mono" disabled value={lastTag ?? ''} />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-tertiary">
+            New tag
+            <Input
+              aria-invalid={!tagValid && tag.length > 0}
+              className="font-mono"
+              onChange={(e) => {
+                setTag(e.target.value)
+                setTagDirty(true)
+              }}
+              placeholder="vX.Y.Z"
+              value={tag}
+            />
+          </label>
+          <div className="flex flex-col gap-1 text-xs">
+            <span className="text-tertiary">AI suggestion</span>
+            <div className="bg-accent/10 flex min-h-[40px] items-start gap-2 rounded-md border border-accent p-2 text-accent">
+              <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              {draftMutation.isPending && !draft ? (
+                <span className="text-tertiary">drafting…</span>
+              ) : draft ? (
+                <span>
+                  Bump <span className="font-medium">{draft.bump}</span> →{' '}
+                  <span className="font-mono">{draft.version}</span>.{' '}
+                  {draft.reasoning}
+                  {draft.degraded ? (
+                    <span className="text-tertiary"> (AI unavailable)</span>
+                  ) : null}
+                </span>
+              ) : (
+                <span className="text-tertiary">
+                  No draft yet — pick a build above.
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-3 flex items-center justify-between">
+          <span className="text-xs text-tertiary">
+            {compare?.commits?.length ?? 0} commits considered
+          </span>
+          <Button
+            disabled={!selectedSha || draftMutation.isPending}
+            onClick={() => {
+              if (!selectedSha) return
+              draftMutation.mutate(
+                { headSha: selectedSha },
+                {
+                  onSuccess: (data) => {
+                    setDraft(data)
+                    setNotesDirty(false)
+                    setTagDirty(false)
+                  },
+                },
+              )
+            }}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <RefreshCw
+              className={cn(
+                'mr-1 h-3.5 w-3.5',
+                draftMutation.isPending && 'animate-spin',
+              )}
+            />
+            Regenerate with AI
+          </Button>
+        </div>
+
+        <Textarea
+          className="mt-2 min-h-[160px] font-mono text-xs"
+          onChange={(e) => {
+            setNotes(e.target.value)
+            setNotesDirty(true)
+          }}
+          placeholder="## Highlights&#10;- …"
+          value={notes}
+        />
+      </section>
+
+      {/* Footer */}
+      <p className="text-xs text-tertiary">
+        On deploy, a release{' '}
+        <span className="font-mono">{tag || 'vX.Y.Z'}</span> will be created at{' '}
+        <span className="font-mono">{selectedSha?.slice(0, 7) ?? '—'}</span> and
+        rolled out to {toEnvironment}.
+      </p>
+      <div className="bg-secondary/30 -mx-6 -mb-6 mt-2 flex items-center justify-end gap-2 border-t border-tertiary px-6 py-3">
+        <Button onClick={onClose} type="button" variant="ghost">
+          Cancel
+        </Button>
+        <Button
+          disabled={!canPromote}
+          onClick={() => promoteMutation.mutate()}
+          type="button"
+        >
+          {promoteMutation.isPending ? (
+            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+          ) : (
+            <Rocket className="mr-1 h-4 w-4" />
+          )}
+          {`Tag ${tag || 'vX.Y.Z'} & deploy to ${toEnvironment}`}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/status-colors.ts
+++ b/src/lib/status-colors.ts
@@ -14,3 +14,15 @@ export function statusBadgeVariant(
 ): BadgeProps['variant'] {
   return (status && STATUS_VARIANTS[status]) || 'neutral'
 }
+
+/** CI roll-up status → Tailwind dot background class. */
+const CI_DOT_CLASSES: Record<string, string> = {
+  fail: 'bg-danger',
+  pass: 'bg-success',
+  unknown: 'bg-tertiary',
+  warn: 'bg-warning',
+}
+
+export function ciStatusDotClass(status: null | string | undefined): string {
+  return (status && CI_DOT_CLASSES[status]) || CI_DOT_CLASSES.unknown
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -358,6 +358,17 @@ export interface DeploymentCompareResult {
   pr_numbers: number[]
 }
 
+export interface DeploymentPromoteRequest {
+  action: 'promote'
+  from_committish: string
+  from_environment: string
+  prerelease?: boolean
+  release_name?: null | string
+  release_notes_markdown?: string
+  tag: string
+  to_environment: string
+}
+
 export interface DeploymentRef {
   ahead?: null | number
   behind?: null | number
@@ -409,7 +420,9 @@ export interface DeploymentTriggerResponse {
   plugin_id: string
   plugin_slug: string
   recorded: boolean
+  release_url?: null | string
   run: DeploymentRun
+  tag?: null | string
 }
 
 export interface Document {
@@ -462,6 +475,21 @@ export interface DocumentTemplateCreate {
   sort_order?: number
   tags?: string[]
   title?: null | string
+}
+
+export interface DraftReleaseNotesRequest {
+  base_sha: string
+  head_sha: string
+  last_tag?: null | string
+}
+
+export interface DraftReleaseNotesResponse {
+  bump: SemverBump
+  commits_considered: number
+  degraded: boolean
+  notes_markdown: string
+  reasoning: string
+  version: string
 }
 
 export interface IdentityConnectionPollResponse {
@@ -674,6 +702,7 @@ export interface PluginAssignmentCreate {
   plugin_id: string
   tab: PluginTab
 }
+
 export interface PluginAssignmentInput {
   default: boolean
   identity_plugin_id?: null | string
@@ -681,6 +710,7 @@ export interface PluginAssignmentInput {
   project_type_slug: string
   tab: PluginTab
 }
+
 export interface PluginAssignmentResponse {
   default: boolean
   identity_plugin_id?: null | string
@@ -692,7 +722,6 @@ export interface PluginAssignmentResponse {
   supports_histogram?: boolean
   tab: PluginTab
 }
-
 export interface PluginAssignmentRow {
   default: boolean
   identity_plugin_id?: null | string
@@ -701,26 +730,26 @@ export interface PluginAssignmentRow {
   project_type_slug: string
   tab: PluginTab
 }
-
 export interface PluginConfigurationResponse {
   auth_type: 'api_token' | 'oauth2'
   fields: PluginCredentialField[]
   plugin_slug: string
   populated: string[]
 }
+
 export interface PluginCreate {
   label: string
   options?: Record<string, unknown>
   plugin_slug: string
   service_application_slug?: null | string
 }
+
 export interface PluginCredentialField {
   description: null | string
   label: string
   name: string
   required: boolean
 }
-
 // A materialized edge from /edges/{rel_type}.
 export interface PluginEdge {
   properties: Record<string, unknown>
@@ -740,7 +769,6 @@ export interface PluginEdgePut {
   target_id: string
   target_label: string
 }
-
 // Generic plugin entity (a graph node declared by a plugin's
 // vertex_labels manifest entry).  Shape varies per plugin model_ref;
 // the host returns whatever Pydantic.model_dump() produced.
@@ -757,6 +785,7 @@ export interface PluginEntitySchema {
   title?: string
   type: 'object'
 }
+
 export interface PluginOptionDef {
   choices?: null | string[]
   default?: boolean | null | number | string
@@ -784,6 +813,7 @@ export interface PluginResponse {
   used_as_login?: boolean
 }
 export type PluginTab = 'configuration' | 'logs'
+
 export interface PluginUpdate {
   // Pass an explicit empty string to clear; omitting the field leaves
   // the existing value untouched on the backend.
@@ -811,15 +841,24 @@ export interface PluginVertexLabel {
   }
 }
 export type ProjectRelationship = Schemas['ProjectRelationship']
-
 export type ProjectRelationshipsResponse =
   Schemas['ProjectRelationshipsResponse']
 // Project Relationships (DEPENDS_ON edges)
 export type ProjectRelationshipSummary = Schemas['ProjectRelationshipSummary']
+
 // Project EXISTS_IN types
 export type ProjectService = Schemas['ExistsInResponse']
-
 export type ProjectServiceCreate = Schemas['ExistsInCreate']
+export interface PromotionOption {
+  commits_pending: null | number
+  from_environment: string
+  from_sha?: null | string
+  from_version?: null | string
+  to_environment: string
+  to_sha?: null | string
+  to_version?: null | string
+}
+
 export interface Release {
   created_at: string
   created_by: string
@@ -831,7 +870,6 @@ export interface Release {
   updated_at?: null | string
   version: string
 }
-
 export interface ReleaseLink {
   label?: null | string
   type: string
@@ -847,6 +885,7 @@ export interface Role {
   slug: string
   updated_at?: null | string
 }
+
 export interface RoleCreate {
   description?: null | string
   name: string
@@ -859,7 +898,6 @@ export interface RoleDetail extends Role {
   permissions: Permission[]
   priority: number
 }
-
 // `RoleUser` stays hand-written: no generated counterpart (the
 // /roles/{slug}/users endpoint returns a flattened user projection).
 export interface RoleUser {
@@ -898,6 +936,8 @@ export interface SchemaProperty {
   required: boolean
   type: 'array' | 'boolean' | 'integer' | 'number' | 'object' | 'string'
 }
+
+export type SemverBump = 'major' | 'minor' | 'patch'
 
 // Service Account types
 export type ServiceAccount = Schemas['ServiceAccountResponse']

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -330,6 +330,65 @@ export interface DashboardStats {
   total_projects: number
 }
 
+export type DeploymentAction = 'deploy' | 'redeploy'
+
+export interface DeploymentCommit {
+  author?: null | string
+  authored_at?: null | string
+  ci_status: DeploymentCommitCiStatus
+  is_head: boolean
+  message: string
+  pr_number?: null | number
+  sha: string
+  short_sha: string
+  url?: null | string
+}
+
+export type DeploymentCommitCiStatus = 'fail' | 'pass' | 'unknown' | 'warn'
+
+export interface DeploymentCompareResult {
+  additions: number
+  ahead: number
+  base_sha: string
+  behind: number
+  commits: DeploymentCommit[]
+  deletions: number
+  files_changed: number
+  head_sha: string
+  pr_numbers: number[]
+}
+
+export interface DeploymentRef {
+  ahead?: null | number
+  behind?: null | number
+  is_default: boolean
+  kind: DeploymentRefKind
+  name: string
+  pr_number?: null | number
+  pr_state?: 'closed' | 'merged' | 'open' | null
+  pr_title?: null | string
+  sha: string
+}
+
+// Deployment plugin shapes (mirrors imbi_common.plugins.base).
+export type DeploymentRefKind = 'branch' | 'default' | 'tag'
+
+export interface DeploymentRun {
+  completed_at?: null | string
+  run_id: string
+  run_url?: null | string
+  started_at?: null | string
+  status: DeploymentRunStatus
+}
+
+export type DeploymentRunStatus =
+  | 'cancelled'
+  | 'failure'
+  | 'in_progress'
+  | 'queued'
+  | 'success'
+  | 'unknown'
+
 // Releases
 export type DeploymentStatus =
   | 'failed'
@@ -337,6 +396,21 @@ export type DeploymentStatus =
   | 'pending'
   | 'rolled_back'
   | 'success'
+
+export interface DeploymentTriggerRequest {
+  action: DeploymentAction
+  committish: string
+  environment: string
+  inputs?: null | Record<string, string>
+  ref_label?: null | string
+}
+
+export interface DeploymentTriggerResponse {
+  plugin_id: string
+  plugin_slug: string
+  recorded: boolean
+  run: DeploymentRun
+}
 
 export interface Document {
   content: string


### PR DESCRIPTION
## Summary

- `DeploymentModal` (Radix `Dialog`, 680px) with **Deploy** / **Promote** tabs.
  - Deploy tab: 3 EnvCards, flat `VersionRow` list with inline release-notes accordion on the selected row, `DiffSummary` panel below.
  - Promote tab: inline-scrollable build picker, 3-column `(Current version | New tag | AI suggestion)`, markdown editor with Write/Preview, semver-validated tag input, "Regenerate with AI" action.
- `PromoteDialog` — Radix `Popover` (360px) anchored under the Promote button; two radio gap options with commit deltas and a top-4 commit preview.
- Click semantics on the release train: 1st chip → Deploy/Testing, 2nd chip → Promote, 3rd chip → Deploy/Production, Promote button → popover. Centralised in `resolveTrainClickIntent`.
- TanStack Query hooks in `src/api/deployments.ts` for refs / commits / compare / promotion-options / draft-release-notes / trigger-deployment.

## Context

UI half of Phase 1 + 2 of [`docs/deployments-plan.md`](https://github.com/AWeber-Imbi/imbi/blob/main/docs/deployments-plan.md). Independent of the imbi-common / imbi-api PRs at the source level — the new endpoints will return 404 until the imbi-api PR lands.

## Test plan

- [ ] Click each release-train chip and the Promote button → modal opens on the right tab/state
- [ ] Pick a committish on Testing, hit Deploy → toast surfaces a "View workflow run" link
- [ ] On Promote tab, hit Regenerate → AI banner + notes editor refresh
- [ ] Inline-scrollable build picker selecting a non-tip commit re-invokes draft-release-notes with the narrower range