### PR TITLE
Phase 3: live deploy/promote status via TanStack refetchInterval

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -23,6 +23,7 @@ import type {
   DeploymentCompareResult,
   DeploymentPromoteRequest,
   DeploymentRef,
+  DeploymentRun,
   DeploymentTriggerRequest,
   DeploymentTriggerResponse,
   Document,
@@ -1474,6 +1475,21 @@ export const draftReleaseNotes = (
   return apiClient.post<DraftReleaseNotesResponse>(
     `${deploymentsBase(orgSlug, projectId)}/draft-release-notes${search}`,
     body,
+  )
+}
+
+export const getDeploymentRunStatus = (
+  orgSlug: string,
+  projectId: string,
+  runId: string,
+  source?: string,
+  signal?: AbortSignal,
+): Promise<DeploymentRun> => {
+  const search = source ? `?source=${encodeURIComponent(source)}` : ''
+  return apiClient.get<DeploymentRun>(
+    `${deploymentsBase(orgSlug, projectId)}/runs/${encodeURIComponent(runId)}${search}`,
+    undefined,
+    signal,
   )
 }
 

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -233,12 +233,25 @@ export function ProjectDetail({
   }, [])
   const handleRunTerminal = useCallback(
     (runId: string) => {
-      setActiveRuns((prev) => prev.filter((r) => r.runId !== runId))
-      void queryClient.invalidateQueries({
-        queryKey: ['currentReleases', orgSlug, project.id],
+      // Invalidate the originating project's release cache rather than
+      // the currently-mounted project, so promotions trigger from one
+      // project but settle while viewing another still refresh
+      // correctly.
+      setActiveRuns((prev) => {
+        const settled = prev.find((r) => r.runId === runId)
+        if (settled) {
+          void queryClient.invalidateQueries({
+            queryKey: [
+              'currentReleases',
+              settled.originOrgSlug,
+              settled.originProjectId,
+            ],
+          })
+        }
+        return prev.filter((r) => r.runId !== runId)
       })
     },
-    [queryClient, orgSlug, project.id],
+    [queryClient],
   )
 
   const { data: projectSchema } = useQuery({
@@ -799,13 +812,18 @@ export function ProjectDetail({
         promoteTo={deployModal.promoteTo}
       />
       {activeRuns.map((run) => (
+        // Bind each watcher to the org/project that triggered the run
+        // so polling stays correct if the user navigates to another
+        // project before the workflow settles.
         <DeploymentRunWatcher
+          actionLabel={run.actionLabel}
+          actionUrl={run.actionUrl}
           envName={run.envName}
           initialStatus={run.initialStatus}
           key={run.runId}
           onTerminal={handleRunTerminal}
-          orgSlug={orgSlug}
-          projectId={project.id}
+          orgSlug={run.originOrgSlug}
+          projectId={run.originProjectId}
           runId={run.runId}
           runUrl={run.runUrl}
           toastId={run.toastId}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useNavigate } from 'react-router-dom'
 
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
   ArrowRight,
@@ -31,8 +31,10 @@ import {
 } from '@/api/endpoints'
 import {
   DeploymentModal,
+  type DeploymentRunStarted,
   type DeployModalTab,
 } from '@/components/deploy/DeploymentModal'
+import { DeploymentRunWatcher } from '@/components/deploy/DeploymentRunWatcher'
 import { PromoteDialog } from '@/components/deploy/PromoteDialog'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
@@ -216,6 +218,28 @@ export function ProjectDetail({
     [],
   )
   const [promotePopoverOpen, setPromotePopoverOpen] = useState(false)
+
+  // Active deployment runs (one watcher per entry).  Pushed by the
+  // DeployTab/PromoteTab onRunStarted callback; the watcher itself
+  // calls back to remove its entry once the run reaches a terminal
+  // state.  Refreshes the release-train view too so the freshly
+  // recorded ``DeploymentEvent.status`` flips out of ``in_progress``.
+  const [activeRuns, setActiveRuns] = useState<DeploymentRunStarted[]>([])
+  const queryClient = useQueryClient()
+  const handleRunStarted = useCallback((run: DeploymentRunStarted) => {
+    setActiveRuns((prev) =>
+      prev.some((r) => r.runId === run.runId) ? prev : [...prev, run],
+    )
+  }, [])
+  const handleRunTerminal = useCallback(
+    (runId: string) => {
+      setActiveRuns((prev) => prev.filter((r) => r.runId !== runId))
+      void queryClient.invalidateQueries({
+        queryKey: ['currentReleases', orgSlug, project.id],
+      })
+    },
+    [queryClient, orgSlug, project.id],
+  )
 
   const { data: projectSchema } = useQuery({
     enabled: !!orgSlug,
@@ -765,6 +789,7 @@ export function ProjectDetail({
         initialEnvSlug={deployModal.envSlug}
         initialTab={deployModal.tab}
         onOpenChange={(open) => setDeployModal((prev) => ({ ...prev, open }))}
+        onRunStarted={handleRunStarted}
         open={deployModal.open}
         orgSlug={orgSlug}
         projectId={project.id}
@@ -773,6 +798,19 @@ export function ProjectDetail({
         promoteFromCommittish={deployModal.promoteFromCommittish}
         promoteTo={deployModal.promoteTo}
       />
+      {activeRuns.map((run) => (
+        <DeploymentRunWatcher
+          envName={run.envName}
+          initialStatus={run.initialStatus}
+          key={run.runId}
+          onTerminal={handleRunTerminal}
+          orgSlug={orgSlug}
+          projectId={project.id}
+          runId={run.runId}
+          runUrl={run.runUrl}
+          toastId={run.toastId}
+        />
+      ))}
     </div>
   )
 }

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -179,8 +179,12 @@ export function DeployTab({
           icon: <Loader2 className="h-4 w-4 animate-spin" />,
         })
         onRunStarted({
+          actionLabel: url ? 'View run' : undefined,
+          actionUrl: url,
           envName,
           initialStatus: data.run.status,
+          originOrgSlug: orgSlug,
+          originProjectId: projectId,
           runId: data.run.run_id,
           runUrl: url,
           toastId,

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -30,6 +30,7 @@ interface DeployTabProps {
   environments: Environment[]
   initialEnvSlug?: string
   onClose: () => void
+  onRunStarted?: (run: import('./DeploymentModal').DeploymentRunStarted) => void
   // Modal-open gate: queries only fire while the modal is open so the
   // hidden DeployTab doesn't issue GitHub round-trips on every page load.
   open: boolean
@@ -46,6 +47,7 @@ export function DeployTab({
   environments,
   initialEnvSlug,
   onClose,
+  onRunStarted,
   open,
   orgSlug,
   projectId,
@@ -162,17 +164,40 @@ export function DeployTab({
         queryKey: ['currentReleases', orgSlug, projectId],
       })
       const url = data.run.run_url
-      toast.success(
-        `Workflow dispatched to ${env?.name ?? envSlug}`,
-        url
-          ? {
-              action: {
+      const envName = env?.name ?? envSlug
+      if (onRunStarted && data.run.run_id) {
+        const toastId = toast.loading(`Deploying to ${envName}…`, {
+          action: url
+            ? {
                 label: 'View run',
                 onClick: () => window.open(url, '_blank', 'noopener'),
-              },
-            }
-          : undefined,
-      )
+              }
+            : undefined,
+          description: data.run.status
+            ? `status: ${data.run.status}`
+            : undefined,
+          icon: <Loader2 className="h-4 w-4 animate-spin" />,
+        })
+        onRunStarted({
+          envName,
+          initialStatus: data.run.status,
+          runId: data.run.run_id,
+          runUrl: url,
+          toastId,
+        })
+      } else {
+        toast.success(
+          `Workflow dispatched to ${envName}`,
+          url
+            ? {
+                action: {
+                  label: 'View run',
+                  onClick: () => window.open(url, '_blank', 'noopener'),
+                },
+              }
+            : undefined,
+        )
+      }
       onClose()
     },
   })

--- a/src/components/deploy/DeploymentModal.tsx
+++ b/src/components/deploy/DeploymentModal.tsx
@@ -8,8 +8,28 @@ import { DeployTab } from './DeployTab'
 import { PromoteTab } from './PromoteTab'
 
 export interface DeploymentRunStarted {
+  /**
+   * Optional label for the toast action button rendered by the
+   * watcher. Lets the originating tab pick between "View run" and
+   * "View release" so promotions that only carry a release URL still
+   * surface a useful deep-link.
+   */
+  actionLabel?: string
+  /**
+   * Optional URL the watcher's toast action should open. Falls back to
+   * ``runUrl`` when omitted so existing callers stay correct.
+   */
+  actionUrl?: null | string
   envName: string
   initialStatus?: DeploymentRunStatus
+  /**
+   * Org slug the run was triggered from. The watcher uses this rather
+   * than the currently-mounted project so polling stays bound to the
+   * originating project even if the user navigates away.
+   */
+  originOrgSlug: string
+  /** Project id the run was triggered from. */
+  originProjectId: string
   runId: string
   runUrl?: null | string
   toastId: number | string

--- a/src/components/deploy/DeploymentModal.tsx
+++ b/src/components/deploy/DeploymentModal.tsx
@@ -2,10 +2,18 @@ import { GitMerge, Rocket } from 'lucide-react'
 
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
-import type { Environment } from '@/types'
+import type { DeploymentRunStatus, Environment } from '@/types'
 
 import { DeployTab } from './DeployTab'
 import { PromoteTab } from './PromoteTab'
+
+export interface DeploymentRunStarted {
+  envName: string
+  initialStatus?: DeploymentRunStatus
+  runId: string
+  runUrl?: null | string
+  toastId: number | string
+}
 
 export type DeployModalTab = 'deploy' | 'promote'
 
@@ -14,6 +22,12 @@ interface DeploymentModalProps {
   initialEnvSlug?: string
   initialTab?: DeployModalTab
   onOpenChange: (open: boolean) => void
+  /**
+   * Called after a successful trigger so the parent can mount a
+   * ``<DeploymentRunWatcher>`` for the run.  Without this prop the
+   * tabs fall back to a one-shot success toast (Phase 1 behavior).
+   */
+  onRunStarted?: (run: DeploymentRunStarted) => void
   open: boolean
   orgSlug: string
   projectId: string
@@ -32,6 +46,7 @@ export function DeploymentModal({
   initialEnvSlug,
   initialTab = 'deploy',
   onOpenChange,
+  onRunStarted,
   open,
   orgSlug,
   projectId,
@@ -64,9 +79,11 @@ export function DeploymentModal({
         <div className="px-6 py-4">
           {isPromote ? (
             <PromoteTab
+              environments={environments}
               fromCommittish={promoteFromCommittish}
               fromEnvironment={promoteFrom}
               onClose={() => onOpenChange(false)}
+              onRunStarted={onRunStarted}
               open={open}
               orgSlug={orgSlug}
               projectId={projectId}
@@ -77,6 +94,7 @@ export function DeploymentModal({
               environments={environments}
               initialEnvSlug={initialEnvSlug}
               onClose={() => onOpenChange(false)}
+              onRunStarted={onRunStarted}
               open={open}
               orgSlug={orgSlug}
               projectId={projectId}

--- a/src/components/deploy/DeploymentRunWatcher.tsx
+++ b/src/components/deploy/DeploymentRunWatcher.tsx
@@ -14,6 +14,16 @@ const TERMINAL_STATUSES: ReadonlySet<DeploymentRun['status']> = new Set([
 ])
 
 interface DeploymentRunWatcherProps {
+  /**
+   * Label for the toast action button. Defaults to ``'View run'`` when
+   * ``actionUrl`` (or the legacy ``runUrl`` fallback) is set.
+   */
+  actionLabel?: string
+  /**
+   * URL the toast action should open. Falls back to ``runUrl`` so
+   * existing callers that only know the workflow run keep working.
+   */
+  actionUrl?: null | string
   envName: string
   /** Initial status reported by `trigger_deployment`. */
   initialStatus?: DeploymentRun['status']
@@ -35,6 +45,8 @@ interface DeploymentRunWatcherProps {
  */
 export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
   const {
+    actionLabel,
+    actionUrl,
     envName,
     initialStatus,
     onTerminal,
@@ -44,6 +56,11 @@ export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
     runUrl,
     toastId,
   } = props
+  // Prefer the explicit action URL; fall back to the workflow run URL
+  // so the toast still surfaces a deep-link for callers that only know
+  // the run (legacy pre-Phase-3 behavior).
+  const toastActionUrl = actionUrl ?? runUrl
+  const toastActionLabel = actionLabel ?? (toastActionUrl ? 'View run' : null)
 
   // Snapshot the latest known status so refetchInterval can short-circuit
   // once we hit a terminal state.
@@ -70,15 +87,17 @@ export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
     const data = query.data
     if (!data) return
     statusRef.current = data.status
+    const action =
+      toastActionUrl && toastActionLabel
+        ? {
+            label: toastActionLabel,
+            onClick: () => window.open(toastActionUrl, '_blank', 'noopener'),
+          }
+        : undefined
     if (data.status === 'success') {
       settledRef.current = true
       toast.success(`Deployed to ${envName}`, {
-        action: runUrl
-          ? {
-              label: 'View run',
-              onClick: () => window.open(runUrl, '_blank', 'noopener'),
-            }
-          : undefined,
+        action,
         icon: <CheckCircle2 className="h-4 w-4 text-emerald-500" />,
         id: toastId,
       })
@@ -87,12 +106,7 @@ export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
       settledRef.current = true
       const verb = data.status === 'cancelled' ? 'cancelled' : 'failed'
       toast.error(`Deployment to ${envName} ${verb}`, {
-        action: runUrl
-          ? {
-              label: 'View run',
-              onClick: () => window.open(runUrl, '_blank', 'noopener'),
-            }
-          : undefined,
+        action,
         icon: <XCircle className="h-4 w-4 text-rose-500" />,
         id: toastId,
       })
@@ -100,18 +114,21 @@ export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
     } else {
       // queued / in_progress — keep the loading toast fresh.
       toast.loading(`Deploying to ${envName}…`, {
-        action: runUrl
-          ? {
-              label: 'View run',
-              onClick: () => window.open(runUrl, '_blank', 'noopener'),
-            }
-          : undefined,
+        action,
         description: data.status ? `status: ${data.status}` : undefined,
         icon: <Loader2 className="h-4 w-4 animate-spin" />,
         id: toastId,
       })
     }
-  }, [query.data, envName, onTerminal, runId, runUrl, toastId])
+  }, [
+    query.data,
+    envName,
+    onTerminal,
+    runId,
+    toastActionLabel,
+    toastActionUrl,
+    toastId,
+  ])
 
   // If the status endpoint itself errors out persistently, bail so the
   // toast doesn't sit on "deploying…" forever.
@@ -119,18 +136,27 @@ export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
     if (!query.isError || settledRef.current) return
     settledRef.current = true
     toast.message(`Lost track of deployment to ${envName}`, {
-      action: runUrl
-        ? {
-            label: 'View run',
-            onClick: () => window.open(runUrl, '_blank', 'noopener'),
-          }
-        : undefined,
+      action:
+        toastActionUrl && toastActionLabel
+          ? {
+              label: toastActionLabel,
+              onClick: () => window.open(toastActionUrl, '_blank', 'noopener'),
+            }
+          : undefined,
       description: 'Status polling failed; check the workflow run directly.',
       icon: <ExternalLink className="h-4 w-4" />,
       id: toastId,
     })
     onTerminal(runId)
-  }, [query.isError, envName, onTerminal, runId, runUrl, toastId])
+  }, [
+    query.isError,
+    envName,
+    onTerminal,
+    runId,
+    toastActionLabel,
+    toastActionUrl,
+    toastId,
+  ])
 
   return null
 }

--- a/src/components/deploy/DeploymentRunWatcher.tsx
+++ b/src/components/deploy/DeploymentRunWatcher.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { CheckCircle2, ExternalLink, Loader2, XCircle } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { getDeploymentRunStatus } from '@/api/endpoints'
+import type { DeploymentRun } from '@/types'
+
+const TERMINAL_STATUSES: ReadonlySet<DeploymentRun['status']> = new Set([
+  'cancelled',
+  'failure',
+  'success',
+])
+
+interface DeploymentRunWatcherProps {
+  envName: string
+  /** Initial status reported by `trigger_deployment`. */
+  initialStatus?: DeploymentRun['status']
+  onTerminal: (runId: string) => void
+  orgSlug: string
+  projectId: string
+  runId: string
+  runUrl?: null | string
+  toastId: number | string
+}
+
+/**
+ * Polls `/deployments/runs/{run_id}` while a workflow is in flight and
+ * updates the matching sonner toast as the status flips.
+ *
+ * Renders nothing — it's a side-effect component the parent mounts per
+ * active run. Removes itself from the parent's tracking list once the
+ * run reaches a terminal state.
+ */
+export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
+  const {
+    envName,
+    initialStatus,
+    onTerminal,
+    orgSlug,
+    projectId,
+    runId,
+    runUrl,
+    toastId,
+  } = props
+
+  // Snapshot the latest known status so refetchInterval can short-circuit
+  // once we hit a terminal state.
+  const statusRef = useRef<DeploymentRun['status']>(initialStatus ?? null)
+  const settledRef = useRef(false)
+
+  const query = useQuery<DeploymentRun>({
+    enabled: !!runId && !settledRef.current,
+    queryFn: ({ signal }) =>
+      getDeploymentRunStatus(orgSlug, projectId, runId, undefined, signal),
+    queryKey: ['deployment-run', orgSlug, projectId, runId],
+    refetchInterval: (q) => {
+      const status = q.state.data?.status
+      if (status && TERMINAL_STATUSES.has(status)) return false
+      return 4000
+    },
+    refetchIntervalInBackground: false,
+    // Keep retrying transient errors a few times before giving up; the
+    // toast still shows the last good status.
+    retry: 3,
+  })
+
+  useEffect(() => {
+    const data = query.data
+    if (!data) return
+    statusRef.current = data.status
+    if (data.status === 'success') {
+      settledRef.current = true
+      toast.success(`Deployed to ${envName}`, {
+        action: runUrl
+          ? {
+              label: 'View run',
+              onClick: () => window.open(runUrl, '_blank', 'noopener'),
+            }
+          : undefined,
+        icon: <CheckCircle2 className="h-4 w-4 text-emerald-500" />,
+        id: toastId,
+      })
+      onTerminal(runId)
+    } else if (data.status === 'failure' || data.status === 'cancelled') {
+      settledRef.current = true
+      const verb = data.status === 'cancelled' ? 'cancelled' : 'failed'
+      toast.error(`Deployment to ${envName} ${verb}`, {
+        action: runUrl
+          ? {
+              label: 'View run',
+              onClick: () => window.open(runUrl, '_blank', 'noopener'),
+            }
+          : undefined,
+        icon: <XCircle className="h-4 w-4 text-rose-500" />,
+        id: toastId,
+      })
+      onTerminal(runId)
+    } else {
+      // queued / in_progress — keep the loading toast fresh.
+      toast.loading(`Deploying to ${envName}…`, {
+        action: runUrl
+          ? {
+              label: 'View run',
+              onClick: () => window.open(runUrl, '_blank', 'noopener'),
+            }
+          : undefined,
+        description: data.status ? `status: ${data.status}` : undefined,
+        icon: <Loader2 className="h-4 w-4 animate-spin" />,
+        id: toastId,
+      })
+    }
+  }, [query.data, envName, onTerminal, runId, runUrl, toastId])
+
+  // If the status endpoint itself errors out persistently, bail so the
+  // toast doesn't sit on "deploying…" forever.
+  useEffect(() => {
+    if (!query.isError || settledRef.current) return
+    settledRef.current = true
+    toast.message(`Lost track of deployment to ${envName}`, {
+      action: runUrl
+        ? {
+            label: 'View run',
+            onClick: () => window.open(runUrl, '_blank', 'noopener'),
+          }
+        : undefined,
+      description: 'Status polling failed; check the workflow run directly.',
+      icon: <ExternalLink className="h-4 w-4" />,
+      id: toastId,
+    })
+    onTerminal(runId)
+  }, [query.isError, envName, onTerminal, runId, runUrl, toastId])
+
+  return null
+}

--- a/src/components/deploy/DeploymentRunWatcher.tsx
+++ b/src/components/deploy/DeploymentRunWatcher.tsx
@@ -73,6 +73,10 @@ export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
       getDeploymentRunStatus(orgSlug, projectId, runId, undefined, signal),
     queryKey: ['deployment-run', orgSlug, projectId, runId],
     refetchInterval: (q) => {
+      // Stop polling immediately once the terminal-status effect has
+      // marked this watcher settled — protects against an extra tick
+      // landing while the parent unmounts us.
+      if (settledRef.current) return false
       const status = q.state.data?.status
       if (status && TERMINAL_STATUSES.has(status)) return false
       return 4000
@@ -84,6 +88,10 @@ export function DeploymentRunWatcher(props: DeploymentRunWatcherProps): null {
   })
 
   useEffect(() => {
+    // The parent removes us on terminal status, but a stale query.data
+    // tick can fire before the unmount lands — bail so we don't
+    // re-toast or re-call onTerminal.
+    if (settledRef.current) return
     const data = query.data
     if (!data) return
     statusRef.current = data.status

--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -159,20 +159,23 @@ export function PromoteTab({
       const releaseUrl = data.release_url
       const runUrl = data.run.run_url
       const tagLabel = data.tag ?? tag
+      // Prefer the run URL when present; fall back to the release URL
+      // so the watcher's recreated toast still has a useful action.
+      const actionUrl = runUrl ?? releaseUrl
+      const actionLabel = runUrl
+        ? 'View run'
+        : releaseUrl
+          ? 'View release'
+          : undefined
       if (onRunStarted && data.run.run_id) {
         const toastId = toast.loading(
           `Promoting ${tagLabel} to ${toEnvName}…`,
           {
-            action: runUrl
-              ? {
-                  label: 'View run',
-                  onClick: () => window.open(runUrl, '_blank', 'noopener'),
-                }
-              : releaseUrl
+            action:
+              actionUrl && actionLabel
                 ? {
-                    label: 'View release',
-                    onClick: () =>
-                      window.open(releaseUrl, '_blank', 'noopener'),
+                    label: actionLabel,
+                    onClick: () => window.open(actionUrl, '_blank', 'noopener'),
                   }
                 : undefined,
             description: data.run.status
@@ -182,8 +185,12 @@ export function PromoteTab({
           },
         )
         onRunStarted({
+          actionLabel,
+          actionUrl,
           envName: toEnvName,
           initialStatus: data.run.status,
+          originOrgSlug: orgSlug,
+          originProjectId: projectId,
           runId: data.run.run_id,
           runUrl,
           toastId,

--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -19,12 +19,14 @@ import { Textarea } from '@/components/ui/textarea'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { ciStatusDotClass } from '@/lib/status-colors'
 import { cn } from '@/lib/utils'
-import type { DraftReleaseNotesResponse } from '@/types'
+import type { DraftReleaseNotesResponse, Environment } from '@/types'
 
 interface PromoteTabProps {
+  environments: Environment[]
   fromCommittish?: null | string
   fromEnvironment: string
   onClose: () => void
+  onRunStarted?: (run: import('./DeploymentModal').DeploymentRunStarted) => void
   open: boolean
   orgSlug: string
   projectId: string
@@ -34,14 +36,21 @@ interface PromoteTabProps {
 const SEMVER_RE = /^v?\d+\.\d+\.\d+(?:[-+].+)?$/
 
 export function PromoteTab({
+  environments,
   fromCommittish,
   fromEnvironment,
   onClose,
+  onRunStarted,
   open,
   orgSlug,
   projectId,
   toEnvironment,
 }: PromoteTabProps) {
+  const toEnvName = useMemo(
+    () =>
+      environments.find((e) => e.slug === toEnvironment)?.name ?? toEnvironment,
+    [environments, toEnvironment],
+  )
   const { data: currentReleases = [] } = useQuery({
     enabled: open && !!orgSlug && !!projectId,
     queryFn: ({ signal }) => listCurrentReleases(orgSlug, projectId, signal),
@@ -147,18 +156,52 @@ export function PromoteTab({
       void queryClient.invalidateQueries({
         queryKey: ['promotionOptions', orgSlug, projectId],
       })
-      const url = data.release_url ?? data.run.run_url
-      toast.success(
-        `Promoted ${data.tag ?? tag} to ${toEnvironment}`,
-        url
-          ? {
-              action: {
-                label: 'View',
-                onClick: () => window.open(url, '_blank', 'noopener'),
-              },
-            }
-          : undefined,
-      )
+      const releaseUrl = data.release_url
+      const runUrl = data.run.run_url
+      const tagLabel = data.tag ?? tag
+      if (onRunStarted && data.run.run_id) {
+        const toastId = toast.loading(
+          `Promoting ${tagLabel} to ${toEnvName}…`,
+          {
+            action: runUrl
+              ? {
+                  label: 'View run',
+                  onClick: () => window.open(runUrl, '_blank', 'noopener'),
+                }
+              : releaseUrl
+                ? {
+                    label: 'View release',
+                    onClick: () =>
+                      window.open(releaseUrl, '_blank', 'noopener'),
+                  }
+                : undefined,
+            description: data.run.status
+              ? `status: ${data.run.status}`
+              : undefined,
+            icon: <Loader2 className="h-4 w-4 animate-spin" />,
+          },
+        )
+        onRunStarted({
+          envName: toEnvName,
+          initialStatus: data.run.status,
+          runId: data.run.run_id,
+          runUrl,
+          toastId,
+        })
+      } else {
+        const url = releaseUrl ?? runUrl
+        toast.success(
+          `Promoted ${tagLabel} to ${toEnvName}`,
+          url
+            ? {
+                action: {
+                  label: 'View',
+                  onClick: () => window.open(url, '_blank', 'noopener'),
+                },
+              }
+            : undefined,
+        )
+      }
       onClose()
     },
   })


### PR DESCRIPTION
## Summary

Phase-1 toasts were one-shot — "Workflow dispatched to Staging" — and never reflected whether the run actually succeeded. This wires the new `GET /deployments/runs/{run_id}` endpoint up to a polling watcher so the toast follows the workflow and flips out of "deploying…" automatically.

- New `getDeploymentRunStatus` API helper.
- New `<DeploymentRunWatcher>` (null-rendering side-effect component): TanStack `useQuery` with a 4 s `refetchInterval` while queued/in_progress, stops on terminal status, updates the originating sonner toast by `id` as state changes. Has an error fallback so the toast doesn't sit on "deploying…" forever if the status endpoint dies.
- `DeploymentModal` exposes optional `onRunStarted({envName, runId, runUrl, toastId, initialStatus})`; `DeployTab` and `PromoteTab` call it after a successful trigger and replace their static success toast with `toast.loading(...)`. Passing `onRunStarted` is optional — without it, the Phase-1 one-shot toast still fires.
- `ProjectDetail` keeps a list of active runs in state, mounts a watcher per entry, removes entries once they settle, and invalidates the `currentReleases` query so the release train updates in lockstep.

## Cross-repo dep

Companion to **AWeber-Imbi/imbi-api#281** — the new `runs/{run_id}` endpoint is what this PR polls. CI here passes standalone (TypeScript + lint), but the live polling won't return useful data until #281 ships.

## Out of scope (explicitly deferred)

Release-train chips don't yet show a CI dot for the deployed SHA per environment — that requires a per-env plugin call in the read path and lands as a follow-up alongside the matching imbi-api endpoint extension.

## Test plan

- [ ] Trigger a deploy from the modal → toast shows "Deploying to <env>…" with the live `status:` description, polls every ~4 s
- [ ] When the GitHub Actions run finishes, toast flips to "Deployed to <env>" (success) or "Deployment to <env> failed/cancelled" — the spinner replaced by a check / X icon
- [ ] "View run" action stays available throughout
- [ ] Promote tab does the same with the `Promoting <tag> to <env>…` copy
- [ ] Disconnect mid-flight → toast reaches "Lost track of deployment…" instead of hanging