### PR TITLE
Disable scroll-lock on ops log filter dropdowns

### DIFF
--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -254,6 +254,7 @@ export function OperationsLogToolbar({
 
       {hideProjectFilter ? null : (
         <DropdownMenu
+          modal={false}
           onOpenChange={(open) => {
             if (!open) setProjectQuery('')
           }}
@@ -390,7 +391,7 @@ function FacetDropdown({
       ? (options.find((o) => o.key === selected[0])?.label ?? selected[0])
       : undefined
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <TriggerButton
           icon={icon}


### PR DESCRIPTION
Radix DropdownMenu defaults to modal=true, which locks body scroll and injects a padding-right compensation when any dropdown opens. This causes visible content shift and is unexpected UX for non-modal filter overlays. Matches the fix applied to nav dropdowns in #252.