### PR TITLE
Surface DeploymentTriggerResponse.warning as an amber promote toast

### DIFF
--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -208,6 +208,17 @@ export function PromoteTab({
             : undefined,
         )
       }
+      // The orchestrator's per-env switch may emit a non-fatal
+      // warning (e.g. the deployment POST failed but the tag +
+      // release still cut, or no DEPLOYS_VIA edge is configured).
+      // Surface it as an amber toast so the operator knows the
+      // promote recorded but didn't drive a remote action through.
+      if (data.warning) {
+        toast.warning(`Promote to ${toEnvName} recorded with a warning`, {
+          description: data.warning,
+          duration: 10_000,
+        })
+      }
       onClose()
     },
   })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -427,6 +427,13 @@ export interface DeploymentTriggerResponse {
   release_url?: null | string
   run: DeploymentRun
   tag?: null | string
+  // Human-readable narrative for any non-fatal failure encountered
+  // while running the per-environment promote steps (e.g. the
+  // GitHub Deployments POST returned 422 because the repo's
+  // ``on: deployment`` workflow isn't wired up yet). The promote
+  // itself still records a DeploymentEvent; the UI surfaces this as
+  // an amber inline note.
+  warning?: null | string
 }
 
 export interface Document {


### PR DESCRIPTION
## Summary

Surfaces the new `DeploymentTriggerResponse.warning` field (introduced in imbi-api #297) on the Promote dialog so operators see a clear amber toast when a promote recorded successfully but a remote step (POST `/deployments`, `create_release`, or "no `DEPLOYS_VIA` edge configured") couldn't complete.

## Problem

After imbi-api #297, the promote orchestrator switches on a per-env `DEPLOYS_VIA` edge action and turns failures (e.g. 422 from the GitHub Deployments API on a repo whose workflow still uses `on: workflow_dispatch`, or a missing `DEPLOYS_VIA` edge) into a non-fatal `warning` on the response. Without UI plumbing, those warnings were silently dropped and the operator only saw the green "promoted" toast.

## Changes

- `DeploymentTriggerResponse` (in `types/index.ts`) gains an optional `warning?: null | string` field.
- `PromoteTab.tsx` reads `data.warning` in `onSuccess` and fires an additional amber `toast.warning(...)` with the warning text. The existing success / loading toast is unchanged so the operator still sees the promote landed.

## Test plan

- [x] `npm run build` (tsc + vite) clean.
- [x] `npm run lint` clean.
- [x] `npm run format:check` clean.
- [ ] Manual: promote into an env with no `DEPLOYS_VIA` edge → expect green "promoted" toast plus amber "Promote to <env> recorded with a warning · No DEPLOYS_VIA edge configured…" toast.
- [ ] Manual: promote into an env with `action='deployment'` but the repo's workflow still uses `on: workflow_dispatch` → expect amber "trigger_deployment failed: 422…" toast.

## Out of scope (follow-up)

The `DEPLOYS_VIA` edge editor surface. `ServicePluginEdgesCard` today only handles edges anchored *at* an `Environment` (e.g. AWS `MAPS_TO`); `DEPLOYS_VIA` is anchored at `ProjectType`/`Project` with `Environment` as the *target*. Wiring up an editor for those needs new plugin-edge endpoints (per-ProjectType, per-Project) and new admin/project-page surfaces — substantial enough to deserve its own design pass and PR.

Operators can populate `DEPLOYS_VIA` via the generic `plugin_edges` API in the interim:

```bash
curl -X PUT $IMBI/admin/plugins/github-deployment/edges/DEPLOYS_VIA/from/ProjectType/<pt_id> \
  -H 'Content-Type: application/json' \
  -d '{
    "target_label": "Environment",
    "target_id": "<env_id>",
    "properties": {
      "action": "release",
      "payload": {},
      "identity_plugin_id": ""
    }
  }'
```

## Related

- imbi-common shipped in 0.10.0 (`PluginContext.environment_config`, `WorkflowFile`, `list_workflows`).
- imbi-plugin-github [#11](https://github.com/AWeber-Imbi/imbi-plugin-github/pull/11) — declares `DEPLOYS_VIA` on each manifest, drives deployments via the GitHub Deployments API.
- imbi-api [#297](https://github.com/AWeber-Imbi/imbi-api/pull/297) — resolves `DEPLOYS_VIA` in `_handle_promote`, switches on `action`, turns failures into warnings.