### PR TITLE
Make Configuration tab list/detail split resizable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "react-day-picker": "^9.4.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^9.0.3",
+        "react-resizable-panels": "^4.11.1",
         "react-router-dom": "^7.1.1",
         "reagraph": "^4.30.8",
         "remark-gfm": "^4.0.0",
@@ -9100,6 +9101,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.1.tgz",
+      "integrity": "sha512-kA4w58V6wYdRLm2rg9pzroZwGlqBLul1FjMP0J8kqTo3zSHtjeH+LXmZaldCo6+HWqs1e5hOcPoajKXdOze37Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-day-picker": "^9.4.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^9.0.3",
+    "react-resizable-panels": "^4.11.1",
     "react-router-dom": "^7.1.1",
     "reagraph": "^4.30.8",
     "remark-gfm": "^4.0.0",

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -16,6 +16,12 @@ import {
   Settings2,
   Trash2,
 } from 'lucide-react'
+import {
+  Group,
+  Panel,
+  Separator,
+  useDefaultLayout,
+} from 'react-resizable-panels'
 import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
@@ -149,6 +155,12 @@ export function ConfigurationTab({
     data_type: 'string',
     key: '',
     values: {},
+  })
+
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: 'imbi:config-tab:split',
+    panelIds: ['list', 'detail'],
+    storage: typeof window === 'undefined' ? undefined : window.localStorage,
   })
 
   const flashTimer = useRef<null | ReturnType<typeof setTimeout>>(null)
@@ -572,9 +584,20 @@ export function ConfigurationTab({
         </div>
       )}
 
-      <div className="border-primary bg-primary grid h-[calc(100dvh-460px)] min-h-80 grid-cols-[420px_1fr] overflow-hidden rounded-lg border">
+      <Group
+        className="border-primary bg-primary h-[calc(100dvh-460px)] min-h-80 overflow-hidden rounded-lg border"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={onLayoutChanged}
+        orientation="horizontal"
+      >
         {/* LEFT pane: filter + key list */}
-        <div className="border-primary bg-secondary flex min-h-0 flex-col border-r">
+        <Panel
+          className="border-primary bg-secondary flex min-h-0 flex-col"
+          defaultSize={28}
+          id="list"
+          maxSize={55}
+          minSize={18}
+        >
           <div className="border-primary flex h-14 shrink-0 items-center border-b px-3.5">
             <div className="relative flex w-full items-center">
               <Search
@@ -611,10 +634,16 @@ export function ConfigurationTab({
               selectedKey={mode === 'create' ? null : selectedKey}
             />
           )}
-        </div>
+        </Panel>
+
+        <Separator className="bg-primary hover:bg-amber-border focus-visible:bg-amber-border w-px transition-colors outline-none" />
 
         {/* RIGHT pane */}
-        <div className="bg-primary flex min-h-0 flex-col">
+        <Panel
+          className="bg-primary flex min-h-0 flex-col"
+          id="detail"
+          minSize={30}
+        >
           {mode === 'create' ? (
             <DetailPane
               draft={draft}
@@ -649,8 +678,8 @@ export function ConfigurationTab({
           ) : (
             <EmptyState onAdd={() => setMode('create')} />
           )}
-        </div>
-      </div>
+        </Panel>
+      </Group>
 
       <ConfirmDialog
         description={`Delete key "${confirmDelete ?? ''}" from every environment? This cannot be undone.`}


### PR DESCRIPTION
## Summary

The project Configuration tab had a fixed 420px parameter list and a flex
right-hand detail pane. Long keys (e.g. `campaign-engine-campaign-state/...`)
got truncated on the left even when the right pane had plenty of headroom,
and there was no way to give the list more room.

This swaps the fixed grid split for a draggable one and remembers the
user's choice across reloads.

## Problem

- Left list width was hard-coded to 420px via `grid-cols-[420px_1fr]`.
- Users editing long path-based keys could see only the right-hand tail
  of each key; widening the list required a code change.

## Solution

- Add `react-resizable-panels` (v4.11.1) and replace the fixed-column
  grid in `ConfigurationTab.tsx` with a `Group` / two `Panel`s and a
  `Separator` drag handle.
- Defaults: left pane 28% (min 18%, max 55%), right pane min 30%.
- Persist the split per-browser via `useDefaultLayout` backed by
  `localStorage` (key `imbi:config-tab:split`).
- Separator picks up `amber-border` on hover/focus for affordance.

Diff is surgical — only the wrapper changes; no class reordering or
unrelated edits.

## Test plan

- [ ] Open a project's Configuration tab; drag the divider between the
      parameter list and the detail pane — list resizes within
      18%–55% of the container.
- [ ] Reload the page; the previously-chosen split is restored from
      `localStorage`.
- [ ] Keyboard: focus the separator (Tab) and use arrow keys to nudge
      the split — built-in a11y from `react-resizable-panels`.
- [ ] Switching between Configuration tabs of different projects keeps
      the same saved split (single layout, shared across projects by
      design).