### PR TITLE
Deploy / Promote / project flow rework

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -401,6 +401,24 @@ export const getOperationsLogEntry = (entryId: string, signal?: AbortSignal) =>
     signal,
   )
 
+export interface OperationsLogCreate {
+  completed_at?: null | string
+  description: string
+  entry_type: string
+  environment_slug: string
+  link?: null | string
+  notes?: null | string
+  occurred_at?: null | string
+  performed_by?: null | string
+  project_id: string
+  project_slug: string
+  ticket_slug?: null | string
+  version?: null | string
+}
+
+export const createOperationsLogEntry = (body: OperationsLogCreate) =>
+  apiClient.post<OperationsLogRecord>('/operations-log/', body)
+
 // Events
 export interface EventRecord {
   attributed_to: string

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useLocation, useNavigate } from 'react-router-dom'
 
@@ -11,7 +11,6 @@ import {
   LogOut,
   Moon,
   Plus,
-  Rocket,
   Settings,
   Sun,
   User,
@@ -27,6 +26,8 @@ import { useIcon } from '@/lib/icons'
 import type { Organization } from '@/types'
 import { UserResponse } from '@/types'
 
+import { NewOpsLogDialog } from './NewOpsLogDialog'
+import { NewProjectDialog } from './NewProjectDialog'
 import { Button } from './ui/button'
 import {
   DropdownMenu,
@@ -39,23 +40,17 @@ import { Gravatar } from './ui/gravatar'
 
 interface NavigationProps {
   currentView?: string
-  onNewDeployment?: () => void
-  onNewOpsEntry?: () => void
-  onNewProject?: () => void
 }
 
-export function Navigation({
-  currentView,
-  onNewDeployment,
-  onNewOpsEntry,
-  onNewProject,
-}: NavigationProps) {
+export function Navigation({ currentView }: NavigationProps) {
   const { isDarkMode, toggleTheme } = useTheme()
   const { logout, user } = useAuth()
   const { organizations, selectedOrganization, setSelectedOrganization } =
     useOrganization()
   const navigate = useNavigate()
   const location = useLocation()
+  const [newProjectOpen, setNewProjectOpen] = useState(false)
+  const [newOpsEntryOpen, setNewOpsEntryOpen] = useState(false)
 
   // Check if user is admin (safely cast to UserResponse to access is_admin)
   const isAdmin = (user as null | UserResponse)?.is_admin === true
@@ -68,12 +63,6 @@ export function Navigation({
         id: 'projects',
         label: 'Projects',
         path: '/projects',
-      },
-      {
-        icon: Rocket,
-        id: 'deployments',
-        label: 'Deployments',
-        path: '/deployments',
       },
       {
         icon: Activity,
@@ -104,206 +93,213 @@ export function Navigation({
     'dashboard'
 
   return (
-    <nav className="fixed left-0 right-0 top-0 z-50 border-b border-tertiary bg-primary transition-colors">
-      <div className="flex h-16 items-center justify-between px-6">
-        {/* Logo and Brand */}
-        <div className="flex items-center gap-8">
-          <Button
-            className="h-auto rounded-lg px-2 py-1.5 transition-all hover:bg-secondary"
-            onClick={() => navigate('/dashboard')}
-            variant="ghost"
-          >
-            <img
-              alt="Imbi"
-              className="h-8 w-8"
-              src={isDarkMode ? logoDark : logoLight}
-            />
-            <span className="text-primary" style={{ fontWeight: 800 }}>
-              Imbi
-            </span>
-          </Button>
+    <>
+      <nav className="fixed left-0 right-0 top-0 z-50 border-b border-tertiary bg-primary transition-colors">
+        <div className="flex h-16 items-center justify-between px-6">
+          {/* Logo and Brand */}
+          <div className="flex items-center gap-8">
+            <Button
+              className="h-auto rounded-lg px-2 py-1.5 transition-all hover:bg-secondary"
+              onClick={() => navigate('/dashboard')}
+              variant="ghost"
+            >
+              <img
+                alt="Imbi"
+                className="h-8 w-8"
+                src={isDarkMode ? logoDark : logoLight}
+              />
+              <span className="text-primary" style={{ fontWeight: 800 }}>
+                Imbi
+              </span>
+            </Button>
 
-          {/* Navigation Items */}
-          <div className="hidden items-center gap-1 md:flex">
-            {navItems.map((item) => {
-              const Icon = item.icon
-              const isActive = activeView === item.id
-              return (
+            {/* Navigation Items */}
+            <div className="hidden items-center gap-1 md:flex">
+              {navItems.map((item) => {
+                const Icon = item.icon
+                const isActive = activeView === item.id
+                return (
+                  <Button
+                    className={`h-auto rounded-lg px-4 py-2 transition-colors ${
+                      isActive
+                        ? 'bg-amber-bg text-amber-text hover:bg-amber-bg hover:text-amber-text'
+                        : 'text-secondary hover:bg-secondary hover:text-primary'
+                    }`}
+                    key={item.id}
+                    onClick={() => navigate(item.path)}
+                    variant="ghost"
+                  >
+                    <Icon className="h-4 w-4" />
+                    <span>{item.label}</span>
+                  </Button>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Right Side Actions */}
+          <div className="flex items-center gap-3">
+            {/* Organization Selector */}
+            {organizations.length > 0 &&
+              selectedOrganization &&
+              (organizations.length === 1 ? (
                 <Button
-                  className={`h-auto rounded-lg px-4 py-2 transition-colors ${
-                    isActive
-                      ? 'bg-amber-bg text-amber-text hover:bg-amber-bg hover:text-amber-text'
-                      : 'text-secondary hover:bg-secondary hover:text-primary'
-                  }`}
-                  key={item.id}
-                  onClick={() => navigate(item.path)}
+                  className="pointer-events-none max-w-[200px] cursor-default gap-2 border-tertiary bg-primary text-primary"
+                  size="sm"
+                  variant="outline"
+                >
+                  <OrgIcon
+                    className="h-4 w-4 flex-shrink-0 rounded object-cover"
+                    org={selectedOrganization}
+                  />
+                  <span className="truncate">{selectedOrganization.name}</span>
+                </Button>
+              ) : (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      className="max-w-[200px] gap-2 border-tertiary bg-primary text-primary hover:bg-secondary"
+                      size="sm"
+                      variant="outline"
+                    >
+                      <OrgIcon
+                        className="h-4 w-4 flex-shrink-0 rounded object-cover"
+                        org={selectedOrganization}
+                      />
+                      <span className="truncate">
+                        {selectedOrganization.name}
+                      </span>
+                      <ChevronDown className="h-3 w-3 flex-shrink-0" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-56">
+                    {organizations.map((org) => (
+                      <DropdownMenuItem
+                        className={
+                          selectedOrganization.slug === org.slug
+                            ? 'font-medium'
+                            : ''
+                        }
+                        key={org.slug}
+                        onClick={() => setSelectedOrganization(org)}
+                      >
+                        <div className="flex items-center gap-2">
+                          <OrgIcon
+                            className="h-4 w-4 flex-shrink-0 rounded object-cover"
+                            org={org}
+                          />
+                          <div className="flex flex-col">
+                            <span>{org.name}</span>
+                            <span className="text-xs text-muted-foreground">
+                              {org.slug}
+                            </span>
+                          </div>
+                        </div>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ))}
+
+            {/* Quick Actions Dropdown */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  className="gap-2 border-tertiary bg-primary text-primary hover:bg-secondary"
+                  size="sm"
+                  variant="outline"
+                >
+                  <Plus className="h-4 w-4" />
+                  <ChevronDown className="h-3 w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuItem onClick={() => setNewOpsEntryOpen(true)}>
+                  <Activity className="mr-2 h-4 w-4" />
+                  <span>New Ops Log Entry</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setNewProjectOpen(true)}>
+                  <FolderKanban className="mr-2 h-4 w-4" />
+                  <span>New Project</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* User Profile Dropdown */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  className="rounded-full p-0 hover:bg-secondary"
+                  size="icon"
                   variant="ghost"
                 >
-                  <Icon className="h-4 w-4" />
-                  <span>{item.label}</span>
+                  {user?.email ? (
+                    <Gravatar
+                      alt={user?.display_name || user?.username || 'User'}
+                      className="h-8 w-8 rounded-full"
+                      email={user.email}
+                      size={32}
+                    />
+                  ) : (
+                    <User className="h-4 w-4" />
+                  )}
                 </Button>
-              )
-            })}
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                {user && (
+                  <div className="px-2 py-1.5 text-sm font-semibold">
+                    {user.display_name || user.username}
+                  </div>
+                )}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  disabled={!user?.email}
+                  onClick={() =>
+                    user?.email &&
+                    navigate(`/users/${encodeURIComponent(user.email)}`)
+                  }
+                >
+                  <UserCircle className="mr-2 h-4 w-4" />
+                  <span>Profile</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => navigate('/settings')}>
+                  <Settings className="mr-2 h-4 w-4" />
+                  <span>Settings</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={logout}>
+                  <LogOut className="mr-2 h-4 w-4" />
+                  <span>Sign Out</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Theme Toggle */}
+            <Button
+              className="rounded-full text-secondary hover:bg-secondary"
+              onClick={toggleTheme}
+              size="icon"
+              variant="ghost"
+            >
+              {isDarkMode ? (
+                <Sun className="h-4 w-4" />
+              ) : (
+                <Moon className="h-4 w-4" />
+              )}
+            </Button>
           </div>
         </div>
-
-        {/* Right Side Actions */}
-        <div className="flex items-center gap-3">
-          {/* Organization Selector */}
-          {organizations.length > 0 &&
-            selectedOrganization &&
-            (organizations.length === 1 ? (
-              <Button
-                className="pointer-events-none max-w-[200px] cursor-default gap-2 border-tertiary bg-primary text-primary"
-                size="sm"
-                variant="outline"
-              >
-                <OrgIcon
-                  className="h-4 w-4 flex-shrink-0 rounded object-cover"
-                  org={selectedOrganization}
-                />
-                <span className="truncate">{selectedOrganization.name}</span>
-              </Button>
-            ) : (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    className="max-w-[200px] gap-2 border-tertiary bg-primary text-primary hover:bg-secondary"
-                    size="sm"
-                    variant="outline"
-                  >
-                    <OrgIcon
-                      className="h-4 w-4 flex-shrink-0 rounded object-cover"
-                      org={selectedOrganization}
-                    />
-                    <span className="truncate">
-                      {selectedOrganization.name}
-                    </span>
-                    <ChevronDown className="h-3 w-3 flex-shrink-0" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-56">
-                  {organizations.map((org) => (
-                    <DropdownMenuItem
-                      className={
-                        selectedOrganization.slug === org.slug
-                          ? 'font-medium'
-                          : ''
-                      }
-                      key={org.slug}
-                      onClick={() => setSelectedOrganization(org)}
-                    >
-                      <div className="flex items-center gap-2">
-                        <OrgIcon
-                          className="h-4 w-4 flex-shrink-0 rounded object-cover"
-                          org={org}
-                        />
-                        <div className="flex flex-col">
-                          <span>{org.name}</span>
-                          <span className="text-xs text-muted-foreground">
-                            {org.slug}
-                          </span>
-                        </div>
-                      </div>
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ))}
-
-          {/* Quick Actions Dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                className="gap-2 border-tertiary bg-primary text-primary hover:bg-secondary"
-                size="sm"
-                variant="outline"
-              >
-                <Plus className="h-4 w-4" />
-                <ChevronDown className="h-3 w-3" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuItem onClick={onNewDeployment}>
-                <Rocket className="mr-2 h-4 w-4" />
-                <span>New Deployment</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={onNewOpsEntry}>
-                <Activity className="mr-2 h-4 w-4" />
-                <span>New Ops Log Entry</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={onNewProject}>
-                <FolderKanban className="mr-2 h-4 w-4" />
-                <span>New Project</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* User Profile Dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                className="rounded-full p-0 hover:bg-secondary"
-                size="icon"
-                variant="ghost"
-              >
-                {user?.email ? (
-                  <Gravatar
-                    alt={user?.display_name || user?.username || 'User'}
-                    className="h-8 w-8 rounded-full"
-                    email={user.email}
-                    size={32}
-                  />
-                ) : (
-                  <User className="h-4 w-4" />
-                )}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              {user && (
-                <div className="px-2 py-1.5 text-sm font-semibold">
-                  {user.display_name || user.username}
-                </div>
-              )}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                disabled={!user?.email}
-                onClick={() =>
-                  user?.email &&
-                  navigate(`/users/${encodeURIComponent(user.email)}`)
-                }
-              >
-                <UserCircle className="mr-2 h-4 w-4" />
-                <span>Profile</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => navigate('/settings')}>
-                <Settings className="mr-2 h-4 w-4" />
-                <span>Settings</span>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={logout}>
-                <LogOut className="mr-2 h-4 w-4" />
-                <span>Sign Out</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* Theme Toggle */}
-          <Button
-            className="rounded-full text-secondary hover:bg-secondary"
-            onClick={toggleTheme}
-            size="icon"
-            variant="ghost"
-          >
-            {isDarkMode ? (
-              <Sun className="h-4 w-4" />
-            ) : (
-              <Moon className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-      </div>
-    </nav>
+      </nav>
+      <NewProjectDialog
+        isOpen={newProjectOpen}
+        onClose={() => setNewProjectOpen(false)}
+        onProjectCreated={(id) => navigate(`/projects/${id}`)}
+      />
+      <NewOpsLogDialog
+        isOpen={newOpsEntryOpen}
+        onClose={() => setNewOpsEntryOpen(false)}
+      />
+    </>
   )
 }
 

--- a/src/components/NewOpsLogDialog.tsx
+++ b/src/components/NewOpsLogDialog.tsx
@@ -50,11 +50,13 @@ export function NewOpsLogDialog({
   // Fetch the selected project on demand so we can show only its
   // environments. ``getProjects`` returns a lighter projection that
   // doesn't include environments.
-  const { data: selectedProject } = useQuery({
-    enabled: !!orgSlug && !!projectId && isOpen,
-    queryFn: ({ signal }) => getProject(orgSlug, projectId, signal),
-    queryKey: ['project', orgSlug, projectId],
-  })
+  const { data: selectedProject, isLoading: selectedProjectLoading } = useQuery(
+    {
+      enabled: !!orgSlug && !!projectId && isOpen,
+      queryFn: ({ signal }) => getProject(orgSlug, projectId, signal),
+      queryKey: ['project', orgSlug, projectId],
+    },
+  )
 
   const projectOptions = useMemo(
     () =>
@@ -180,16 +182,22 @@ export function NewOpsLogDialog({
               </label>
               <select
                 className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm disabled:bg-slate-50 disabled:text-slate-400"
-                disabled={!projectId || projectEnvironments.length === 0}
+                disabled={
+                  !projectId ||
+                  selectedProjectLoading ||
+                  projectEnvironments.length === 0
+                }
                 id="new-ops-environment"
                 onChange={(e) => setEnvironmentSlug(e.target.value)}
                 value={environmentSlug}
               >
                 <option value="">
                   {projectId
-                    ? projectEnvironments.length === 0
-                      ? 'Project has no environments'
-                      : 'Select environment...'
+                    ? selectedProjectLoading
+                      ? 'Loading environments...'
+                      : projectEnvironments.length === 0
+                        ? 'Project has no environments'
+                        : 'Select environment...'
                     : 'Pick a project first'}
                 </option>
                 {projectEnvironments.map((env) => (

--- a/src/components/NewOpsLogDialog.tsx
+++ b/src/components/NewOpsLogDialog.tsx
@@ -1,0 +1,342 @@
+import { useMemo, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import {
+  createOperationsLogEntry,
+  getProject,
+  getProjects,
+  type OperationsLogCreate,
+} from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import {
+  OPERATIONS_LOG_ENTRY_TYPES,
+  type OperationsLogEntryType,
+} from '@/types'
+
+interface NewOpsLogDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  onEntryCreated?: (id: string) => void
+}
+
+export function NewOpsLogDialog({
+  isOpen,
+  onClose,
+  onEntryCreated,
+}: NewOpsLogDialogProps) {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug || ''
+  const queryClient = useQueryClient()
+
+  const [projectId, setProjectId] = useState('')
+  const [environmentSlug, setEnvironmentSlug] = useState('')
+  const [entryType, setEntryType] = useState<'' | OperationsLogEntryType>('')
+  const [description, setDescription] = useState('')
+  const [version, setVersion] = useState('')
+  const [link, setLink] = useState('')
+  const [ticketSlug, setTicketSlug] = useState('')
+  const [notes, setNotes] = useState('')
+
+  const { data: projects = [] } = useQuery({
+    enabled: !!orgSlug && isOpen,
+    queryFn: ({ signal }) => getProjects(orgSlug, signal),
+    queryKey: ['projects', orgSlug],
+  })
+
+  // Fetch the selected project on demand so we can show only its
+  // environments. ``getProjects`` returns a lighter projection that
+  // doesn't include environments.
+  const { data: selectedProject } = useQuery({
+    enabled: !!orgSlug && !!projectId && isOpen,
+    queryFn: ({ signal }) => getProject(orgSlug, projectId, signal),
+    queryKey: ['project', orgSlug, projectId],
+  })
+
+  const projectOptions = useMemo(
+    () =>
+      [...projects].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    [projects],
+  )
+
+  const projectSlug = selectedProject?.slug ?? ''
+  const projectEnvironments = selectedProject?.environments ?? []
+
+  const createMutation = useMutation({
+    mutationFn: (data: OperationsLogCreate) => createOperationsLogEntry(data),
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: ['operations-log'] })
+      queryClient.invalidateQueries({
+        queryKey: ['projectActivity', orgSlug, projectId],
+      })
+      if (created?.id) onEntryCreated?.(created.id)
+      handleClose()
+    },
+  })
+
+  const canProceed =
+    projectId && projectSlug && environmentSlug && entryType && description
+
+  const handleSave = () => {
+    if (!canProceed || createMutation.isPending) return
+    createMutation.mutate({
+      description,
+      entry_type: entryType,
+      environment_slug: environmentSlug,
+      link: link || null,
+      notes: notes || null,
+      project_id: projectId,
+      project_slug: projectSlug,
+      ticket_slug: ticketSlug || null,
+      version: version || null,
+    })
+  }
+
+  const handleClose = () => {
+    setProjectId('')
+    setEnvironmentSlug('')
+    setEntryType('')
+    setDescription('')
+    setVersion('')
+    setLink('')
+    setTicketSlug('')
+    setNotes('')
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      aria-label="New Ops Log Entry"
+      aria-modal="true"
+      className="fixed inset-x-0 top-0 z-50 flex items-center justify-center"
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') handleClose()
+      }}
+      role="dialog"
+      style={{
+        bottom: 'var(--assistant-height, 0px)',
+      }}
+    >
+      <button
+        aria-label="Close dialog"
+        className="absolute inset-0 bg-black/50"
+        onClick={handleClose}
+        type="button"
+      />
+      <div
+        className="relative mx-4 flex w-full max-w-2xl flex-col rounded-lg bg-white shadow-xl"
+        style={{
+          maxHeight: 'calc(100vh - var(--assistant-height, 0px) - 2rem - 10px)',
+        }}
+      >
+        {/* Header */}
+        <div className="border-b p-6">
+          <h2 className="text-lg font-semibold text-slate-900">
+            New Ops Log Entry
+          </h2>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6">
+          <div className="space-y-6">
+            {/* Project */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-ops-project"
+              >
+                Project <span className="text-red-500">*</span>
+              </label>
+              <select
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+                id="new-ops-project"
+                onChange={(e) => {
+                  setProjectId(e.target.value)
+                  setEnvironmentSlug('')
+                }}
+                value={projectId}
+              >
+                <option value="">Select project...</option>
+                {projectOptions.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Environment */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-ops-environment"
+              >
+                Environment <span className="text-red-500">*</span>
+              </label>
+              <select
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm disabled:bg-slate-50 disabled:text-slate-400"
+                disabled={!projectId || projectEnvironments.length === 0}
+                id="new-ops-environment"
+                onChange={(e) => setEnvironmentSlug(e.target.value)}
+                value={environmentSlug}
+              >
+                <option value="">
+                  {projectId
+                    ? projectEnvironments.length === 0
+                      ? 'Project has no environments'
+                      : 'Select environment...'
+                    : 'Pick a project first'}
+                </option>
+                {projectEnvironments.map((env) => (
+                  <option key={env.slug} value={env.slug}>
+                    {env.name}
+                  </option>
+                ))}
+              </select>
+              <p className="text-sm text-slate-500">
+                The environment the operation was performed in
+              </p>
+            </div>
+
+            {/* Entry Type */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-ops-entry-type"
+              >
+                Entry Type <span className="text-red-500">*</span>
+              </label>
+              <select
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+                id="new-ops-entry-type"
+                onChange={(e) =>
+                  setEntryType(e.target.value as OperationsLogEntryType)
+                }
+                value={entryType}
+              >
+                <option value="">Select type...</option>
+                {OPERATIONS_LOG_ENTRY_TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Description */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-ops-description"
+              >
+                Description <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                className="min-h-[96px] w-full resize-none rounded-md border border-slate-200 px-3 py-2 text-sm"
+                id="new-ops-description"
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Short summary of what was done"
+                value={description}
+              />
+            </div>
+
+            {/* Version */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-ops-version"
+              >
+                Version
+              </label>
+              <Input
+                id="new-ops-version"
+                onChange={(e) => setVersion(e.target.value)}
+                placeholder="e.g., 6.3.0"
+                value={version}
+              />
+            </div>
+
+            {/* Link */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-ops-link"
+              >
+                Link
+              </label>
+              <Input
+                id="new-ops-link"
+                onChange={(e) => setLink(e.target.value)}
+                placeholder="https://..."
+                type="url"
+                value={link}
+              />
+            </div>
+
+            {/* Ticket */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-ops-ticket"
+              >
+                Ticket
+              </label>
+              <Input
+                id="new-ops-ticket"
+                onChange={(e) => setTicketSlug(e.target.value)}
+                placeholder="e.g., INC-1234"
+                value={ticketSlug}
+              />
+            </div>
+
+            {/* Notes */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-ops-notes"
+              >
+                Notes
+              </label>
+              <textarea
+                className="min-h-[96px] w-full resize-none rounded-md border border-slate-200 px-3 py-2 text-sm"
+                id="new-ops-notes"
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Optional context for future readers"
+                value={notes}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Error display */}
+        {createMutation.error && (
+          <div className="px-6 py-2">
+            <Card className="border-red-200 bg-red-50 p-3">
+              <p className="text-sm text-red-700">
+                Failed to create entry: {String(createMutation.error)}
+              </p>
+            </Card>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t p-6">
+          <Button onClick={handleClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            disabled={!canProceed || createMutation.isPending}
+            onClick={handleSave}
+          >
+            {createMutation.isPending ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -10,6 +10,13 @@ import {
 } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { slugify } from '@/lib/utils'
@@ -106,39 +113,21 @@ export function NewProjectDialog({
 
   const canProceed = teamSlug && projectTypeSlug && name && slug
 
-  if (!isOpen) return null
-
   return (
-    <div
-      aria-label="Create New Project"
-      aria-modal="true"
-      className="fixed inset-x-0 top-0 z-50 flex items-center justify-center"
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') handleClose()
-      }}
-      role="dialog"
-      style={{
-        bottom: 'var(--assistant-height, 0px)',
-      }}
-    >
-      <button
-        aria-label="Close dialog"
-        className="absolute inset-0 bg-black/50"
-        onClick={handleClose}
-        type="button"
-      />
-      <div
-        className="relative mx-4 flex w-full max-w-2xl flex-col rounded-lg bg-white shadow-xl"
+    <Dialog onOpenChange={(open) => !open && handleClose()} open={isOpen}>
+      <DialogContent
+        aria-label="Create New Project"
+        className="flex max-w-2xl flex-col gap-0 p-0 sm:max-w-2xl"
         style={{
           maxHeight: 'calc(100vh - var(--assistant-height, 0px) - 2rem - 10px)',
         }}
       >
         {/* Header */}
-        <div className="border-b p-6">
-          <h2 className="text-lg font-semibold text-slate-900">
+        <DialogHeader className="border-b p-6">
+          <DialogTitle className="text-lg font-semibold text-slate-900">
             Create New Project
-          </h2>
-        </div>
+          </DialogTitle>
+        </DialogHeader>
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-6">
@@ -289,7 +278,7 @@ export function NewProjectDialog({
         )}
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-2 border-t p-6">
+        <DialogFooter className="flex items-center justify-end gap-2 border-t p-6 sm:justify-end sm:space-x-0">
           <Button onClick={handleClose} variant="outline">
             Cancel
           </Button>
@@ -299,8 +288,8 @@ export function NewProjectDialog({
           >
             {createMutation.isPending ? 'Creating...' : 'Save'}
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -1,19 +1,10 @@
 import { useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import {
-  Bell,
-  Bug,
-  ExternalLink,
-  Github,
-  icons,
-  type LucideIcon,
-} from 'lucide-react'
 
 import {
   createProject,
   listEnvironments,
-  listLinkDefinitions,
   listProjectTypes,
   listTeams,
 } from '@/api/endpoints'
@@ -38,7 +29,6 @@ export function NewProjectDialog({
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug || ''
   const queryClient = useQueryClient()
-  const [step, setStep] = useState<'basic' | 'urls'>('basic')
 
   // Basic fields
   const [teamSlug, setTeamSlug] = useState('')
@@ -47,14 +37,6 @@ export function NewProjectDialog({
   const [slug, setSlug] = useState('')
   const [description, setDescription] = useState('')
   const [selectedEnvSlugs, setSelectedEnvSlugs] = useState<string[]>([])
-
-  // URL fields
-  const [links, setLinks] = useState<Record<string, string>>({})
-
-  // Automation toggles (mocked for now)
-  const [createGithubRepo, setCreateGithubRepo] = useState(true)
-  const [createSentryProject, setCreateSentryProject] = useState(true)
-  const [createPagerdutyService, setCreatePagerdutyService] = useState(true)
 
   const { data: teams = [] } = useQuery({
     enabled: !!orgSlug && isOpen,
@@ -74,12 +56,6 @@ export function NewProjectDialog({
     queryKey: ['environments', orgSlug],
   })
 
-  const { data: linkDefs = [] } = useQuery({
-    enabled: !!orgSlug && isOpen,
-    queryFn: ({ signal }) => listLinkDefinitions(orgSlug, signal),
-    queryKey: ['linkDefinitions', orgSlug],
-  })
-
   const createMutation = useMutation({
     mutationFn: (data: ProjectCreate) => createProject(orgSlug, data),
     onSuccess: (created) => {
@@ -96,17 +72,6 @@ export function NewProjectDialog({
     }
   }
 
-  const handleLinkChange = (key: string, value: string) => {
-    setLinks((prev) => {
-      if (!value) {
-        const next = { ...prev }
-        delete next[key]
-        return next
-      }
-      return { ...prev, [key]: value }
-    })
-  }
-
   const toggleEnv = (envSlug: string) => {
     setSelectedEnvSlugs((prev) =>
       prev.includes(envSlug)
@@ -121,7 +86,6 @@ export function NewProjectDialog({
       description: description || null,
       environment_slugs:
         selectedEnvSlugs.length > 0 ? selectedEnvSlugs : undefined,
-      links: Object.keys(links).length > 0 ? links : undefined,
       name,
       project_type_slugs: [projectTypeSlug],
       slug,
@@ -131,17 +95,12 @@ export function NewProjectDialog({
   }
 
   const handleClose = () => {
-    setStep('basic')
     setTeamSlug('')
     setProjectTypeSlug('')
     setName('')
     setSlug('')
     setDescription('')
     setSelectedEnvSlugs([])
-    setLinks({})
-    setCreateGithubRepo(true)
-    setCreateSentryProject(true)
-    setCreatePagerdutyService(true)
     onClose()
   }
 
@@ -149,254 +108,173 @@ export function NewProjectDialog({
 
   if (!isOpen) return null
 
-  const linkFields = linkDefs.map((ld) => {
-    const pascalName = (ld.icon || '')
-      .split('-')
-      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-      .join('') as keyof typeof icons
-    const Icon = icons[pascalName] || ExternalLink
-    const placeholder = ld.url_template || 'https://example.com/...'
-    return { icon: Icon, key: ld.slug, label: ld.name, placeholder }
-  })
-
   return (
     <div
       aria-label="Create New Project"
       aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center"
+      className="fixed inset-x-0 top-0 z-50 flex items-center justify-center"
       onKeyDown={(e) => {
         if (e.key === 'Escape') handleClose()
       }}
       role="dialog"
+      style={{
+        bottom: 'var(--assistant-height, 0px)',
+      }}
     >
       <button
         aria-label="Close dialog"
-        className="fixed inset-0 bg-black/50"
+        className="absolute inset-0 bg-black/50"
         onClick={handleClose}
         type="button"
       />
-      <div className="relative mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col rounded-lg bg-white shadow-xl">
+      <div
+        className="relative mx-4 flex w-full max-w-2xl flex-col rounded-lg bg-white shadow-xl"
+        style={{
+          maxHeight: 'calc(100vh - var(--assistant-height, 0px) - 2rem - 10px)',
+        }}
+      >
         {/* Header */}
         <div className="border-b p-6">
           <h2 className="text-lg font-semibold text-slate-900">
             Create New Project
           </h2>
-          <p className="mt-1 text-sm text-slate-500">
-            Create a new project with the following details.
-          </p>
-        </div>
-
-        {/* Tab Switcher */}
-        <div className="px-6 pt-4">
-          <div className="grid grid-cols-2 gap-1 rounded-lg bg-slate-100 p-1">
-            <button
-              className={`rounded-md px-4 py-2 text-sm transition-colors ${
-                step === 'basic'
-                  ? 'bg-white text-slate-900 shadow'
-                  : 'text-slate-600'
-              }`}
-              onClick={() => setStep('basic')}
-            >
-              Basic Information
-            </button>
-            <button
-              className={`rounded-md px-4 py-2 text-sm transition-colors ${
-                step === 'urls'
-                  ? 'bg-white text-slate-900 shadow'
-                  : 'text-slate-600'
-              } ${!canProceed ? 'cursor-not-allowed opacity-50' : ''}`}
-              onClick={() => canProceed && setStep('urls')}
-            >
-              URLs & Links
-            </button>
-          </div>
         </div>
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-6">
-          {step === 'basic' ? (
-            <div className="space-y-6">
-              {/* Team */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium text-slate-900"
-                  htmlFor="new-project-team"
-                >
-                  Team <span className="text-red-500">*</span>
-                </label>
-                <select
-                  className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
-                  id="new-project-team"
-                  onChange={(e) => setTeamSlug(e.target.value)}
-                  value={teamSlug}
-                >
-                  <option value="">Select team...</option>
-                  {teams.map((t) => (
-                    <option key={t.slug} value={t.slug}>
-                      {t.name}
-                    </option>
-                  ))}
-                </select>
-                <p className="text-sm text-slate-500">
-                  Team that owns this project
-                </p>
-              </div>
-
-              {/* Project Type */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium text-slate-900"
-                  htmlFor="new-project-type"
-                >
-                  Project Type <span className="text-red-500">*</span>
-                </label>
-                <select
-                  className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
-                  id="new-project-type"
-                  onChange={(e) => setProjectTypeSlug(e.target.value)}
-                  value={projectTypeSlug}
-                >
-                  <option value="">Select project type...</option>
-                  {projectTypes.map((pt) => (
-                    <option key={pt.slug} value={pt.slug}>
-                      {pt.name}
-                    </option>
-                  ))}
-                </select>
-                <p className="text-sm text-slate-500">
-                  Type of the new project
-                </p>
-              </div>
-
-              {/* Name */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium text-slate-900"
-                  htmlFor="new-project-name"
-                >
-                  Name <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  id="new-project-name"
-                  onChange={(e) => handleNameChange(e.target.value)}
-                  placeholder="e.g., My Service"
-                  value={name}
-                />
-                <p className="text-sm text-slate-500">
-                  Human-readable name for this project
-                </p>
-              </div>
-
-              {/* Slug */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium text-slate-900"
-                  htmlFor="new-project-slug"
-                >
-                  Slug <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  id="new-project-slug"
-                  onChange={(e) => setSlug(e.target.value)}
-                  placeholder="e.g., my-service"
-                  value={slug}
-                />
-                <p className="text-sm text-slate-500">
-                  URL-friendly identifier for this project
-                </p>
-              </div>
-
-              {/* Description */}
-              <div className="space-y-2">
-                <label
-                  className="text-sm font-medium text-slate-900"
-                  htmlFor="new-project-description"
-                >
-                  Description
-                </label>
-                <textarea
-                  className="min-h-[120px] w-full resize-none rounded-md border border-slate-200 px-3 py-2 text-sm"
-                  id="new-project-description"
-                  onChange={(e) => setDescription(e.target.value)}
-                  placeholder="Provide a high-level purpose and context for the project"
-                  value={description}
-                />
-              </div>
-
-              {/* Environments */}
-              {environments.length > 0 && (
-                <div className="space-y-2">
-                  <label className="text-sm font-medium text-slate-900">
-                    Environments
-                  </label>
-                  <div className="flex flex-wrap gap-2">
-                    {environments.map((env) => (
-                      <button
-                        className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
-                          selectedEnvSlugs.includes(env.slug)
-                            ? 'border-blue-300 bg-blue-50 text-blue-700'
-                            : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
-                        }`}
-                        key={env.slug}
-                        onClick={() => toggleEnv(env.slug)}
-                      >
-                        {env.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Automations (mocked) */}
-              <div className="space-y-2 border-t pt-4">
-                <label className="text-sm font-medium text-slate-900">
-                  Automations
-                </label>
-                <AutomationToggle
-                  checked={createGithubRepo}
-                  description="Automatically create a GitHub repository for this project"
-                  icon={Github}
-                  onChange={setCreateGithubRepo}
-                  title="Create GitHub Repository"
-                />
-                <AutomationToggle
-                  checked={createSentryProject}
-                  description="Automatically create a Sentry project for this project"
-                  icon={Bug}
-                  onChange={setCreateSentryProject}
-                  title="Create Sentry Project"
-                />
-                <AutomationToggle
-                  checked={createPagerdutyService}
-                  description="Automatically create a PagerDuty service for this project"
-                  icon={Bell}
-                  onChange={setCreatePagerdutyService}
-                  title="Create PagerDuty Service"
-                />
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-6">
+          <div className="space-y-6">
+            {/* Team */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-project-team"
+              >
+                Team <span className="text-red-500">*</span>
+              </label>
+              <select
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+                id="new-project-team"
+                onChange={(e) => setTeamSlug(e.target.value)}
+                value={teamSlug}
+              >
+                <option value="">Select team...</option>
+                {teams.map((t) => (
+                  <option key={t.slug} value={t.slug}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
               <p className="text-sm text-slate-500">
-                Configure external links and integrations for this project. All
-                fields are optional.
+                Team that owns this project
               </p>
-              {linkFields.map(({ icon: Icon, key, label, placeholder }) => (
-                <div className="space-y-2" key={key}>
-                  <label className="flex items-center gap-2 text-sm font-medium text-slate-900">
-                    <Icon className="h-4 w-4 text-slate-500" />
-                    {label}
-                  </label>
-                  <Input
-                    onChange={(e) => handleLinkChange(key, e.target.value)}
-                    placeholder={placeholder}
-                    type="url"
-                    value={links[key] || ''}
-                  />
-                </div>
-              ))}
             </div>
-          )}
+
+            {/* Project Type */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-project-type"
+              >
+                Project Type <span className="text-red-500">*</span>
+              </label>
+              <select
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+                id="new-project-type"
+                onChange={(e) => setProjectTypeSlug(e.target.value)}
+                value={projectTypeSlug}
+              >
+                <option value="">Select project type...</option>
+                {projectTypes.map((pt) => (
+                  <option key={pt.slug} value={pt.slug}>
+                    {pt.name}
+                  </option>
+                ))}
+              </select>
+              <p className="text-sm text-slate-500">Type of the new project</p>
+            </div>
+
+            {/* Name */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-project-name"
+              >
+                Name <span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="new-project-name"
+                onChange={(e) => handleNameChange(e.target.value)}
+                placeholder="e.g., My Service"
+                value={name}
+              />
+              <p className="text-sm text-slate-500">
+                Human-readable name for this project
+              </p>
+            </div>
+
+            {/* Slug */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-project-slug"
+              >
+                Slug <span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="new-project-slug"
+                onChange={(e) => setSlug(e.target.value)}
+                placeholder="e.g., my-service"
+                value={slug}
+              />
+              <p className="text-sm text-slate-500">
+                URL-friendly identifier for this project
+              </p>
+            </div>
+
+            {/* Description */}
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium text-slate-900"
+                htmlFor="new-project-description"
+              >
+                Description
+              </label>
+              <textarea
+                className="min-h-[120px] w-full resize-none rounded-md border border-slate-200 px-3 py-2 text-sm"
+                id="new-project-description"
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Provide a high-level purpose and context for the project"
+                value={description}
+              />
+            </div>
+
+            {/* Environments */}
+            {environments.length > 0 && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-900">
+                  Environments
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  {environments.map((env) => (
+                    <button
+                      className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
+                        selectedEnvSlugs.includes(env.slug)
+                          ? 'border-blue-300 bg-blue-50 text-blue-700'
+                          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+                      }`}
+                      key={env.slug}
+                      onClick={() => toggleEnv(env.slug)}
+                    >
+                      {env.name}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-sm text-slate-500">
+                  The environment the project runs in
+                </p>
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Error display */}
@@ -411,71 +289,18 @@ export function NewProjectDialog({
         )}
 
         {/* Footer */}
-        <div className="flex items-center justify-between border-t p-6">
-          <div>
-            {step === 'urls' && (
-              <Button onClick={() => setStep('basic')} variant="ghost">
-                Back
-              </Button>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <Button onClick={handleClose} variant="outline">
-              Cancel
-            </Button>
-            {step === 'basic' ? (
-              <Button disabled={!canProceed} onClick={() => setStep('urls')}>
-                Next
-              </Button>
-            ) : (
-              <Button disabled={createMutation.isPending} onClick={handleSave}>
-                {createMutation.isPending ? 'Creating...' : 'Save'}
-              </Button>
-            )}
-          </div>
+        <div className="flex items-center justify-end gap-2 border-t p-6">
+          <Button onClick={handleClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            disabled={!canProceed || createMutation.isPending}
+            onClick={handleSave}
+          >
+            {createMutation.isPending ? 'Creating...' : 'Save'}
+          </Button>
         </div>
       </div>
-    </div>
-  )
-}
-
-function AutomationToggle({
-  checked,
-  description,
-  icon: Icon,
-  onChange,
-  title,
-}: {
-  checked: boolean
-  description: string
-  icon: LucideIcon
-  onChange: (val: boolean) => void
-  title: string
-}) {
-  return (
-    <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 p-4">
-      <div className="flex items-center gap-3">
-        <Icon className="h-5 w-5 text-slate-600" />
-        <div>
-          <p className="text-sm text-slate-900">{title}</p>
-          <p className="text-xs text-slate-500">{description}</p>
-        </div>
-      </div>
-      <button
-        aria-checked={checked}
-        aria-label={title}
-        className={`relative h-5 w-9 rounded-full transition-colors ${
-          checked ? 'bg-blue-600' : 'bg-slate-300'
-        }`}
-        onClick={() => onChange(!checked)}
-        role="switch"
-      >
-        <span
-          className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
-            checked ? 'translate-x-4' : 'translate-x-0'
-          }`}
-        />
-      </button>
     </div>
   )
 }

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -129,37 +129,6 @@ export function ProjectDetail({
     [project.environments],
   )
 
-  // Redirect to clean URL when the tab slug is invalid. ``deploy`` and
-  // ``promote`` are not page tabs — they are URL-driven modal triggers
-  // (``/projects/<id>/deploy/<env>``) — so they're allowed to bypass
-  // the page-tab redirect, but they must carry a *known* env in
-  // ``subId`` to be meaningful, and ``promote`` further requires a
-  // previous env in the pipeline.
-  useEffect(() => {
-    const isModalTab = initialTab === 'deploy' || initialTab === 'promote'
-    if (initialTab && !VALID_TAB_SET.has(initialTab) && !isModalTab) {
-      navigate(`/projects/${project.id}`, { replace: true })
-      return
-    }
-    if (isModalTab) {
-      if (!initialSubId) {
-        navigate(`/projects/${project.id}`, { replace: true })
-        return
-      }
-      // Wait for environments to load before validating; an empty list
-      // here just means the project hasn't finished resolving.
-      if (sortedEnvironments.length === 0) return
-      const idx = sortedEnvironments.findIndex((e) => e.slug === initialSubId)
-      if (idx < 0) {
-        navigate(`/projects/${project.id}`, { replace: true })
-        return
-      }
-      if (initialTab === 'promote' && idx <= 0) {
-        navigate(`/projects/${project.id}`, { replace: true })
-      }
-    }
-  }, [initialTab, initialSubId, navigate, project.id, sortedEnvironments])
-
   const { data: currentReleases = [] } = useQuery({
     enabled: !!orgSlug && !!project.id,
     queryFn: ({ signal }) => listCurrentReleases(orgSlug, project.id, signal),
@@ -204,6 +173,60 @@ export function ProjectDetail({
     }
     return out
   }, [currentReleases])
+
+  // Redirect to clean URL when the tab slug or sub-id is invalid.
+  // ``deploy`` and ``promote`` are not page tabs — they are URL-driven
+  // modal triggers (``/projects/<id>/deploy/<env>``) — so they bypass
+  // the page-tab redirect, but they must carry a *known* env in
+  // ``subId`` to be meaningful, ``promote`` requires a previous env in
+  // the pipeline, *and* ``promote`` requires the upstream env to have a
+  // deployed version (otherwise ``fromCommittish`` would be undefined
+  // and the promote flow can't succeed).
+  useEffect(() => {
+    const isModalTab = initialTab === 'deploy' || initialTab === 'promote'
+    if (initialTab && !VALID_TAB_SET.has(initialTab) && !isModalTab) {
+      navigate(`/projects/${project.id}`, { replace: true })
+      return
+    }
+    if (isModalTab) {
+      if (!initialSubId) {
+        navigate(`/projects/${project.id}`, { replace: true })
+        return
+      }
+      // Wait for environments to load before validating; an empty list
+      // here just means the project hasn't finished resolving.
+      if (sortedEnvironments.length === 0) return
+      const idx = sortedEnvironments.findIndex((e) => e.slug === initialSubId)
+      if (idx < 0) {
+        navigate(`/projects/${project.id}`, { replace: true })
+        return
+      }
+      if (initialTab === 'promote') {
+        if (idx <= 0) {
+          navigate(`/projects/${project.id}`, { replace: true })
+          return
+        }
+        const fromSlug = sortedEnvironments[idx - 1]?.slug
+        const fromVersion = fromSlug
+          ? deploymentStatus[fromSlug]?.version
+          : undefined
+        // Wait for the releases query (drives ``deploymentStatus``) to
+        // settle before deciding the upstream is empty.
+        if (currentReleases.length === 0) return
+        if (!fromVersion) {
+          navigate(`/projects/${project.id}`, { replace: true })
+        }
+      }
+    }
+  }, [
+    currentReleases,
+    deploymentStatus,
+    initialSubId,
+    initialTab,
+    navigate,
+    project.id,
+    sortedEnvironments,
+  ])
 
   const { data: linkDefs = [] } = useQuery({
     enabled: !!orgSlug,
@@ -989,41 +1012,41 @@ export function ProjectDetail({
         projectId={project.id}
         projectName={project.name}
       />
-      {isPromoteModal &&
-      (() => {
+      {(() => {
+        if (!isPromoteModal) return null
         const toIdx = sortedEnvironments.findIndex(
           (e) => e.slug === initialSubId,
         )
         // Promote requires a previous env in the pipeline to act as the
-        // source. ``idx <= 0`` means the URL points at the entry-point
-        // env (or an unknown one); fall back to the clean URL.
-        return toIdx > 0
-      })() ? (
-        <PromoteModal
-          environments={sortedEnvironments}
-          fromCommittish={(() => {
-            const toIdx = sortedEnvironments.findIndex(
-              (e) => e.slug === initialSubId,
-            )
-            const fromSlug = sortedEnvironments[toIdx - 1]?.slug
-            return fromSlug ? deploymentStatus[fromSlug]?.version : undefined
-          })()}
-          fromEnvironment={
-            sortedEnvironments[
-              sortedEnvironments.findIndex((e) => e.slug === initialSubId) - 1
-            ].slug
-          }
-          onOpenChange={(open) => {
-            if (!open) closeModal()
-          }}
-          onRunStarted={handleRunStarted}
-          open={isPromoteModal}
-          orgSlug={orgSlug}
-          projectId={project.id}
-          projectName={project.name}
-          toEnvironment={initialSubId as string}
-        />
-      ) : null}
+        // source AND a deployed version on that upstream env (else
+        // ``fromCommittish`` would be undefined and the API can't
+        // resolve the source). ``idx <= 0`` means the URL points at the
+        // entry-point env (or an unknown one); the redirect effect
+        // above will already navigate away — render nothing here so we
+        // never mount PromoteModal in an impossible state.
+        if (toIdx <= 0) return null
+        const fromSlug = sortedEnvironments[toIdx - 1]?.slug
+        const fromVersion = fromSlug
+          ? deploymentStatus[fromSlug]?.version
+          : undefined
+        if (!fromSlug || !fromVersion) return null
+        return (
+          <PromoteModal
+            environments={sortedEnvironments}
+            fromCommittish={fromVersion}
+            fromEnvironment={fromSlug}
+            onOpenChange={(open) => {
+              if (!open) closeModal()
+            }}
+            onRunStarted={handleRunStarted}
+            open={isPromoteModal}
+            orgSlug={orgSlug}
+            projectId={project.id}
+            projectName={project.name}
+            toEnvironment={initialSubId as string}
+          />
+        )
+      })()}
       {activeRuns.map((run) => (
         // Bind each watcher to the org/project that triggered the run
         // so polling stays correct if the user navigates to another

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -124,21 +124,41 @@ export function ProjectDetail({
     navigate(path, { replace: true })
   }
 
+  const sortedEnvironments = useMemo(
+    () => sortEnvironments(project.environments || []),
+    [project.environments],
+  )
+
   // Redirect to clean URL when the tab slug is invalid. ``deploy`` and
   // ``promote`` are not page tabs — they are URL-driven modal triggers
   // (``/projects/<id>/deploy/<env>``) — so they're allowed to bypass
-  // the page-tab redirect, but they must carry an env in ``subId`` to
-  // be meaningful.
+  // the page-tab redirect, but they must carry a *known* env in
+  // ``subId`` to be meaningful, and ``promote`` further requires a
+  // previous env in the pipeline.
   useEffect(() => {
     const isModalTab = initialTab === 'deploy' || initialTab === 'promote'
     if (initialTab && !VALID_TAB_SET.has(initialTab) && !isModalTab) {
       navigate(`/projects/${project.id}`, { replace: true })
       return
     }
-    if (isModalTab && !initialSubId) {
-      navigate(`/projects/${project.id}`, { replace: true })
+    if (isModalTab) {
+      if (!initialSubId) {
+        navigate(`/projects/${project.id}`, { replace: true })
+        return
+      }
+      // Wait for environments to load before validating; an empty list
+      // here just means the project hasn't finished resolving.
+      if (sortedEnvironments.length === 0) return
+      const idx = sortedEnvironments.findIndex((e) => e.slug === initialSubId)
+      if (idx < 0) {
+        navigate(`/projects/${project.id}`, { replace: true })
+        return
+      }
+      if (initialTab === 'promote' && idx <= 0) {
+        navigate(`/projects/${project.id}`, { replace: true })
+      }
     }
-  }, [initialTab, initialSubId, navigate, project.id])
+  }, [initialTab, initialSubId, navigate, project.id, sortedEnvironments])
 
   const { data: currentReleases = [] } = useQuery({
     enabled: !!orgSlug && !!project.id,
@@ -184,11 +204,6 @@ export function ProjectDetail({
     }
     return out
   }, [currentReleases])
-
-  const sortedEnvironments = useMemo(
-    () => sortEnvironments(project.environments || []),
-    [project.environments],
-  )
 
   const { data: linkDefs = [] } = useQuery({
     enabled: !!orgSlug,
@@ -339,7 +354,12 @@ export function ProjectDetail({
   // Fetch any time a deployment plugin exists so we can also surface the
   // identity-plugin label in the "connect to ..." banner even when the
   // assignment lacks an explicit identity_plugin_id.
-  const { data: myIdentities, isSuccess: myIdentitiesSuccess } = useQuery({
+  const {
+    data: myIdentities,
+    isError: myIdentitiesError,
+    isLoading: myIdentitiesLoading,
+    isSuccess: myIdentitiesSuccess,
+  } = useQuery({
     enabled: !!deploymentPlugin,
     queryFn: ({ signal }) => getMyIdentities(signal),
     queryKey: ['my-identities'],
@@ -351,7 +371,11 @@ export function ProjectDetail({
   // Fetch whenever a deployment plugin is present so the catalog is
   // available — we may need it even before ``deploymentIdentityPluginId``
   // resolves on the first render.
-  const { data: identityPlugins } = useQuery({
+  const {
+    data: identityPlugins,
+    isError: identityPluginsError,
+    isLoading: identityPluginsLoading,
+  } = useQuery({
     enabled: !!orgSlug && !!deploymentPlugin,
     queryFn: ({ signal }) => listIdentityPlugins(orgSlug, signal),
     queryKey: ['identity-plugins', orgSlug],
@@ -386,7 +410,9 @@ export function ProjectDetail({
 
   // A deployment plugin ALWAYS needs an identity connection — without an
   // active connection to the resolved identity plugin we keep the chips
-  // non-interactive (the API would 401 anyway).
+  // non-interactive (the API would 401 anyway). Distinguish the three
+  // not-ready states so the banner doesn't tell already-connected users
+  // to "connect" while queries are still in flight or failing.
   const isUserConnectedToDeployment =
     !!resolvedIdentityPlugin &&
     myIdentitiesSuccess &&
@@ -395,8 +421,21 @@ export function ProjectDetail({
         i.plugin_id === resolvedIdentityPlugin.plugin_id &&
         i.status === 'active',
     )
+  const deploymentReadiness:
+    | 'connected'
+    | 'disconnected'
+    | 'error'
+    | 'loading' = !deploymentPlugin
+    ? 'disconnected'
+    : myIdentitiesLoading || identityPluginsLoading
+      ? 'loading'
+      : myIdentitiesError || identityPluginsError
+        ? 'error'
+        : isUserConnectedToDeployment
+          ? 'connected'
+          : 'disconnected'
   const canTriggerDeployments =
-    !!deploymentPlugin && isUserConnectedToDeployment
+    !!deploymentPlugin && deploymentReadiness === 'connected'
 
   const deploymentConnectLabel = (() => {
     if (resolvedIdentityPlugin?.label) return resolvedIdentityPlugin.label
@@ -555,89 +594,95 @@ export function ProjectDetail({
                for Deploy/Promote, routed by position in the train. */}
           <div className="flex flex-col items-end gap-2">
             <div className="flex items-center gap-2">
-              {Object.keys(deploymentStatus).length > 0 &&
-                (() => {
-                  const visible = sortedEnvironments.filter(
-                    (env) => !!deploymentStatus[env.slug],
-                  )
-                  return visible.map((env, idx) => {
-                    const deployment = deploymentStatus[env.slug]
-                    const color = env.label_color
-                    const ciDot = renderCiDot(deployment.ciStatus)
-                    // Release-train conventions, by position only — no
-                    // hardcoded env names:
-                    //   idx 0   — entry point, Deploy a chosen commit
-                    //   idx 1   — Promote (tag + release the idx-0 build)
-                    //   idx 2+  — Deploy: re-roll whatever was tagged at
-                    //             idx 1 to a downstream env
-                    const isPromoteSlot = idx === 1
-                    const previousSlug = isPromoteSlot
-                      ? visible[0].slug
-                      : undefined
-                    const handleClick = isPromoteSlot
-                      ? () => openPromote(previousSlug as string, env.slug)
-                      : () => openDeploy(env.slug)
-                    const tooltipText = isPromoteSlot
-                      ? 'Promote'
-                      : 'Deploy / Redeploy'
-                    const chipBody = color ? (
-                      <LabelChip
-                        className="rounded-md px-3 py-1.5 text-sm"
-                        hex={color}
-                      >
-                        <span className="inline-flex items-center gap-1.5">
-                          {env.name}: {deployment.version}
-                          {ciDot}
-                        </span>
-                      </LabelChip>
-                    ) : (
-                      <span className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium">
-                        {env.name}: {deployment.version}
+              {sortedEnvironments.length > 0 &&
+                sortedEnvironments.map((env, idx) => {
+                  const deployment = deploymentStatus[env.slug]
+                  const color = env.label_color
+                  const ciDot = deployment
+                    ? renderCiDot(deployment.ciStatus)
+                    : null
+                  // Release-train conventions, by position only — no
+                  // hardcoded env names:
+                  //   idx 0   — entry point, Deploy a chosen commit
+                  //   idx 1   — Promote (tag + release the idx-0 build)
+                  //   idx 2+  — Deploy: re-roll whatever was tagged at
+                  //             idx 1 to a downstream env
+                  const isPromoteSlot = idx === 1
+                  const previousSlug = isPromoteSlot
+                    ? sortedEnvironments[0]?.slug
+                    : undefined
+                  const handleClick = isPromoteSlot
+                    ? () => openPromote(previousSlug as string, env.slug)
+                    : () => openDeploy(env.slug)
+                  const tooltipText = isPromoteSlot
+                    ? 'Promote'
+                    : 'Deploy / Redeploy'
+                  const versionSuffix = deployment
+                    ? `: ${deployment.version}`
+                    : ''
+                  const chipBody = color ? (
+                    <LabelChip
+                      className="rounded-md px-3 py-1.5 text-sm"
+                      hex={color}
+                    >
+                      <span className="inline-flex items-center gap-1.5">
+                        {env.name}
+                        {versionSuffix}
                         {ciDot}
                       </span>
-                    )
-                    return (
-                      <span className="contents" key={env.slug}>
-                        {idx > 0 && (
-                          <ArrowRight className="h-4 w-4 text-tertiary" />
-                        )}
-                        {canTriggerDeployments ? (
-                          <TooltipProvider delayDuration={200}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <button
-                                  aria-label={
-                                    isPromoteSlot
-                                      ? `Promote ${previousSlug} to ${env.name}`
-                                      : `Deploy to ${env.name}`
-                                  }
-                                  className="cursor-pointer rounded-md transition hover:shadow-md hover:ring-1 hover:ring-ring hover:ring-offset-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                  onClick={handleClick}
-                                  type="button"
-                                >
-                                  {chipBody}
-                                </button>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                <p>{tooltipText}</p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ) : (
-                          chipBody
-                        )}
-                      </span>
-                    )
-                  })
-                })()}
+                    </LabelChip>
+                  ) : (
+                    <span className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium">
+                      {env.name}
+                      {versionSuffix}
+                      {ciDot}
+                    </span>
+                  )
+                  return (
+                    <span className="contents" key={env.slug}>
+                      {idx > 0 && (
+                        <ArrowRight className="h-4 w-4 text-tertiary" />
+                      )}
+                      {canTriggerDeployments ? (
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                aria-label={
+                                  isPromoteSlot
+                                    ? `Promote ${previousSlug} to ${env.name}`
+                                    : `Deploy to ${env.name}`
+                                }
+                                className="cursor-pointer rounded-md transition hover:shadow-md hover:ring-1 hover:ring-ring hover:ring-offset-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                onClick={handleClick}
+                                type="button"
+                              >
+                                {chipBody}
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>{tooltipText}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      ) : (
+                        chipBody
+                      )}
+                    </span>
+                  )
+                })}
             </div>
             {deploymentPlugin && (
               <div className="flex items-center gap-1.5 text-xs italic text-tertiary">
                 <Info className="h-3.5 w-3.5" />
                 <span>
-                  {canTriggerDeployments
+                  {deploymentReadiness === 'connected'
                     ? 'Click on an environment to deploy to it'
-                    : `Connect to ${deploymentConnectLabel} to enable deployments`}
+                    : deploymentReadiness === 'loading'
+                      ? 'Checking deployment access…'
+                      : deploymentReadiness === 'error'
+                        ? 'Could not check deployment access — retry shortly'
+                        : `Connect to ${deploymentConnectLabel} to enable deployments`}
                 </span>
               </div>
             )}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -11,8 +11,7 @@ import {
   CheckCircle2,
   ChevronDown,
   Filter,
-  GitMerge,
-  Rocket,
+  Info,
   Settings2 as SettingsIcon,
   TrendingDown,
   XCircle,
@@ -20,10 +19,12 @@ import {
 
 import {
   type AttributeContribution,
+  getMyIdentities,
   getProjectBreakdown,
   getProjectSchema,
   getScoreTrend,
   listCurrentReleases,
+  listIdentityPlugins,
   listLinkDefinitions,
   listProjectDocuments,
   listProjectPlugins,
@@ -33,12 +34,11 @@ import {
   type ScoreTrend,
 } from '@/api/endpoints'
 import {
-  DeploymentModal,
   type DeploymentRunStarted,
-  type DeployModalTab,
+  DeployModal,
+  PromoteModal,
 } from '@/components/deploy/DeploymentModal'
 import { DeploymentRunWatcher } from '@/components/deploy/DeploymentRunWatcher'
-import { PromoteDialog } from '@/components/deploy/PromoteDialog'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
 import { ConfigurationTab } from '@/components/project/ConfigurationTab'
@@ -49,7 +49,6 @@ import { ProjectEnvironmentsCard } from '@/components/ProjectEnvironmentsCard'
 import { ProjectRelationshipsTab } from '@/components/ProjectRelationshipsTab'
 import { ProjectSettingsTab } from '@/components/ProjectSettingsTab'
 import { ScoreHistoryTab } from '@/components/ScoreHistoryTab'
-import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
@@ -125,12 +124,21 @@ export function ProjectDetail({
     navigate(path, { replace: true })
   }
 
-  // Redirect to clean URL when the tab slug is invalid
+  // Redirect to clean URL when the tab slug is invalid. ``deploy`` and
+  // ``promote`` are not page tabs — they are URL-driven modal triggers
+  // (``/projects/<id>/deploy/<env>``) — so they're allowed to bypass
+  // the page-tab redirect, but they must carry an env in ``subId`` to
+  // be meaningful.
   useEffect(() => {
-    if (initialTab && !VALID_TAB_SET.has(initialTab)) {
+    const isModalTab = initialTab === 'deploy' || initialTab === 'promote'
+    if (initialTab && !VALID_TAB_SET.has(initialTab) && !isModalTab) {
+      navigate(`/projects/${project.id}`, { replace: true })
+      return
+    }
+    if (isModalTab && !initialSubId) {
       navigate(`/projects/${project.id}`, { replace: true })
     }
-  }, [initialTab, navigate, project.id])
+  }, [initialTab, initialSubId, navigate, project.id])
 
   const { data: currentReleases = [] } = useQuery({
     enabled: !!orgSlug && !!project.id,
@@ -214,31 +222,30 @@ export function ProjectDetail({
   // even when the 30d baseline equals the current live score.
   const sessionBaseScore = useRef<null | number>(project.score ?? null)
 
-  const [deployModal, setDeployModal] = useState<{
-    envSlug?: string
-    open: boolean
-    promoteFrom?: string
-    promoteFromCommittish?: string
-    promoteTo?: string
-    tab: DeployModalTab
-  }>({ open: false, tab: 'deploy' })
+  // Modal state is derived from the URL: ``/projects/<id>/deploy/<env>``
+  // and ``/projects/<id>/promote/<env>``. Closing a modal navigates
+  // back to ``/projects/<id>`` so the URL is the single source of truth
+  // and a deploy/promote view is deep-linkable.
+  const isDeployModal = initialTab === 'deploy' && !!initialSubId
+  const isPromoteModal = initialTab === 'promote' && !!initialSubId
+  const closeModal = useCallback(
+    () => navigate(`/projects/${project.id}`, { replace: true }),
+    [navigate, project.id],
+  )
   const openDeploy = useCallback(
-    (envSlug?: string) =>
-      setDeployModal({ envSlug, open: true, tab: 'deploy' }),
-    [],
+    (envSlug?: string) => {
+      // The bare "Deploy" button doesn't carry an env, so default to
+      // the entry-point env (idx 0) for first-time deployments.
+      const slug = envSlug ?? sortedEnvironments[0]?.slug
+      if (slug) navigate(`/projects/${project.id}/deploy/${slug}`)
+    },
+    [navigate, project.id, sortedEnvironments],
   )
   const openPromote = useCallback(
-    (promoteFrom: string, promoteTo: string, promoteFromCommittish?: string) =>
-      setDeployModal({
-        open: true,
-        promoteFrom,
-        promoteFromCommittish,
-        promoteTo,
-        tab: 'promote',
-      }),
-    [],
+    (_fromEnvironment: string, toEnvironment: string) =>
+      navigate(`/projects/${project.id}/promote/${toEnvironment}`),
+    [navigate, project.id],
   )
-  const [promotePopoverOpen, setPromotePopoverOpen] = useState(false)
 
   // Active deployment runs (one watcher per entry).  Pushed by the
   // DeployTab/PromoteTab onRunStarted callback; the watcher itself
@@ -320,6 +327,88 @@ export function ProjectDetail({
   const hasLogsPlugin =
     projectPluginsSuccess &&
     (projectPlugins ?? []).some((a) => a.tab === 'logs')
+  const deploymentPlugin = projectPluginsSuccess
+    ? (projectPlugins ?? []).find((a) => a.tab === 'deployment')
+    : undefined
+  const deploymentIdentityPluginId =
+    deploymentPlugin?.identity_plugin_id ?? null
+
+  // Per-user identity connections — used to gate deploy/promote on the
+  // current user actually having an active connection to the deployment
+  // provider. Without this, chips render as buttons that 401 on click.
+  // Fetch any time a deployment plugin exists so we can also surface the
+  // identity-plugin label in the "connect to ..." banner even when the
+  // assignment lacks an explicit identity_plugin_id.
+  const { data: myIdentities, isSuccess: myIdentitiesSuccess } = useQuery({
+    enabled: !!deploymentPlugin,
+    queryFn: ({ signal }) => getMyIdentities(signal),
+    queryKey: ['my-identities'],
+    staleTime: 5 * 60 * 1000,
+  })
+  // Look up the identity plugin's display label so the banner names the
+  // provider the user actually has to authenticate against (e.g.
+  // "GitHub Enterprise Cloud") rather than the deployment plugin label.
+  // Fetch whenever a deployment plugin is present so the catalog is
+  // available — we may need it even before ``deploymentIdentityPluginId``
+  // resolves on the first render.
+  const { data: identityPlugins } = useQuery({
+    enabled: !!orgSlug && !!deploymentPlugin,
+    queryFn: ({ signal }) => listIdentityPlugins(orgSlug, signal),
+    queryKey: ['identity-plugins', orgSlug],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Resolve the identity plugin we expect the user to authenticate
+  // against. Prefer the explicit binding on the merged assignment; fall
+  // back to a sibling identity plugin whose slug shares a prefix with
+  // the deployment plugin's slug (e.g. ``github-enterprise-cloud`` ↔
+  // ``github-deployment-ec``). The fallback covers the case where the
+  // project-type assignment didn't bind an identity plugin but a
+  // matching one exists in the org's plugin catalog.
+  const resolvedIdentityPlugin = useMemo(() => {
+    if (!deploymentPlugin) return null
+    const catalog = identityPlugins ?? []
+    if (deploymentIdentityPluginId) {
+      const match = catalog.find(
+        (p) => p.plugin_id === deploymentIdentityPluginId,
+      )
+      if (match) return match
+    }
+    if (catalog.length === 0) return null
+    const dSlug = deploymentPlugin.plugin_slug
+    const dHead = dSlug.split('-')[0] ?? ''
+    return (
+      catalog.find((p) => dSlug.startsWith(p.plugin_slug)) ??
+      catalog.find((p) => p.plugin_slug.startsWith(dHead)) ??
+      null
+    )
+  }, [deploymentPlugin, deploymentIdentityPluginId, identityPlugins])
+
+  // A deployment plugin ALWAYS needs an identity connection — without an
+  // active connection to the resolved identity plugin we keep the chips
+  // non-interactive (the API would 401 anyway).
+  const isUserConnectedToDeployment =
+    !!resolvedIdentityPlugin &&
+    myIdentitiesSuccess &&
+    (myIdentities ?? []).some(
+      (i) =>
+        i.plugin_id === resolvedIdentityPlugin.plugin_id &&
+        i.status === 'active',
+    )
+  const canTriggerDeployments =
+    !!deploymentPlugin && isUserConnectedToDeployment
+
+  const deploymentConnectLabel = (() => {
+    if (resolvedIdentityPlugin?.label) return resolvedIdentityPlugin.label
+    if (deploymentIdentityPluginId) {
+      const match = (myIdentities ?? []).find(
+        (i) => i.plugin_id === deploymentIdentityPluginId,
+      )
+      if (match?.plugin_label) return match.plugin_label
+    }
+    if (deploymentPlugin?.label) return deploymentPlugin.label
+    return 'the identity provider'
+  })()
 
   // Redirect to overview when a deep-link points at a tab that no
   // longer surfaces (e.g. /configuration on a project type with no
@@ -462,80 +551,96 @@ export function ProjectDetail({
             </div>
           </div>
 
-          {/* Deployment Pipeline — chips render only when there's
-               release history; the Deploy/Promote controls render
-               unconditionally so first-time deployments are reachable. */}
-          <div className="flex items-center gap-2">
-            {Object.keys(deploymentStatus).length > 0 &&
-              sortedEnvironments
-                .filter((env) => !!deploymentStatus[env.slug])
-                .map((env, idx) => {
-                  const deployment = deploymentStatus[env.slug]
-                  const color = env.label_color
-                  const ciDot = renderCiDot(deployment.ciStatus)
-                  const title = deployment.runUrl
-                    ? `${env.name}: ${deployment.version} · ${deployment.updated} · run: ${deployment.runUrl}`
-                    : `${env.name}: ${deployment.version} · ${deployment.updated}`
-                  return (
-                    <span className="contents" key={env.slug}>
-                      {idx > 0 && (
-                        <ArrowRight className="h-4 w-4 text-tertiary" />
-                      )}
-                      <button
-                        aria-label={`Deploy to ${env.name}`}
-                        className="cursor-pointer rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        onClick={() => openDeploy(env.slug)}
-                        title={title}
-                        type="button"
-                      >
-                        {color ? (
-                          <LabelChip
-                            className="rounded-md px-3 py-1.5 text-sm"
-                            hex={color}
-                          >
-                            <span className="inline-flex items-center gap-1.5">
-                              {env.name}: {deployment.version}
-                              {ciDot}
-                            </span>
-                          </LabelChip>
-                        ) : (
-                          <span className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium">
-                            {env.name}: {deployment.version}
-                            {ciDot}
-                          </span>
-                        )}
-                      </button>
-                    </span>
+          {/* Deployment Pipeline — chips are the only entry points
+               for Deploy/Promote, routed by position in the train. */}
+          <div className="flex flex-col items-end gap-2">
+            <div className="flex items-center gap-2">
+              {Object.keys(deploymentStatus).length > 0 &&
+                (() => {
+                  const visible = sortedEnvironments.filter(
+                    (env) => !!deploymentStatus[env.slug],
                   )
-                })}
-            <Button
-              className="ml-4 border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100"
-              onClick={() => openDeploy()}
-              size="sm"
-              variant="outline"
-            >
-              <Rocket className="mr-1 h-4 w-4" />
-              Deploy
-            </Button>
-            <PromoteDialog
-              onOpenChange={setPromotePopoverOpen}
-              onPromote={(opt) => {
-                setPromotePopoverOpen(false)
-                openPromote(
-                  opt.from_environment,
-                  opt.to_environment,
-                  opt.from_sha ?? opt.from_version ?? undefined,
-                )
-              }}
-              open={promotePopoverOpen}
-              orgSlug={orgSlug}
-              projectId={project.id}
-            >
-              <Button size="sm" variant="outline">
-                <GitMerge className="mr-1 h-4 w-4" />
-                Promote
-              </Button>
-            </PromoteDialog>
+                  return visible.map((env, idx) => {
+                    const deployment = deploymentStatus[env.slug]
+                    const color = env.label_color
+                    const ciDot = renderCiDot(deployment.ciStatus)
+                    // Release-train conventions, by position only — no
+                    // hardcoded env names:
+                    //   idx 0   — entry point, Deploy a chosen commit
+                    //   idx 1   — Promote (tag + release the idx-0 build)
+                    //   idx 2+  — Deploy: re-roll whatever was tagged at
+                    //             idx 1 to a downstream env
+                    const isPromoteSlot = idx === 1
+                    const previousSlug = isPromoteSlot
+                      ? visible[0].slug
+                      : undefined
+                    const handleClick = isPromoteSlot
+                      ? () => openPromote(previousSlug as string, env.slug)
+                      : () => openDeploy(env.slug)
+                    const tooltipText = isPromoteSlot
+                      ? 'Promote'
+                      : 'Deploy / Redeploy'
+                    const chipBody = color ? (
+                      <LabelChip
+                        className="rounded-md px-3 py-1.5 text-sm"
+                        hex={color}
+                      >
+                        <span className="inline-flex items-center gap-1.5">
+                          {env.name}: {deployment.version}
+                          {ciDot}
+                        </span>
+                      </LabelChip>
+                    ) : (
+                      <span className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium">
+                        {env.name}: {deployment.version}
+                        {ciDot}
+                      </span>
+                    )
+                    return (
+                      <span className="contents" key={env.slug}>
+                        {idx > 0 && (
+                          <ArrowRight className="h-4 w-4 text-tertiary" />
+                        )}
+                        {canTriggerDeployments ? (
+                          <TooltipProvider delayDuration={200}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  aria-label={
+                                    isPromoteSlot
+                                      ? `Promote ${previousSlug} to ${env.name}`
+                                      : `Deploy to ${env.name}`
+                                  }
+                                  className="cursor-pointer rounded-md transition hover:shadow-md hover:ring-1 hover:ring-ring hover:ring-offset-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                  onClick={handleClick}
+                                  type="button"
+                                >
+                                  {chipBody}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>{tooltipText}</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        ) : (
+                          chipBody
+                        )}
+                      </span>
+                    )
+                  })
+                })()}
+            </div>
+            {deploymentPlugin && (
+              <div className="flex items-center gap-1.5 text-xs italic text-tertiary">
+                <Info className="h-3.5 w-3.5" />
+                <span>
+                  {canTriggerDeployments
+                    ? 'Click on an environment to deploy to it'
+                    : `Connect to ${deploymentConnectLabel} to enable deployments`}
+                </span>
+              </div>
+            )}
           </div>
         </div>
 
@@ -827,20 +932,53 @@ export function ProjectDetail({
           <ProjectSettingsTab project={project} />
         </TabsContent>
       </Tabs>
-      <DeploymentModal
+      <DeployModal
         environments={sortedEnvironments}
-        initialEnvSlug={deployModal.envSlug}
-        initialTab={deployModal.tab}
-        onOpenChange={(open) => setDeployModal((prev) => ({ ...prev, open }))}
+        initialEnvSlug={isDeployModal ? initialSubId : undefined}
+        onOpenChange={(open) => {
+          if (!open) closeModal()
+        }}
         onRunStarted={handleRunStarted}
-        open={deployModal.open}
+        open={isDeployModal}
         orgSlug={orgSlug}
         projectId={project.id}
         projectName={project.name}
-        promoteFrom={deployModal.promoteFrom}
-        promoteFromCommittish={deployModal.promoteFromCommittish}
-        promoteTo={deployModal.promoteTo}
       />
+      {isPromoteModal &&
+      (() => {
+        const toIdx = sortedEnvironments.findIndex(
+          (e) => e.slug === initialSubId,
+        )
+        // Promote requires a previous env in the pipeline to act as the
+        // source. ``idx <= 0`` means the URL points at the entry-point
+        // env (or an unknown one); fall back to the clean URL.
+        return toIdx > 0
+      })() ? (
+        <PromoteModal
+          environments={sortedEnvironments}
+          fromCommittish={(() => {
+            const toIdx = sortedEnvironments.findIndex(
+              (e) => e.slug === initialSubId,
+            )
+            const fromSlug = sortedEnvironments[toIdx - 1]?.slug
+            return fromSlug ? deploymentStatus[fromSlug]?.version : undefined
+          })()}
+          fromEnvironment={
+            sortedEnvironments[
+              sortedEnvironments.findIndex((e) => e.slug === initialSubId) - 1
+            ].slug
+          }
+          onOpenChange={(open) => {
+            if (!open) closeModal()
+          }}
+          onRunStarted={handleRunStarted}
+          open={isPromoteModal}
+          orgSlug={orgSlug}
+          projectId={project.id}
+          projectName={project.name}
+          toEnvironment={initialSubId as string}
+        />
+      ) : null}
       {activeRuns.map((run) => (
         // Bind each watcher to the org/project that triggered the run
         // so polling stays correct if the user navigates to another

--- a/src/components/admin/PluginPackageDetail.tsx
+++ b/src/components/admin/PluginPackageDetail.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, RotateCcw } from 'lucide-react'
+import { ArrowLeft, CirclePlay, PowerOff, RotateCcw } from 'lucide-react'
 import { toast } from 'sonner'
 
 import {
   type AdminPluginPatch,
   getAdminPlugin,
+  setAdminPluginEnabled,
   updateAdminPlugin,
 } from '@/api/endpoints'
 import { Badge } from '@/components/ui/badge'
@@ -18,6 +19,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
 import { LoadingState } from '@/components/ui/loading-state'
@@ -75,6 +77,7 @@ export function PluginPackageDetail({
 
   const [widgetText, setWidgetText] = useState('')
   const [vertexForm, setVertexForm] = useState<VertexFormMap>({})
+  const [confirmDisableOpen, setConfirmDisableOpen] = useState(false)
 
   // Initialize on first arrival, then again only when the server-known
   // override actually changes — otherwise a background refetch would
@@ -139,6 +142,21 @@ export function PluginPackageDetail({
     },
   })
 
+  const enabledMutation = useMutation({
+    mutationFn: (enabled: boolean) => setAdminPluginEnabled(slug, enabled),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to update plugin state')
+    },
+    onSuccess: (data, enabled) => {
+      toast.success(enabled ? `${slug} enabled` : `${slug} disabled`)
+      queryClient.setQueryData(queryKeys.adminPlugin(slug), data)
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.adminPlugins(),
+      })
+      setConfirmDisableOpen(false)
+    },
+  })
+
   if (pluginQuery.isLoading) {
     return <LoadingState label="Loading plugin…" />
   }
@@ -193,7 +211,7 @@ export function PluginPackageDetail({
 
       <Card>
         <CardHeader>
-          <div className="flex items-start justify-between">
+          <div className="flex items-start justify-between gap-4">
             <div>
               <CardTitle className="text-xl">{plugin.name}</CardTitle>
               <CardDescription>{plugin.description}</CardDescription>
@@ -208,6 +226,29 @@ export function PluginPackageDetail({
                   {plugin.enabled ? 'Enabled' : 'Disabled'}
                 </Badge>
               </div>
+            </div>
+            <div className="shrink-0">
+              {plugin.enabled ? (
+                <Button
+                  disabled={enabledMutation.isPending}
+                  onClick={() => setConfirmDisableOpen(true)}
+                  size="sm"
+                  variant="outline"
+                >
+                  <PowerOff className="mr-1 h-3.5 w-3.5" />
+                  Disable
+                </Button>
+              ) : (
+                <Button
+                  disabled={enabledMutation.isPending}
+                  onClick={() => enabledMutation.mutate(true)}
+                  size="sm"
+                  variant="outline"
+                >
+                  <CirclePlay className="mr-1 h-3.5 w-3.5" />
+                  Enable
+                </Button>
+              )}
             </div>
           </div>
         </CardHeader>
@@ -392,6 +433,17 @@ export function PluginPackageDetail({
           </CardContent>
         </Card>
       ))}
+
+      <ConfirmDialog
+        confirmLabel="Disable"
+        description={`Disable ${plugin.name}? It will no longer be available for new project type or service assignments. Existing configuration is preserved and the plugin can be re-enabled at any time.`}
+        onCancel={() => {
+          if (!enabledMutation.isPending) setConfirmDisableOpen(false)
+        }}
+        onConfirm={() => enabledMutation.mutate(false)}
+        open={confirmDisableOpen}
+        title="Disable plugin"
+      />
     </div>
   )
 }

--- a/src/components/admin/PluginsManagement.tsx
+++ b/src/components/admin/PluginsManagement.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ChevronRight, CirclePlay, Package } from 'lucide-react'
+import { ChevronRight, CirclePlay, Package, PowerOff } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { getAdminPlugins, setAdminPluginEnabled } from '@/api/endpoints'
@@ -16,6 +16,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { LoadingState } from '@/components/ui/loading-state'
 import {
   Table,
@@ -199,6 +200,27 @@ function DisabledList({ parentLoading, plugins }: DisabledListProps) {
 
 function EnabledList({ error, isError, isLoading, plugins }: EnabledListProps) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [pluginToDisable, setPluginToDisable] =
+    useState<InstalledPlugin | null>(null)
+
+  const disableMutation = useMutation({
+    mutationFn: (slug: string) => setAdminPluginEnabled(slug, false),
+    onError: (err) => {
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to disable plugin')
+    },
+    onSuccess: (_, slug) => {
+      toast.success(`${slug} disabled`)
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.adminPlugins(),
+      })
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.adminPlugin(slug),
+      })
+      setPluginToDisable(null)
+    },
+  })
+
   if (isLoading) {
     return <LoadingState label="Loading..." />
   }
@@ -229,71 +251,104 @@ function EnabledList({ error, isError, isLoading, plugins }: EnabledListProps) {
   }
 
   return (
-    <Card>
-      <CardContent className="p-0">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Plugin</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead>Package</TableHead>
-              <TableHead>Version</TableHead>
-              <TableHead>Auth</TableHead>
-              <TableHead>Tabs</TableHead>
-              <TableHead className="w-10" />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {plugins.map((plugin) => (
-              <TableRow
-                className="hover:bg-secondary/40 cursor-pointer"
-                key={plugin.slug}
-                onClick={() => navigate(`/admin/plugins/${plugin.slug}`)}
-              >
-                <TableCell>
-                  <div className="font-medium">{plugin.name}</div>
-                  <div className="text-xs text-secondary">
-                    {plugin.description}
-                  </div>
-                  {plugin.login_capable && (
-                    <div className="mt-1">
-                      <Badge variant="outline">Login provider</Badge>
-                    </div>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Badge variant="secondary">
-                    {plugin.plugin_type ?? plugin.supported_tabs[0] ?? '—'}
-                  </Badge>
-                </TableCell>
-                <TableCell>
-                  <code className="rounded bg-secondary px-1.5 py-0.5 text-xs">
-                    {plugin.package_name}
-                  </code>
-                </TableCell>
-                <TableCell className="text-sm text-secondary">
-                  {plugin.package_version}
-                </TableCell>
-                <TableCell>
-                  <Badge variant="secondary">{plugin.auth_type}</Badge>
-                </TableCell>
-                <TableCell>
-                  <div className="flex gap-1">
-                    {plugin.supported_tabs.map((tab) => (
-                      <Badge key={tab} variant="secondary">
-                        {tab}
-                      </Badge>
-                    ))}
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <ChevronRight className="h-4 w-4 text-tertiary" />
-                </TableCell>
+    <>
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Plugin</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Package</TableHead>
+                <TableHead>Version</TableHead>
+                <TableHead>Auth</TableHead>
+                <TableHead>Tabs</TableHead>
+                <TableHead className="w-28" />
+                <TableHead className="w-10" />
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </CardContent>
-    </Card>
+            </TableHeader>
+            <TableBody>
+              {plugins.map((plugin) => (
+                <TableRow
+                  className="hover:bg-secondary/40 cursor-pointer"
+                  key={plugin.slug}
+                  onClick={() => navigate(`/admin/plugins/${plugin.slug}`)}
+                >
+                  <TableCell>
+                    <div className="font-medium">{plugin.name}</div>
+                    <div className="text-xs text-secondary">
+                      {plugin.description}
+                    </div>
+                    {plugin.login_capable && (
+                      <div className="mt-1">
+                        <Badge variant="outline">Login provider</Badge>
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">
+                      {plugin.plugin_type ?? plugin.supported_tabs[0] ?? '—'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <code className="rounded bg-secondary px-1.5 py-0.5 text-xs">
+                      {plugin.package_name}
+                    </code>
+                  </TableCell>
+                  <TableCell className="text-sm text-secondary">
+                    {plugin.package_version}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">{plugin.auth_type}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex gap-1">
+                      {plugin.supported_tabs.map((tab) => (
+                        <Badge key={tab} variant="secondary">
+                          {tab}
+                        </Badge>
+                      ))}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      disabled={disableMutation.isPending}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setPluginToDisable(plugin)
+                      }}
+                      size="sm"
+                      variant="outline"
+                    >
+                      <PowerOff className="mr-1 h-3 w-3" />
+                      Disable
+                    </Button>
+                  </TableCell>
+                  <TableCell>
+                    <ChevronRight className="h-4 w-4 text-tertiary" />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <ConfirmDialog
+        confirmLabel="Disable"
+        description={
+          pluginToDisable
+            ? `Disable ${pluginToDisable.name}? It will no longer be available for new project type or service assignments. Existing configuration is preserved and the plugin can be re-enabled at any time.`
+            : ''
+        }
+        onCancel={() => {
+          if (!disableMutation.isPending) setPluginToDisable(null)
+        }}
+        onConfirm={() => {
+          if (pluginToDisable) disableMutation.mutate(pluginToDisable.slug)
+        }}
+        open={pluginToDisable !== null}
+        title="Disable plugin"
+      />
+    </>
   )
 }

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Plus, Trash2 } from 'lucide-react'
+import { ChevronDown, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 
 import {
@@ -25,6 +26,12 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { LoadingState } from '@/components/ui/loading-state'
@@ -751,6 +758,14 @@ function ProjectTypesCard({
 }: ProjectTypesCardProps) {
   const [drafts, setDrafts] = useState<DraftAssignment[]>([])
   const [seedHash, setSeedHash] = useState<null | string>(null)
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+  const toggleExpanded = (idx: number) =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(idx)) next.delete(idx)
+      else next.add(idx)
+      return next
+    })
 
   const { data: existing } = useQuery({
     queryFn: ({ signal }) =>
@@ -834,22 +849,34 @@ function ProjectTypesCard({
   const supportedTab = (manifest?.supported_tabs[0] ??
     'configuration') as PluginTab
 
-  const handleAdd = () => {
-    if (!remainingPts.length) return
-    setDrafts((prev) => [
-      ...prev,
-      {
-        default: false,
-        identity_plugin_id: null,
-        options: {},
-        project_type_slug: remainingPts[0].slug,
-        tab: supportedTab,
-      },
-    ])
+  const handleAdd = (slug: string) => {
+    setDrafts((prev) => {
+      if (prev.some((d) => d.project_type_slug === slug)) return prev
+      return [
+        ...prev,
+        {
+          default: true,
+          identity_plugin_id: null,
+          options: {},
+          project_type_slug: slug,
+          tab: supportedTab,
+        },
+      ]
+    })
   }
 
   const handleRemove = (idx: number) => {
     setDrafts((prev) => prev.filter((_, i) => i !== idx))
+    setExpanded((prev) => {
+      const next = new Set<number>()
+      // Indices shift left by 1 once we drop ``idx``; rebuild the set
+      // accordingly so a different row doesn't suddenly appear expanded.
+      for (const i of prev) {
+        if (i === idx) continue
+        next.add(i > idx ? i - 1 : i)
+      }
+      return next
+    })
   }
 
   const updateDraft = (idx: number, patch: Partial<DraftAssignment>) => {
@@ -896,15 +923,28 @@ function ProjectTypesCard({
               {saveMutation.isPending ? 'Saving…' : 'Save'}
             </Button>
           )}
-          <Button
-            disabled={remainingPts.length === 0}
-            onClick={handleAdd}
-            size="sm"
-            variant="outline"
-          >
-            <Plus className="mr-1 h-3 w-3" />
-            Add
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                disabled={remainingPts.length === 0}
+                size="sm"
+                variant="outline"
+              >
+                <Plus className="mr-1 h-3 w-3" />
+                Add
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="max-h-72 overflow-auto">
+              {remainingPts.map((pt) => (
+                <DropdownMenuItem
+                  key={pt.slug}
+                  onSelect={() => handleAdd(pt.slug)}
+                >
+                  {pt.name}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </CardHeader>
       <CardContent className="px-6 pb-6">
@@ -918,116 +958,123 @@ function ProjectTypesCard({
             <TableHeader>
               <TableRow>
                 <TableHead>Project Type</TableHead>
-                <TableHead>Tab</TableHead>
-                <TableHead>Default</TableHead>
-                <TableHead>Identity Plugin</TableHead>
-                <TableHead>Option Overrides</TableHead>
+                <TableHead className="w-24">Default</TableHead>
+                <TableHead className="w-12" />
                 <TableHead className="w-12" />
               </TableRow>
             </TableHeader>
             <TableBody>
               {drafts.map((draft, idx) => {
-                const usedSlugs = new Set(
-                  drafts
-                    .filter((_, i) => i !== idx)
-                    .map((d) => d.project_type_slug),
-                )
-                const ptOptions = (projectTypes ?? []).filter(
-                  (pt) =>
-                    pt.slug === draft.project_type_slug ||
-                    !usedSlugs.has(pt.slug),
-                )
+                const isExpanded = expanded.has(idx)
+                // Override count = identity-plugin override (if set) + each
+                // explicitly overridden option field. The identity selector
+                // lives inside the accordion now, so the row is always
+                // expandable even when the manifest has no option fields.
+                const overrideCount =
+                  Object.keys(draft.options).length +
+                  (draft.identity_plugin_id ? 1 : 0)
                 return (
-                  <TableRow key={`${draft.project_type_slug}-${idx}`}>
-                    <TableCell className="align-top">
-                      <Select
-                        onValueChange={(v) =>
-                          updateDraft(idx, { project_type_slug: v })
-                        }
-                        value={draft.project_type_slug}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select…">
-                            {ptByName.get(draft.project_type_slug) ??
-                              draft.project_type_slug}
-                          </SelectValue>
-                        </SelectTrigger>
-                        <SelectContent>
-                          {ptOptions.map((pt) => (
-                            <SelectItem key={pt.slug} value={pt.slug}>
-                              {pt.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </TableCell>
-                    <TableCell className="align-top">
-                      <Badge variant="secondary">{draft.tab}</Badge>
-                    </TableCell>
-                    <TableCell className="align-top">
-                      <input
-                        checked={draft.default}
-                        onChange={(e) =>
-                          updateDraft(idx, { default: e.target.checked })
-                        }
-                        type="checkbox"
-                      />
-                    </TableCell>
-                    <TableCell className="align-top">
-                      <IdentityPluginSelect
-                        identityPlugins={identityPlugins ?? []}
-                        onChange={(next) =>
-                          updateDraft(idx, { identity_plugin_id: next })
-                        }
-                        value={draft.identity_plugin_id ?? null}
-                      />
-                    </TableCell>
-                    <TableCell className="align-top">
-                      {(manifest?.options ?? []).length === 0 ? (
-                        <span className="text-xs text-secondary">—</span>
-                      ) : (
-                        <div className="space-y-2">
-                          {(manifest?.options ?? []).map((opt) => {
-                            const defaultVal =
-                              plugin.options[opt.name] ?? opt.default ?? null
-                            const overridden = opt.name in draft.options
-                            return (
-                              <OptionRow
-                                description={null}
-                                key={opt.name}
-                                label={opt.label}
-                                name={`${opt.name}-${idx}`}
+                  <React.Fragment key={`${draft.project_type_slug}-${idx}`}>
+                    <TableRow
+                      aria-expanded={isExpanded}
+                      className="hover:bg-secondary/40 cursor-pointer"
+                      onClick={() => toggleExpanded(idx)}
+                    >
+                      <TableCell className="align-middle">
+                        <span className="text-sm">
+                          {ptByName.get(draft.project_type_slug) ??
+                            draft.project_type_slug}
+                        </span>
+                      </TableCell>
+                      <TableCell className="align-middle">
+                        <input
+                          checked={draft.default}
+                          onChange={(e) =>
+                            updateDraft(idx, { default: e.target.checked })
+                          }
+                          onClick={(e) => e.stopPropagation()}
+                          type="checkbox"
+                        />
+                      </TableCell>
+                      <TableCell className="align-middle">
+                        <span className="relative inline-flex items-center">
+                          <ChevronDown
+                            className={`h-3.5 w-3.5 text-tertiary transition-transform ${
+                              isExpanded ? 'rotate-180' : ''
+                            }`}
+                          />
+                          {overrideCount > 0 && (
+                            <Badge
+                              className="ml-1 h-4 px-1 text-[10px]"
+                              variant="secondary"
+                            >
+                              {overrideCount}
+                            </Badge>
+                          )}
+                        </span>
+                      </TableCell>
+                      <TableCell className="align-middle">
+                        <Button
+                          aria-label="Remove assignment"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleRemove(idx)
+                          }}
+                          size="icon"
+                          variant="ghost"
+                        >
+                          <Trash2 className="h-3 w-3 text-destructive" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                    {isExpanded && (
+                      <TableRow className="bg-secondary/30 hover:bg-secondary/30">
+                        <TableCell className="p-0" colSpan={4}>
+                          <div className="space-y-3 px-6 py-4">
+                            <div className="grid grid-cols-[160px_1fr] items-center gap-3">
+                              <Label className="text-sm">Identity Plugin</Label>
+                              <IdentityPluginSelect
+                                identityPlugins={identityPlugins ?? []}
                                 onChange={(next) =>
-                                  updateOverride(idx, opt.name, next)
+                                  updateDraft(idx, {
+                                    identity_plugin_id: next,
+                                  })
                                 }
-                                opt={opt}
-                                placeholder={
-                                  overridden
-                                    ? undefined
-                                    : defaultVal !== null
-                                      ? `Inherits: ${String(defaultVal)}`
-                                      : 'Inherits default'
-                                }
-                                value={
-                                  overridden ? draft.options[opt.name] : ''
-                                }
+                                value={draft.identity_plugin_id ?? null}
                               />
-                            )
-                          })}
-                        </div>
-                      )}
-                    </TableCell>
-                    <TableCell className="align-top">
-                      <Button
-                        aria-label="Remove assignment"
-                        onClick={() => handleRemove(idx)}
-                        size="icon"
-                        variant="ghost"
-                      >
-                        <Trash2 className="h-3 w-3 text-destructive" />
-                      </Button>
-                    </TableCell>
-                  </TableRow>
+                            </div>
+                            {(manifest?.options ?? []).map((opt) => {
+                              const defaultVal =
+                                plugin.options[opt.name] ?? opt.default ?? null
+                              const overridden = opt.name in draft.options
+                              return (
+                                <OptionRow
+                                  description={null}
+                                  key={opt.name}
+                                  label={opt.label}
+                                  name={`${opt.name}-${idx}`}
+                                  onChange={(next) =>
+                                    updateOverride(idx, opt.name, next)
+                                  }
+                                  opt={opt}
+                                  placeholder={
+                                    overridden
+                                      ? undefined
+                                      : defaultVal !== null
+                                        ? `Inherits: ${String(defaultVal)}`
+                                        : 'Inherits default'
+                                  }
+                                  value={
+                                    overridden ? draft.options[opt.name] : ''
+                                  }
+                                />
+                              )
+                            })}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </React.Fragment>
                 )
               })}
             </TableBody>

--- a/src/components/admin/third-party-services/ServicePluginList.tsx
+++ b/src/components/admin/third-party-services/ServicePluginList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { AlertTriangle, Plus, Trash2 } from 'lucide-react'
+import { AlertTriangle, ChevronRight, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 
 import {
@@ -201,12 +201,17 @@ export function ServicePluginList({
                   <TableHead>Plugin</TableHead>
                   <TableHead>Version</TableHead>
                   <TableHead>Status</TableHead>
-                  <TableHead className="w-20" />
+                  <TableHead className="w-12" />
+                  <TableHead className="w-12" />
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {(plugins ?? []).map((plugin) => (
-                  <TableRow key={plugin.id}>
+                  <TableRow
+                    className="hover:bg-secondary/40 cursor-pointer"
+                    key={plugin.id}
+                    onClick={() => setConfigurePluginId(plugin.id)}
+                  >
                     <TableCell className="font-medium">
                       {plugin.label}
                     </TableCell>
@@ -232,23 +237,20 @@ export function ServicePluginList({
                       )}
                     </TableCell>
                     <TableCell>
-                      <div className="flex justify-end gap-1">
-                        <Button
-                          onClick={() => setConfigurePluginId(plugin.id)}
-                          size="sm"
-                          variant="ghost"
-                        >
-                          Configure
-                        </Button>
-                        <Button
-                          aria-label={`Remove ${plugin.label}`}
-                          onClick={() => setConfirmDeleteId(plugin.id)}
-                          size="icon"
-                          variant="ghost"
-                        >
-                          <Trash2 className="h-3 w-3 text-destructive" />
-                        </Button>
-                      </div>
+                      <Button
+                        aria-label={`Remove ${plugin.label}`}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setConfirmDeleteId(plugin.id)
+                        }}
+                        size="icon"
+                        variant="ghost"
+                      >
+                        <Trash2 className="h-3 w-3 text-destructive" />
+                      </Button>
+                    </TableCell>
+                    <TableCell>
+                      <ChevronRight className="h-4 w-4 text-tertiary" />
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -17,7 +17,6 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { LoadingState } from '@/components/ui/loading-state'
 import { extractApiErrorDetail } from '@/lib/apiError'
-import { ciStatusDotClass } from '@/lib/status-colors'
 import { cn, sortEnvironments } from '@/lib/utils'
 import type {
   CurrentReleaseEnvironment,
@@ -53,18 +52,10 @@ export function DeployTab({
   projectId,
 }: DeployTabProps) {
   const sorted = useMemo(() => sortEnvironments(environments), [environments])
-  const [envSlug, setEnvSlug] = useState<string>(
-    initialEnvSlug ?? sorted[sorted.length - 1]?.slug ?? '',
-  )
-  useEffect(() => {
-    // Reset to the requested env whenever the modal is reopened with
-    // a different chip.  ``envSlug`` is intentionally excluded — listing
-    // it would re-snap to ``initialEnvSlug`` after the user picks
-    // another env card.
-    if (initialEnvSlug && initialEnvSlug !== envSlug) setEnvSlug(initialEnvSlug)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialEnvSlug])
-
+  // Env is locked at modal open time — the URL ``/deploy/<env>`` carries
+  // the target, and re-deploys are scoped to that single env. No picker
+  // is rendered; users navigate to a different chip to change env.
+  const envSlug = initialEnvSlug ?? sorted[0]?.slug ?? ''
   const env = sorted.find((e) => e.slug === envSlug) ?? sorted[0]
 
   const { data: currentReleases = [] } = useQuery<CurrentReleaseEnvironment[]>({
@@ -72,12 +63,13 @@ export function DeployTab({
     queryFn: ({ signal }) => listCurrentReleases(orgSlug, projectId, signal),
     queryKey: ['currentReleases', orgSlug, projectId],
   })
-  const currentByEnv = useMemo(() => {
-    const map = new Map<string, CurrentReleaseEnvironment>()
-    for (const row of currentReleases) map.set(row.environment.slug, row)
-    return map
-  }, [currentReleases])
-  const current = env ? currentByEnv.get(env.slug) : undefined
+  const current = useMemo(
+    () =>
+      env
+        ? currentReleases.find((r) => r.environment.slug === env.slug)
+        : undefined,
+    [currentReleases, env],
+  )
 
   // For the first env (e.g. Testing) we list commits on the default
   // branch.  For staging / production we list tags.
@@ -255,62 +247,44 @@ export function DeployTab({
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Step 1 — environment pickers */}
+      {/* Locked target environment */}
       <section>
         <p className="mb-2 text-xs uppercase tracking-wider text-tertiary">
-          Step 1 — Environment
+          Environment
         </p>
-        <div className="grid grid-cols-3 gap-2">
-          {sorted.map((e) => {
-            const row = currentByEnv.get(e.slug)
-            const active = e.slug === envSlug
-            return (
-              <button
-                className={cn(
-                  'rounded-md border p-3 text-left transition-colors',
-                  active
-                    ? 'border-action bg-action/5'
-                    : 'border-secondary hover:bg-tertiary/30',
-                )}
-                key={e.slug}
-                onClick={() => setEnvSlug(e.slug)}
-                type="button"
-              >
-                <div className="text-sm font-medium">{e.name}</div>
-                <div className="mt-1 text-xs text-tertiary">
-                  {row?.release ? (
-                    <>
-                      <span className="font-mono">{row.release.version}</span>
-                      {row.last_event_at ? (
-                        <>
-                          {' · '}
-                          {formatDistanceToNow(new Date(row.last_event_at), {
-                            addSuffix: true,
-                          })}
-                        </>
-                      ) : null}
-                    </>
-                  ) : (
-                    'not deployed'
-                  )}
-                </div>
-              </button>
-            )
-          })}
+        <div className="bg-action/5 rounded-md border border-action p-3">
+          <div className="text-sm font-medium">{env?.name ?? envSlug}</div>
+          <div className="mt-1 text-xs text-tertiary">
+            {current?.release ? (
+              <>
+                <span className="font-mono">{current.release.version}</span>
+                {current.last_event_at ? (
+                  <>
+                    {' · '}
+                    {formatDistanceToNow(new Date(current.last_event_at), {
+                      addSuffix: true,
+                    })}
+                  </>
+                ) : null}
+              </>
+            ) : (
+              'not deployed'
+            )}
+          </div>
         </div>
       </section>
 
-      {/* Step 2 — version picker */}
+      {/* Version picker */}
       <section className="min-h-[180px]">
         <div className="mb-2 flex items-center justify-between">
           <p className="text-xs uppercase tracking-wider text-tertiary">
             {isFirstEnv
               ? showBranchPane
                 ? activeBranch
-                  ? `Step 2 — Commit on ${activeBranch}`
-                  : 'Step 2 — Pick a branch'
-                : `Step 2 — Commit on ${defaultBranchName}`
-              : 'Step 2 — Tag'}
+                  ? `Commit on ${activeBranch}`
+                  : 'Pick a branch'
+                : `Commit on ${defaultBranchName}`
+              : 'Tag'}
           </p>
           {isFirstEnv ? (
             <PickerToggle
@@ -375,7 +349,7 @@ export function DeployTab({
       ) : null}
 
       {/* Footer */}
-      <div className="bg-secondary/30 -mx-6 -mb-6 mt-2 flex items-center justify-end gap-2 border-t border-tertiary px-6 py-3">
+      <div className="bg-secondary/30 -mx-6 -mb-4 mt-2 flex items-center justify-end gap-2 border-t border-tertiary px-6 py-4">
         <Button onClick={onClose} type="button" variant="ghost">
           Cancel
         </Button>
@@ -453,11 +427,13 @@ function BranchPicker({
                   key={b.name}
                 >
                   <button
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left"
+                    className="flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left"
                     onClick={() => onBranchSelect(b.name)}
                     type="button"
                   >
-                    <span className="flex-1 truncate text-sm">{b.name}</span>
+                    <span className="min-w-0 flex-1 truncate text-sm">
+                      {b.name}
+                    </span>
                     {b.pr_number ? (
                       <Badge variant="outline">#{b.pr_number}</Badge>
                     ) : null}
@@ -516,25 +492,20 @@ function CommitList({
         return (
           <li
             className={cn(
-              'flex items-center gap-3 border-b border-tertiary px-3 py-2 last:border-b-0',
+              'flex min-w-0 items-center gap-3 border-b border-tertiary px-3 py-2 last:border-b-0',
               active && 'bg-action/5',
             )}
             key={c.sha}
           >
             <button
-              className="flex flex-1 items-center gap-3 text-left"
+              className="flex min-w-0 flex-1 items-center gap-3 text-left"
               onClick={() => onSelect(c)}
               type="button"
             >
-              <span
-                aria-label={`CI ${c.ci_status}`}
-                className={cn(
-                  'inline-block h-2 w-2 rounded-full',
-                  ciStatusDotClass(c.ci_status),
-                )}
-              />
-              <span className="font-mono text-xs">{c.short_sha}</span>
-              <span className="flex-1 truncate text-sm">{c.message}</span>
+              <span className="shrink-0 font-mono text-xs">{c.short_sha}</span>
+              <span className="min-w-0 flex-1 truncate text-sm">
+                {c.message}
+              </span>
               <span className="shrink-0 text-xs text-tertiary">{c.author}</span>
               {c.is_head ? <Badge variant="outline">HEAD</Badge> : null}
               {isCurrent ? <Badge variant="neutral">current</Badge> : null}

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -55,8 +55,12 @@ export function DeployTab({
   // Env is locked at modal open time — the URL ``/deploy/<env>`` carries
   // the target, and re-deploys are scoped to that single env. No picker
   // is rendered; users navigate to a different chip to change env.
-  const envSlug = initialEnvSlug ?? sorted[0]?.slug ?? ''
-  const env = sorted.find((e) => e.slug === envSlug) ?? sorted[0]
+  // Resolve the env first so a stale ``initialEnvSlug`` falls back to the
+  // first env *and* the slug used to display / dispatch matches.
+  const env = initialEnvSlug
+    ? (sorted.find((e) => e.slug === initialEnvSlug) ?? sorted[0])
+    : sorted[0]
+  const envSlug = env?.slug ?? ''
 
   const { data: currentReleases = [] } = useQuery<CurrentReleaseEnvironment[]>({
     enabled: open && !!orgSlug && !!projectId,

--- a/src/components/deploy/DeploymentModal.tsx
+++ b/src/components/deploy/DeploymentModal.tsx
@@ -1,7 +1,6 @@
 import { GitMerge, Rocket } from 'lucide-react'
 
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { cn } from '@/lib/utils'
 import type { DeploymentRunStatus, Environment } from '@/types'
 
 import { DeployTab } from './DeployTab'
@@ -35,12 +34,9 @@ export interface DeploymentRunStarted {
   toastId: number | string
 }
 
-export type DeployModalTab = 'deploy' | 'promote'
-
-interface DeploymentModalProps {
+interface DeployModalProps {
   environments: Environment[]
   initialEnvSlug?: string
-  initialTab?: DeployModalTab
   onOpenChange: (open: boolean) => void
   /**
    * Called after a successful trigger so the parent can mount a
@@ -52,109 +48,109 @@ interface DeploymentModalProps {
   orgSlug: string
   projectId: string
   projectName: string
-  // Promote-tab inputs.  When set together with initialTab='promote'
-  // the modal opens directly into the Promote flow with the gap
-  // pre-selected (via the popover hand-off) or the testing → next-env
-  // gap inferred from the chip click.
-  promoteFrom?: null | string
-  promoteFromCommittish?: null | string
-  promoteTo?: null | string
 }
 
-export function DeploymentModal({
+interface PromoteModalProps {
+  environments: Environment[]
+  fromCommittish?: null | string
+  fromEnvironment: string
+  onOpenChange: (open: boolean) => void
+  onRunStarted?: (run: DeploymentRunStarted) => void
+  open: boolean
+  orgSlug: string
+  projectId: string
+  projectName: string
+  toEnvironment: string
+}
+
+export function DeployModal({
   environments,
   initialEnvSlug,
-  initialTab = 'deploy',
   onOpenChange,
   onRunStarted,
   open,
   orgSlug,
   projectId,
   projectName,
-  promoteFrom,
-  promoteFromCommittish,
-  promoteTo,
-}: DeploymentModalProps) {
-  const isPromote = initialTab === 'promote' && !!promoteFrom && !!promoteTo
+}: DeployModalProps) {
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-[680px] gap-0 p-0 sm:max-w-[680px]">
-        <header className="flex items-stretch border-b border-secondary px-6">
-          <DialogTitle className="sr-only">
-            {isPromote ? `Promote ${projectName}` : `Deploy ${projectName}`}
-          </DialogTitle>
-          <TabHeader
-            active={!isPromote}
-            icon={<Rocket className="h-4 w-4" />}
-            subtitle="existing version"
-            title="Deploy"
-          />
-          <TabHeader
-            active={isPromote}
-            icon={<GitMerge className="h-4 w-4" />}
-            subtitle="tag & release notes"
-            title="Promote"
-          />
-        </header>
+      <DialogContent className="max-w-[920px] gap-0 p-0 sm:max-w-[920px]">
+        <ModalHeader
+          icon={<Rocket className="h-4 w-4" />}
+          subtitle="Roll an existing commit or tag onto an environment"
+          title={`Deploy ${projectName}`}
+        />
         <div className="px-6 py-4">
-          {isPromote ? (
-            <PromoteTab
-              environments={environments}
-              fromCommittish={promoteFromCommittish}
-              fromEnvironment={promoteFrom}
-              onClose={() => onOpenChange(false)}
-              onRunStarted={onRunStarted}
-              open={open}
-              orgSlug={orgSlug}
-              projectId={projectId}
-              toEnvironment={promoteTo}
-            />
-          ) : (
-            <DeployTab
-              environments={environments}
-              initialEnvSlug={initialEnvSlug}
-              onClose={() => onOpenChange(false)}
-              onRunStarted={onRunStarted}
-              open={open}
-              orgSlug={orgSlug}
-              projectId={projectId}
-            />
-          )}
+          <DeployTab
+            environments={environments}
+            initialEnvSlug={initialEnvSlug}
+            onClose={() => onOpenChange(false)}
+            onRunStarted={onRunStarted}
+            open={open}
+            orgSlug={orgSlug}
+            projectId={projectId}
+          />
         </div>
       </DialogContent>
     </Dialog>
   )
 }
 
-function TabHeader({
-  active,
+export function PromoteModal({
+  environments,
+  fromCommittish,
+  fromEnvironment,
+  onOpenChange,
+  onRunStarted,
+  open,
+  orgSlug,
+  projectId,
+  projectName,
+  toEnvironment,
+}: PromoteModalProps) {
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-[920px] gap-0 p-0 sm:max-w-[920px]">
+        <ModalHeader
+          icon={<GitMerge className="h-4 w-4" />}
+          subtitle={`Tag & release ${fromEnvironment} → ${toEnvironment}`}
+          title={`Promote ${projectName}`}
+        />
+        <div className="px-6 py-4">
+          <PromoteTab
+            environments={environments}
+            fromCommittish={fromCommittish}
+            fromEnvironment={fromEnvironment}
+            onClose={() => onOpenChange(false)}
+            onRunStarted={onRunStarted}
+            open={open}
+            orgSlug={orgSlug}
+            projectId={projectId}
+            toEnvironment={toEnvironment}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ModalHeader({
   icon,
   subtitle,
   title,
 }: {
-  active: boolean
   icon: React.ReactNode
   subtitle: string
   title: string
 }) {
-  // Headers are presentational — the modal mode is fixed by props at
-  // mount time, so mark non-active headers as disabled to make that
-  // unambiguous to assistive tech and keyboard users.
   return (
-    <div
-      aria-current={active ? 'page' : undefined}
-      aria-disabled={!active}
-      className={cn(
-        'flex flex-col py-4 pr-6 text-sm',
-        active ? '-mb-px border-b-2 border-action' : 'text-tertiary opacity-60',
-      )}
-      role="presentation"
-    >
-      <span className="flex items-center gap-1.5 font-medium">
+    <header className="border-b border-secondary px-6 py-4">
+      <DialogTitle className="flex items-center gap-1.5 text-sm font-medium">
         {icon}
         {title}
-      </span>
-      <span className="mt-0.5 text-xs">{subtitle}</span>
-    </div>
+      </DialogTitle>
+      <p className="mt-0.5 text-xs text-tertiary">{subtitle}</p>
+    </header>
   )
 }

--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -17,7 +17,6 @@ import { Input } from '@/components/ui/input'
 import { LoadingState } from '@/components/ui/loading-state'
 import { Textarea } from '@/components/ui/textarea'
 import { extractApiErrorDetail } from '@/lib/apiError'
-import { ciStatusDotClass } from '@/lib/status-colors'
 import { cn } from '@/lib/utils'
 import type { DraftReleaseNotesResponse, Environment } from '@/types'
 
@@ -259,25 +258,22 @@ export function PromoteTab({
               return (
                 <li
                   className={cn(
-                    'flex items-center gap-3 border-b border-tertiary px-3 py-2 last:border-b-0',
+                    'flex min-w-0 items-center gap-3 border-b border-tertiary px-3 py-2 last:border-b-0',
                     active && 'bg-action/5',
                   )}
                   key={c.sha}
                 >
                   <button
-                    className="flex flex-1 items-center gap-3 text-left"
+                    className="flex min-w-0 flex-1 items-center gap-3 text-left"
                     onClick={() => setSelectedSha(c.sha)}
                     type="button"
                   >
-                    <span
-                      aria-label={`CI ${c.ci_status}`}
-                      className={cn(
-                        'inline-block h-2 w-2 rounded-full',
-                        ciStatusDotClass(c.ci_status),
-                      )}
-                    />
-                    <span className="font-mono text-xs">{c.short_sha}</span>
-                    <span className="flex-1 truncate text-sm">{c.message}</span>
+                    <span className="shrink-0 font-mono text-xs">
+                      {c.short_sha}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-sm">
+                      {c.message}
+                    </span>
                     <Badge variant="neutral">{tipIndex}</Badge>
                   </button>
                 </li>
@@ -385,7 +381,7 @@ export function PromoteTab({
         <span className="font-mono">{selectedSha?.slice(0, 7) ?? '—'}</span> and
         rolled out to {toEnvironment}.
       </p>
-      <div className="bg-secondary/30 -mx-6 -mb-6 mt-2 flex items-center justify-end gap-2 border-t border-tertiary px-6 py-3">
+      <div className="bg-secondary/30 -mx-6 -mb-4 mt-2 flex items-center justify-end gap-2 border-t border-tertiary px-6 py-4">
         <Button onClick={onClose} type="button" variant="ghost">
           Cancel
         </Button>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -814,7 +814,7 @@ export interface PluginResponse {
   status: 'active' | 'unavailable'
   used_as_login?: boolean
 }
-export type PluginTab = 'configuration' | 'logs'
+export type PluginTab = 'configuration' | 'deployment' | 'logs'
 
 export interface PluginUpdate {
   // Pass an explicit empty string to clear; omitting the field leaves


### PR DESCRIPTION
## Summary

Big batch of frontend work that lined up alongside the backend changes in **imbi-api #286** and **imbi-plugin-github #10**. One PR per the request — the changes are interlocked enough that splitting them would just create churn.

### Release-train (`ProjectDetail.tsx`)
- Removed the standalone Deploy / Promote buttons next to the train — env chips are the only entry points now.
- Chip routing is by position, no hardcoded names: idx 0 → Deploy, idx 1 → Promote, idx 2+ → Deploy.
- Tooltips moved from native `title` attributes to shadcn `Tooltip`s ("Deploy / Redeploy" / "Promote").
- Hover state on chips so they read as buttons; chip interactivity gates on the project actually having a deployment plugin **and** the current user having an active identity connection.
- Italic info banner under the train: `Connect to <provider> to enable deployments` when not connected, `Click on an environment to deploy to it` when connected. Resolves the identity plugin via the merged assignment, then a slug-affinity fallback against `listIdentityPlugins`, so the provider name renders even when the project-type assignment didn't bind one.

### Deploy / Promote dialogs (`deploy/*`)
- Replaced the single tabbed modal with two distinct `DeployModal` / `PromoteModal` components, each with its own header.
- Modals are URL-driven: `/projects/<id>/deploy/<env>`, `/projects/<id>/promote/<env>`. Deep-linkable; close routes back to `/projects/<id>`.
- Locked the env in the Deploy dialog (no picker; passed via the URL slug).
- Dropped the "Step 1/2" framing — selection isn't a multi-step creation flow.
- Footer padding for visual balance, dialog widened to 920 px so long commit subjects don't bleed.

### Top nav (`Navigation.tsx`)
- Removed the dead `/deployments` tab and the unwired `onNewDeployment` / `onNewProject` / `onNewOpsEntry` props.
- Wired the dropdown's **New Project** and **New Ops Log Entry** items to inline-mounted dialogs so they work from every page.

### `NewProjectDialog.tsx`
- Removed the URLs & Links tab + footer Back/Next; single-pane.
- Removed the mocked Automations toggles — those will be plugin-driven.
- Removed the subtitle copy.
- Sized the dialog with `--assistant-height` so it never overlaps the bottom assistant bar; trimmed an extra 10 px so the gap reads as deliberate.
- Added a helper line under the Environments chips.

### `NewOpsLogDialog.tsx` (new)
- Mirrors `NewProjectDialog`'s shape and sizing. Project picker, project-scoped environment picker, entry type, description (required), plus optional version / link / ticket / notes. POSTs to `/operations-log/` via the new `createOperationsLogEntry` endpoint.

### Service plugin admin (`admin/third-party-services/*`)
- `ServicePluginList`: whole row is now a clickable surface that opens the configure panel; removed the per-row Configure button and added a trailing chevron-right indicator (matches `PluginsManagement`).
- `ServicePluginConfiguration`: reworked the per-project-type bindings table — compact columns + accordion slide-down for the overridable fields. Project type is immutable once added (Add button is now a dropdown of remaining types). Tab column gone. Identity Plugin moved into the accordion. Override count badge next to the chevron. New rows default to `default: true` and stay collapsed; clicking anywhere on the row toggles the panel.

### Misc
- `PluginAssignment.tab` literal extended to include `deployment` (matches imbi-api #286).
- `DeploymentModal.tsx`: reordered `PromoteModalProps` interface above the function declarations to satisfy `perfectionist/sort-modules`.
- `createOperationsLogEntry` + `OperationsLogCreate` interface in the API client (POST `/operations-log/`).
- `PluginsManagement` / `PluginPackageDetail`: minor alignment tweaks bundled along.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 warnings, 0 errors)
- [ ] CI green
- [ ] Smoke: deploy / promote flow end-to-end against imbi-api #286 + imbi-plugin-github #10
- [ ] Smoke: New Project from the top-nav dropdown navigates to `/projects/<id>` after creation
- [ ] Smoke: New Ops Log Entry from the top-nav dropdown writes through to the project's Operations Log tab
- [ ] Smoke: Project Types editor on a third-party plugin — add row, expand accordion, override identity plugin, save

🤖 Generated with [Claude Code](https://claude.com/claude-code)