### PR TITLE
Fix timeline dot alignment in project activity log

### DIFF
--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -145,7 +145,7 @@ export function ProjectActivityLog({ orgSlug, projectId, projectSlug }: Props) {
               </div>
 
               <div className="relative px-6">
-                <div className="absolute bottom-4 left-[26px] top-4 w-px bg-tertiary" />
+                <div className="absolute bottom-4 left-[31.5px] top-4 w-px bg-muted" />
 
                 {group.items.map((item, i) =>
                   item.kind === 'event' ? (


### PR DESCRIPTION
Fixes the vertical timeline line position in the Recent Activity card on the project detail page. The line was offset from the dots due to an incorrect `left` value.

- Adjusted `left-[26px]` → `left-[31.5px]` to center the line with the dot indicators
- Changed line color from `bg-tertiary` to `bg-muted` for better visual consistency

Before
<img width="635" height="572" alt="Screenshot 2026-05-11 at 10 19 51 PM" src="https://github.com/user-attachments/assets/0d00f120-c1c3-4f10-bd3d-bc15723780ba" />
<img width="644" height="572" alt="Screenshot 2026-05-11 at 10 19 56 PM" src="https://github.com/user-attachments/assets/4065b5cf-0e1e-4a5e-b1f0-9106d897d1c0" />


After
<img width="639" height="574" alt="Screenshot 2026-05-11 at 10 17 10 PM" src="https://github.com/user-attachments/assets/3598d340-9ed8-4e93-9f11-3db3d9f19d11" />
<img width="646" height="575" alt="Screenshot 2026-05-11 at 10 17 16 PM" src="https://github.com/user-attachments/assets/3027aaf2-9a6f-45ae-b5bb-7a45e1e68409" />
<img width="639" height="629" alt="Screenshot 2026-05-11 at 10 17 25 PM" src="https://github.com/user-attachments/assets/a8fc1921-831a-4017-9de7-a1d240569ce2" />
<img width="632" height="623" alt="Screenshot 2026-05-11 at 10 17 31 PM" src="https://github.com/user-attachments/assets/7d1f7b13-2e78-43e5-8a87-bbbf1b38fecb" />
