### PR TITLE
Fix project creation request shape

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -238,13 +238,9 @@ export const setProjectRelationships = (
     { depends_on: dependsOn },
   )
 
-export const createProject = (
-  orgSlug: string,
-  projectTypeSlug: string,
-  project: ProjectCreate,
-) =>
+export const createProject = (orgSlug: string, project: ProjectCreate) =>
   apiClient.post<Project>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectTypeSlug)}`,
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/`,
     project,
   )
 

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -81,13 +81,7 @@ export function NewProjectDialog({
   })
 
   const createMutation = useMutation({
-    mutationFn: ({
-      data,
-      typeSlug,
-    }: {
-      data: ProjectCreate
-      typeSlug: string
-    }) => createProject(orgSlug, typeSlug, data),
+    mutationFn: (data: ProjectCreate) => createProject(orgSlug, data),
     onSuccess: (created) => {
       queryClient.invalidateQueries({ queryKey: ['projects', orgSlug] })
       onProjectCreated?.(created.id)
@@ -129,10 +123,11 @@ export function NewProjectDialog({
         selectedEnvSlugs.length > 0 ? selectedEnvSlugs : undefined,
       links: Object.keys(links).length > 0 ? links : undefined,
       name,
+      project_type_slugs: [projectTypeSlug],
       slug,
       team_slug: teamSlug,
     }
-    createMutation.mutate({ data: projectData, typeSlug: projectTypeSlug })
+    createMutation.mutate(projectData)
   }
 
   const handleClose = () => {


### PR DESCRIPTION
## Summary
- post project creation to the organization projects collection endpoint
- include the selected project type slug in the create payload
- remove the now-unused typeSlug plumbing from the dialog mutation

## Testing
- npm run build