### PR TITLE
Release 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imbi-ui-v2",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imbi-ui-v2",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imbi-ui-v2",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Release 2.1.0. First tagged release for imbi-ui v2. Aligns with the Imbi v2 platform version family (api/ui/common all at 2.1.0).

## Highlights Since 2.0.0

- Fix score breakdown labels and uppercase-acronym detection (#254)
- Surface DeploymentTriggerResponse.warning as an amber promote toast (#253)
- Disable scroll-lock on nav dropdowns (#252)
- Render plugin-emitted ops log entries via a renderer registry (#251)
- Format numbers with `toLocaleString` for thousands separators (#250)
- Unify report table styles (#249)
- Match reports sidebar highlight to settings sidebar (#248)
- Tone down search highlight in configuration parameter list (#247)
- Fix timeline dot alignment in project activity log (#246)
- Replace native selects with searchable combobox in dialogs (#245)
- Consolidate dialog styling into shared dialog.tsx defaults (#244)
- Render InlineSwitch as a visual toggle instead of text (#243)

## Test plan

- [ ] CI passes
- [ ] Tag 2.1.0 after merge