### PR TITLE
Wire up project archive / unarchive in settings

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -259,6 +259,16 @@ export const deleteProject = (orgSlug: string, projectId: string) =>
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
   )
 
+export const archiveProject = (orgSlug: string, projectId: string) =>
+  apiClient.post<Project>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/archive`,
+  )
+
+export const unarchiveProject = (orgSlug: string, projectId: string) =>
+  apiClient.post<Project>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/unarchive`,
+  )
+
 // Link Definitions (org-scoped)
 export const listLinkDefinitions = async (
   orgSlug: string,

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -610,6 +610,11 @@ export function ProjectDetail({
                 renderValue={renderNameValue}
                 value={project.name}
               />
+              {project.archived && (
+                <span className="rounded border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                  Archived
+                </span>
+              )}
             </div>
           </div>
 

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -6,11 +6,13 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import {
+  archiveProject,
   deleteProject,
   listEnvironments,
   listLinkDefinitions,
   patchProject,
   rescoreProject,
+  unarchiveProject,
 } from '@/api/endpoints'
 import { EditEnvironmentsCard } from '@/components/EditEnvironmentsCard'
 import { EditIdentifiersCard } from '@/components/EditIdentifiersCard'
@@ -24,6 +26,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAuth } from '@/hooks/useAuth'
@@ -42,6 +45,8 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   const { patch, scheduleScoreRefresh } = useProjectPatch(orgSlug, project.id)
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showArchiveConfirm, setShowArchiveConfirm] = useState(false)
+  const isArchived = project.archived === true
 
   const invalidateProject = () => {
     queryClient.invalidateQueries({
@@ -57,6 +62,22 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
     mutationFn: () => deleteProject(orgSlug, project.id),
     onError: mutationErrorHandler('delete project'),
     onSuccess: () => navigate('/'),
+  })
+
+  const archiveMutation = useMutation({
+    mutationFn: () =>
+      isArchived
+        ? unarchiveProject(orgSlug, project.id)
+        : archiveProject(orgSlug, project.id),
+    onError: mutationErrorHandler(
+      isArchived ? 'unarchive project' : 'archive project',
+    ),
+    onSuccess: () => {
+      toast.success(isArchived ? 'Project restored' : 'Project archived')
+      setShowArchiveConfirm(false)
+      invalidateProject()
+      queryClient.invalidateQueries({ queryKey: ['projects', orgSlug] })
+    },
   })
 
   const rescoreMutation = useMutation({
@@ -163,20 +184,47 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
 
       <Card className="border-amber-300">
         <CardHeader>
-          <CardTitle>Archive project</CardTitle>
+          <CardTitle>
+            {isArchived ? 'Restore project' : 'Archive project'}
+          </CardTitle>
           <CardDescription className="text-secondary">
-            Archiving the project will make it entirely read only. It will be
-            hidden from the dashboard, won&apos;t show up in searches, and will
-            be disabled as a dependency for any other projects that are
-            dependent upon it.
+            {isArchived
+              ? 'This project is archived. Restoring will return it to the dashboard and search results.'
+              : 'Archiving the project will hide it from the dashboard and search results. Existing data is preserved and the project can be restored at any time.'}
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Button disabled size="sm" variant="outline">
-            Archive project
+          <Button
+            disabled={archiveMutation.isPending}
+            onClick={() => {
+              if (isArchived) {
+                archiveMutation.mutate()
+              } else {
+                setShowArchiveConfirm(true)
+              }
+            }}
+            size="sm"
+            variant="outline"
+          >
+            {archiveMutation.isPending
+              ? isArchived
+                ? 'Restoring...'
+                : 'Archiving...'
+              : isArchived
+                ? 'Restore project'
+                : 'Archive project'}
           </Button>
         </CardContent>
       </Card>
+
+      <ConfirmDialog
+        confirmLabel="Archive project"
+        description={`Archiving ${project.slug} will hide it from the dashboard and search results until it is restored.`}
+        onCancel={() => setShowArchiveConfirm(false)}
+        onConfirm={() => archiveMutation.mutate()}
+        open={showArchiveConfirm}
+        title="Archive this project?"
+      />
 
       <Card className="border-red-300">
         <CardHeader>

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -65,15 +65,18 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   })
 
   const archiveMutation = useMutation({
-    mutationFn: () =>
-      isArchived
+    mutationFn: (action: 'archive' | 'unarchive') =>
+      action === 'unarchive'
         ? unarchiveProject(orgSlug, project.id)
         : archiveProject(orgSlug, project.id),
-    onError: mutationErrorHandler(
-      isArchived ? 'unarchive project' : 'archive project',
-    ),
-    onSuccess: () => {
-      toast.success(isArchived ? 'Project restored' : 'Project archived')
+    onError: (error, action) =>
+      mutationErrorHandler(
+        action === 'unarchive' ? 'unarchive project' : 'archive project',
+      )(error),
+    onSuccess: (_data, action) => {
+      toast.success(
+        action === 'unarchive' ? 'Project restored' : 'Project archived',
+      )
       setShowArchiveConfirm(false)
       invalidateProject()
       queryClient.invalidateQueries({ queryKey: ['projects', orgSlug] })
@@ -198,7 +201,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
             disabled={archiveMutation.isPending}
             onClick={() => {
               if (isArchived) {
-                archiveMutation.mutate()
+                archiveMutation.mutate('unarchive')
               } else {
                 setShowArchiveConfirm(true)
               }
@@ -221,7 +224,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
         confirmLabel="Archive project"
         description={`Archiving ${project.slug} will hide it from the dashboard and search results until it is restored.`}
         onCancel={() => setShowArchiveConfirm(false)}
-        onConfirm={() => archiveMutation.mutate()}
+        onConfirm={() => archiveMutation.mutate('archive')}
         open={showArchiveConfirm}
         title="Archive this project?"
       />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,6 +86,8 @@ export interface OperationsLogEntry {
 // a looser `relationships` shape than the generated `ProjectResponse`.
 export interface Project {
   [key: string]: unknown
+  archived?: boolean
+  archived_at?: null | string
   created_at?: null | string
   description?: null | string
   environments?: Environment[]


### PR DESCRIPTION
## Summary
- Replaces the disabled stub Archive button in `ProjectSettingsTab` with a working archive/restore mutation against the new `imbi-api` endpoints (`POST /projects/{id}/archive` and `/unarchive`).
- Archive opens a `ConfirmDialog`; restore is a single-click action. Both invalidate the per-project and org-projects query keys and toast on success.
- Adds `archived` / `archived_at` to the hand-written `Project` type so the UI can read state.
- Renders an "Archived" badge next to the project name in the detail header when `project.archived` is true.

Paired with imbi-api PR #292.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean (tsc + vite bundle)
- [ ] Manual smoke (requires imbi-api PR #292 merged or deployed locally): archive an active project, confirm the dialog, expect a toast, the page reloads with an "Archived" badge, the project disappears from the dashboard list. Restore, confirm it returns.