### PR TITLE
Deployment resync UI (project + admin TPS)

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1501,6 +1501,43 @@ export const getDeploymentRunStatus = (
   )
 }
 
+// Deployment resync
+
+export interface DeploymentResyncError {
+  detail: string
+  environment?: null | string
+  project_id?: null | string
+}
+
+export interface DeploymentResyncSummary {
+  errors: DeploymentResyncError[]
+  events_recorded: number
+  events_skipped: number
+  observed: number
+  projects: number
+  releases_created: number
+  releases_updated: number
+}
+
+export const resyncProjectDeployments = (
+  orgSlug: string,
+  projectId: string,
+  source?: string,
+): Promise<DeploymentResyncSummary> => {
+  const search = source ? `?source=${encodeURIComponent(source)}` : ''
+  return apiClient.post<DeploymentResyncSummary>(
+    `${deploymentsBase(orgSlug, projectId)}/resync${search}`,
+  )
+}
+
+export const resyncServiceDeployments = (
+  orgSlug: string,
+  serviceSlug: string,
+): Promise<DeploymentResyncSummary> =>
+  apiClient.post<DeploymentResyncSummary>(
+    `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/deployments/resync`,
+  )
+
 // Identity Plugins (org-scoped)
 export interface IdentityPluginRef {
   label: string

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -10,6 +10,7 @@ import {
   deleteProject,
   listEnvironments,
   listLinkDefinitions,
+  listProjectPlugins,
   patchProject,
   rescoreProject,
   unarchiveProject,
@@ -30,6 +31,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAuth } from '@/hooks/useAuth'
+import { useProjectDeploymentResync } from '@/hooks/useDeploymentResync'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { sortEnvironments } from '@/lib/utils'
@@ -91,6 +93,28 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
       scheduleScoreRefresh()
     },
   })
+
+  const { data: projectPlugins = [] } = useQuery({
+    enabled: !!orgSlug && !!project.id,
+    queryFn: ({ signal }) => listProjectPlugins(orgSlug, project.id, signal),
+    queryKey: ['projectPlugins', orgSlug, project.id],
+  })
+
+  // Pick the project's deployment plugin (project-level or inherited)
+  // and only render the resync card when its manifest opts in. Multiple
+  // deployment assignments are rare; we resync the default one and
+  // expose ``source`` via the existing endpoint flag if needed later.
+  const deploymentPlugin = useMemo(
+    () =>
+      projectPlugins.find(
+        (assignment) =>
+          assignment.tab === 'deployment' &&
+          assignment.supports_deployment_sync === true,
+      ),
+    [projectPlugins],
+  )
+
+  const resyncMutation = useProjectDeploymentResync(orgSlug, project.id)
 
   const {
     data: linkDefs = [],
@@ -161,6 +185,30 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
       />
 
       <ProjectPluginsSection orgSlug={orgSlug} projectId={project.id} />
+
+      {deploymentPlugin && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Resync deployments</CardTitle>
+            <CardDescription className="text-secondary">
+              Fetch the latest deployment for each environment from{' '}
+              <strong>{deploymentPlugin.label}</strong> and backfill releases
+              and deployment history. Useful when webhook delivery has lapsed or
+              the badge appears stale.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button
+              disabled={resyncMutation.isPending}
+              onClick={() => resyncMutation.mutate()}
+              size="sm"
+              variant="outline"
+            >
+              {resyncMutation.isPending ? 'Resyncing...' : 'Resync Deployments'}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       {isAdmin && (
         <Card>

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -104,15 +104,14 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   // and only render the resync card when its manifest opts in. Multiple
   // deployment assignments are rare; we resync the default one and
   // expose ``source`` via the existing endpoint flag if needed later.
-  const deploymentPlugin = useMemo(
-    () =>
-      projectPlugins.find(
-        (assignment) =>
-          assignment.tab === 'deployment' &&
-          assignment.supports_deployment_sync === true,
-      ),
-    [projectPlugins],
-  )
+  const deploymentPlugin = useMemo(() => {
+    const candidates = projectPlugins.filter(
+      (assignment) =>
+        assignment.tab === 'deployment' &&
+        assignment.supports_deployment_sync === true,
+    )
+    return candidates.find((assignment) => assignment.default) ?? candidates[0]
+  }, [projectPlugins])
 
   const resyncMutation = useProjectDeploymentResync(orgSlug, project.id)
 

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -50,6 +50,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { useServiceDeploymentResync } from '@/hooks/useDeploymentResync'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { queryKeys } from '@/lib/queryKeys'
 import type {
@@ -189,8 +190,92 @@ export function ServicePluginConfiguration({
           {manifest && (
             <ServicePluginEdgesCard manifest={manifest} orgSlug={orgSlug} />
           )}
+          {manifest?.supports_deployment_sync === true && (
+            <ResyncCard orgSlug={orgSlug} serviceSlug={serviceSlug} />
+          )}
         </>
       )}
+    </div>
+  )
+}
+
+// --------------------------- Resync ------------------------------------
+
+function ResyncCard({
+  orgSlug,
+  serviceSlug,
+}: {
+  orgSlug: string
+  serviceSlug: string
+}) {
+  const [showConfirm, setShowConfirm] = useState(false)
+  const resync = useServiceDeploymentResync(orgSlug, serviceSlug)
+  const onConfirm = () => {
+    resync.mutate(undefined, { onSettled: () => setShowConfirm(false) })
+  }
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Resync deployments for all projects</CardTitle>
+        <CardDescription>
+          Backfill <strong>Release</strong> nodes and deployment history for
+          every project that uses this plugin. Runs the per-project resync
+          against the remote with bounded concurrency. Use this when webhook
+          delivery has lapsed across the fleet and badges are stale.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {showConfirm ? (
+          <ResyncConfirm
+            isPending={resync.isPending}
+            onCancel={() => setShowConfirm(false)}
+            onConfirm={onConfirm}
+          />
+        ) : (
+          <Button
+            disabled={resync.isPending}
+            onClick={() => setShowConfirm(true)}
+            size="sm"
+            variant="outline"
+          >
+            Resync All Projects
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ResyncConfirm({
+  isPending,
+  onCancel,
+  onConfirm,
+}: {
+  isPending: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-secondary text-sm">This may take a while. Continue?</p>
+      <div className="flex gap-2">
+        <Button
+          disabled={isPending}
+          onClick={onConfirm}
+          size="sm"
+          variant="outline"
+        >
+          {isPending ? 'Resyncing...' : 'Confirm Resync'}
+        </Button>
+        <Button
+          disabled={isPending}
+          onClick={onCancel}
+          size="sm"
+          variant="outline"
+        >
+          Cancel
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/hooks/useDeploymentResync.ts
+++ b/src/hooks/useDeploymentResync.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import type { DeploymentResyncSummary } from '@/api/endpoints'
+import {
+  resyncProjectDeployments,
+  resyncServiceDeployments,
+} from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+// Project-level resync. Invalidates the project + currentReleases +
+// operationsLog query keys so badges and deploy widgets refresh once
+// the backfill completes.
+export function useProjectDeploymentResync(orgSlug: string, projectId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => resyncProjectDeployments(orgSlug, projectId),
+    onError: onResyncError,
+    onSuccess: (summary: DeploymentResyncSummary) => {
+      toastResult(summary)
+      void queryClient.invalidateQueries({
+        queryKey: ['project', orgSlug, projectId],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: ['currentReleases', orgSlug, projectId],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: ['operationsLog', orgSlug, projectId],
+      })
+    },
+  })
+}
+
+// TPS-wide resync. The fan-out can touch any project, so we drop the
+// org-key scope on the currentReleases and operationsLog query keys and
+// let TanStack invalidate every matching scope.
+export function useServiceDeploymentResync(
+  orgSlug: string,
+  serviceSlug: string,
+) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => resyncServiceDeployments(orgSlug, serviceSlug),
+    onError: onResyncError,
+    onSuccess: (summary: DeploymentResyncSummary) => {
+      toastResult(summary)
+      void queryClient.invalidateQueries({ queryKey: ['currentReleases'] })
+      void queryClient.invalidateQueries({ queryKey: ['operationsLog'] })
+    },
+  })
+}
+
+function onResyncError(err: unknown): void {
+  toast.error(extractApiErrorDetail(err) ?? 'Failed to resync deployments')
+}
+
+// Build the "X event(s) recorded • Y release(s) created" headline shown
+// on both the project-level and TPS-wide success toasts. Skips counters
+// that are zero so the summary stays short on idle remotes.
+// fallow-ignore-next-line complexity
+function summarize(s: DeploymentResyncSummary): string {
+  const parts: string[] = []
+  if (s.events_recorded > 0)
+    parts.push(`${s.events_recorded} event(s) recorded`)
+  if (s.releases_created > 0)
+    parts.push(`${s.releases_created} release(s) created`)
+  if (s.releases_updated > 0)
+    parts.push(`${s.releases_updated} release(s) updated`)
+  return parts.length > 0 ? parts.join(', ') : 'Nothing to update'
+}
+
+function toastResult(s: DeploymentResyncSummary): void {
+  const headline = summarize(s)
+  if (s.errors.length > 0) {
+    toast.warning(`Resync finished with warnings: ${headline}`, {
+      description: s.errors
+        .slice(0, 5)
+        .map((e) => {
+          const env = e.environment ? ` / ${e.environment}` : ''
+          const where = e.project_id ? `${e.project_id}${env}` : 'unknown'
+          return `${where}: ${e.detail}`
+        })
+        .join(' • '),
+    })
+  } else {
+    toast.success(`Resync complete: ${headline}`)
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -601,6 +601,7 @@ export interface InstalledPlugin {
   requires_identity?: boolean
   slug: string
   supported_tabs: PluginTab[]
+  supports_deployment_sync?: boolean
   vertex_labels?: PluginVertexLabel[]
   // Body copy shown on the dashboard "unconnected integration" widget.
   // Resolved server-side (override > manifest > null).  ``_default`` is
@@ -766,6 +767,7 @@ export interface PluginAssignmentResponse {
   plugin_id: string
   plugin_slug: string
   source: 'merged' | 'project' | 'project_type'
+  supports_deployment_sync?: boolean
   supports_histogram?: boolean
   tab: PluginTab
 }


### PR DESCRIPTION
## Summary

- New `useDeploymentResync` hook centralises the mutation, the success-toast headline, the warning-toast errors list, and the post-success TanStack query invalidations. Two thin entry points — `useProjectDeploymentResync` (scoped invalidations) and `useServiceDeploymentResync` (org-wide invalidations).
- `resyncProjectDeployments` + `resyncServiceDeployments` API bindings call the new imbi-api endpoints; `DeploymentResyncSummary` / `DeploymentResyncError` TypeScript types model the response.
- Renders a "Resync deployments" card on `ProjectSettingsTab` when the project's deployment plugin advertises `supports_deployment_sync` on its manifest, alongside the existing Recompute / Archive / Delete cards.
- Renders a "Resync all projects" card on `ServicePluginConfiguration` (admin TPS plugin detail) when the plugin manifest advertises `supports_deployment_sync`. Has a confirm step so an accidental click doesn't fan out across O(100) projects.
- Adds `supports_deployment_sync?: boolean` to the `InstalledPlugin` and `PluginAssignmentResponse` types so both consumers can gate on the same flag.

## Problem

When gateway webhook delivery lapses, badges and deployment-history widgets freeze — `_handle_deploy` on the API silently records only the audit row because no matching `Release` node exists for the deploying SHA. There's been no operator-facing recovery path: the only fix was to push a fresh webhook, which assumes the webhook plumbing itself is healthy.

The companion imbi-api PR adds resync endpoints that walk the remote for the most recent deployment per environment and backfill the graph. This PR surfaces those endpoints to the operator: project-scoped from the project's settings page, fleet-scoped from the admin TPS page.

## Solution

### Shared hook (`src/hooks/useDeploymentResync.ts`)

Both consumers fire the same mutation flavor: `(orgSlug, target) -> Promise<DeploymentResyncSummary>`, then show a toast that summarises the counters. Extracting:

- `summarize(summary)` builds the "X event(s) recorded, Y release(s) created" headline; skipping counters that are zero keeps the toast short on idle remotes.
- `toastResult(summary)` picks success vs warning depending on `errors.length`; the warning surfaces the first five per-project / per-env failures inline so the operator can fix the bad ones without re-reading server logs.
- `useProjectDeploymentResync(orgSlug, projectId)` invalidates `['project', org, id]`, `['currentReleases', org, id]`, and `['operationsLog', org, id]` so the badge / current-release widgets / operations log feed all refresh after the backfill.
- `useServiceDeploymentResync(orgSlug, serviceSlug)` drops the project scope on the invalidations (the fan-out can touch any project) and lets TanStack invalidate every matching prefix.

### Project Settings card (`src/components/ProjectSettingsTab.tsx`)

- Adds a `listProjectPlugins` query; `useMemo` picks the assignment with `tab === 'deployment'` and `supports_deployment_sync === true`. Card body names the plugin label so the operator can tell which integration is being called.
- Renders alongside the existing Recompute / Archive / Delete cards; mirrors the surface area of the Recompute card.

### Admin TPS card (`src/components/admin/third-party-services/ServicePluginConfiguration.tsx`)

- A new `ResyncCard` is added to the configuration page when the plugin manifest advertises `supports_deployment_sync`. The trigger is gated by an explicit `ResyncConfirm` panel — extracted so the parent `ResyncCard` stays inside the function-size threshold.
- Reuses the toast / invalidation machinery via the same hook so the wording matches what the project-page operator would see.

### Type additions (`src/types/index.ts`)

`supports_deployment_sync?: boolean` is added on both `InstalledPlugin` (manifest detail used by admin pages) and `PluginAssignmentResponse` (assignment-level view used by the project page). The server populates them from the manifest in both responses (companion imbi-api PR).

## Companion PRs

- imbi-common: <https://github.com/AWeber-Imbi/imbi-common/pull/104>
- imbi-plugin-github: <https://github.com/AWeber-Imbi/imbi-plugin-github/pull/13>
- imbi-api: <https://github.com/AWeber-Imbi/imbi-api/pull/304>

## Test plan

- [x] `tsc -p . --noEmit` clean.
- [x] `oxlint` clean (4 pre-existing `enforce-sort-order` warnings on untouched code in `ProjectSettingsTab`).
- [x] `oxfmt --check` clean.
- [x] `fallow audit` gate passes (the 13 reported above-threshold functions are all inherited; the gate excluded 15 inherited findings).
- [ ] Manual smoke-test once imbi-api PR merges: confirm both cards appear only when the resolved plugin advertises `supports_deployment_sync`, and that the post-success invalidations refresh the badge.