### PR TITLE
Match reports sidebar highlight to settings sidebar

### DIFF
--- a/src/components/reports/ScoreHistoryReport.tsx
+++ b/src/components/reports/ScoreHistoryReport.tsx
@@ -130,7 +130,7 @@ export function ScoreHistoryReport() {
             Recent score recomputations across all projects, newest first.
           </div>
         </div>
-        <div className="px-2 py-1">
+        <div>
           {feedLoading ? (
             <div className="py-10 text-center text-sm text-tertiary">
               Loading…

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -57,10 +57,10 @@ export function ReportsPage() {
     <div className="min-h-screen bg-tertiary text-primary">
       <Navigation />
       <main
-        className="mx-auto max-w-[1400px] px-6 pt-24"
+        className="pt-16"
         style={{ paddingBottom: 'var(--assistant-height, 64px)' }}
       >
-        <div className="flex gap-6">
+        <div className="mx-auto flex max-w-[1400px] gap-6 px-6 py-7">
           {/* Left sidebar — report list */}
           <aside className="w-56 flex-shrink-0">
             <div className="rounded-lg border border-tertiary bg-primary">
@@ -69,14 +69,14 @@ export function ReportsPage() {
                   Reports
                 </div>
               </div>
-              <div className="p-1">
+              <div className="space-y-1 p-2">
                 {REPORTS.map((r) => {
                   const isActive = r.id === activeId
                   return (
                     <button
-                      className={`flex w-full items-start gap-2.5 rounded-md px-3 py-2.5 text-left transition-colors ${
+                      className={`flex w-full items-start gap-3 rounded-lg px-4 py-3 text-left transition-colors ${
                         isActive
-                          ? 'bg-amber-bg text-amber-text'
+                          ? 'bg-warning text-warning'
                           : 'text-secondary hover:bg-secondary hover:text-primary'
                       }`}
                       key={r.id}


### PR DESCRIPTION
The reports sidebar used `bg-amber-bg text-amber-text` for the active item, while the settings sidebar uses `bg-warning text-warning`. This made the two pages look inconsistent.

Updated the reports sidebar to match settings:
- Highlight: `bg-amber-bg text-amber-text` → `bg-warning text-warning`
- Border radius: `rounded-md` → `rounded-lg`
- Padding: `px-3 py-2.5` → `px-4 py-3`
- Gap: `gap-2.5` → `gap-3`
- Container: `p-1` → `space-y-1 p-2`

Before
<img width="253" height="277" alt="Screenshot 2026-05-11 at 10 41 29 PM" src="https://github.com/user-attachments/assets/b8e6492c-bb63-499c-80d7-e72e5eb72c62" />

After
<img width="249" height="315" alt="Screenshot 2026-05-11 at 10 41 41 PM" src="https://github.com/user-attachments/assets/f87a2159-f0b8-406d-a978-dad839d9289f" />

