### PR TITLE
Add 'lifecycle' to the PluginTab union

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -859,7 +859,7 @@ export interface PluginResponse {
   status: 'active' | 'unavailable'
   used_as_login?: boolean
 }
-export type PluginTab = 'configuration' | 'deployment' | 'logs'
+export type PluginTab = 'configuration' | 'deployment' | 'lifecycle' | 'logs'
 
 export interface PluginUpdate {
   // Pass an explicit empty string to clear; omitting the field leaves


### PR DESCRIPTION
## Summary

- Widens the `PluginTab` union in `src/types/index.ts` to include `'lifecycle'` so the third-party-services assignment editor type-checks for plugins whose manifest reports `supported_tabs: ['lifecycle']`.

## Problem

`ServicePluginConfiguration.tsx` already submits `tab: manifest.supported_tabs[0]` for newly added project-type assignments. Once the GitHub lifecycle plugin (and other lifecycle plugins) ship, that value becomes `'lifecycle'` — but the TS union only listed `'configuration' | 'deployment' | 'logs'`, so the `supportedTab` cast and the API client's request type are both too narrow.

## Solution

Add `'lifecycle'` to the `PluginTab` union. No other UI changes — the existing assignment editor is fully tab-agnostic, and the project-page tab strip (which still renders only configuration/logs/deployment) is deliberately untouched here; surfacing lifecycle results on the project page is a separate product question.

Pairs with [AWeber-Imbi/imbi-api#303](https://github.com/AWeber-Imbi/imbi-api/pull/303), which widens the matching Pydantic `Literal`s.

## Test plan

- [x] `tsc --noEmit` clean
- [x] oxlint / oxfmt clean (via pre-commit)
- [ ] Manual: in the third-party-services admin, assign the GitHub lifecycle plugin to a project type and confirm no type errors and a successful PUT against the matching API branch.