### PR TITLE
Scoring phase 2 UI: presence, link-presence, and age policies

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -33,3 +33,11 @@ done || exit 1
 
 # Lint and format staged files
 npx lint-staged
+
+# Dead-code audit (mirrors the lint.yml CI step). Compares against
+# origin/main so we only flag new dead exports, not the existing
+# backlog. Skip silently when origin/main isn't fetched yet (fresh
+# clones); CI catches it in that case.
+if git rev-parse --verify --quiet origin/main >/dev/null; then
+  npx fallow audit --base origin/main
+fi

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1078,11 +1078,12 @@ function buildRecommendation(
   c: AttributeContribution,
   policy: ScoringPolicy,
 ): null | string {
+  if (policy.category !== 'attribute') return null
   const current = c.mapped_score
   if (policy.value_score_map) {
     const better = Object.entries(policy.value_score_map)
-      .filter(([, score]) => score > current)
-      .sort(([, a], [, b]) => b - a)
+      .filter(([, score]) => (score as number) > current)
+      .sort(([, a], [, b]) => (b as number) - (a as number))
     if (better.length === 0) return null
     const topScore = better[0][1]
     const top = better
@@ -1094,8 +1095,8 @@ function buildRecommendation(
   }
   if (policy.range_score_map) {
     const better = Object.entries(policy.range_score_map)
-      .filter(([, score]) => score > current)
-      .sort(([, a], [, b]) => b - a)
+      .filter(([, score]) => (score as number) > current)
+      .sort(([, a], [, b]) => (b as number) - (a as number))
     if (better.length === 0) return null
     const [target] = better[0]
     return `Update to reach ${target}`

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1081,9 +1081,7 @@ function buildRecommendation(
   if (policy.category !== 'attribute') return null
   const current = c.mapped_score
   if (policy.value_score_map) {
-    const better = Object.entries(policy.value_score_map)
-      .filter(([, score]) => (score as number) > current)
-      .sort(([, a], [, b]) => (b as number) - (a as number))
+    const better = entriesAbove(policy.value_score_map, current)
     if (better.length === 0) return null
     const topScore = better[0][1]
     const top = better
@@ -1094,14 +1092,21 @@ function buildRecommendation(
     return `Update to ${top.slice(0, -1).join(', ')}, or ${top[top.length - 1]}`
   }
   if (policy.range_score_map) {
-    const better = Object.entries(policy.range_score_map)
-      .filter(([, score]) => (score as number) > current)
-      .sort(([, a], [, b]) => (b as number) - (a as number))
+    const better = entriesAbove(policy.range_score_map, current)
     if (better.length === 0) return null
     const [target] = better[0]
     return `Update to reach ${target}`
   }
   return null
+}
+
+function entriesAbove(
+  map: Record<string, number>,
+  current: number,
+): [string, number][] {
+  return Object.entries(map)
+    .filter(([, score]) => score > current)
+    .sort(([, a], [, b]) => b - a)
 }
 
 function fmtAttributeValue(value: unknown): string {

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -31,12 +31,20 @@ import { buildDiffPatch } from '@/lib/json-patch'
 import type {
   PatchOperation,
   ScoringPolicy,
+  ScoringPolicyCategory,
   ScoringPolicyCreate,
 } from '@/types'
 
 import { AdminSection } from './AdminSection'
 import { ImportScoringPolicyDialog } from './scoring-policies/ImportScoringPolicyDialog'
 import { ScoringPolicyForm } from './scoring-policies/ScoringPolicyForm'
+
+const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
+  age: 'Age',
+  attribute: 'Attribute',
+  link_presence: 'Link Presence',
+  presence: 'Presence',
+}
 
 export function ScoringPolicyManagement() {
   const {
@@ -90,11 +98,12 @@ export function ScoringPolicyManagement() {
   const filteredPolicies = policies.filter((p) => {
     if (searchQuery) {
       const q = searchQuery.toLowerCase()
+      const subjectKey = policySubjectKey(p).toLowerCase()
       if (
         !p.name.toLowerCase().includes(q) &&
         !p.slug.toLowerCase().includes(q) &&
         !(p.description?.toLowerCase().includes(q) ?? false) &&
-        !p.attribute_name.toLowerCase().includes(q)
+        !subjectKey.includes(q)
       )
         return false
     }
@@ -104,22 +113,7 @@ export function ScoringPolicyManagement() {
   })
 
   const handleCopy = (policy: ScoringPolicy) => {
-    const exportObj = {
-      attribute_name: policy.attribute_name,
-      ...(policy.description ? { description: policy.description } : {}),
-      enabled: policy.enabled,
-      name: policy.name,
-      priority: policy.priority,
-      ...(policy.range_score_map
-        ? { range_score_map: policy.range_score_map }
-        : {}),
-      slug: policy.slug,
-      targets: policy.targets ?? [],
-      ...(policy.value_score_map
-        ? { value_score_map: policy.value_score_map }
-        : {}),
-      weight: policy.weight,
-    }
+    const exportObj = policyToExportPayload(policy)
     if (!navigator.clipboard?.writeText) return
     navigator.clipboard
       .writeText(JSON.stringify(exportObj, null, 2))
@@ -268,12 +262,23 @@ export function ScoringPolicyManagement() {
             },
             {
               cellAlign: 'left',
-              header: 'Attribute',
+              header: 'Category',
               headerAlign: 'left',
-              key: 'attribute',
+              key: 'category',
+              render: (p) => (
+                <span className="rounded bg-secondary px-1.5 py-0.5 text-xs text-secondary">
+                  {CATEGORY_LABELS[p.category]}
+                </span>
+              ),
+            },
+            {
+              cellAlign: 'left',
+              header: 'Subject',
+              headerAlign: 'left',
+              key: 'subject',
               render: (p) => (
                 <code className="rounded bg-secondary px-1.5 py-0.5 text-xs text-primary">
-                  {p.attribute_name}
+                  {policySubjectKey(p)}
                 </code>
               ),
             },
@@ -342,4 +347,40 @@ export function ScoringPolicyManagement() {
       />
     </>
   )
+}
+
+function policySubjectKey(policy: ScoringPolicy): string {
+  return policy.category === 'link_presence'
+    ? policy.link_slug
+    : policy.attribute_name
+}
+
+function policyToExportPayload(policy: ScoringPolicy): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    category: policy.category,
+    enabled: policy.enabled,
+    name: policy.name,
+    priority: policy.priority,
+    slug: policy.slug,
+    targets: policy.targets ?? [],
+    weight: policy.weight,
+  }
+  if (policy.description) base.description = policy.description
+  if (policy.category === 'attribute') {
+    base.attribute_name = policy.attribute_name
+    if (policy.value_score_map) base.value_score_map = policy.value_score_map
+    if (policy.range_score_map) base.range_score_map = policy.range_score_map
+  } else if (policy.category === 'presence') {
+    base.attribute_name = policy.attribute_name
+    if (policy.present_score != null) base.present_score = policy.present_score
+    if (policy.missing_score != null) base.missing_score = policy.missing_score
+  } else if (policy.category === 'link_presence') {
+    base.link_slug = policy.link_slug
+    if (policy.present_score != null) base.present_score = policy.present_score
+    if (policy.missing_score != null) base.missing_score = policy.missing_score
+  } else {
+    base.attribute_name = policy.attribute_name
+    base.age_score_map = policy.age_score_map
+  }
+  return base
 }

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -29,6 +29,7 @@ import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import { buildDiffPatch } from '@/lib/json-patch'
 import type {
+  AttributeScoringPolicy,
   PatchOperation,
   ScoringPolicy,
   ScoringPolicyCategory,
@@ -349,6 +350,42 @@ export function ScoringPolicyManagement() {
   )
 }
 
+function attributeExport(
+  policy: AttributeScoringPolicy,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { attribute_name: policy.attribute_name }
+  if (policy.value_score_map) out.value_score_map = policy.value_score_map
+  if (policy.range_score_map) out.range_score_map = policy.range_score_map
+  return out
+}
+
+// fallow-ignore-next-line complexity
+function categorySpecificExport(
+  policy: ScoringPolicy,
+): Record<string, unknown> {
+  switch (policy.category) {
+    case 'age':
+      return {
+        age_score_map: policy.age_score_map,
+        attribute_name: policy.attribute_name,
+      }
+    case 'attribute':
+      return attributeExport(policy)
+    case 'link_presence':
+      return presenceExport({
+        missing_score: policy.missing_score,
+        present_score: policy.present_score,
+        subject: { link_slug: policy.link_slug },
+      })
+    case 'presence':
+      return presenceExport({
+        missing_score: policy.missing_score,
+        present_score: policy.present_score,
+        subject: { attribute_name: policy.attribute_name },
+      })
+  }
+}
+
 function policySubjectKey(policy: ScoringPolicy): string {
   return policy.category === 'link_presence'
     ? policy.link_slug
@@ -366,21 +403,16 @@ function policyToExportPayload(policy: ScoringPolicy): Record<string, unknown> {
     weight: policy.weight,
   }
   if (policy.description) base.description = policy.description
-  if (policy.category === 'attribute') {
-    base.attribute_name = policy.attribute_name
-    if (policy.value_score_map) base.value_score_map = policy.value_score_map
-    if (policy.range_score_map) base.range_score_map = policy.range_score_map
-  } else if (policy.category === 'presence') {
-    base.attribute_name = policy.attribute_name
-    if (policy.present_score != null) base.present_score = policy.present_score
-    if (policy.missing_score != null) base.missing_score = policy.missing_score
-  } else if (policy.category === 'link_presence') {
-    base.link_slug = policy.link_slug
-    if (policy.present_score != null) base.present_score = policy.present_score
-    if (policy.missing_score != null) base.missing_score = policy.missing_score
-  } else {
-    base.attribute_name = policy.attribute_name
-    base.age_score_map = policy.age_score_map
-  }
-  return base
+  return { ...base, ...categorySpecificExport(policy) }
+}
+
+function presenceExport(args: {
+  missing_score?: null | number
+  present_score?: null | number
+  subject: Record<string, unknown>
+}): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...args.subject }
+  if (args.present_score != null) out.present_score = args.present_score
+  if (args.missing_score != null) out.missing_score = args.missing_score
+  return out
 }

--- a/src/components/admin/blueprints/ImportBlueprintDialog.tsx
+++ b/src/components/admin/blueprints/ImportBlueprintDialog.tsx
@@ -2,22 +2,21 @@ import { useCallback, useEffect, useState } from 'react'
 
 import Ajv from 'ajv'
 import yaml from 'js-yaml'
-import { AlertCircle, FileJson, FileText, Upload } from 'lucide-react'
+import { AlertCircle, FileJson, FileText } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { type DetectedFormat, detectFormat } from '@/lib/import-format'
 import type { BlueprintCreate, BlueprintFilter } from '@/types'
 
-const ajv = new Ajv()
+import { ImportDialogFooter } from '../import-dialog-shared'
 
-type DetectedFormat = 'json' | 'unknown' | 'yaml'
+const ajv = new Ajv()
 
 interface ImportBlueprintDialogProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -343,34 +342,15 @@ export function ImportBlueprintDialog({
           )}
         </div>
 
-        <DialogFooter>
-          <Button disabled={isLoading} onClick={handleClose} variant="outline">
-            Cancel
-          </Button>
-          <Button
-            className="bg-action text-action-foreground hover:bg-action-hover"
-            disabled={isLoading || !rawInput.trim()}
-            onClick={handleValidateAndImport}
-          >
-            <Upload className="mr-2 h-4 w-4" />
-            {isLoading ? 'Importing...' : 'Import'}
-          </Button>
-        </DialogFooter>
+        <ImportDialogFooter
+          hasInput={!!rawInput.trim()}
+          isLoading={isLoading}
+          onClose={handleClose}
+          onImport={handleValidateAndImport}
+        />
       </DialogContent>
     </Dialog>
   )
-}
-
-function detectFormat(input: string): DetectedFormat {
-  const trimmed = input.trim()
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json'
-  if (
-    trimmed.includes(':') ||
-    trimmed.includes(':\n') ||
-    trimmed.startsWith('---')
-  )
-    return 'yaml'
-  return 'unknown'
 }
 
 function validateBlueprintShape(

--- a/src/components/admin/import-dialog-shared.tsx
+++ b/src/components/admin/import-dialog-shared.tsx
@@ -1,0 +1,34 @@
+import { Upload } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { DialogFooter } from '@/components/ui/dialog'
+
+interface ImportDialogFooterProps {
+  hasInput: boolean
+  isLoading: boolean
+  onClose: () => void
+  onImport: () => void
+}
+
+export function ImportDialogFooter({
+  hasInput,
+  isLoading,
+  onClose,
+  onImport,
+}: ImportDialogFooterProps) {
+  return (
+    <DialogFooter>
+      <Button disabled={isLoading} onClick={onClose} variant="outline">
+        Cancel
+      </Button>
+      <Button
+        className="bg-action text-action-foreground hover:bg-action-hover"
+        disabled={isLoading || !hasInput}
+        onClick={onImport}
+      >
+        <Upload className="mr-2 h-4 w-4" />
+        {isLoading ? 'Importing...' : 'Import'}
+      </Button>
+    </DialogFooter>
+  )
+}

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -12,7 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import type { ScoringPolicyCreate } from '@/types'
+import type { ScoringPolicyCategory, ScoringPolicyCreate } from '@/types'
 
 type DetectedFormat = 'json' | 'unknown' | 'yaml'
 
@@ -25,7 +25,21 @@ interface ImportScoringPolicyDialogProps {
   onImport: (policy: ScoringPolicyCreate) => void
 }
 
-const REQUIRED_FIELDS = ['name', 'slug', 'attribute_name', 'weight'] as const
+const COMMON_REQUIRED = ['name', 'slug', 'weight'] as const
+
+const VALID_CATEGORIES: ScoringPolicyCategory[] = [
+  'attribute',
+  'presence',
+  'link_presence',
+  'age',
+]
+
+const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
+  age: 'Age',
+  attribute: 'Attribute',
+  link_presence: 'Link Presence',
+  presence: 'Presence',
+}
 
 export function ImportScoringPolicyDialog({
   apiError,
@@ -162,21 +176,33 @@ export function ImportScoringPolicyDialog({
           <DialogDescription>
             Paste a JSON or YAML scoring policy definition below. Required
             fields:{' '}
-            {REQUIRED_FIELDS.map((f, i) => (
+            {COMMON_REQUIRED.map((f, i) => (
               <span key={f}>
                 <code className="rounded bg-secondary px-1 py-0.5 text-xs">
                   {f}
                 </code>
-                {i < REQUIRED_FIELDS.length - 1 ? ', ' : ''}
+                {i < COMMON_REQUIRED.length - 1 ? ', ' : ''}
               </span>
-            ))}{' '}
-            and at least one of{' '}
+            ))}
+            . Optional{' '}
             <code className="rounded bg-secondary px-1 py-0.5 text-xs">
-              value_score_map
+              category
             </code>{' '}
-            or{' '}
+            defaults to{' '}
             <code className="rounded bg-secondary px-1 py-0.5 text-xs">
-              range_score_map
+              attribute
+            </code>
+            ; other supported values are{' '}
+            <code className="rounded bg-secondary px-1 py-0.5 text-xs">
+              presence
+            </code>
+            ,{' '}
+            <code className="rounded bg-secondary px-1 py-0.5 text-xs">
+              link_presence
+            </code>
+            , and{' '}
+            <code className="rounded bg-secondary px-1 py-0.5 text-xs">
+              age
             </code>
             .
           </DialogDescription>
@@ -260,20 +286,24 @@ export function ImportScoringPolicyDialog({
                   </span>
                 </div>
                 <div>
-                  <span className="text-tertiary">Attribute: </span>
+                  <span className="text-tertiary">Category: </span>
+                  <span className="text-primary">
+                    {CATEGORY_LABELS[parsedPreview.category]}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-tertiary">
+                    {parsedPreview.category === 'link_presence'
+                      ? 'Link slug: '
+                      : 'Attribute: '}
+                  </span>
                   <code className="rounded bg-card px-1 py-0.5 text-xs text-primary">
-                    {parsedPreview.attribute_name}
+                    {policySubjectKey(parsedPreview)}
                   </code>
                 </div>
                 <div>
                   <span className="text-tertiary">Weight: </span>
                   <span className="text-primary">{parsedPreview.weight}</span>
-                </div>
-                <div>
-                  <span className="text-tertiary">Map type: </span>
-                  <span className="text-primary">
-                    {parsedPreview.range_score_map ? 'Range' : 'Value'}
-                  </span>
                 </div>
                 {(parsedPreview.targets ?? []).length > 0 && (
                   <div className="col-span-2">
@@ -318,6 +348,49 @@ function detectFormat(input: string): DetectedFormat {
   return 'unknown'
 }
 
+function isNonEmptyNumberMap(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const entries = Object.entries(value as Record<string, unknown>)
+  if (entries.length === 0) return false
+  return entries.every(([, v]) => typeof v === 'number' && Number.isFinite(v))
+}
+
+function optionalScore(
+  value: unknown,
+  field: string,
+): { error: string; ok: false } | { ok: true; value: null | number } {
+  if (value === undefined || value === null) return { ok: true, value: null }
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    value > 100
+  ) {
+    return {
+      error: `"${field}" must be a number between 0 and 100.`,
+      ok: false,
+    }
+  }
+  return { ok: true, value }
+}
+
+function policySubjectKey(policy: ScoringPolicyCreate): string {
+  return policy.category === 'link_presence'
+    ? policy.link_slug
+    : policy.attribute_name
+}
+
+function requireString(
+  obj: Record<string, unknown>,
+  field: string,
+): { error: string; ok: false } | { ok: true; value: string } {
+  const value = obj[field]
+  if (typeof value !== 'string' || !value.trim()) {
+    return { error: `"${field}" must be a non-empty string.`, ok: false }
+  }
+  return { ok: true, value: value.trim() }
+}
+
 function validatePolicyShape(
   data: unknown,
 ):
@@ -329,7 +402,7 @@ function validatePolicyShape(
 
   const obj = data as Record<string, unknown>
 
-  for (const field of REQUIRED_FIELDS) {
+  for (const field of COMMON_REQUIRED) {
     if (obj[field] === undefined || obj[field] === null) {
       return { error: `Missing required field: "${field}".`, valid: false }
     }
@@ -342,12 +415,6 @@ function validatePolicyShape(
     return {
       error:
         '"slug" must be lowercase letters, numbers, hyphens, or underscores.',
-      valid: false,
-    }
-  }
-  if (typeof obj.attribute_name !== 'string' || !obj.attribute_name.trim()) {
-    return {
-      error: '"attribute_name" must be a non-empty string.',
       valid: false,
     }
   }
@@ -364,27 +431,6 @@ function validatePolicyShape(
     }
   }
   const weight = obj.weight
-
-  const hasValueMap =
-    obj.value_score_map !== null &&
-    obj.value_score_map !== undefined &&
-    typeof obj.value_score_map === 'object' &&
-    !Array.isArray(obj.value_score_map) &&
-    Object.keys(obj.value_score_map as object).length > 0
-  const hasRangeMap =
-    obj.range_score_map !== null &&
-    obj.range_score_map !== undefined &&
-    typeof obj.range_score_map === 'object' &&
-    !Array.isArray(obj.range_score_map) &&
-    Object.keys(obj.range_score_map as object).length > 0
-
-  if (!hasValueMap && !hasRangeMap) {
-    return {
-      error:
-        'At least one of "value_score_map" or "range_score_map" must have entries.',
-      valid: false,
-    }
-  }
 
   if (
     obj.targets !== undefined &&
@@ -406,47 +452,142 @@ function validatePolicyShape(
     return { error: '"priority" must be a number.', valid: false }
   }
 
-  const hasOnlyNumericValues = (map: unknown): map is Record<string, number> =>
-    !!map &&
-    typeof map === 'object' &&
-    !Array.isArray(map) &&
-    Object.values(map as Record<string, unknown>).every(
-      (v) => typeof v === 'number' && Number.isFinite(v),
-    )
-
-  if (hasValueMap && !hasOnlyNumericValues(obj.value_score_map)) {
+  const rawCategory = obj.category ?? 'attribute'
+  if (
+    typeof rawCategory !== 'string' ||
+    !VALID_CATEGORIES.includes(rawCategory as ScoringPolicyCategory)
+  ) {
     return {
-      error: '"value_score_map" values must be numbers.',
+      error: `"category" must be one of: ${VALID_CATEGORIES.join(', ')}.`,
       valid: false,
     }
   }
+  const category = rawCategory as ScoringPolicyCategory
 
-  if (hasRangeMap && !hasOnlyNumericValues(obj.range_score_map)) {
-    return {
-      error: '"range_score_map" values must be numbers.',
-      valid: false,
-    }
-  }
-
-  const policy: ScoringPolicyCreate = {
-    attribute_name: (obj.attribute_name as string).trim(),
+  const base = {
     description:
       typeof obj.description === 'string'
         ? obj.description.trim() || null
         : null,
-    enabled: obj.enabled === undefined ? true : obj.enabled,
+    enabled: obj.enabled === undefined ? true : (obj.enabled as boolean),
     name: (obj.name as string).trim(),
-    priority: obj.priority === undefined ? 0 : obj.priority,
-    range_score_map: hasRangeMap
-      ? (obj.range_score_map as Record<string, number>)
-      : null,
+    priority: obj.priority === undefined ? 0 : (obj.priority as number),
     slug: obj.slug as string,
     targets: Array.isArray(obj.targets) ? (obj.targets as string[]) : [],
-    value_score_map: hasValueMap
-      ? (obj.value_score_map as Record<string, number>)
-      : null,
     weight,
   }
 
-  return { policy, valid: true }
+  if (category === 'attribute') {
+    const attrCheck = requireString(obj, 'attribute_name')
+    if (!attrCheck.ok) return { error: attrCheck.error, valid: false }
+    const hasValueMap = isNonEmptyNumberMap(obj.value_score_map)
+    const hasRangeMap = isNonEmptyNumberMap(obj.range_score_map)
+    if (!hasValueMap && !hasRangeMap) {
+      return {
+        error:
+          'At least one of "value_score_map" or "range_score_map" must have entries.',
+        valid: false,
+      }
+    }
+    if (
+      obj.value_score_map !== undefined &&
+      obj.value_score_map !== null &&
+      !hasValueMap
+    ) {
+      return {
+        error: '"value_score_map" values must be numbers.',
+        valid: false,
+      }
+    }
+    if (
+      obj.range_score_map !== undefined &&
+      obj.range_score_map !== null &&
+      !hasRangeMap
+    ) {
+      return {
+        error: '"range_score_map" values must be numbers.',
+        valid: false,
+      }
+    }
+    return {
+      policy: {
+        ...base,
+        attribute_name: attrCheck.value,
+        category: 'attribute',
+        range_score_map: hasRangeMap
+          ? (obj.range_score_map as Record<string, number>)
+          : null,
+        value_score_map: hasValueMap
+          ? (obj.value_score_map as Record<string, number>)
+          : null,
+      },
+      valid: true,
+    }
+  }
+
+  if (category === 'presence') {
+    const attrCheck = requireString(obj, 'attribute_name')
+    if (!attrCheck.ok) return { error: attrCheck.error, valid: false }
+    const present = optionalScore(obj.present_score, 'present_score')
+    if (!present.ok) return { error: present.error, valid: false }
+    const missing = optionalScore(obj.missing_score, 'missing_score')
+    if (!missing.ok) return { error: missing.error, valid: false }
+    return {
+      policy: {
+        ...base,
+        attribute_name: attrCheck.value,
+        category: 'presence',
+        missing_score: missing.value ?? null,
+        present_score: present.value ?? null,
+      },
+      valid: true,
+    }
+  }
+
+  if (category === 'link_presence') {
+    const linkCheck = requireString(obj, 'link_slug')
+    if (!linkCheck.ok) return { error: linkCheck.error, valid: false }
+    const present = optionalScore(obj.present_score, 'present_score')
+    if (!present.ok) return { error: present.error, valid: false }
+    const missing = optionalScore(obj.missing_score, 'missing_score')
+    if (!missing.ok) return { error: missing.error, valid: false }
+    return {
+      policy: {
+        ...base,
+        category: 'link_presence',
+        link_slug: linkCheck.value,
+        missing_score: missing.value ?? null,
+        present_score: present.value ?? null,
+      },
+      valid: true,
+    }
+  }
+
+  // age
+  const attrCheck = requireString(obj, 'attribute_name')
+  if (!attrCheck.ok) return { error: attrCheck.error, valid: false }
+  if (!isNonEmptyNumberMap(obj.age_score_map)) {
+    return {
+      error:
+        '"age_score_map" must be a non-empty object whose values are numbers.',
+      valid: false,
+    }
+  }
+  for (const key of Object.keys(obj.age_score_map as object)) {
+    if (!/^(>=|>|<=|<|==)\s*\d+(?:\.\d+)?\s*[smhdw]$/.test(key)) {
+      return {
+        error: `"age_score_map" key ${JSON.stringify(key)} is not a valid threshold (e.g. ">30d", "<=7d").`,
+        valid: false,
+      }
+    }
+  }
+  return {
+    policy: {
+      ...base,
+      age_score_map: obj.age_score_map as Record<string, number>,
+      attribute_name: attrCheck.value,
+      category: 'age',
+    },
+    valid: true,
+  }
 }

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -1,20 +1,31 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import yaml from 'js-yaml'
-import { AlertCircle, FileJson, FileText, Upload } from 'lucide-react'
+import { AlertCircle, FileJson, FileText } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import type { ScoringPolicyCategory, ScoringPolicyCreate } from '@/types'
+import { type DetectedFormat, detectFormat } from '@/lib/import-format'
+import type {
+  AgeScoringPolicyCreate,
+  AttributeScoringPolicyCreate,
+  LinkPresenceScoringPolicyCreate,
+  PresenceScoringPolicyCreate,
+  ScoringPolicyCategory,
+  ScoringPolicyCreate,
+} from '@/types'
 
-type DetectedFormat = 'json' | 'unknown' | 'yaml'
+import { ImportDialogFooter } from '../import-dialog-shared'
+
+interface FieldRule {
+  error: string
+  ok: (obj: Record<string, unknown>) => boolean
+}
 
 interface ImportScoringPolicyDialogProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,6 +35,20 @@ interface ImportScoringPolicyDialogProps {
   onClose: () => void
   onImport: (policy: ScoringPolicyCreate) => void
 }
+
+interface PolicyBase {
+  description: null | string
+  enabled: boolean
+  name: string
+  priority: number
+  slug: string
+  targets: string[]
+  weight: number
+}
+
+type PolicyResult<T> =
+  | { error: string; valid: false }
+  | { policy: T; valid: true }
 
 const COMMON_REQUIRED = ['name', 'slug', 'weight'] as const
 
@@ -40,6 +65,42 @@ const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
   link_presence: 'Link Presence',
   presence: 'Presence',
 }
+
+const BASE_FIELD_RULES: FieldRule[] = [
+  {
+    error: 'Missing required fields: name, slug, weight.',
+    ok: (obj) =>
+      COMMON_REQUIRED.every((f) => obj[f] !== undefined && obj[f] !== null),
+  },
+  {
+    error: '"name" must be a non-empty string.',
+    ok: (obj) => typeof obj.name === 'string' && obj.name.trim().length > 0,
+  },
+  {
+    error:
+      '"slug" must be lowercase letters, numbers, hyphens, or underscores.',
+    ok: (obj) => typeof obj.slug === 'string' && /^[a-z0-9_-]+$/.test(obj.slug),
+  },
+  {
+    error: '"weight" must be a number between 0 and 100.',
+    ok: (obj) => isNumberInRange(obj.weight, 0, 100),
+  },
+  {
+    error: '"targets" must be an array of strings.',
+    ok: (obj) =>
+      obj.targets === undefined ||
+      obj.targets === null ||
+      isStringArray(obj.targets),
+  },
+  {
+    error: '"enabled" must be a boolean.',
+    ok: (obj) => obj.enabled === undefined || typeof obj.enabled === 'boolean',
+  },
+  {
+    error: '"priority" must be a number.',
+    ok: (obj) => obj.priority === undefined || isFiniteNumber(obj.priority),
+  },
+]
 
 export function ImportScoringPolicyDialog({
   apiError,
@@ -318,41 +379,60 @@ export function ImportScoringPolicyDialog({
           )}
         </div>
 
-        <DialogFooter>
-          <Button disabled={isLoading} onClick={handleClose} variant="outline">
-            Cancel
-          </Button>
-          <Button
-            className="bg-action text-action-foreground hover:bg-action-hover"
-            disabled={isLoading || !rawInput.trim()}
-            onClick={handleValidateAndImport}
-          >
-            <Upload className="mr-2 h-4 w-4" />
-            {isLoading ? 'Importing...' : 'Import'}
-          </Button>
-        </DialogFooter>
+        <ImportDialogFooter
+          hasInput={!!rawInput.trim()}
+          isLoading={isLoading}
+          onClose={handleClose}
+          onImport={handleValidateAndImport}
+        />
       </DialogContent>
     </Dialog>
   )
 }
 
-function detectFormat(input: string): DetectedFormat {
-  const trimmed = input.trim()
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json'
-  if (
-    trimmed.includes(': ') ||
-    trimmed.includes(':\n') ||
-    trimmed.startsWith('---')
-  )
-    return 'yaml'
-  return 'unknown'
+function buildBase(obj: Record<string, unknown>): PolicyBase {
+  return {
+    description: trimDescription(obj.description),
+    enabled: (obj.enabled ?? true) as boolean,
+    name: (obj.name as string).trim(),
+    priority: (obj.priority ?? 0) as number,
+    slug: obj.slug as string,
+    targets: Array.isArray(obj.targets) ? (obj.targets as string[]) : [],
+    weight: obj.weight as number,
+  }
+}
+
+function checkBaseFields(obj: Record<string, unknown>): null | string {
+  for (const rule of BASE_FIELD_RULES) {
+    if (!rule.ok(obj)) return rule.error
+  }
+  return null
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
 }
 
 function isNonEmptyNumberMap(value: unknown): boolean {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
-  const entries = Object.entries(value as Record<string, unknown>)
-  if (entries.length === 0) return false
-  return entries.every(([, v]) => typeof v === 'number' && Number.isFinite(v))
+  if (!isPlainObject(value)) return false
+  const entries = Object.entries(value)
+  return entries.length > 0 && entries.every(([, v]) => isFiniteNumber(v))
+}
+
+function isNumberInRange(
+  value: unknown,
+  min: number,
+  max: number,
+): value is number {
+  return isFiniteNumber(value) && value >= min && value <= max
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string')
 }
 
 function optionalScore(
@@ -360,12 +440,7 @@ function optionalScore(
   field: string,
 ): { error: string; ok: false } | { ok: true; value: null | number } {
   if (value === undefined || value === null) return { ok: true, value: null }
-  if (
-    typeof value !== 'number' ||
-    !Number.isFinite(value) ||
-    value < 0 ||
-    value > 100
-  ) {
+  if (!isNumberInRange(value, 0, 100)) {
     return {
       error: `"${field}" must be a number between 0 and 100.`,
       ok: false,
@@ -380,6 +455,31 @@ function policySubjectKey(policy: ScoringPolicyCreate): string {
     : policy.attribute_name
 }
 
+function readScoreMap(
+  raw: unknown,
+  field: string,
+):
+  | { error: string; ok: false }
+  | { ok: true; value: null | Record<string, number> } {
+  if (raw === undefined || raw === null) return { ok: true, value: null }
+  if (!isNonEmptyNumberMap(raw)) {
+    return { error: `"${field}" values must be numbers.`, ok: false }
+  }
+  return { ok: true, value: raw as Record<string, number> }
+}
+
+function readScorePair(
+  obj: Record<string, unknown>,
+):
+  | { error: string; ok: false }
+  | { missing: null | number; ok: true; present: null | number } {
+  const present = optionalScore(obj.present_score, 'present_score')
+  if (!present.ok) return { error: present.error, ok: false }
+  const missing = optionalScore(obj.missing_score, 'missing_score')
+  if (!missing.ok) return { error: missing.error, ok: false }
+  return { missing: missing.value, ok: true, present: present.value }
+}
+
 function requireString(
   obj: Record<string, unknown>,
   field: string,
@@ -391,202 +491,189 @@ function requireString(
   return { ok: true, value: value.trim() }
 }
 
-function validatePolicyShape(
-  data: unknown,
-):
-  | { error: string; valid: false }
-  | { policy: ScoringPolicyCreate; valid: true } {
-  if (!data || typeof data !== 'object' || Array.isArray(data)) {
-    return { error: 'Input must be a JSON/YAML object.', valid: false }
-  }
-
-  const obj = data as Record<string, unknown>
-
-  for (const field of COMMON_REQUIRED) {
-    if (obj[field] === undefined || obj[field] === null) {
-      return { error: `Missing required field: "${field}".`, valid: false }
-    }
-  }
-
-  if (typeof obj.name !== 'string' || !obj.name.trim()) {
-    return { error: '"name" must be a non-empty string.', valid: false }
-  }
-  if (typeof obj.slug !== 'string' || !/^[a-z0-9_-]+$/.test(obj.slug)) {
-    return {
-      error:
-        '"slug" must be lowercase letters, numbers, hyphens, or underscores.',
-      valid: false,
-    }
-  }
-
+function resolveCategory(
+  raw: unknown,
+): { error: string; ok: false } | { ok: true; value: ScoringPolicyCategory } {
+  const candidate = raw ?? 'attribute'
   if (
-    typeof obj.weight !== 'number' ||
-    !Number.isFinite(obj.weight) ||
-    obj.weight < 0 ||
-    obj.weight > 100
-  ) {
-    return {
-      error: '"weight" must be a number between 0 and 100.',
-      valid: false,
-    }
-  }
-  const weight = obj.weight
-
-  if (
-    obj.targets !== undefined &&
-    obj.targets !== null &&
-    (!Array.isArray(obj.targets) ||
-      !(obj.targets as unknown[]).every((v) => typeof v === 'string'))
-  ) {
-    return { error: '"targets" must be an array of strings.', valid: false }
-  }
-
-  if (obj.enabled !== undefined && typeof obj.enabled !== 'boolean') {
-    return { error: '"enabled" must be a boolean.', valid: false }
-  }
-
-  if (
-    obj.priority !== undefined &&
-    (typeof obj.priority !== 'number' || !Number.isFinite(obj.priority))
-  ) {
-    return { error: '"priority" must be a number.', valid: false }
-  }
-
-  const rawCategory = obj.category ?? 'attribute'
-  if (
-    typeof rawCategory !== 'string' ||
-    !VALID_CATEGORIES.includes(rawCategory as ScoringPolicyCategory)
+    typeof candidate !== 'string' ||
+    !VALID_CATEGORIES.includes(candidate as ScoringPolicyCategory)
   ) {
     return {
       error: `"category" must be one of: ${VALID_CATEGORIES.join(', ')}.`,
-      valid: false,
+      ok: false,
     }
   }
-  const category = rawCategory as ScoringPolicyCategory
+  return { ok: true, value: candidate as ScoringPolicyCategory }
+}
 
-  const base = {
-    description:
-      typeof obj.description === 'string'
-        ? obj.description.trim() || null
-        : null,
-    enabled: obj.enabled === undefined ? true : (obj.enabled as boolean),
-    name: (obj.name as string).trim(),
-    priority: obj.priority === undefined ? 0 : (obj.priority as number),
-    slug: obj.slug as string,
-    targets: Array.isArray(obj.targets) ? (obj.targets as string[]) : [],
-    weight,
-  }
+function trimDescription(value: unknown): null | string {
+  return typeof value === 'string' ? value.trim() || null : null
+}
 
-  if (category === 'attribute') {
-    const attrCheck = requireString(obj, 'attribute_name')
-    if (!attrCheck.ok) return { error: attrCheck.error, valid: false }
-    const hasValueMap = isNonEmptyNumberMap(obj.value_score_map)
-    const hasRangeMap = isNonEmptyNumberMap(obj.range_score_map)
-    if (!hasValueMap && !hasRangeMap) {
-      return {
-        error:
-          'At least one of "value_score_map" or "range_score_map" must have entries.',
-        valid: false,
-      }
-    }
-    if (
-      obj.value_score_map !== undefined &&
-      obj.value_score_map !== null &&
-      !hasValueMap
-    ) {
-      return {
-        error: '"value_score_map" values must be numbers.',
-        valid: false,
-      }
-    }
-    if (
-      obj.range_score_map !== undefined &&
-      obj.range_score_map !== null &&
-      !hasRangeMap
-    ) {
-      return {
-        error: '"range_score_map" values must be numbers.',
-        valid: false,
-      }
-    }
-    return {
-      policy: {
-        ...base,
-        attribute_name: attrCheck.value,
-        category: 'attribute',
-        range_score_map: hasRangeMap
-          ? (obj.range_score_map as Record<string, number>)
-          : null,
-        value_score_map: hasValueMap
-          ? (obj.value_score_map as Record<string, number>)
-          : null,
-      },
-      valid: true,
-    }
-  }
-
-  if (category === 'presence') {
-    const attrCheck = requireString(obj, 'attribute_name')
-    if (!attrCheck.ok) return { error: attrCheck.error, valid: false }
-    const present = optionalScore(obj.present_score, 'present_score')
-    if (!present.ok) return { error: present.error, valid: false }
-    const missing = optionalScore(obj.missing_score, 'missing_score')
-    if (!missing.ok) return { error: missing.error, valid: false }
-    return {
-      policy: {
-        ...base,
-        attribute_name: attrCheck.value,
-        category: 'presence',
-        missing_score: missing.value ?? null,
-        present_score: present.value ?? null,
-      },
-      valid: true,
-    }
-  }
-
-  if (category === 'link_presence') {
-    const linkCheck = requireString(obj, 'link_slug')
-    if (!linkCheck.ok) return { error: linkCheck.error, valid: false }
-    const present = optionalScore(obj.present_score, 'present_score')
-    if (!present.ok) return { error: present.error, valid: false }
-    const missing = optionalScore(obj.missing_score, 'missing_score')
-    if (!missing.ok) return { error: missing.error, valid: false }
-    return {
-      policy: {
-        ...base,
-        category: 'link_presence',
-        link_slug: linkCheck.value,
-        missing_score: missing.value ?? null,
-        present_score: present.value ?? null,
-      },
-      valid: true,
-    }
-  }
-
-  // age
+function validateAgePolicy(
+  obj: Record<string, unknown>,
+  base: PolicyBase,
+): PolicyResult<AgeScoringPolicyCreate> {
   const attrCheck = requireString(obj, 'attribute_name')
   if (!attrCheck.ok) return { error: attrCheck.error, valid: false }
-  if (!isNonEmptyNumberMap(obj.age_score_map)) {
-    return {
-      error:
-        '"age_score_map" must be a non-empty object whose values are numbers.',
-      valid: false,
-    }
-  }
-  for (const key of Object.keys(obj.age_score_map as object)) {
-    if (!/^(>=|>|<=|<|==)\s*\d+(?:\.\d+)?\s*[smhdw]$/.test(key)) {
-      return {
-        error: `"age_score_map" key ${JSON.stringify(key)} is not a valid threshold (e.g. ">30d", "<=7d").`,
-        valid: false,
-      }
-    }
-  }
+  const ageCheck = validateAgeScoreMap(obj.age_score_map)
+  if (!ageCheck.ok) return { error: ageCheck.error, valid: false }
   return {
     policy: {
       ...base,
       age_score_map: obj.age_score_map as Record<string, number>,
       attribute_name: attrCheck.value,
       category: 'age',
+    },
+    valid: true,
+  }
+}
+
+function validateAgeScoreMap(
+  raw: unknown,
+): { error: string; ok: false } | { ok: true } {
+  if (!isNonEmptyNumberMap(raw)) {
+    return {
+      error:
+        '"age_score_map" must be a non-empty object whose values are numbers.',
+      ok: false,
+    }
+  }
+  const invalid = Object.keys(raw as object).find(
+    (key) => !/^(>=|>|<=|<|==)\s*\d+(?:\.\d+)?\s*[smhdw]$/.test(key),
+  )
+  if (invalid !== undefined) {
+    return {
+      error: `"age_score_map" key ${JSON.stringify(invalid)} is not a valid threshold (e.g. ">30d", "<=7d").`,
+      ok: false,
+    }
+  }
+  return { ok: true }
+}
+
+// fallow-ignore-next-line complexity
+function validateAttributeMaps(obj: Record<string, unknown>):
+  | { error: string; ok: false }
+  | {
+      ok: true
+      range: null | Record<string, number>
+      value: null | Record<string, number>
+    } {
+  const valueCheck = readScoreMap(obj.value_score_map, 'value_score_map')
+  if (!valueCheck.ok) return { error: valueCheck.error, ok: false }
+  const rangeCheck = readScoreMap(obj.range_score_map, 'range_score_map')
+  if (!rangeCheck.ok) return { error: rangeCheck.error, ok: false }
+  if (!valueCheck.value && !rangeCheck.value) {
+    return {
+      error:
+        'At least one of "value_score_map" or "range_score_map" must have entries.',
+      ok: false,
+    }
+  }
+  return { ok: true, range: rangeCheck.value, value: valueCheck.value }
+}
+
+function validateAttributePolicy(
+  obj: Record<string, unknown>,
+  base: PolicyBase,
+): PolicyResult<AttributeScoringPolicyCreate> {
+  const attrCheck = requireString(obj, 'attribute_name')
+  if (!attrCheck.ok) return { error: attrCheck.error, valid: false }
+  const maps = validateAttributeMaps(obj)
+  if (!maps.ok) return { error: maps.error, valid: false }
+  return {
+    policy: {
+      ...base,
+      attribute_name: attrCheck.value,
+      category: 'attribute',
+      range_score_map: maps.range,
+      value_score_map: maps.value,
+    },
+    valid: true,
+  }
+}
+
+function validateBaseShape(obj: Record<string, unknown>):
+  | {
+      base: PolicyBase
+      category: ScoringPolicyCategory
+      obj: Record<string, unknown>
+      valid: true
+    }
+  | { error: string; valid: false } {
+  const fieldError = checkBaseFields(obj)
+  if (fieldError) return { error: fieldError, valid: false }
+  const categoryCheck = resolveCategory(obj.category)
+  if (!categoryCheck.ok) return { error: categoryCheck.error, valid: false }
+  return {
+    base: buildBase(obj),
+    category: categoryCheck.value,
+    obj,
+    valid: true,
+  }
+}
+
+function validateLinkPresencePolicy(
+  obj: Record<string, unknown>,
+  base: PolicyBase,
+): PolicyResult<LinkPresenceScoringPolicyCreate> {
+  const linkCheck = requireString(obj, 'link_slug')
+  if (!linkCheck.ok) return { error: linkCheck.error, valid: false }
+  const scores = readScorePair(obj)
+  if (!scores.ok) return { error: scores.error, valid: false }
+  return {
+    policy: {
+      ...base,
+      category: 'link_presence',
+      link_slug: linkCheck.value,
+      missing_score: scores.missing,
+      present_score: scores.present,
+    },
+    valid: true,
+  }
+}
+
+const CATEGORY_VALIDATORS: Record<
+  ScoringPolicyCategory,
+  (
+    obj: Record<string, unknown>,
+    base: PolicyBase,
+  ) => PolicyResult<ScoringPolicyCreate>
+> = {
+  age: validateAgePolicy,
+  attribute: validateAttributePolicy,
+  link_presence: validateLinkPresencePolicy,
+  presence: validatePresencePolicy,
+}
+
+function validatePolicyShape(data: unknown): PolicyResult<ScoringPolicyCreate> {
+  if (!isPlainObject(data)) {
+    return { error: 'Input must be a JSON/YAML object.', valid: false }
+  }
+  const baseResult = validateBaseShape(data)
+  if (!baseResult.valid) return baseResult
+  return CATEGORY_VALIDATORS[baseResult.category](
+    baseResult.obj,
+    baseResult.base,
+  )
+}
+
+function validatePresencePolicy(
+  obj: Record<string, unknown>,
+  base: PolicyBase,
+): PolicyResult<PresenceScoringPolicyCreate> {
+  const attrCheck = requireString(obj, 'attribute_name')
+  if (!attrCheck.ok) return { error: attrCheck.error, valid: false }
+  const scores = readScorePair(obj)
+  if (!scores.ok) return { error: scores.error, valid: false }
+  return {
+    policy: {
+      ...base,
+      attribute_name: attrCheck.value,
+      category: 'presence',
+      missing_score: scores.missing,
+      present_score: scores.present,
     },
     valid: true,
   }

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -29,6 +29,7 @@ import type {
 type AttributeMapType = 'range' | 'value'
 
 interface MapRow {
+  id: string
   key: string
   score: string
 }
@@ -118,16 +119,16 @@ export function ScoringPolicyForm({
         ? parseMapToRows(policy.range_score_map)
         : parseMapToRows(policy.value_score_map)
     }
-    return [{ key: '', score: '' }]
+    return [emptyRow()]
   })
   const [ageMapRows, setAgeMapRows] = useState<MapRow[]>(() =>
     policy?.category === 'age'
       ? parseMapToRows(policy.age_score_map)
       : [
-          { key: '>90d', score: '0' },
-          { key: '>30d', score: '25' },
-          { key: '>7d', score: '75' },
-          { key: '<=7d', score: '100' },
+          newRow('>90d', '0'),
+          newRow('>30d', '25'),
+          newRow('>7d', '75'),
+          newRow('<=7d', '100'),
         ],
   )
 
@@ -166,54 +167,22 @@ export function ScoringPolicyForm({
 
   const handleAttributeMapTypeChange = (type: AttributeMapType) => {
     setAttributeMapType(type)
-    setAttributeMapRows([{ key: '', score: '' }])
+    setAttributeMapRows([emptyRow()])
   }
 
   const validate = (): boolean => {
-    const newErrors: Record<string, string> = {}
-    if (!name.trim()) newErrors.name = 'Name is required'
-    if (!slug.trim()) newErrors.slug = 'Slug is required'
-    if (slug && !/^[a-z0-9_-]+$/.test(slug))
-      newErrors.slug =
-        'Slug must be lowercase letters, numbers, hyphens, or underscores'
-
-    if (category !== 'link_presence' && !attributeName.trim()) {
-      newErrors.attribute_name = 'Attribute name is required'
+    const newErrors: Record<string, string> = {
+      ...validateIdentity({ name, slug }),
+      ...validateSubject({ attributeName, category, linkSlug }),
+      ...validateWeight(weight),
+      ...validateCategoryFields({
+        ageMapRows,
+        attributeMapRows,
+        category,
+        missingScore,
+        presentScore,
+      }),
     }
-    if (category === 'link_presence' && !linkSlug.trim()) {
-      newErrors.link_slug = 'Link type is required'
-    }
-
-    const w = parseInt(weight, 10)
-    if (isNaN(w) || w < 0 || w > 100) newErrors.weight = 'Weight must be 0–100'
-
-    if (category === 'attribute') {
-      const hasMap = attributeMapRows.some(
-        (r) => r.key.trim() && r.score.trim(),
-      )
-      if (!hasMap) newErrors.map = 'At least one mapping entry is required'
-    }
-
-    if (category === 'age') {
-      const validRows = ageMapRows.filter((r) => r.key.trim() && r.score.trim())
-      if (validRows.length === 0) {
-        newErrors.age_map = 'At least one age threshold is required'
-      } else if (
-        validRows.some((r) => !isAgeThreshold(r.key.trim())) ||
-        validRows.some((r) => !isScoreInRange(r.score))
-      ) {
-        newErrors.age_map =
-          'Each entry must use a threshold like ">30d" or "<=7d" and a score 0–100'
-      }
-    }
-
-    if (category === 'presence' || category === 'link_presence') {
-      if (!isScoreInRange(presentScore))
-        newErrors.present_score = 'Score must be 0–100'
-      if (!isScoreInRange(missingScore))
-        newErrors.missing_score = 'Score must be 0–100'
-    }
-
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
   }
@@ -741,7 +710,7 @@ function MapEditor({
     onChange(next)
   }
 
-  const addRow = () => onChange([...rows, { key: '', score: '' }])
+  const addRow = () => onChange([...rows, emptyRow()])
   const removeRow = (i: number) => onChange(rows.filter((_, idx) => idx !== i))
 
   return (
@@ -754,7 +723,7 @@ function MapEditor({
       {rows.map((row, i) => (
         <div
           className="grid grid-cols-[1fr_100px_32px] items-center gap-2"
-          key={i}
+          key={row.id}
         >
           <Input
             disabled={disabled}
@@ -803,15 +772,19 @@ function MapEditor({
   )
 }
 
+function newRow(key: string, score: string): MapRow {
+  rowIdCounter += 1
+  return { id: `row-${rowIdCounter}`, key, score }
+}
+
 function parseMapToRows(
   map: null | Record<string, number> | undefined,
 ): MapRow[] {
-  if (!map) return [{ key: '', score: '' }]
-  const rows = Object.entries(map).map(([key, score]) => ({
-    key,
-    score: String(score),
-  }))
-  return rows.length > 0 ? rows : [{ key: '', score: '' }]
+  if (!map) return [emptyRow()]
+  const rows = Object.entries(map).map(([key, score]) =>
+    newRow(key, String(score)),
+  )
+  return rows.length > 0 ? rows : [emptyRow()]
 }
 
 function rowsToMap(rows: MapRow[]): null | Record<string, number> {
@@ -828,6 +801,11 @@ function rowsToMap(rows: MapRow[]): null | Record<string, number> {
 
 const AGE_THRESHOLD_RE = /^(>=|>|<=|<|==)\s*\d+(?:\.\d+)?\s*[smhdw]$/
 
+let rowIdCounter = 0
+function emptyRow(): MapRow {
+  return newRow('', '')
+}
+
 function isAgeThreshold(value: string): boolean {
   return AGE_THRESHOLD_RE.test(value.trim())
 }
@@ -835,4 +813,87 @@ function isAgeThreshold(value: string): boolean {
 function isScoreInRange(value: string): boolean {
   const n = parseInt(value, 10)
   return !isNaN(n) && n >= 0 && n <= 100
+}
+
+function validateAgeMap(rows: MapRow[]): null | string {
+  const valid = rows.filter((r) => r.key.trim() && r.score.trim())
+  if (valid.length === 0) return 'At least one age threshold is required'
+  const anyInvalid = valid.some(
+    (r) => !isAgeThreshold(r.key.trim()) || !isScoreInRange(r.score),
+  )
+  return anyInvalid
+    ? 'Each entry must use a threshold like ">30d" or "<=7d" and a score 0–100'
+    : null
+}
+
+function validateAttributeMap(rows: MapRow[]): null | string {
+  const valid = rows.filter((r) => r.key.trim() && r.score.trim())
+  if (valid.length === 0) return 'At least one mapping entry is required'
+  if (valid.some((r) => !isScoreInRange(r.score))) {
+    return 'All scores must be between 0 and 100'
+  }
+  return null
+}
+
+// fallow-ignore-next-line complexity
+function validateCategoryFields(args: {
+  ageMapRows: MapRow[]
+  attributeMapRows: MapRow[]
+  category: ScoringPolicyCategory
+  missingScore: string
+  presentScore: string
+}): Record<string, string> {
+  if (args.category === 'age') {
+    const err = validateAgeMap(args.ageMapRows)
+    return err ? { age_map: err } : {}
+  }
+  if (args.category === 'attribute') {
+    const err = validateAttributeMap(args.attributeMapRows)
+    return err ? { map: err } : {}
+  }
+  return validatePresenceScores(args.presentScore, args.missingScore)
+}
+
+function validateIdentity(args: {
+  name: string
+  slug: string
+}): Record<string, string> {
+  const errors: Record<string, string> = {}
+  if (!args.name.trim()) errors.name = 'Name is required'
+  if (!args.slug.trim()) errors.slug = 'Slug is required'
+  else if (!/^[a-z0-9_-]+$/.test(args.slug)) {
+    errors.slug =
+      'Slug must be lowercase letters, numbers, hyphens, or underscores'
+  }
+  return errors
+}
+
+function validatePresenceScores(
+  presentScore: string,
+  missingScore: string,
+): Record<string, string> {
+  const errors: Record<string, string> = {}
+  if (!isScoreInRange(presentScore))
+    errors.present_score = 'Score must be 0–100'
+  if (!isScoreInRange(missingScore))
+    errors.missing_score = 'Score must be 0–100'
+  return errors
+}
+
+function validateSubject(args: {
+  attributeName: string
+  category: ScoringPolicyCategory
+  linkSlug: string
+}): Record<string, string> {
+  if (args.category === 'link_presence') {
+    return args.linkSlug.trim() ? {} : { link_slug: 'Link type is required' }
+  }
+  return args.attributeName.trim()
+    ? {}
+    : { attribute_name: 'Attribute name is required' }
+}
+
+function validateWeight(weight: string): Record<string, string> {
+  const w = parseInt(weight, 10)
+  return isNaN(w) || w < 0 || w > 100 ? { weight: 'Weight must be 0–100' } : {}
 }

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -1,26 +1,63 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import { AlertCircle, Plus, Trash2 } from 'lucide-react'
 
-import { listProjectTypes } from '@/api/endpoints'
+import { listLinkDefinitions, listProjectTypes } from '@/api/endpoints'
 import { FormHeader } from '@/components/admin/form-header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { slugify } from '@/lib/utils'
-import type { ScoringPolicy, ScoringPolicyCreate } from '@/types'
+import type {
+  ScoringPolicy,
+  ScoringPolicyCategory,
+  ScoringPolicyCreate,
+} from '@/types'
+
+type AttributeMapType = 'range' | 'value'
 
 interface MapRow {
   key: string
   score: string
 }
 
-type MapType = 'range' | 'value'
+const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
+  age: 'Age',
+  attribute: 'Attribute',
+  link_presence: 'Link Presence',
+  presence: 'Presence',
+}
+
+const CATEGORY_DESCRIPTIONS: Record<ScoringPolicyCategory, string> = {
+  age: 'Score a datetime attribute by how recently it changed.',
+  attribute: 'Map a specific attribute value to a score.',
+  link_presence:
+    'Score whether the project has a link of a specific link type.',
+  presence: 'Score whether an attribute has a non-empty value.',
+}
+
+interface MapEditorProps {
+  addLabel: string
+  disabled?: boolean
+  error?: string
+  keyHeader: string
+  keyPlaceholder: string
+  onChange: (rows: MapRow[]) => void
+  rows: MapRow[]
+  scoreHeader: string
+}
 
 interface ScoringPolicyFormProps {
   error?: unknown
@@ -39,24 +76,61 @@ export function ScoringPolicyForm({
 }: ScoringPolicyFormProps) {
   const isEditing = policy !== null
 
+  const initialCategory: ScoringPolicyCategory = policy?.category ?? 'attribute'
+
+  const [category, setCategory] =
+    useState<ScoringPolicyCategory>(initialCategory)
   const [name, setName] = useState(policy?.name ?? '')
   const [slug, setSlug] = useState(policy?.slug ?? '')
   const [description, setDescription] = useState(policy?.description ?? '')
-  const [attributeName, setAttributeName] = useState(
-    policy?.attribute_name ?? '',
-  )
   const [weight, setWeight] = useState(String(policy?.weight ?? 50))
   const [priority, setPriority] = useState(String(policy?.priority ?? 0))
   const [enabled, setEnabled] = useState(policy?.enabled ?? true)
   const [targets, setTargets] = useState<string[]>(policy?.targets ?? [])
-  const [mapType, setMapType] = useState<MapType>(
-    policy?.range_score_map != null ? 'range' : 'value',
+
+  // Per-category state
+  const [attributeName, setAttributeName] = useState(
+    policy && 'attribute_name' in policy ? policy.attribute_name : '',
   )
-  const [mapRows, setMapRows] = useState<MapRow[]>(
-    mapType === 'range'
-      ? parseMapToRows(policy?.range_score_map)
-      : parseMapToRows(policy?.value_score_map),
+  const [linkSlug, setLinkSlug] = useState(
+    policy && policy.category === 'link_presence' ? policy.link_slug : '',
   )
+  const [presentScore, setPresentScore] = useState(
+    policy &&
+      (policy.category === 'presence' || policy.category === 'link_presence')
+      ? String(policy.present_score ?? 100)
+      : '100',
+  )
+  const [missingScore, setMissingScore] = useState(
+    policy &&
+      (policy.category === 'presence' || policy.category === 'link_presence')
+      ? String(policy.missing_score ?? 0)
+      : '0',
+  )
+  const [attributeMapType, setAttributeMapType] = useState<AttributeMapType>(
+    policy?.category === 'attribute' && policy.range_score_map != null
+      ? 'range'
+      : 'value',
+  )
+  const [attributeMapRows, setAttributeMapRows] = useState<MapRow[]>(() => {
+    if (policy?.category === 'attribute') {
+      return attributeMapType === 'range'
+        ? parseMapToRows(policy.range_score_map)
+        : parseMapToRows(policy.value_score_map)
+    }
+    return [{ key: '', score: '' }]
+  })
+  const [ageMapRows, setAgeMapRows] = useState<MapRow[]>(() =>
+    policy?.category === 'age'
+      ? parseMapToRows(policy.age_score_map)
+      : [
+          { key: '>90d', score: '0' },
+          { key: '>30d', score: '25' },
+          { key: '>7d', score: '75' },
+          { key: '<=7d', score: '100' },
+        ],
+  )
+
   const [errors, setErrors] = useState<Record<string, string>>({})
 
   const { selectedOrganization } = useOrganization()
@@ -73,34 +147,26 @@ export function ScoringPolicyForm({
     staleTime: 5 * 60 * 1000,
   })
 
+  const { data: linkDefinitions = [] } = useQuery({
+    enabled: !!orgSlug && category === 'link_presence',
+    queryFn: ({ signal }) => listLinkDefinitions(orgSlug!, signal),
+    queryKey: ['linkDefinitions', orgSlug],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const sortedLinkDefinitions = useMemo(
+    () => [...linkDefinitions].sort((a, b) => a.name.localeCompare(b.name)),
+    [linkDefinitions],
+  )
+
   const handleNameChange = (value: string) => {
     setName(value)
     if (!isEditing) setSlug(slugify(value))
   }
 
-  const handleMapTypeChange = (type: MapType) => {
-    setMapType(type)
-    setMapRows([{ key: '', score: '' }])
-  }
-
-  const addMapRow = () =>
-    setMapRows((prev) => [...prev, { key: '', score: '' }])
-
-  const removeMapRow = (i: number) =>
-    setMapRows((prev) => prev.filter((_, idx) => idx !== i))
-
-  const updateMapRow = (i: number, field: 'key' | 'score', value: string) => {
-    setMapRows((prev) => {
-      const next = [...prev]
-      next[i] = { ...next[i], [field]: value }
-      return next
-    })
-  }
-
-  const toggleTarget = (slug: string) => {
-    setTargets((prev) =>
-      prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug],
-    )
+  const handleAttributeMapTypeChange = (type: AttributeMapType) => {
+    setAttributeMapType(type)
+    setAttributeMapRows([{ key: '', score: '' }])
   }
 
   const validate = (): boolean => {
@@ -110,30 +176,97 @@ export function ScoringPolicyForm({
     if (slug && !/^[a-z0-9_-]+$/.test(slug))
       newErrors.slug =
         'Slug must be lowercase letters, numbers, hyphens, or underscores'
-    if (!attributeName.trim())
+
+    if (category !== 'link_presence' && !attributeName.trim()) {
       newErrors.attribute_name = 'Attribute name is required'
+    }
+    if (category === 'link_presence' && !linkSlug.trim()) {
+      newErrors.link_slug = 'Link type is required'
+    }
+
     const w = parseInt(weight, 10)
     if (isNaN(w) || w < 0 || w > 100) newErrors.weight = 'Weight must be 0–100'
-    const hasMap = mapRows.some((r) => r.key.trim() && r.score.trim())
-    if (!hasMap) newErrors.map = 'At least one mapping entry is required'
+
+    if (category === 'attribute') {
+      const hasMap = attributeMapRows.some(
+        (r) => r.key.trim() && r.score.trim(),
+      )
+      if (!hasMap) newErrors.map = 'At least one mapping entry is required'
+    }
+
+    if (category === 'age') {
+      const validRows = ageMapRows.filter((r) => r.key.trim() && r.score.trim())
+      if (validRows.length === 0) {
+        newErrors.age_map = 'At least one age threshold is required'
+      } else if (
+        validRows.some((r) => !isAgeThreshold(r.key.trim())) ||
+        validRows.some((r) => !isScoreInRange(r.score))
+      ) {
+        newErrors.age_map =
+          'Each entry must use a threshold like ">30d" or "<=7d" and a score 0–100'
+      }
+    }
+
+    if (category === 'presence' || category === 'link_presence') {
+      if (!isScoreInRange(presentScore))
+        newErrors.present_score = 'Score must be 0–100'
+      if (!isScoreInRange(missingScore))
+        newErrors.missing_score = 'Score must be 0–100'
+    }
+
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
   }
 
   const handleSave = () => {
     if (!validate()) return
-    const map = rowsToMap(mapRows)
-    onSave({
-      attribute_name: attributeName.trim(),
+    const base = {
       description: description.trim() || null,
       enabled,
       name: name.trim(),
       priority: parseInt(priority, 10) || 0,
-      range_score_map: mapType === 'range' ? map : null,
       slug: slug.trim(),
       targets,
-      value_score_map: mapType === 'value' ? map : null,
       weight: parseInt(weight, 10),
+    }
+    if (category === 'attribute') {
+      const map = rowsToMap(attributeMapRows)
+      onSave({
+        ...base,
+        attribute_name: attributeName.trim(),
+        category: 'attribute',
+        range_score_map: attributeMapType === 'range' ? map : null,
+        value_score_map: attributeMapType === 'value' ? map : null,
+      })
+      return
+    }
+    if (category === 'presence') {
+      onSave({
+        ...base,
+        attribute_name: attributeName.trim(),
+        category: 'presence',
+        missing_score: parseInt(missingScore, 10),
+        present_score: parseInt(presentScore, 10),
+      })
+      return
+    }
+    if (category === 'link_presence') {
+      onSave({
+        ...base,
+        category: 'link_presence',
+        link_slug: linkSlug.trim(),
+        missing_score: parseInt(missingScore, 10),
+        present_score: parseInt(presentScore, 10),
+      })
+      return
+    }
+    // age
+    const ageMap = rowsToMap(ageMapRows) ?? {}
+    onSave({
+      ...base,
+      age_score_map: ageMap,
+      attribute_name: attributeName.trim(),
+      category: 'age',
     })
   }
 
@@ -229,6 +362,40 @@ export function ScoringPolicyForm({
                 value={description}
               />
             </div>
+
+            <div>
+              <label className="mb-1.5 block text-sm text-secondary">
+                Category <span className="text-danger">*</span>
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {(
+                  [
+                    'attribute',
+                    'presence',
+                    'link_presence',
+                    'age',
+                  ] as ScoringPolicyCategory[]
+                ).map((c) => (
+                  <button
+                    className={`rounded-lg border px-3 py-1.5 text-sm transition-colors ${
+                      category === c
+                        ? 'border-amber-text bg-amber-bg text-amber-text'
+                        : 'border-input text-secondary hover:bg-secondary'
+                    }`}
+                    disabled={isEditing || isLoading}
+                    key={c}
+                    onClick={() => setCategory(c)}
+                    type="button"
+                  >
+                    {CATEGORY_LABELS[c]}
+                  </button>
+                ))}
+              </div>
+              <p className="mt-1.5 text-xs text-tertiary">
+                {CATEGORY_DESCRIPTIONS[category]}
+                {isEditing && ' Category cannot be changed after creation.'}
+              </p>
+            </div>
           </CardContent>
         </Card>
 
@@ -238,26 +405,73 @@ export function ScoringPolicyForm({
             <CardTitle>Policy Settings</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div>
-              <label
-                className="mb-1.5 block text-sm text-secondary"
-                htmlFor="sp-attribute"
-              >
-                Attribute Name <span className="text-danger">*</span>
-              </label>
-              <Input
-                className={errors.attribute_name ? 'border-danger' : ''}
-                disabled={isLoading}
-                id="sp-attribute"
-                onChange={(e) => setAttributeName(e.target.value)}
-                placeholder="e.g., test_coverage"
-                value={attributeName}
-              />
-              <p className="mt-1 text-xs text-tertiary">
-                The blueprint attribute key this policy evaluates
-              </p>
-              {fieldError('attribute_name')}
-            </div>
+            {category === 'link_presence' ? (
+              <div>
+                <label
+                  className="mb-1.5 block text-sm text-secondary"
+                  htmlFor="sp-link-slug"
+                >
+                  Required Link Type <span className="text-danger">*</span>
+                </label>
+                <Select
+                  disabled={isLoading}
+                  onValueChange={setLinkSlug}
+                  value={linkSlug}
+                >
+                  <SelectTrigger
+                    className={errors.link_slug ? 'border-danger' : ''}
+                    id="sp-link-slug"
+                  >
+                    <SelectValue placeholder="Pick a link type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sortedLinkDefinitions.length === 0 ? (
+                      <div className="px-2 py-1.5 text-xs text-tertiary">
+                        No link definitions configured for this organization
+                      </div>
+                    ) : (
+                      sortedLinkDefinitions.map((def) => (
+                        <SelectItem key={def.slug} value={def.slug}>
+                          {def.name}
+                        </SelectItem>
+                      ))
+                    )}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-tertiary">
+                  The link slug the project must have to score{' '}
+                  <code>present_score</code>
+                </p>
+                {fieldError('link_slug')}
+              </div>
+            ) : (
+              <div>
+                <label
+                  className="mb-1.5 block text-sm text-secondary"
+                  htmlFor="sp-attribute"
+                >
+                  Attribute Name <span className="text-danger">*</span>
+                </label>
+                <Input
+                  className={errors.attribute_name ? 'border-danger' : ''}
+                  disabled={isLoading}
+                  id="sp-attribute"
+                  onChange={(e) => setAttributeName(e.target.value)}
+                  placeholder={
+                    category === 'age'
+                      ? 'e.g., oldest_open_pr'
+                      : 'e.g., test_coverage'
+                  }
+                  value={attributeName}
+                />
+                <p className="mt-1 text-xs text-tertiary">
+                  {category === 'age'
+                    ? 'The datetime attribute on the project model whose age is scored'
+                    : 'The blueprint attribute key this policy evaluates'}
+                </p>
+                {fieldError('attribute_name')}
+              </div>
+            )}
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
               <div>
@@ -311,99 +525,151 @@ export function ScoringPolicyForm({
           </CardContent>
         </Card>
 
-        {/* Score mapping */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Score Mapping</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <label className="mb-1.5 block text-sm text-secondary">
-                Mapping type
-              </label>
-              <div className="flex gap-3">
-                {(['value', 'range'] as const).map((t) => (
-                  <button
-                    className={`rounded-lg border px-4 py-2 text-sm transition-colors ${
-                      mapType === t
-                        ? 'border-amber-text bg-amber-bg text-amber-text'
-                        : 'border-input text-secondary hover:bg-secondary'
-                    }`}
-                    disabled={isLoading}
-                    key={t}
-                    onClick={() => handleMapTypeChange(t)}
-                    type="button"
-                  >
-                    {t === 'value' ? 'Value map' : 'Range map'}
-                  </button>
-                ))}
+        {/* Score mapping — category-specific */}
+        {category === 'attribute' && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Score Mapping</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label className="mb-1.5 block text-sm text-secondary">
+                  Mapping type
+                </label>
+                <div className="flex gap-3">
+                  {(['value', 'range'] as const).map((t) => (
+                    <button
+                      className={`rounded-lg border px-4 py-2 text-sm transition-colors ${
+                        attributeMapType === t
+                          ? 'border-amber-text bg-amber-bg text-amber-text'
+                          : 'border-input text-secondary hover:bg-secondary'
+                      }`}
+                      disabled={isLoading}
+                      key={t}
+                      onClick={() => handleAttributeMapTypeChange(t)}
+                      type="button"
+                    >
+                      {t === 'value' ? 'Value map' : 'Range map'}
+                    </button>
+                  ))}
+                </div>
+                <p className="mt-1.5 text-xs text-tertiary">
+                  {attributeMapType === 'value'
+                    ? 'Maps exact attribute values (strings) to scores'
+                    : 'Maps numeric ranges like "0..70" to scores'}
+                </p>
               </div>
-              <p className="mt-1.5 text-xs text-tertiary">
-                {mapType === 'value'
-                  ? 'Maps exact attribute values (strings) to scores'
-                  : 'Maps numeric ranges like "0..70" to scores'}
+
+              <MapEditor
+                addLabel="Add entry"
+                disabled={isLoading}
+                error={errors.map}
+                keyHeader={
+                  attributeMapType === 'value'
+                    ? 'Value (string)'
+                    : 'Range (lo..hi)'
+                }
+                keyPlaceholder={
+                  attributeMapType === 'value'
+                    ? 'e.g., passing'
+                    : 'e.g., 80..100'
+                }
+                onChange={setAttributeMapRows}
+                rows={attributeMapRows}
+                scoreHeader="Score (0–100)"
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {category === 'age' && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Age Thresholds</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-xs text-tertiary">
+                Each entry uses an operator (<code>&gt;</code>,{' '}
+                <code>&gt;=</code>, <code>&lt;</code>, <code>&lt;=</code>,{' '}
+                <code>==</code>) and a duration in <code>s</code> /{' '}
+                <code>m</code> / <code>h</code> / <code>d</code> /{' '}
+                <code>w</code> (for example, <code>&gt;30d</code>,{' '}
+                <code>&lt;=7d</code>). Entries are evaluated in document order;
+                the first match wins.
               </p>
-            </div>
+              <MapEditor
+                addLabel="Add threshold"
+                disabled={isLoading}
+                error={errors.age_map}
+                keyHeader="Threshold"
+                keyPlaceholder="e.g., >30d"
+                onChange={setAgeMapRows}
+                rows={ageMapRows}
+                scoreHeader="Score (0–100)"
+              />
+            </CardContent>
+          </Card>
+        )}
 
-            <div className="space-y-2">
-              <div className="grid grid-cols-[1fr_100px_32px] gap-2 text-xs text-tertiary">
-                <span>
-                  {mapType === 'value' ? 'Value (string)' : 'Range (lo..hi)'}
-                </span>
-                <span>Score (0–100)</span>
-                <span />
-              </div>
-
-              {mapRows.map((row, i) => (
-                <div
-                  className="grid grid-cols-[1fr_100px_32px] items-center gap-2"
-                  key={i}
-                >
+        {(category === 'presence' || category === 'link_presence') && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Scores</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <label
+                    className="mb-1.5 block text-sm text-secondary"
+                    htmlFor="sp-present-score"
+                  >
+                    Present score (0–100)
+                  </label>
                   <Input
+                    className={errors.present_score ? 'border-danger' : ''}
                     disabled={isLoading}
-                    onChange={(e) => updateMapRow(i, 'key', e.target.value)}
-                    placeholder={
-                      mapType === 'value' ? 'e.g., passing' : 'e.g., 80..100'
-                    }
-                    value={row.key}
-                  />
-                  <Input
-                    disabled={isLoading}
+                    id="sp-present-score"
                     max={100}
                     min={0}
-                    onChange={(e) => updateMapRow(i, 'score', e.target.value)}
-                    placeholder="100"
+                    onChange={(e) => setPresentScore(e.target.value)}
                     type="number"
-                    value={row.score}
+                    value={presentScore}
                   />
-                  <Button
-                    disabled={isLoading || mapRows.length === 1}
-                    onClick={() => removeMapRow(i)}
-                    size="sm"
-                    type="button"
-                    variant="ghost"
-                  >
-                    <Trash2 className="h-4 w-4 text-secondary" />
-                  </Button>
+                  <p className="mt-1 text-xs text-tertiary">
+                    {category === 'link_presence'
+                      ? 'Score when the project has this link type'
+                      : 'Score when the attribute has a non-empty value'}
+                  </p>
+                  {fieldError('present_score')}
                 </div>
-              ))}
-
-              <Button
-                className="mt-1"
-                disabled={isLoading}
-                onClick={addMapRow}
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                <Plus className="mr-1.5 h-3.5 w-3.5" />
-                Add entry
-              </Button>
-
-              {fieldError('map')}
-            </div>
-          </CardContent>
-        </Card>
+                <div>
+                  <label
+                    className="mb-1.5 block text-sm text-secondary"
+                    htmlFor="sp-missing-score"
+                  >
+                    Missing score (0–100)
+                  </label>
+                  <Input
+                    className={errors.missing_score ? 'border-danger' : ''}
+                    disabled={isLoading}
+                    id="sp-missing-score"
+                    max={100}
+                    min={0}
+                    onChange={(e) => setMissingScore(e.target.value)}
+                    type="number"
+                    value={missingScore}
+                  />
+                  <p className="mt-1 text-xs text-tertiary">
+                    {category === 'link_presence'
+                      ? 'Score when the project does not have this link type'
+                      : 'Score when the attribute is null, empty, or whitespace'}
+                  </p>
+                  {fieldError('missing_score')}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Target project types */}
         <Card>
@@ -434,7 +700,13 @@ export function ScoringPolicyForm({
                       checked={targets.includes(pt.slug)}
                       disabled={isLoading}
                       id={`target-pt-${pt.slug}`}
-                      onCheckedChange={() => toggleTarget(pt.slug)}
+                      onCheckedChange={() =>
+                        setTargets((prev) =>
+                          prev.includes(pt.slug)
+                            ? prev.filter((s) => s !== pt.slug)
+                            : [...prev, pt.slug],
+                        )
+                      }
                     />
                     <label
                       className="cursor-pointer select-none text-sm text-secondary"
@@ -449,6 +721,84 @@ export function ScoringPolicyForm({
           </CardContent>
         </Card>
       </form>
+    </div>
+  )
+}
+
+function MapEditor({
+  addLabel,
+  disabled = false,
+  error,
+  keyHeader,
+  keyPlaceholder,
+  onChange,
+  rows,
+  scoreHeader,
+}: MapEditorProps) {
+  const updateRow = (i: number, field: 'key' | 'score', value: string) => {
+    const next = [...rows]
+    next[i] = { ...next[i], [field]: value }
+    onChange(next)
+  }
+
+  const addRow = () => onChange([...rows, { key: '', score: '' }])
+  const removeRow = (i: number) => onChange(rows.filter((_, idx) => idx !== i))
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-[1fr_100px_32px] gap-2 text-xs text-tertiary">
+        <span>{keyHeader}</span>
+        <span>{scoreHeader}</span>
+        <span />
+      </div>
+      {rows.map((row, i) => (
+        <div
+          className="grid grid-cols-[1fr_100px_32px] items-center gap-2"
+          key={i}
+        >
+          <Input
+            disabled={disabled}
+            onChange={(e) => updateRow(i, 'key', e.target.value)}
+            placeholder={keyPlaceholder}
+            value={row.key}
+          />
+          <Input
+            disabled={disabled}
+            max={100}
+            min={0}
+            onChange={(e) => updateRow(i, 'score', e.target.value)}
+            placeholder="100"
+            type="number"
+            value={row.score}
+          />
+          <Button
+            disabled={disabled || rows.length === 1}
+            onClick={() => removeRow(i)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <Trash2 className="h-4 w-4 text-secondary" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        className="mt-1"
+        disabled={disabled}
+        onClick={addRow}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <Plus className="mr-1.5 h-3.5 w-3.5" />
+        {addLabel}
+      </Button>
+      {error && (
+        <div className="mt-1 flex items-center gap-1 text-xs text-danger">
+          <AlertCircle className="h-3 w-3" />
+          {error}
+        </div>
+      )}
     </div>
   )
 }
@@ -474,4 +824,15 @@ function rowsToMap(rows: MapRow[]): null | Record<string, number> {
     }
   }
   return Object.keys(out).length > 0 ? out : null
+}
+
+const AGE_THRESHOLD_RE = /^(>=|>|<=|<|==)\s*\d+(?:\.\d+)?\s*[smhdw]$/
+
+function isAgeThreshold(value: string): boolean {
+  return AGE_THRESHOLD_RE.test(value.trim())
+}
+
+function isScoreInRange(value: string): boolean {
+  const n = parseInt(value, 10)
+  return !isNaN(n) && n >= 0 && n <= 100
 }

--- a/src/lib/import-format.ts
+++ b/src/lib/import-format.ts
@@ -1,0 +1,14 @@
+export type DetectedFormat = 'json' | 'unknown' | 'yaml'
+
+// fallow-ignore-next-line complexity
+export function detectFormat(input: string): DetectedFormat {
+  const trimmed = input.trim()
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json'
+  if (
+    trimmed.includes(': ') ||
+    trimmed.includes(':\n') ||
+    trimmed.startsWith('---')
+  )
+    return 'yaml'
+  return 'unknown'
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,32 @@ import type { components } from './api-generated'
 
 export type ActivityFeedEntry = OperationsLogEntry | ProjectFeedEntry
 
+export interface AgeScoringPolicy extends ScoringPolicyBase {
+  age_score_map: Record<string, number>
+  attribute_name: string
+  category: 'age'
+}
+
+export interface AgeScoringPolicyCreate extends ScoringPolicyCreateBase {
+  age_score_map: Record<string, number>
+  attribute_name: string
+  category: 'age'
+}
+
+export interface AttributeScoringPolicy extends ScoringPolicyBase {
+  attribute_name: string
+  category: 'attribute'
+  range_score_map?: null | Record<string, number>
+  value_score_map?: null | Record<string, number>
+}
+
+export interface AttributeScoringPolicyCreate extends ScoringPolicyCreateBase {
+  attribute_name: string
+  category: 'attribute'
+  range_score_map?: null | Record<string, number>
+  value_score_map?: null | Record<string, number>
+}
+
 // API Response Wrappers
 export interface CollectionResponse<T> {
   data: T[]
@@ -30,6 +56,20 @@ export interface EnvironmentCreate {
 export type LinkDefinition = Schemas['LinkDefinitionResponse']
 
 export type LinkDefinitionCreate = Schemas['LinkDefinitionCreate']
+
+export interface LinkPresenceScoringPolicy extends ScoringPolicyBase {
+  category: 'link_presence'
+  link_slug: string
+  missing_score?: null | number
+  present_score?: null | number
+}
+
+export interface LinkPresenceScoringPolicyCreate extends ScoringPolicyCreateBase {
+  category: 'link_presence'
+  link_slug: string
+  missing_score?: null | number
+  present_score?: null | number
+}
 // Activity feed projection; distinct from `OperationsLogRecord`.
 export interface OperationsLogEntry {
   change_type:
@@ -59,6 +99,20 @@ export interface OperationsLogEntry {
   ticket_slug?: null | string
   type: 'OperationsLogEntry'
   version?: null | string
+}
+
+export interface PresenceScoringPolicy extends ScoringPolicyBase {
+  attribute_name: string
+  category: 'presence'
+  missing_score?: null | number
+  present_score?: null | number
+}
+
+export interface PresenceScoringPolicyCreate extends ScoringPolicyCreateBase {
+  attribute_name: string
+  category: 'presence'
+  missing_score?: null | number
+  present_score?: null | number
 }
 
 // `Project` keeps its hand-written shape: it has UI-only convenience fields
@@ -158,33 +212,25 @@ export interface ProjectTypeCreate {
 
 export type RelationshipLink = Schemas['RelationshipLink']
 
-export interface ScoringPolicy {
-  attribute_name: string
-  category: 'attribute'
-  description?: null | string
-  enabled: boolean
-  id: string
-  name: string
-  priority: number
-  range_score_map?: null | Record<string, number>
-  slug: string
-  targets?: string[]
-  value_score_map?: null | Record<string, number>
-  weight: number
-}
+// Scoring policy types — discriminated union on `category`. See
+// imbi-common/scoring/models.py for the canonical shape.
+export type ScoringPolicy =
+  | AgeScoringPolicy
+  | AttributeScoringPolicy
+  | LinkPresenceScoringPolicy
+  | PresenceScoringPolicy
 
-export interface ScoringPolicyCreate {
-  attribute_name: string
-  description?: null | string
-  enabled: boolean
-  name: string
-  priority: number
-  range_score_map?: null | Record<string, number>
-  slug: string
-  targets: string[]
-  value_score_map?: null | Record<string, number>
-  weight: number
-}
+export type ScoringPolicyCategory =
+  | 'age'
+  | 'attribute'
+  | 'link_presence'
+  | 'presence'
+
+export type ScoringPolicyCreate =
+  | AgeScoringPolicyCreate
+  | AttributeScoringPolicyCreate
+  | LinkPresenceScoringPolicyCreate
+  | PresenceScoringPolicyCreate
 
 // `User` is the UI-side profile shape used by auth/session consumers.
 // It does not map cleanly to the backend `UserResponse` (different key set:
@@ -200,6 +246,28 @@ export interface User {
 }
 
 type Schemas = components['schemas']
+
+interface ScoringPolicyBase {
+  description?: null | string
+  enabled: boolean
+  id: string
+  name: string
+  priority: number
+  slug: string
+  targets?: string[]
+  weight: number
+}
+
+interface ScoringPolicyCreateBase {
+  category: ScoringPolicyCategory
+  description?: null | string
+  enabled: boolean
+  name: string
+  priority: number
+  slug: string
+  targets: string[]
+  weight: number
+}
 
 export const OPERATIONS_LOG_ENTRY_TYPES = [
   'Configured',


### PR DESCRIPTION
## Summary

Adds UI for the three new scoring-policy categories landed in imbi-common v2.2.0 + imbi-api (PRs #101 / #102 / #301):

- **Presence** — score an attribute by whether it has a non-empty value (e.g. project description).
- **Link presence** — score by whether the project has a link of a given type.
- **Age** — score a datetime attribute by how recently it changed, using the same \`>30d\` / \`<=7d\` threshold DSL the UI already uses for \`color-age\`.

Types in \`src/types/index.ts\` become a discriminated union on \`category\` (\`AttributeScoringPolicy | PresenceScoringPolicy | LinkPresenceScoringPolicy | AgeScoringPolicy\`), with matching \`*ScoringPolicyCreate\` variants. \`AttributeContribution\` consumers (\`ProjectDetail.buildRecommendation\`) narrow on \`policy.category\` before reading value/range maps.

\`ScoringPolicyForm\`:
- New category selector (locked on edit — category is immutable on the API).
- Per-category configuration card: existing value/range editor for \`attribute\`, link-type \`Select\` sourced from \`listLinkDefinitions\` for \`link_presence\`, present/missing score inputs for both presence variants, and a threshold editor pre-seeded with \`>90d/>30d/>7d/<=7d\` for \`age\`. Age keys are validated against \`/^(>=|>|<=|<|==)\s*\d+(?:\.\d+)?\s*[smhdw]$/\`.

\`ScoringPolicyManagement\` table swaps the static Attribute column for **Category** + **Subject** (attribute name or link slug per row). Copy/export and search both respect the category.

\`ImportScoringPolicyDialog\` validates per category. \`category\` is optional and defaults to \`attribute\`, so existing JSON payloads in \`scoring-policies/*.json\` keep working.

## Test plan

- [x] \`npm run lint\` — clean (0 warnings, 0 errors)
- [x] \`npm run format:check\`
- [x] \`npm run build\` (tsc strict + vite) — clean
- [ ] Manual smoke: create one policy of each category against a local imbi-api, edit each, import a JSON payload of each, copy export round-trips.