### PR TITLE
Route team row clicks to detail view

### DIFF
--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -22,6 +22,7 @@ export function TeamManagement() {
   const { selectedOrganization } = useOrganization()
   const {
     goToCreate,
+    goToDetail,
     goToEdit,
     goToList,
     slug: selectedTeamSlug,
@@ -291,7 +292,7 @@ export function TeamManagement() {
         getRowKey={(team) => team.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(team) => goToEdit(team.slug)}
+        onRowClick={(team) => goToDetail(team.slug)}
         rows={filteredTeams}
       />
     </AdminSection>


### PR DESCRIPTION
## Summary
- Admin team rows now open the detail view instead of jumping straight to the edit form, restoring access to the members add/remove UI.
- Detail view already provides an "Edit Team" button for the form, matching the `ThirdPartyServiceManagement` pattern.

## Test plan
- [ ] In Admin → Teams, click a team row and confirm the detail page renders with the members list.
- [ ] From the detail view, use "Add Member" / remove (×) to verify member mutations still work.
- [ ] Click "Edit Team" and confirm the edit form opens.