### PR TITLE
Promote Policy Type to its own card on the scoring form

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -148,7 +148,8 @@ export function Admin() {
       scope: 'org',
     },
     {
-      description: 'Define attribute-based project scoring policies',
+      description:
+        'Define attribute, presence, link, and age-based scoring policies',
       icon: Target,
       id: 'scoring-policies',
       label: 'Scoring Policies',

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -42,11 +42,13 @@ const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
 }
 
 const CATEGORY_DESCRIPTIONS: Record<ScoringPolicyCategory, string> = {
-  age: 'Score a datetime attribute by how recently it changed.',
-  attribute: 'Map a specific attribute value to a score.',
+  age: 'Score by how recently a datetime attribute changed, using the same threshold DSL as blueprint age maps (e.g. >30d, <=7d). Recomputed daily.',
+  attribute:
+    'Map a specific attribute value or numeric range to a score (e.g. test-coverage tiers).',
   link_presence:
-    'Score whether the project has a link of a specific link type.',
-  presence: 'Score whether an attribute has a non-empty value.',
+    'Penalize projects that do not have a link of a specific type (e.g. missing source-code link).',
+  presence:
+    'Penalize projects whose attribute is null, empty, or whitespace (e.g. empty description).',
 }
 
 interface MapEditorProps {
@@ -271,6 +273,45 @@ export function ScoringPolicyForm({
       )}
 
       <form className="space-y-6" onSubmit={handleSubmit}>
+        {/* Category — primary decision, shown first */}
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              Policy Type <span className="text-danger">*</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex flex-wrap gap-2">
+              {(
+                [
+                  'attribute',
+                  'presence',
+                  'link_presence',
+                  'age',
+                ] as ScoringPolicyCategory[]
+              ).map((c) => (
+                <button
+                  className={`rounded-lg border px-3 py-1.5 text-sm transition-colors ${
+                    category === c
+                      ? 'border-amber-text bg-amber-bg text-amber-text'
+                      : 'border-input text-secondary hover:bg-secondary'
+                  }`}
+                  disabled={isEditing || isLoading}
+                  key={c}
+                  onClick={() => setCategory(c)}
+                  type="button"
+                >
+                  {CATEGORY_LABELS[c]}
+                </button>
+              ))}
+            </div>
+            <p className="text-tertiary text-xs">
+              {CATEGORY_DESCRIPTIONS[category]}
+              {isEditing && ' Category cannot be changed after creation.'}
+            </p>
+          </CardContent>
+        </Card>
+
         {/* Identity */}
         <Card>
           <CardHeader>
@@ -330,40 +371,6 @@ export function ScoringPolicyForm({
                 rows={2}
                 value={description}
               />
-            </div>
-
-            <div>
-              <label className="text-secondary mb-1.5 block text-sm">
-                Category <span className="text-danger">*</span>
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {(
-                  [
-                    'attribute',
-                    'presence',
-                    'link_presence',
-                    'age',
-                  ] as ScoringPolicyCategory[]
-                ).map((c) => (
-                  <button
-                    className={`rounded-lg border px-3 py-1.5 text-sm transition-colors ${
-                      category === c
-                        ? 'border-amber-text bg-amber-bg text-amber-text'
-                        : 'border-input text-secondary hover:bg-secondary'
-                    }`}
-                    disabled={isEditing || isLoading}
-                    key={c}
-                    onClick={() => setCategory(c)}
-                    type="button"
-                  >
-                    {CATEGORY_LABELS[c]}
-                  </button>
-                ))}
-              </div>
-              <p className="text-tertiary mt-1.5 text-xs">
-                {CATEGORY_DESCRIPTIONS[category]}
-                {isEditing && ' Category cannot be changed after creation.'}
-              </p>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- Moves the category picker (attribute / presence / link_presence / age) out of the Identity card into a new "Policy Type" card placed first in the scoring-policy form so the primary decision is the first thing the user sees.
- Expands the category descriptions to name the concrete signal — e.g. the age description now references the blueprint age-map DSL (`>30d`, `<=7d`) and the daily recompute cadence; presence and link_presence explicitly call out the penalty framing.
- Updates the Admin sidebar blurb for Scoring Policies to enumerate the category families.

## Test plan
- [ ] Open Admin → Scoring Policies → New policy and verify Policy Type appears as a card above Identity.
- [ ] Toggle through all four categories and verify the description text updates and matches the new copy.
- [ ] Edit an existing policy and verify Policy Type is rendered but disabled with "Category cannot be changed after creation."
- [ ] Confirm the sidebar entry reads "Define attribute, presence, link, and age-based scoring policies."