### PR TITLE
Add e/Escape hotkeys for admin edit views

### DIFF
--- a/src/hooks/__tests__/useAdminNav.test.tsx
+++ b/src/hooks/__tests__/useAdminNav.test.tsx
@@ -1,0 +1,217 @@
+import { type ReactNode } from 'react'
+
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { useAdminNav } from '../useAdminNav'
+
+let latestPath = '/'
+
+function LocationProbe() {
+  const loc = useLocation()
+  latestPath = loc.pathname
+  return null
+}
+
+function pressKey(
+  key: string,
+  init: Partial<KeyboardEventInit> & {
+    target?: EventTarget
+  } = {},
+) {
+  const { target, ...rest } = init
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key,
+    ...rest,
+  })
+  if (target) {
+    target.dispatchEvent(event)
+  } else {
+    window.dispatchEvent(event)
+  }
+  return event
+}
+
+function wrap(initialPath: string) {
+  return ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <LocationProbe />
+      <Routes>
+        <Route
+          element={<>{children}</>}
+          path="/admin/:section?/:slug?/:action?"
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('useAdminNav hotkeys', () => {
+  beforeEach(() => {
+    latestPath = '/'
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('pressing "e" on a detail view navigates to edit', () => {
+    const { result } = renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube'),
+    })
+
+    expect(result.current.viewMode).toBe('detail')
+    expect(result.current.slug).toBe('sonarqube')
+
+    act(() => {
+      pressKey('e')
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services/sonarqube/edit')
+  })
+
+  it('pressing Escape on an edit view navigates to the list', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube/edit'),
+    })
+
+    act(() => {
+      pressKey('Escape')
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services')
+  })
+
+  it('pressing Escape on a create view navigates to the list', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/new'),
+    })
+
+    act(() => {
+      pressKey('Escape')
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services')
+  })
+
+  it('does not navigate when "e" is pressed in a list view', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services'),
+    })
+
+    act(() => {
+      pressKey('e')
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services')
+  })
+
+  it('does not navigate when "e" is pressed inside an input', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube'),
+    })
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    act(() => {
+      pressKey('e', { target: input })
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services/sonarqube')
+  })
+
+  it('does not navigate when "e" is pressed inside a textarea', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube'),
+    })
+
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    act(() => {
+      pressKey('e', { target: textarea })
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services/sonarqube')
+  })
+
+  it('does not navigate when "e" is pressed in a contenteditable element', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube'),
+    })
+
+    const div = document.createElement('div')
+    div.setAttribute('contenteditable', 'true')
+    document.body.appendChild(div)
+    div.focus()
+
+    act(() => {
+      pressKey('e', { target: div })
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services/sonarqube')
+  })
+
+  it('skips hotkey when a modifier key is held', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube'),
+    })
+
+    act(() => {
+      pressKey('e', { metaKey: true })
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services/sonarqube')
+  })
+
+  it('skips hotkey when an overlay (Radix data-state="open") is present', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube'),
+    })
+
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    dialog.setAttribute('data-state', 'open')
+    document.body.appendChild(dialog)
+
+    act(() => {
+      pressKey('e')
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services/sonarqube')
+  })
+
+  it('skips hotkey when the event was already handled', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube'),
+    })
+
+    act(() => {
+      const consumer = (e: Event) => e.preventDefault()
+      window.addEventListener('keydown', consumer, { capture: true })
+      pressKey('e')
+      window.removeEventListener('keydown', consumer, { capture: true })
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services/sonarqube')
+  })
+
+  it('does not act on Escape from a detail view', () => {
+    renderHook(() => useAdminNav(), {
+      wrapper: wrap('/admin/third-party-services/sonarqube'),
+    })
+
+    act(() => {
+      pressKey('Escape')
+    })
+
+    expect(latestPath).toBe('/admin/third-party-services/sonarqube')
+  })
+})

--- a/src/hooks/useAdminNav.ts
+++ b/src/hooks/useAdminNav.ts
@@ -56,6 +56,24 @@ export function useAdminNav(): AdminNavState {
     }
   }, [viewMode])
 
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (shouldIgnoreHotkey(event)) return
+      if (event.key === 'e' && viewMode === 'detail' && itemSlug) {
+        event.preventDefault()
+        goToEdit(itemSlug)
+      } else if (
+        event.key === 'Escape' &&
+        (viewMode === 'edit' || viewMode === 'create')
+      ) {
+        event.preventDefault()
+        goToList()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [viewMode, itemSlug, goToEdit, goToList])
+
   return {
     goToCreate,
     goToDetail,
@@ -64,4 +82,26 @@ export function useAdminNav(): AdminNavState {
     slug: itemSlug,
     viewMode,
   }
+}
+
+function hasOpenOverlay(): boolean {
+  // Radix marks open dialogs, popovers, menus, etc. with data-state="open".
+  // Any open overlay should swallow these hotkeys so they don't fight it.
+  return document.querySelector('[data-state="open"]') !== null
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  if (target.closest('[contenteditable="true"], [contenteditable=""]'))
+    return true
+  const tag = target.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+}
+
+function shouldIgnoreHotkey(event: KeyboardEvent): boolean {
+  if (event.defaultPrevented || event.repeat) return true
+  if (event.ctrlKey || event.metaKey || event.altKey) return true
+  if (isTypingTarget(event.target)) return true
+  return hasOpenOverlay()
 }


### PR DESCRIPTION
## Summary
Add keyboard shortcuts to the admin Detail/Form pages: `e` enters edit mode from a detail view, and `Escape` cancels back to the list from an edit or create view.

## Problem
The admin pages (third-party services, organizations, teams, users, roles, webhooks, environments, blueprints, etc.) all expose an Edit button on the detail view and a Cancel button on the form view, but there was no way to drive them from the keyboard. Power users who navigate by URL had to reach for the mouse for every edit/cancel cycle.

## Solution
Wire a single `keydown` listener inside `useAdminNav`. Every admin Detail and Form page already routes through this hook, so the hotkeys apply systemically without per-page changes:

- `e` on a detail view (`viewMode === 'detail'`) calls `goToEdit(slug)`.
- `Escape` on edit or create views calls `goToList()` — the same path the form's Cancel button uses.

The handler skips when:
- focus is in `<input>`, `<textarea>`, `<select>`, or any `[contenteditable]` element;
- a modifier key (Ctrl/Meta/Alt) is held;
- the event is an auto-repeat or already `defaultPrevented`;
- a Radix overlay (`[data-state="open"]`) is visible — so dialogs, popovers, dropdowns, and menus keep owning Escape.

## Impact
- Keyboard-only navigation now works for every admin entity (e.g. visit `/admin/third-party-services/sonarqube`, press `e`, edit, press `Escape`).
- Behavior unchanged when typing in forms, when dialogs are open, or when the user holds modifier keys — no regressions to existing keyboard handling.
- No API or visual changes; affects `src/hooks/useAdminNav.ts` only.

## Testing
- Added `src/hooks/__tests__/useAdminNav.test.tsx` with 11 cases covering the happy paths, every guard (input/textarea/contenteditable/modifier/overlay/defaultPrevented), and the two views where the hotkey must *not* fire.
- Full suite: `npm test` — 183/183 passing.
- `npm run lint` and `npm run build` clean.