### PR TITLE
Tone down search highlight in configuration parameter list

### DIFF
--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -1155,7 +1155,7 @@ function Highlight({ q, text }: { q: string; text: string }) {
   return (
     <>
       {text.slice(0, idx)}
-      <mark className="rounded-sm bg-amber-bg px-0 text-inherit">
+      <mark className="rounded-sm bg-amber-border/25 px-0 text-inherit">
         {text.slice(idx, idx + q.length)}
       </mark>
       {text.slice(idx + q.length)}


### PR DESCRIPTION
The search highlight `<mark>` in the config parameter sidebar used `bg-amber-bg` which was too opaque against the dark background, making matched text look like selected items.

Changed to `bg-amber-border/25` for a subtler, semi-transparent highlight.

Before
<img width="448" height="239" alt="Screenshot 2026-05-11 at 10 25 38 PM" src="https://github.com/user-attachments/assets/f8da51ee-b21b-4d76-840c-40cca3d54f46" />
<img width="447" height="257" alt="Screenshot 2026-05-11 at 10 25 44 PM" src="https://github.com/user-attachments/assets/3332eff1-8fcf-4daf-b303-7af9d6460b50" />

After
<img width="447" height="272" alt="Screenshot 2026-05-11 at 10 25 19 PM" src="https://github.com/user-attachments/assets/b604ab94-10ac-418f-8455-455cc950a8b8" />
<img width="457" height="276" alt="Screenshot 2026-05-11 at 10 28 14 PM" src="https://github.com/user-attachments/assets/22d9c945-6027-4c53-844f-d6ca9f0f785a" />
