### PR TITLE
Fix score breakdown labels and uppercase-acronym detection

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -818,7 +818,7 @@ export function ProjectDetail({
                     <div
                       className={`flex items-center justify-between border-b py-1.5 ${divider}`}
                     >
-                      <span className={`text-sm ${label}`}>Project types</span>
+                      <span className={`text-sm ${label}`}>Project Types</span>
                       <InlineMultiSelect
                         onCommit={handleCommitProjectTypeSlugs}
                         options={projectTypeOptions}
@@ -1184,9 +1184,7 @@ function ScoreBreakdownDetail({
               const fillPct =
                 maxPts > 0 ? (c.weighted_contribution / maxPts) * 100 : 0
               const lost = Math.round(maxPts - c.weighted_contribution)
-              const policyName = formatFieldKey(
-                c.policy_slug.replace(/-/g, '_'),
-              )
+              const policyName = formatFieldKey(c.attribute_name)
               const recommendation = policy
                 ? buildRecommendation(c, policy)
                 : null
@@ -1252,9 +1250,7 @@ function ScoreBreakdownDetail({
           </div>
           <div className="overflow-hidden rounded-md border border-tertiary">
             {perfect.map(({ contribution: c, maxPts }, idx) => {
-              const policyName = formatFieldKey(
-                c.policy_slug.replace(/-/g, '_'),
-              )
+              const policyName = formatFieldKey(c.attribute_name)
               return (
                 <div
                   className={`grid grid-cols-[auto_1fr_auto] items-center gap-2.5 bg-primary px-3 py-2.5 ${

--- a/src/lib/project-field-formatting.ts
+++ b/src/lib/project-field-formatting.ts
@@ -28,7 +28,12 @@ export function formatFieldKey(key: string): string {
     .replace(/([a-z])([A-Z])/g, '$1 $2')
     .replace(/\b\w/g, (c) => c.toUpperCase())
     .split(' ')
-    .map((w) => WORD_OVERRIDES[w.toLowerCase()] ?? w)
+    .map((w) => {
+      const override = WORD_OVERRIDES[w.toLowerCase()]
+      if (override) return override
+      if (w.length > 0 && /^[^aeiouAEIOU]+$/.test(w)) return w.toUpperCase()
+      return w
+    })
     .join(' ')
 }
 


### PR DESCRIPTION
## Summary
- Score breakdown rows now use the attribute name (e.g. **Programming Language**, **Test Coverage**) instead of the scoring-policy slug. Uses `AttributeContribution.attribute_name` from the API.
- `formatFieldKey` now uppercases words that contain no vowels (a/e/i/o/u), so acronyms like `css`, `ssh`, `tcp` render as **CSS**, **SSH**, **TCP**. Existing `WORD_OVERRIDES` (aws, ci, github, gitlab, sonarqube) still win.
- Capitalize "Project Types" label on the project details card.

## Test plan
- [ ] Score breakdown shows attribute names, not policy slugs, in both **To improve** and **At maximum** sections
- [ ] A field key like `tcp_endpoint` renders as **TCP Endpoint**
- [ ] Words with vowels (`api`, `ui`) are unchanged unless overridden
- [ ] Project details card shows **Project Types** with a capital T