### PR TITLE
Format numbers with toLocaleString for thousands separators

### DIFF
--- a/src/components/operations-log/OperationsLogFeedItem.tsx
+++ b/src/components/operations-log/OperationsLogFeedItem.tsx
@@ -40,7 +40,7 @@ export function OperationsLogFeedItem({
         </span>
         <span className="flex-1" />
         <span className="font-mono text-[11px] text-tertiary">
-          {vi.count} {vi.count === 1 ? 'event' : 'events'}
+          {vi.count.toLocaleString()} {vi.count === 1 ? 'event' : 'events'}
         </span>
       </div>
     )

--- a/src/components/operations-log/OperationsLogSummary.tsx
+++ b/src/components/operations-log/OperationsLogSummary.tsx
@@ -137,7 +137,9 @@ export function OperationsLogSummary({
           <SkeletonBlock className="mt-0.5 h-5 w-16" />
         ) : (
           <span className="flex items-baseline gap-1.5 font-medium tabular-nums text-primary">
-            <span className="text-xl leading-none">{events}</span>
+            <span className="text-xl leading-none">
+              {events.toLocaleString()}
+            </span>
             <span className="text-[11px] uppercase tracking-wide text-tertiary">
               in {rangeLabel}
             </span>
@@ -174,12 +176,12 @@ export function OperationsLogSummary({
         ) : (
           <>
             <span className="text-xl font-medium tabular-nums leading-none text-primary">
-              {deploys}
+              {deploys.toLocaleString()}
             </span>
             <span className="text-[11.5px] text-secondary">
               {terminalEnv
-                ? `${terminalDeploys} to ${terminalEnv.name}`
-                : `${deploys} total`}
+                ? `${terminalDeploys.toLocaleString()} to ${terminalEnv.name}`
+                : `${deploys.toLocaleString()} total`}
             </span>
           </>
         )}
@@ -196,10 +198,10 @@ export function OperationsLogSummary({
         ) : (
           <>
             <span className="text-xl font-medium tabular-nums leading-none text-primary">
-              {projects}
+              {projects.toLocaleString()}
             </span>
             <span className="text-[11.5px] text-secondary">
-              across {envCount}{' '}
+              across {envCount.toLocaleString()}{' '}
               {envCount === 1 ? 'environment' : 'environments'}
             </span>
           </>
@@ -217,7 +219,7 @@ export function OperationsLogSummary({
         ) : (
           <>
             <span className="text-xl font-medium tabular-nums leading-none text-primary">
-              {people}
+              {people.toLocaleString()}
             </span>
             <span className="text-[11.5px] text-secondary">
               active in {rangeLabel}

--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -113,7 +113,7 @@ const TriggerButton = forwardRef<HTMLButtonElement, TriggerButtonProps>(
         <span className={cn(value && 'text-primary')}>{value ?? label}</span>
         {count !== undefined ? (
           <span className="ml-0.5 rounded bg-secondary px-1.5 text-[11px] tabular-nums text-tertiary">
-            {count}
+            {count.toLocaleString()}
           </span>
         ) : null}
         <ChevronDown className="h-3.5 w-3.5 text-tertiary" />
@@ -318,7 +318,9 @@ export function OperationsLogToolbar({
                     <span className="flex-1 truncate font-mono text-[13px]">
                       {slug}
                     </span>
-                    <span className="ml-3 text-xs text-tertiary">{c}</span>
+                    <span className="ml-3 text-xs text-tertiary">
+                      {c.toLocaleString()}
+                    </span>
                   </button>
                 )
               })}
@@ -424,7 +426,9 @@ function FacetDropdown({
             }}
           >
             <span className="flex-1">{o.label}</span>
-            <span className="ml-3 text-xs text-tertiary">{o.count}</span>
+            <span className="ml-3 text-xs text-tertiary">
+              {o.count.toLocaleString()}
+            </span>
           </DropdownMenuCheckboxItem>
         ))}
       </DropdownMenuContent>

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -175,12 +175,12 @@ export function AdminTable<T>({
                           }}
                           variant="link"
                         >
-                          {b.count} {b.label}
+                          {b.count.toLocaleString()} {b.label}
                           {b.count !== 1 ? 's' : ''}
                         </Button>
                       ) : (
                         <span className="font-medium">
-                          {b.count} {b.label}
+                          {b.count.toLocaleString()} {b.label}
                           {b.count !== 1 ? 's' : ''}
                         </span>
                       )}


### PR DESCRIPTION
Adds number-formatting to places where raw numbers were being rendered previously.