### PR TITLE
Render plugin-emitted ops log entries via a renderer registry

### DIFF
--- a/src/components/operations-log/OperationsLogEntryDetails.tsx
+++ b/src/components/operations-log/OperationsLogEntryDetails.tsx
@@ -12,6 +12,13 @@ import {
 } from '@/components/ui/tooltip'
 import type { OperationsLogRecord } from '@/types'
 
+import { parseDescription } from './parseDescription'
+import {
+  GenericPluginPayload,
+  getPluginRenderer,
+  type PluginOpsLogContext,
+} from './plugin-renderers'
+
 interface Props {
   entry: OperationsLogRecord
 }
@@ -26,14 +33,26 @@ export function OperationsLogEntryDetails({ entry }: Props) {
 
   const record = data ?? entry
   const performer = record.performed_by ?? record.recorded_by
+  const parsed = parseDescription(record)
+  const pluginRenderer =
+    parsed.kind === 'plugin' ? getPluginRenderer(record.plugin_slug) : undefined
+  const pluginCtx: null | PluginOpsLogContext =
+    parsed.kind === 'plugin'
+      ? { action: parsed.action, entry: record, payload: parsed.payload }
+      : null
 
-  // Notes from the v1 migration often duplicate the description; suppress
-  // identical notes so the panel shows real long-form content only.
+  // Notes from the v1 migration often duplicate the free-text description;
+  // suppress identical notes so the panel shows real long-form content only.
+  // Plugin-emitted entries don't share that lineage, so the comparison is
+  // skipped when `description` carries a structured payload.
   const hasNotes =
-    !!record.notes && record.notes.trim() !== record.description.trim()
+    !!record.notes &&
+    (parsed.kind === 'plugin' ||
+      record.notes.trim() !== record.description.trim())
 
   const hasExtras =
     hasNotes ||
+    !!pluginCtx ||
     !!record.link ||
     !!record.ticket_slug ||
     !!record.completed_at ||
@@ -41,6 +60,18 @@ export function OperationsLogEntryDetails({ entry }: Props) {
 
   return (
     <div className="space-y-4 py-4 pl-[60px] pr-4">
+      {pluginCtx && (
+        <div>
+          <h3 className="mb-1.5 text-overline uppercase text-tertiary">
+            {pluginRenderer?.displayName ?? record.plugin_slug}
+          </h3>
+          <div className="rounded-md border border-tertiary bg-primary p-3">
+            {pluginRenderer?.details?.(pluginCtx) ?? (
+              <GenericPluginPayload {...pluginCtx} />
+            )}
+          </div>
+        </div>
+      )}
       {hasNotes && (
         <div>
           <h3 className="mb-1.5 text-overline uppercase text-tertiary">

--- a/src/components/operations-log/OperationsLogStreamRow.tsx
+++ b/src/components/operations-log/OperationsLogStreamRow.tsx
@@ -18,6 +18,8 @@ import type { Environment, OperationsLogRecord, Project } from '@/types'
 import { OperationsLogEntryDetails } from './OperationsLogEntryDetails'
 import { absTime, cleanDescription, relTime } from './opsLogHelpers'
 import { OPS_ROW_GRID, OPS_ROW_PAD } from './opsRowLayout'
+import { parseDescription } from './parseDescription'
+import { getPluginRenderer } from './plugin-renderers'
 
 interface Props {
   entry: OperationsLogRecord
@@ -43,8 +45,20 @@ export const OperationsLogStreamRow = memo(function OperationsLogStreamRow({
   const displayName = performerDisplayNames.get(performer) ?? performer
   const isDeploy = entry.entry_type === 'Deployed'
   const isRestart = entry.entry_type === 'Restarted'
-  const Icon = ENTRY_TYPE_ICONS[entry.entry_type]
-  const desc = cleanDescription(entry.description, entry.version)
+  const parsed = parseDescription(entry)
+  const pluginRenderer =
+    parsed.kind === 'plugin' ? getPluginRenderer(entry.plugin_slug) : undefined
+  const Icon = pluginRenderer?.icon ?? ENTRY_TYPE_ICONS[entry.entry_type]
+  const desc =
+    parsed.kind === 'plugin'
+      ? (pluginRenderer?.label?.({
+          action: parsed.action,
+          entry,
+          payload: parsed.payload,
+        }) ??
+        parsed.summary ??
+        `${entry.plugin_slug}${parsed.action ? ` · ${parsed.action}` : ''}`)
+      : cleanDescription(entry.description, entry.version)
   const projectLabel = project?.name ?? entry.project_slug
   const envDisplay = environment?.name ?? entry.environment_slug
   const envColors = environment?.label_color

--- a/src/components/operations-log/__tests__/parseDescription.test.ts
+++ b/src/components/operations-log/__tests__/parseDescription.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import type { OperationsLogRecord } from '@/types'
+
+import { parseDescription } from '../parseDescription'
+
+function makeEntry(
+  overrides: Partial<OperationsLogRecord> = {},
+): OperationsLogRecord {
+  return {
+    description: '',
+    entry_type: 'Configured',
+    environment_slug: 'testing',
+    id: 'opslog-1',
+    occurred_at: '2026-05-12T02:24:59.841Z',
+    plugin_slug: '',
+    project_id: 'proj-1',
+    project_slug: 'ai-content',
+    recorded_at: '2026-05-12T02:24:59.841Z',
+    recorded_by: 'alexs@aweber.com',
+    ...overrides,
+  }
+}
+
+describe('parseDescription', () => {
+  it('returns text when plugin_slug is empty', () => {
+    const result = parseDescription(
+      makeEntry({ description: 'released v1.2.3 to testing' }),
+    )
+    expect(result).toEqual({ kind: 'text', text: 'released v1.2.3 to testing' })
+  })
+
+  it('returns text when description is not JSON', () => {
+    const result = parseDescription(
+      makeEntry({ description: 'plain text', plugin_slug: 'aws-ssm' }),
+    )
+    expect(result).toEqual({ kind: 'text', text: 'plain text' })
+  })
+
+  it('returns text when description is malformed JSON', () => {
+    const result = parseDescription(
+      makeEntry({ description: '{"oops"', plugin_slug: 'aws-ssm' }),
+    )
+    expect(result.kind).toBe('text')
+  })
+
+  it('returns text when JSON payload is an array', () => {
+    const result = parseDescription(
+      makeEntry({ description: '[1,2,3]', plugin_slug: 'aws-ssm' }),
+    )
+    expect(result.kind).toBe('text')
+  })
+
+  it('parses a valid plugin payload', () => {
+    const raw =
+      '{"action":"set_value","data_type":"string","key":"acm-pca-cacert-path","plugin_slug":"aws-ssm","secret":false}'
+    const result = parseDescription(
+      makeEntry({ description: raw, plugin_slug: 'aws-ssm' }),
+    )
+    expect(result).toEqual({
+      action: 'set_value',
+      kind: 'plugin',
+      payload: {
+        action: 'set_value',
+        data_type: 'string',
+        key: 'acm-pca-cacert-path',
+        plugin_slug: 'aws-ssm',
+        secret: false,
+      },
+      raw,
+      summary: undefined,
+    })
+  })
+
+  it('captures summary when present in the payload', () => {
+    const raw = '{"summary":"Rotated production secret"}'
+    const result = parseDescription(
+      makeEntry({ description: raw, plugin_slug: 'aws-ssm' }),
+    )
+    expect(result).toMatchObject({
+      kind: 'plugin',
+      summary: 'Rotated production secret',
+    })
+  })
+
+  it('treats non-string action values as missing', () => {
+    const raw = '{"action":123}'
+    const result = parseDescription(
+      makeEntry({ description: raw, plugin_slug: 'aws-ssm' }),
+    )
+    expect(result).toMatchObject({ action: undefined, kind: 'plugin' })
+  })
+
+  it('handles whitespace before the JSON object', () => {
+    const raw = '   {"action":"noop"}'
+    const result = parseDescription(
+      makeEntry({ description: raw, plugin_slug: 'aws-ssm' }),
+    )
+    expect(result).toMatchObject({ action: 'noop', kind: 'plugin' })
+  })
+})

--- a/src/components/operations-log/parseDescription.ts
+++ b/src/components/operations-log/parseDescription.ts
@@ -1,0 +1,42 @@
+import type { OperationsLogRecord } from '@/types'
+
+export type ParsedDescription =
+  | {
+      action?: string
+      kind: 'plugin'
+      payload: Record<string, unknown>
+      raw: string
+      summary?: string
+    }
+  | { kind: 'text'; text: string }
+
+// When the API returns a non-empty `plugin_slug` on an ops-log entry, the
+// `description` column carries a JSON-encoded payload owned by that plugin.
+// Older / human-written entries leave `plugin_slug` empty and use the field
+// as free text — keep treating those as text without trying to parse.
+export function parseDescription(
+  entry: OperationsLogRecord,
+): ParsedDescription {
+  const raw = entry.description ?? ''
+  if (!entry.plugin_slug) return { kind: 'text', text: raw }
+  const payload = tryParseObject(raw)
+  if (!payload) return { kind: 'text', text: raw }
+  const action = typeof payload.action === 'string' ? payload.action : undefined
+  const summary =
+    typeof payload.summary === 'string' ? payload.summary : undefined
+  return { action, kind: 'plugin', payload, raw, summary }
+}
+
+function tryParseObject(raw: string): null | Record<string, unknown> {
+  const trimmed = raw.trim()
+  if (!trimmed.startsWith('{')) return null
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    // fall through
+  }
+  return null
+}

--- a/src/components/operations-log/plugin-renderers/aws-ssm.tsx
+++ b/src/components/operations-log/plugin-renderers/aws-ssm.tsx
@@ -1,0 +1,62 @@
+import { ShieldCheck } from 'lucide-react'
+
+import type { PluginOpsLogContext, PluginOpsLogRenderer } from './types'
+
+function details({ payload }: PluginOpsLogContext) {
+  const key = readString(payload, 'key')
+  const dataType = readString(payload, 'data_type')
+  const isSecret = payload.secret === true
+  return (
+    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
+      {key && (
+        <>
+          <dt className="text-overline uppercase text-tertiary">Key</dt>
+          <dd className="break-all font-mono text-xs text-primary">{key}</dd>
+        </>
+      )}
+      {dataType && (
+        <>
+          <dt className="text-overline uppercase text-tertiary">Data type</dt>
+          <dd className="font-mono text-xs text-primary">{dataType}</dd>
+        </>
+      )}
+      <dt className="text-overline uppercase text-tertiary">Secret</dt>
+      <dd className="flex items-center gap-1.5 text-xs text-primary">
+        {isSecret ? (
+          <>
+            <ShieldCheck className="h-3.5 w-3.5 text-amber-text" />
+            <span>Yes</span>
+          </>
+        ) : (
+          <span>No</span>
+        )}
+      </dd>
+    </dl>
+  )
+}
+
+function label({ action, payload }: PluginOpsLogContext): string {
+  const key = readString(payload, 'key')
+  if (!key) {
+    return action ? `aws-ssm · ${action}` : 'aws-ssm'
+  }
+  switch (action) {
+    case 'delete_value':
+      return `Deleted parameter "${key}"`
+    case 'set_value':
+      return `Set parameter "${key}"`
+    default:
+      return action ? `${action} "${key}"` : `aws-ssm "${key}"`
+  }
+}
+
+function readString(payload: Record<string, unknown>, key: string): string {
+  const value = payload[key]
+  return typeof value === 'string' ? value : ''
+}
+
+export const awsSsmRenderer: PluginOpsLogRenderer = {
+  details,
+  displayName: 'AWS SSM Parameter Store',
+  label,
+}

--- a/src/components/operations-log/plugin-renderers/generic.tsx
+++ b/src/components/operations-log/plugin-renderers/generic.tsx
@@ -1,0 +1,64 @@
+import { ShieldCheck } from 'lucide-react'
+
+import type { PluginOpsLogContext } from './types'
+
+const HIDDEN_KEYS = new Set(['action', 'plugin_slug', 'summary'])
+
+export function GenericPluginPayload({ payload }: PluginOpsLogContext) {
+  const isSecret = payload.secret === true
+  const entries = Object.entries(payload).filter(
+    ([key]) => !HIDDEN_KEYS.has(key),
+  )
+  if (entries.length === 0) {
+    return (
+      <p className="text-sm text-tertiary">No additional payload fields.</p>
+    )
+  }
+  return (
+    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
+      {entries.map(([key, value]) => (
+        <PayloadRow
+          fieldKey={key}
+          key={key}
+          mask={isSecret && key === 'value'}
+          value={value}
+        />
+      ))}
+    </dl>
+  )
+}
+
+function formatValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean')
+    return String(value)
+  return JSON.stringify(value)
+}
+
+function PayloadRow({
+  fieldKey,
+  mask,
+  value,
+}: {
+  fieldKey: string
+  mask: boolean
+  value: unknown
+}) {
+  return (
+    <>
+      <dt className="font-mono text-xs text-tertiary">{fieldKey}</dt>
+      <dd className="flex items-center gap-1.5 break-words font-mono text-xs text-primary">
+        {mask ? (
+          <>
+            <ShieldCheck className="h-3.5 w-3.5 text-tertiary" />
+            <span>••••••</span>
+          </>
+        ) : (
+          formatValue(value)
+        )}
+      </dd>
+    </>
+  )
+}

--- a/src/components/operations-log/plugin-renderers/index.ts
+++ b/src/components/operations-log/plugin-renderers/index.ts
@@ -1,0 +1,19 @@
+import { awsSsmRenderer } from './aws-ssm'
+import type { PluginOpsLogRenderer } from './types'
+
+// Maps `plugin_slug` from the ops log entry to its renderer. Unregistered
+// slugs fall back to the generic key/value payload renderer; the entry still
+// renders, just without plugin-specific polish.
+const RENDERERS: Record<string, PluginOpsLogRenderer> = {
+  'aws-ssm': awsSsmRenderer,
+}
+
+export function getPluginRenderer(
+  pluginSlug: string | undefined,
+): PluginOpsLogRenderer | undefined {
+  if (!pluginSlug) return undefined
+  return RENDERERS[pluginSlug]
+}
+
+export { GenericPluginPayload } from './generic'
+export type { PluginOpsLogContext, PluginOpsLogRenderer } from './types'

--- a/src/components/operations-log/plugin-renderers/types.ts
+++ b/src/components/operations-log/plugin-renderers/types.ts
@@ -1,0 +1,20 @@
+import type { LucideIcon } from 'lucide-react'
+
+import type { OperationsLogRecord } from '@/types'
+
+export interface PluginOpsLogContext {
+  action?: string
+  entry: OperationsLogRecord
+  payload: Record<string, unknown>
+}
+
+export interface PluginOpsLogRenderer {
+  // Expanded panel content (rendered above Notes / Link in the details view).
+  details?(ctx: PluginOpsLogContext): React.ReactNode
+  // Human-readable name surfaced as the details section heading.
+  displayName: string
+  // Optional plugin-branded icon override for the stream row.
+  icon?: LucideIcon
+  // Compact one-liner shown under the row title.
+  label?(ctx: PluginOpsLogContext): string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -676,7 +676,11 @@ export interface OperationsLogFilters {
 
 // Raw record returned by the /operations-log/ API (distinct from the
 // activity-feed projection defined above in `OperationsLogEntry`).
-export type OperationsLogRecord = Schemas['OperationLogResponse']
+// `plugin_slug` is augmented here pending an openapi snapshot refresh against
+// the upstream `imbi-api` change — the backend already returns it.
+export type OperationsLogRecord = Schemas['OperationLogResponse'] & {
+  plugin_slug?: string
+}
 
 // Organization types
 export type Organization = Schemas['OrganizationResponse']


### PR DESCRIPTION
## Summary
- Ops log entries emitted by plugins ship a structured JSON payload in `description`, discriminated by the new `plugin_slug` column. The feed used to render that JSON verbatim — now it dispatches to a per-plugin renderer with a sensible fallback.
- First concrete renderer: `aws-ssm` (`set_value` / `delete_value`). Unknown slugs fall back to a generic key/value renderer that masks the `value` field when `secret: true`.
- `OperationsLogRecord` is augmented locally with `plugin_slug?: string` pending an `openapi.json` snapshot refresh — the field already ships from `imbi-api`.

## Problem
The backend started emitting plugin ops log rows like:
```
entry_type:  Configured
description: {"action":"set_value","data_type":"string","key":"acm-pca-cacert-path","plugin_slug":"aws-ssm","secret":false}
plugin_slug: aws-ssm
```
The UI rendered the raw JSON in the row body and the details pane — unreadable, and gave plugins no way to brand their entries.

## Solution
- `parseDescription` returns `{ kind: 'text' | 'plugin', ... }` for an entry. Defensive: only `plugin` when `plugin_slug` is set *and* the description parses to a JSON object.
- `plugin-renderers/` is a small registry keyed on `plugin_slug`:
  - `label(ctx)` — compact one-liner shown under the row title.
  - `details(ctx)` — expanded section rendered above Notes / Link in the entry details panel.
  - Fallbacks: pre-rendered `payload.summary` → `\`${plugin_slug} · ${action}\`` for the label; `<GenericPluginPayload>` (definition list, masks `value` when `secret`) for the details.
- Wired into `OperationsLogStreamRow.tsx` and `OperationsLogEntryDetails.tsx`. The v1-migration "notes duplicates description" suppression is skipped for plugin payloads (different content domain).
- 8 unit tests for `parseDescription`: null/text/malformed-JSON/array/valid-payload/summary/non-string-action/leading-whitespace.

## Plugin contract (for plugin authors)
- `description` carries a stringified JSON **object**.
- Required: `plugin_slug: string` (matches the renderer registry key), `action: string` (stable per-plugin discriminator).
- Recommended: `summary: string` (fallback label for plugins without a registered renderer), `secret: boolean` (generic renderer masks `value` when true).
- All other fields are plugin-specific; use `snake_case`.

## Follow-ups (out of scope here)
- Refresh `openapi.json` and drop the `OperationsLogRecord` augmentation once the canonical API snapshot lines up.
- Filter chip on the ops log toolbar for "by plugin" (now feasible — `plugin_slug` is an indexed `LowCardinality(String)` column).

## Test plan
- [x] `npm test` — 172/172 pass (8 new)
- [x] `npm run lint`, `npm run format:check` — clean
- [x] `npm run build` — clean (TS + Vite)
- [ ] Smoke test in browser: an `aws-ssm` `Configured` entry renders the compact "Set parameter ..." label and the details section shows key / data_type / secret
- [ ] Smoke test in browser: an entry with an unregistered `plugin_slug` falls back to the generic key/value table
- [ ] Smoke test in browser: existing free-text entries (empty `plugin_slug`) still render exactly as before