### PR TITLE
Replace native selects with searchable combobox in dialogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "aws-svg-icons": "^3.0.0-2021-07-30",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "devicon": "^2.17.0",
         "js-yaml": "^4.1.1",
@@ -5308,6 +5309,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://npm.aweber.io/repository/npm/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/colorette": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5313,7 +5313,7 @@
     },
     "node_modules/cmdk": {
       "version": "1.1.1",
-      "resolved": "https://npm.aweber.io/repository/npm/cmdk/-/cmdk-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
       "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "aws-svg-icons": "^3.0.0-2021-07-30",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "devicon": "^2.17.0",
     "js-yaml": "^4.1.1",

--- a/src/components/NewOpsLogDialog.tsx
+++ b/src/components/NewOpsLogDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Combobox } from '@/components/ui/combobox'
 import {
   Dialog,
   DialogContent,
@@ -138,22 +139,18 @@ export function NewOpsLogDialog({
               <label className="text-sm font-medium" htmlFor="new-ops-project">
                 Project <span className="text-red-500">*</span>
               </label>
-              <select
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="new-ops-project"
-                onChange={(e) => {
-                  setProjectId(e.target.value)
+              <Combobox
+                onChange={(val) => {
+                  setProjectId(val)
                   setEnvironmentSlug('')
                 }}
+                options={projectOptions.map((p) => ({
+                  label: p.name ?? '',
+                  value: p.id,
+                }))}
+                placeholder="Select project..."
                 value={projectId}
-              >
-                <option value="">Select project...</option>
-                {projectOptions.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
+              />
             </div>
 
             {/* Environment */}
@@ -164,32 +161,28 @@ export function NewOpsLogDialog({
               >
                 Environment <span className="text-red-500">*</span>
               </label>
-              <select
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              <Combobox
                 disabled={
                   !projectId ||
                   selectedProjectLoading ||
                   projectEnvironments.length === 0
                 }
-                id="new-ops-environment"
-                onChange={(e) => setEnvironmentSlug(e.target.value)}
-                value={environmentSlug}
-              >
-                <option value="">
-                  {projectId
+                onChange={setEnvironmentSlug}
+                options={projectEnvironments.map((env) => ({
+                  label: env.name,
+                  value: env.slug,
+                }))}
+                placeholder={
+                  projectId
                     ? selectedProjectLoading
                       ? 'Loading environments...'
                       : projectEnvironments.length === 0
                         ? 'Project has no environments'
                         : 'Select environment...'
-                    : 'Pick a project first'}
-                </option>
-                {projectEnvironments.map((env) => (
-                  <option key={env.slug} value={env.slug}>
-                    {env.name}
-                  </option>
-                ))}
-              </select>
+                    : 'Pick a project first'
+                }
+                value={environmentSlug}
+              />
               <p className="text-sm text-muted-foreground">
                 The environment the operation was performed in
               </p>
@@ -203,21 +196,15 @@ export function NewOpsLogDialog({
               >
                 Entry Type <span className="text-red-500">*</span>
               </label>
-              <select
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="new-ops-entry-type"
-                onChange={(e) =>
-                  setEntryType(e.target.value as OperationsLogEntryType)
-                }
+              <Combobox
+                onChange={(val) => setEntryType(val as OperationsLogEntryType)}
+                options={OPERATIONS_LOG_ENTRY_TYPES.map((t) => ({
+                  label: t,
+                  value: t,
+                }))}
+                placeholder="Select type..."
                 value={entryType}
-              >
-                <option value="">Select type...</option>
-                {OPERATIONS_LOG_ENTRY_TYPES.map((t) => (
-                  <option key={t} value={t}>
-                    {t}
-                  </option>
-                ))}
-              </select>
+              />
             </div>
 
             {/* Description */}

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Combobox } from '@/components/ui/combobox'
 import {
   Dialog,
   DialogContent,
@@ -135,19 +136,15 @@ export function NewProjectDialog({
               <label className="text-sm font-medium" htmlFor="new-project-team">
                 Team <span className="text-red-500">*</span>
               </label>
-              <select
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="new-project-team"
-                onChange={(e) => setTeamSlug(e.target.value)}
+              <Combobox
+                onChange={setTeamSlug}
+                options={teams.map((t) => ({
+                  label: t.name,
+                  value: t.slug,
+                }))}
+                placeholder="Select team..."
                 value={teamSlug}
-              >
-                <option value="">Select team...</option>
-                {teams.map((t) => (
-                  <option key={t.slug} value={t.slug}>
-                    {t.name}
-                  </option>
-                ))}
-              </select>
+              />
               <p className="text-sm text-muted-foreground">
                 Team that owns this project
               </p>
@@ -158,19 +155,15 @@ export function NewProjectDialog({
               <label className="text-sm font-medium" htmlFor="new-project-type">
                 Project Type <span className="text-red-500">*</span>
               </label>
-              <select
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="new-project-type"
-                onChange={(e) => setProjectTypeSlug(e.target.value)}
+              <Combobox
+                onChange={setProjectTypeSlug}
+                options={projectTypes.map((pt) => ({
+                  label: pt.name,
+                  value: pt.slug,
+                }))}
+                placeholder="Select project type..."
                 value={projectTypeSlug}
-              >
-                <option value="">Select project type...</option>
-                {projectTypes.map((pt) => (
-                  <option key={pt.slug} value={pt.slug}>
-                    {pt.name}
-                  </option>
-                ))}
-              </select>
+              />
               <p className="text-sm text-muted-foreground">
                 Type of the new project
               </p>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -42,7 +42,7 @@ export function Combobox({
   const selectedLabel = options.find((o) => o.value === value)?.label
 
   return (
-    <Popover onOpenChange={setOpen} open={open}>
+    <Popover modal onOpenChange={setOpen} open={open}>
       <PopoverTrigger asChild>
         <button
           aria-expanded={open}

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+
+import { Check, ChevronsUpDown } from 'lucide-react'
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+
+export interface ComboboxOption {
+  label: string
+  value: string
+}
+
+interface ComboboxProps {
+  disabled?: boolean
+  onChange: (value: string) => void
+  options: ComboboxOption[]
+  placeholder?: string
+  value: string
+}
+
+export function Combobox({
+  disabled = false,
+  onChange,
+  options,
+  placeholder = 'Select...',
+  value,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false)
+
+  const selectedLabel = options.find((o) => o.value === value)?.label
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>
+        <button
+          aria-expanded={open}
+          className={cn(
+            'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+            !selectedLabel && 'text-muted-foreground',
+            disabled && 'cursor-not-allowed opacity-50',
+          )}
+          disabled={disabled}
+          role="combobox"
+          type="button"
+        >
+          <span className="truncate">{selectedLabel ?? placeholder}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="p-0"
+        style={{ width: 'var(--radix-popover-trigger-width)' }}
+      >
+        <Command>
+          <CommandInput placeholder={`Search...`} />
+          <CommandList>
+            <CommandEmpty>No results found.</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  onSelect={() => {
+                    onChange(option.value)
+                    setOpen(false)
+                  }}
+                  value={option.label}
+                >
+                  <Check
+                    className={cn(
+                      'h-4 w-4',
+                      value === option.value ? 'opacity-100' : 'opacity-0',
+                    )}
+                  />
+                  {option.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react'
+
+import { type DialogProps } from '@radix-ui/react-dialog'
+import { Command as CommandPrimitive } from 'cmdk'
+import { Search } from 'lucide-react'
+
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    className={cn(
+      'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+))
+Command.displayName = CommandPrimitive.displayName
+
+function CommandDialog({ children, ...props }: DialogProps) {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      className={cn(
+        'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  </div>
+))
+CommandInput.displayName = CommandPrimitive.Input.displayName
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
+    ref={ref}
+    {...props}
+  />
+))
+CommandList.displayName = CommandPrimitive.List.displayName
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    className="py-6 text-center text-sm"
+    ref={ref}
+    {...props}
+  />
+))
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    className={cn(
+      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+))
+CommandGroup.displayName = CommandPrimitive.Group.displayName
+
+const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    className={cn('-mx-1 h-px bg-border', className)}
+    ref={ref}
+    {...props}
+  />
+))
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    className={cn(
+      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-secondary data-[selected=true]:text-primary data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+))
+CommandItem.displayName = CommandPrimitive.Item.displayName
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={cn(
+        'ml-auto text-xs tracking-widest text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+}


### PR DESCRIPTION
Replaces native `<select>` elements in the **New Project** and **New Ops Log Entry** dialogs with a searchable `Combobox` component built on `cmdk` (shadcn/ui pattern).

## Changes

### New components
- `src/components/ui/command.tsx` — shadcn/ui Command primitives wrapping `cmdk`
- `src/components/ui/combobox.tsx` — reusable Popover + Command combobox with search, check marks, and disabled state

### Updated dialogs
- **NewProjectDialog** — Team, Project Type selects → Combobox
- **NewOpsLogDialog** — Project, Environment, Entry Type selects → Combobox

## Features
- Type-ahead search filtering (built into cmdk)
- Keyboard navigation (arrow keys, enter, escape)
- Disabled state with dynamic placeholder (e.g. "Pick a project first")
- Check mark on selected item
- Dropdown matches trigger width

<img width="738" height="642" alt="Screenshot 2026-05-11 at 9 19 33 PM" src="https://github.com/user-attachments/assets/0e9423aa-f56b-4dda-9160-d64974a2d641" />
<img width="719" height="688" alt="Screenshot 2026-05-11 at 9 19 42 PM" src="https://github.com/user-attachments/assets/25854866-c395-4873-86d9-09c343277474" />
