### PR TITLE
Unify report table styles

### DIFF
--- a/src/components/ScoreHistoryTab.tsx
+++ b/src/components/ScoreHistoryTab.tsx
@@ -325,7 +325,7 @@ export function ScoreHistoryTab({ orgSlug, projectId }: Props) {
       </div>
 
       {/* Change events card */}
-      <div className="rounded-lg border border-tertiary bg-primary">
+      <div className="overflow-hidden rounded-lg border border-tertiary bg-primary">
         <div className="flex items-center justify-between border-b border-tertiary px-[18px] py-3.5">
           <div>
             <div className="text-overline uppercase tracking-wide text-tertiary">
@@ -346,7 +346,7 @@ export function ScoreHistoryTab({ orgSlug, projectId }: Props) {
             </button>
           </div>
         </div>
-        <div className="px-2 py-1">
+        <div>
           {rawLoading ? (
             <div className="py-10 text-center text-sm text-tertiary">
               Loading…

--- a/src/components/reports/MonthlyImprovementReport.tsx
+++ b/src/components/reports/MonthlyImprovementReport.tsx
@@ -160,7 +160,7 @@ export function MonthlyImprovementReport() {
       </div>
 
       {/* Table */}
-      <div className="rounded-lg border border-tertiary bg-primary">
+      <div className="overflow-hidden rounded-lg border border-tertiary bg-primary">
         {/* Table header */}
         <div
           className="grid border-b border-tertiary bg-secondary"
@@ -193,7 +193,7 @@ export function MonthlyImprovementReport() {
           <>
             {sorted.map((row, i) => (
               <div
-                className="grid items-center border-b border-tertiary transition-colors last:border-0 hover:bg-secondary"
+                className={`grid items-center border-tertiary transition-colors last:border-0 hover:bg-secondary ${i === sorted.length - 1 ? 'border-0' : 'border-b'}`}
                 key={row.key}
                 style={COL_GRID}
               >

--- a/src/components/reports/ScoreHistoryReport.tsx
+++ b/src/components/reports/ScoreHistoryReport.tsx
@@ -95,7 +95,7 @@ export function ScoreHistoryReport() {
   return (
     <div className="flex flex-col gap-5">
       {/* Chart card */}
-      <div className="rounded-lg border border-tertiary bg-primary p-[18px]">
+      <div className="overflow-hidden rounded-lg border border-tertiary bg-primary p-[18px]">
         <div className="mb-3.5 flex items-end justify-between gap-6">
           <div className="text-overline uppercase tracking-wide text-tertiary">
             Avg score by team
@@ -121,7 +121,7 @@ export function ScoreHistoryReport() {
       </div>
 
       {/* Feed card */}
-      <div className="rounded-lg border border-tertiary bg-primary">
+      <div className="overflow-hidden rounded-lg border border-tertiary bg-primary">
         <div className="border-b border-tertiary px-[18px] py-3.5">
           <div className="text-overline uppercase tracking-wide text-tertiary">
             Change events

--- a/src/components/reports/TeamKPIReport.tsx
+++ b/src/components/reports/TeamKPIReport.tsx
@@ -101,7 +101,7 @@ export function TeamKPIReport() {
       </div>
 
       {/* Bar chart card */}
-      <div className="rounded-lg border border-tertiary bg-primary p-[18px]">
+      <div className="overflow-hidden rounded-lg border border-tertiary bg-primary p-[18px]">
         <div className="mb-4 flex items-center justify-between">
           <div>
             <div className="text-overline uppercase tracking-wide text-tertiary">
@@ -138,7 +138,7 @@ export function TeamKPIReport() {
       </div>
 
       {/* Table card */}
-      <div className="rounded-lg border border-tertiary bg-primary">
+      <div className="overflow-hidden rounded-lg border border-tertiary bg-primary">
         <div className="border-b border-tertiary px-[18px] py-3.5">
           <div className="text-overline uppercase tracking-wide text-tertiary">
             Team details
@@ -181,8 +181,8 @@ export function TeamKPIReport() {
             <tbody>
               {sorted.map((row, i) => (
                 <tr
-                  className={`border-b border-tertiary transition-colors hover:bg-secondary ${
-                    i === sorted.length - 1 ? 'border-0' : ''
+                  className={`border-tertiary transition-colors hover:bg-secondary ${
+                    i === sorted.length - 1 ? 'border-0' : 'border-b'
                   }`}
                   key={row.key}
                 >


### PR DESCRIPTION
Standardizes table/card styling across all report components and the project-level score history tab.

### Changes
- **overflow-hidden** on all card wrappers so `rounded-lg` clips row hover backgrounds cleanly
- **Removed wrapper padding** (`px-2 py-1`) from change events feeds so rows go edge-to-edge
- **Fixed last-row border** handling — consistent `border-b`/`border-0` pattern across TeamKPIReport, MonthlyImprovementReport, ScoreHistoryReport, and ScoreHistoryTab

### Files
- `src/components/reports/ScoreHistoryReport.tsx`
- `src/components/reports/TeamKPIReport.tsx`
- `src/components/reports/MonthlyImprovementReport.tsx`
- `src/components/ScoreHistoryTab.tsx`

Before
<img width="1148" height="560" alt="Screenshot 2026-05-11 at 11 03 23 PM" src="https://github.com/user-attachments/assets/ab7ba08c-f149-4dbc-b128-098abf4f4561" />
<img width="1148" height="193" alt="Screenshot 2026-05-11 at 10 54 08 PM" src="https://github.com/user-attachments/assets/640dbd1a-5b44-4593-97be-17a292ac35e7" />
<img width="1160" height="81" alt="Screenshot 2026-05-11 at 10 58 49 PM" src="https://github.com/user-attachments/assets/526de099-bd90-4f58-8f40-b66cce5c2265" />


After
<img width="1590" height="637" alt="Screenshot 2026-05-11 at 11 09 15 PM" src="https://github.com/user-attachments/assets/187a3ed5-8125-4fd5-8d26-b3d0305e8920" />
<img width="1160" height="76" alt="Screenshot 2026-05-11 at 10 57 48 PM" src="https://github.com/user-attachments/assets/d516c27a-1a06-4173-8363-064a1e655dcd" />
<img width="1140" height="252" alt="Screenshot 2026-05-11 at 10 53 57 PM" src="https://github.com/user-attachments/assets/7a4a9634-0f04-48b6-843b-5413027f6f1f" />
