### PR TITLE
Add Duplicate button to ops log entry details

### DIFF
--- a/src/components/NewOpsLogDialog.tsx
+++ b/src/components/NewOpsLogDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
@@ -26,13 +26,28 @@ import {
   type OperationsLogEntryType,
 } from '@/types'
 
+export type NewOpsLogInitialValues = Partial<
+  Pick<
+    OperationsLogCreate,
+    | 'description'
+    | 'environment_slug'
+    | 'link'
+    | 'notes'
+    | 'project_id'
+    | 'ticket_slug'
+    | 'version'
+  >
+> & { entry_type?: null | OperationsLogEntryType }
+
 interface NewOpsLogDialogProps {
+  initialValues?: NewOpsLogInitialValues
   isOpen: boolean
   onClose: () => void
   onEntryCreated?: (id: string) => void
 }
 
 export function NewOpsLogDialog({
+  initialValues,
   isOpen,
   onClose,
   onEntryCreated,
@@ -49,6 +64,20 @@ export function NewOpsLogDialog({
   const [link, setLink] = useState('')
   const [ticketSlug, setTicketSlug] = useState('')
   const [notes, setNotes] = useState('')
+
+  // Re-seed on every open so Duplicate reflects the source entry even if the
+  // user previously opened, edited, and cancelled the dialog.
+  useEffect(() => {
+    if (!isOpen) return
+    setProjectId(initialValues?.project_id ?? '')
+    setEnvironmentSlug(initialValues?.environment_slug ?? '')
+    setEntryType(initialValues?.entry_type ?? '')
+    setDescription(initialValues?.description ?? '')
+    setVersion(initialValues?.version ?? '')
+    setLink(initialValues?.link ?? '')
+    setTicketSlug(initialValues?.ticket_slug ?? '')
+    setNotes(initialValues?.notes ?? '')
+  }, [isOpen]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const { data: projects = [] } = useQuery({
     enabled: !!orgSlug && isOpen,

--- a/src/components/operations-log/OperationsLogEntryDetails.tsx
+++ b/src/components/operations-log/OperationsLogEntryDetails.tsx
@@ -1,9 +1,16 @@
+import { useState } from 'react'
+
 import { useQuery } from '@tanstack/react-query'
-import { ExternalLink } from 'lucide-react'
+import { Copy, ExternalLink } from 'lucide-react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 import { getOperationsLogEntry } from '@/api/endpoints'
+import {
+  NewOpsLogDialog,
+  type NewOpsLogInitialValues,
+} from '@/components/NewOpsLogDialog'
+import { Button } from '@/components/ui/button'
 import {
   Tooltip,
   TooltipContent,
@@ -33,6 +40,18 @@ export function OperationsLogEntryDetails({ entry }: Props) {
 
   const record = data ?? entry
   const performer = record.performed_by ?? record.recorded_by
+  const [duplicateOpen, setDuplicateOpen] = useState(false)
+
+  const duplicateInitialValues: NewOpsLogInitialValues = {
+    description: record.description,
+    entry_type: record.entry_type,
+    environment_slug: record.environment_slug,
+    link: record.link,
+    notes: record.notes,
+    project_id: record.project_id,
+    ticket_slug: record.ticket_slug,
+    version: record.version,
+  }
   const parsed = parseDescription(record)
   const pluginRenderer =
     parsed.kind === 'plugin' ? getPluginRenderer(record.plugin_slug) : undefined
@@ -134,6 +153,23 @@ export function OperationsLogEntryDetails({ entry }: Props) {
           No additional notes, link, or ticket for this entry.
         </p>
       )}
+
+      <div className="flex justify-end pt-2">
+        <Button
+          onClick={() => setDuplicateOpen(true)}
+          size="sm"
+          variant="outline"
+        >
+          <Copy className="mr-1.5 h-3.5 w-3.5" />
+          Duplicate
+        </Button>
+      </div>
+
+      <NewOpsLogDialog
+        initialValues={duplicateInitialValues}
+        isOpen={duplicateOpen}
+        onClose={() => setDuplicateOpen(false)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Adds a **Duplicate** button to the expanded operations log entry detail panel. Clicking it opens the existing _New Ops Log Entry_ dialog pre-filled with the source entry's project, environment, entry type, description, version, link, ticket, and notes — making it fast to record a repeat operation (e.g. a redeploy of the same version) without re-typing.

## Problem

Recording an ops log entry that's nearly identical to a previous one required re-selecting the project + environment, re-picking the entry type, and re-typing the description, version, ticket, and notes from scratch.

## Solution

- `NewOpsLogDialog` now accepts an optional `initialValues` prop and re-seeds its form fields each time the dialog opens. The `initialValues` shape is a `Partial<Pick<OperationsLogCreate, …>>` so it stays in lockstep with the create payload.
- `OperationsLogEntryDetails` renders a **Duplicate** button at the bottom of the panel and mounts its own `NewOpsLogDialog` instance prefilled from the current record. `performed_by`, `occurred_at`, and `completed_at` are intentionally not duplicated so the new entry reflects the current operation.

## Test plan

- [ ] Expand an ops log entry, click **Duplicate** — dialog opens with project, environment, entry type, description, version, link, ticket, notes prefilled.
- [ ] Edit a field, cancel, reopen — fields are re-seeded from the source entry.
- [ ] Save — a new entry is created and the feed refreshes.
- [ ] Duplicate from an entry whose project has only one environment — environment combobox shows the prefilled value and is selectable.
- [ ] `npm run lint`, `npm run format:check`, `npx tsc --noEmit`, and `npm test` all pass.