### PR TITLE
Resolve API base URL from index.html at runtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Imbi</title>
     <script>
+      window.__IMBI_API_URL__ = '{{env "IMBI_API_URL"}}'
+    </script>
+    <script>
       (function () {
         try {
           var stored = window.localStorage.getItem('imbi-theme')

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,9 +1,21 @@
 import { useAuthStore } from '@/stores/authStore'
 import type { TokenResponse } from '@/types'
 
-export const API_BASE_URL = import.meta.env.VITE_API_URL
+function resolveApiBaseUrl(): string {
+  // Runtime value injected into index.html via `{{env "IMBI_API_URL"}}`.
+  // When served without a templater (e.g. Vite dev), the placeholder
+  // reaches the browser literally — detect that and fall back.
+  const runtime =
+    typeof window !== 'undefined' ? window.__IMBI_API_URL__ : undefined
+  if (typeof runtime === 'string' && runtime && !runtime.includes('{{')) {
+    return runtime
+  }
+  return import.meta.env.VITE_API_URL
+}
+
+export const API_BASE_URL = resolveApiBaseUrl()
 if (!API_BASE_URL) {
-  throw new Error('VITE_API_URL is required')
+  throw new Error('IMBI_API_URL (or VITE_API_URL) is required')
 }
 
 export const apiUrl = (path: string): string =>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,12 +2,11 @@ import { useAuthStore } from '@/stores/authStore'
 import type { TokenResponse } from '@/types'
 
 function resolveApiBaseUrl(): string {
-  // Runtime value injected into index.html via `{{env "IMBI_API_URL"}}`.
-  // When served without a templater (e.g. Vite dev), the placeholder
-  // reaches the browser literally — detect that and fall back.
-  const runtime =
-    typeof window !== 'undefined' ? window.__IMBI_API_URL__ : undefined
-  if (typeof runtime === 'string' && runtime && !runtime.includes('{{')) {
+  // index.html injects `{{env "IMBI_API_URL"}}`; when served without a
+  // templater (e.g. Vite dev) the placeholder reaches the browser literally,
+  // so detect the unsubstituted form and fall back.
+  const runtime = window.__IMBI_API_URL__
+  if (runtime && !runtime.includes('{{')) {
     return runtime
   }
   return import.meta.env.VITE_API_URL

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,3 +10,7 @@ interface ImportMetaEnv {
   readonly VITE_OAUTH_CLIENT_ID?: string
   readonly VITE_OAUTH_REDIRECT_URI?: string
 }
+
+interface Window {
+  __IMBI_API_URL__?: string
+}


### PR DESCRIPTION
## Summary
- Inject `window.__IMBI_API_URL__` via a `{{env "IMBI_API_URL"}}` template in `index.html` so the API base URL can be supplied at request time by the reverse proxy rendering the page.
- API client (`src/api/client.ts`) prefers the runtime value and falls back to `import.meta.env.VITE_API_URL` when the placeholder is unsubstituted (e.g. local Vite dev).
- Declare the new `Window.__IMBI_API_URL__` global in `src/vite-env.d.ts`.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Local Vite dev (`npm run dev`) still resolves to `VITE_API_URL` (template literal triggers fallback)
- [ ] When served behind a templater, `window.__IMBI_API_URL__` populates `API_BASE_URL` and API calls hit the templated origin