### PR TITLE
Add Fallow to lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -28,3 +30,6 @@ jobs:
 
       - name: Check formatting
         run: npm run format:check
+
+      - name: Fallow audit
+        run: npx fallow audit --base origin/${{ github.base_ref || 'main' }}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "oxfmt 'src/**/*.{ts,tsx,css}' package.json '*.config.{js,ts}'",
     "format:check": "oxfmt --check 'src/**/*.{ts,tsx,css}' package.json '*.config.{js,ts}'",
     "lint": "oxlint .",
+    "lint:fallow": "fallow dead-code",
     "lint:fix": "oxlint --fix .",
     "prepare": "husky",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary

Wires the already-installed [Fallow](https://fallow.tools/) (codebase intelligence for TS/JS: unused code, circular deps, duplication, complexity) into the lint pipeline:

- New `lint:fallow` npm script runs `fallow dead-code` against the whole project so devs can inspect findings locally.
- New **Fallow audit** step in the Lint GitHub workflow runs `fallow audit`. Audit auto-detects the base branch and, by default (`--gate new-only`), only fails on findings introduced by the changeset — existing tech debt doesn't break PR CI, but newly added dead code, circular dependencies, or unresolved imports do.

## Problem

Fallow was already a `devDependencies` entry with a `.fallowrc.json` config, but nothing in CI or our npm scripts actually invoked it, so it was effectively unused.

## Solution

- `package.json`: add `lint:fallow` → `fallow dead-code`.
- `.github/workflows/lint.yml`: add a `Fallow audit` step after `Check formatting`, running `npx fallow audit`.

Pre-existing project findings are intentionally left to be cleaned up incrementally; `audit` makes the PR gate forward-looking rather than blocking on inherited debt.

## Test plan

- [ ] Lint workflow runs the new Fallow audit step on this PR and passes (no new findings introduced).
- [ ] `npm run lint:fallow` runs locally and prints the existing findings without breaking other scripts.
- [ ] A PR that introduces an unused export fails the Fallow audit step.