### PR TITLE
Disable scroll-lock on nav dropdowns

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -155,7 +155,7 @@ export function Navigation({ currentView }: NavigationProps) {
                   <span className="truncate">{selectedOrganization.name}</span>
                 </Button>
               ) : (
-                <DropdownMenu>
+                <DropdownMenu modal={false}>
                   <DropdownMenuTrigger asChild>
                     <Button
                       className="max-w-[200px] gap-2 border-tertiary bg-primary text-primary hover:bg-secondary"
@@ -202,7 +202,7 @@ export function Navigation({ currentView }: NavigationProps) {
               ))}
 
             {/* Quick Actions Dropdown */}
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <Button
                   className="gap-2 border-tertiary bg-primary text-primary hover:bg-secondary"
@@ -226,7 +226,7 @@ export function Navigation({ currentView }: NavigationProps) {
             </DropdownMenu>
 
             {/* User Profile Dropdown */}
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <Button
                   className="rounded-full p-0 hover:bg-secondary"


### PR DESCRIPTION
Radix DropdownMenu defaults to modal=true, which locks body scroll and injects a padding-right compensation when any nav dropdown opens. This causes visible content shift and is unexpected UX for non-modal overlays.