### PR TITLE
Combine Deploy/Promote into a tabbed release dialog

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -5,14 +5,11 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
-  AlertCircle,
   ArrowRight,
   Check,
-  CheckCircle2,
   ChevronDown,
   Filter,
   Info,
-  Rocket,
   Settings2 as SettingsIcon,
   TrendingDown,
 } from 'lucide-react'
@@ -35,8 +32,7 @@ import {
 } from '@/api/endpoints'
 import {
   type DeploymentRunStarted,
-  DeployModal,
-  PromoteModal,
+  ReleaseModal,
 } from '@/components/deploy/DeploymentModal'
 import { DeploymentRunWatcher } from '@/components/deploy/DeploymentRunWatcher'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
@@ -74,7 +70,7 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { getIcon, useIconRegistryVersion } from '@/lib/icons'
 import { formatFieldKey } from '@/lib/project-field-formatting'
-import { cn, sanitizeHttpUrl, sortEnvironments } from '@/lib/utils'
+import { sanitizeHttpUrl, sortEnvironments } from '@/lib/utils'
 import type { Project, ScoringPolicy } from '@/types'
 
 interface ProjectDetailProps {
@@ -634,9 +630,6 @@ export function ProjectDetail({
                 sortedEnvironments.map((env, idx) => {
                   const deployment = deploymentStatus[env.slug]
                   const color = env.label_color
-                  const ciDot = deployment
-                    ? renderCiDot(deployment.ciStatus)
-                    : null
                   // Release-train action selection is driven by per-env
                   // flags (``can_deploy`` / ``can_promote``).  Defaults
                   // match the backend model: deployable, opt-in promote.
@@ -661,29 +654,17 @@ export function ProjectDetail({
                       : () => openDeploy(env.slug)
                   const tooltipText = isPromoteSlot
                     ? 'Promote'
-                    : 'Deploy / Redeploy'
-                  const versionSlot =
-                    deployment || releasesLoading ? (
-                      <span className="inline-grid items-center transition-discrete">
-                        <span
-                          aria-hidden
-                          className={cn(
-                            'col-start-1 row-start-1 transition-opacity duration-500 ease-out',
-                            deployment ? 'opacity-0' : 'opacity-100',
-                          )}
-                        >
-                          <span className="inline-block h-3 w-14 animate-pulse rounded bg-current/25 align-middle blur-[2px]" />
-                        </span>
-                        <span
-                          className={cn(
-                            'col-start-1 row-start-1 transition-opacity duration-500 ease-out',
-                            deployment ? 'opacity-100' : 'opacity-0',
-                          )}
-                        >
-                          {deployment ? `: ${deployment.version}` : ' '}
-                        </span>
-                      </span>
-                    ) : null
+                    : canPromote
+                      ? 'Deploy / Promote'
+                      : 'Deploy'
+                  const versionSlot = deployment ? (
+                    <span className="font-mono">{deployment.version}</span>
+                  ) : releasesLoading ? (
+                    <span
+                      aria-hidden
+                      className="inline-block h-3 w-14 animate-pulse rounded bg-current/25 align-middle blur-[2px]"
+                    />
+                  ) : null
                   const chipBody = color ? (
                     <LabelChip
                       className="rounded-md px-3 py-1.5 text-sm"
@@ -692,14 +673,12 @@ export function ProjectDetail({
                       <span className="inline-flex items-center gap-1.5">
                         {env.name}
                         {versionSlot}
-                        {ciDot}
                       </span>
                     </LabelChip>
                   ) : (
                     <span className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium">
                       {env.name}
                       {versionSlot}
-                      {ciDot}
                     </span>
                   )
                   return (
@@ -1041,53 +1020,53 @@ export function ProjectDetail({
           <ProjectSettingsTab project={project} />
         </TabsContent>
       </Tabs>
-      <DeployModal
-        environments={sortedEnvironments}
-        initialEnvSlug={isDeployModal ? initialSubId : undefined}
-        onOpenChange={(open) => {
-          if (!open) closeModal()
-        }}
-        onRunStarted={handleRunStarted}
-        open={isDeployModal}
-        orgSlug={orgSlug}
-        projectId={project.id}
-        projectName={project.name}
-      />
-      {(() => {
-        if (!isPromoteModal) return null
-        const toIdx = sortedEnvironments.findIndex(
-          (e) => e.slug === initialSubId,
-        )
-        // Promote requires a previous env in the pipeline to act as the
-        // source AND a deployed version on that upstream env (else
-        // ``fromCommittish`` would be undefined and the API can't
-        // resolve the source). ``idx <= 0`` means the URL points at the
-        // entry-point env (or an unknown one); the redirect effect
-        // above will already navigate away — render nothing here so we
-        // never mount PromoteModal in an impossible state.
-        if (toIdx <= 0) return null
-        const fromSlug = sortedEnvironments[toIdx - 1]?.slug
-        const fromVersion = fromSlug
-          ? deploymentStatus[fromSlug]?.version
-          : undefined
-        if (!fromSlug || !fromVersion) return null
-        return (
-          <PromoteModal
-            environments={sortedEnvironments}
-            fromCommittish={fromVersion}
-            fromEnvironment={fromSlug}
-            onOpenChange={(open) => {
-              if (!open) closeModal()
-            }}
-            onRunStarted={handleRunStarted}
-            open={isPromoteModal}
-            orgSlug={orgSlug}
-            projectId={project.id}
-            projectName={project.name}
-            toEnvironment={initialSubId as string}
-          />
-        )
-      })()}
+      {
+        // fallow-ignore-next-line complexity
+        (() => {
+          if (!isDeployModal && !isPromoteModal) return null
+          if (!initialSubId) return null
+          const targetIdx = sortedEnvironments.findIndex(
+            (e) => e.slug === initialSubId,
+          )
+          if (targetIdx < 0) return null
+          const targetEnv = sortedEnvironments[targetIdx]
+          const canDeploy = targetEnv?.can_deploy ?? true
+          const canPromote = targetEnv?.can_promote ?? false
+          // Promote needs an upstream env with a deployed version. When the
+          // user lands on /promote/<env> we already short-circuit in the
+          // redirect effect above if that's missing — but the modal can
+          // still open for /deploy/<env> on an env that *also* supports
+          // promote, so we resolve the source here when possible and just
+          // omit the Promote tab when prerequisites are unmet.
+          const fromSlug =
+            targetIdx > 0 ? sortedEnvironments[targetIdx - 1]?.slug : undefined
+          const fromVersion = fromSlug
+            ? deploymentStatus[fromSlug]?.version
+            : undefined
+          const promoteAvailable =
+            canPromote && !!fromSlug && !!fromVersion && targetIdx > 0
+          if (!canDeploy && !promoteAvailable) return null
+          return (
+            <ReleaseModal
+              canDeploy={canDeploy}
+              canPromote={promoteAvailable}
+              environments={sortedEnvironments}
+              fromCommittish={fromVersion}
+              fromEnvironment={fromSlug}
+              initialAction={isPromoteModal ? 'promote' : 'deploy'}
+              initialEnvSlug={initialSubId}
+              onOpenChange={(open) => {
+                if (!open) closeModal()
+              }}
+              onRunStarted={handleRunStarted}
+              open={isDeployModal || isPromoteModal}
+              orgSlug={orgSlug}
+              projectId={project.id}
+              projectName={project.name}
+            />
+          )
+        })()
+      }
       {activeRuns.map((run) => (
         // Bind each watcher to the org/project that triggered the run
         // so polling stays correct if the user navigates to another
@@ -1163,16 +1142,6 @@ function PlaceholderTab({ name }: { name: string }) {
       </CardContent>
     </Card>
   )
-}
-
-function renderCiDot(status: 'fail' | 'pass' | 'warn' | null): React.ReactNode {
-  if (status === 'pass')
-    return <CheckCircle2 aria-label="CI passing" className="size-3.5" />
-  if (status === 'fail')
-    return <Rocket aria-label="CI failing" className="size-3.5" />
-  if (status === 'warn')
-    return <AlertCircle aria-label="CI warning" className="size-3.5" />
-  return null
 }
 
 function ScoreBreakdownDetail({

--- a/src/components/deploy/DeploymentModal.tsx
+++ b/src/components/deploy/DeploymentModal.tsx
@@ -1,10 +1,12 @@
+import { useEffect, useState } from 'react'
+
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type { DeploymentRunStatus, Environment } from '@/types'
 
 import { DeployTab } from './DeployTab'
@@ -38,37 +40,33 @@ export interface DeploymentRunStarted {
   toastId: number | string
 }
 
-interface DeployModalProps {
+interface ReleaseModalProps {
+  canDeploy: boolean
+  canPromote: boolean
   environments: Environment[]
-  initialEnvSlug?: string
-  onOpenChange: (open: boolean) => void
-  /**
-   * Called after a successful trigger so the parent can mount a
-   * ``<DeploymentRunWatcher>`` for the run.  Without this prop the
-   * tabs fall back to a one-shot success toast (Phase 1 behavior).
-   */
-  onRunStarted?: (run: DeploymentRunStarted) => void
-  open: boolean
-  orgSlug: string
-  projectId: string
-  projectName: string
-}
-
-interface PromoteModalProps {
-  environments: Environment[]
+  // For the promote tab — the source env (preceding the target) and the
+  // committish from its current release.  Required when ``canPromote`` is
+  // true; ignored otherwise.
   fromCommittish?: null | string
-  fromEnvironment: string
+  fromEnvironment?: string
+  initialAction: 'deploy' | 'promote'
+  initialEnvSlug: string
   onOpenChange: (open: boolean) => void
   onRunStarted?: (run: DeploymentRunStarted) => void
   open: boolean
   orgSlug: string
   projectId: string
   projectName: string
-  toEnvironment: string
 }
 
-export function DeployModal({
+// fallow-ignore-next-line complexity
+export function ReleaseModal({
+  canDeploy,
+  canPromote,
   environments,
+  fromCommittish,
+  fromEnvironment,
+  initialAction,
   initialEnvSlug,
   onOpenChange,
   onRunStarted,
@@ -76,64 +74,81 @@ export function DeployModal({
   orgSlug,
   projectId,
   projectName,
-}: DeployModalProps) {
-  return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-230 sm:max-w-230">
-        <DialogHeader>
-          <DialogTitle>{`Deploy ${projectName}`}</DialogTitle>
-          <DialogDescription>
-            Roll an existing commit or tag onto an environment
-          </DialogDescription>
-        </DialogHeader>
-        <div className="px-6 py-4">
-          <DeployTab
-            environments={environments}
-            initialEnvSlug={initialEnvSlug}
-            onClose={() => onOpenChange(false)}
-            onRunStarted={onRunStarted}
-            open={open}
-            orgSlug={orgSlug}
-            projectId={projectId}
-          />
-        </div>
-      </DialogContent>
-    </Dialog>
+}: ReleaseModalProps) {
+  // Lock the active tab to whichever action is actually available so a
+  // deep-link to /promote/<env> on an env that no longer supports promote
+  // doesn't render an empty pane.
+  const resolveTab = (a: 'deploy' | 'promote') =>
+    a === 'promote' ? (canPromote ? 'promote' : 'deploy') : 'deploy'
+  const [tab, setTab] = useState<'deploy' | 'promote'>(
+    resolveTab(initialAction),
   )
-}
+  useEffect(() => {
+    if (open) setTab(resolveTab(initialAction))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initialAction, canDeploy, canPromote])
 
-export function PromoteModal({
-  environments,
-  fromCommittish,
-  fromEnvironment,
-  onOpenChange,
-  onRunStarted,
-  open,
-  orgSlug,
-  projectId,
-  projectName,
-  toEnvironment,
-}: PromoteModalProps) {
+  const promoteReady = canPromote && !!fromEnvironment
+  const description =
+    tab === 'promote' && fromEnvironment
+      ? `Tag & release ${fromEnvironment} → ${initialEnvSlug}`
+      : 'Roll an existing commit or tag onto an environment'
+
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-230 sm:max-w-230">
-        <DialogHeader>
-          <DialogTitle>{`Promote ${projectName}`}</DialogTitle>
-          <DialogDescription>{`Tag & release ${fromEnvironment} → ${toEnvironment}`}</DialogDescription>
-        </DialogHeader>
-        <div className="px-6 py-4">
-          <PromoteTab
-            environments={environments}
-            fromCommittish={fromCommittish}
-            fromEnvironment={fromEnvironment}
-            onClose={() => onOpenChange(false)}
-            onRunStarted={onRunStarted}
-            open={open}
-            orgSlug={orgSlug}
-            projectId={projectId}
-            toEnvironment={toEnvironment}
-          />
-        </div>
+        <DialogTitle className="sr-only">{`Release ${projectName}`}</DialogTitle>
+        <Tabs
+          onValueChange={(v) => setTab(v as 'deploy' | 'promote')}
+          value={tab}
+        >
+          <TabsList className="border-tertiary h-auto justify-start gap-6 rounded-none border-b px-6 pt-5">
+            {canDeploy ? (
+              <TabsTrigger value="deploy">Deploy</TabsTrigger>
+            ) : null}
+            {canPromote ? (
+              <TabsTrigger value="promote">Promote</TabsTrigger>
+            ) : null}
+          </TabsList>
+          <DialogDescription className="px-6 pt-3">
+            {description}
+          </DialogDescription>
+          {canDeploy ? (
+            <TabsContent className="px-6 pt-3 pb-4" value="deploy">
+              <DeployTab
+                environments={environments}
+                initialEnvSlug={initialEnvSlug}
+                onClose={() => onOpenChange(false)}
+                onRunStarted={onRunStarted}
+                open={open && tab === 'deploy'}
+                orgSlug={orgSlug}
+                projectId={projectId}
+              />
+            </TabsContent>
+          ) : null}
+          {canPromote ? (
+            <TabsContent className="px-6 pt-3 pb-4" value="promote">
+              {promoteReady ? (
+                <PromoteTab
+                  environments={environments}
+                  fromCommittish={fromCommittish}
+                  fromEnvironment={fromEnvironment as string}
+                  onClose={() => onOpenChange(false)}
+                  onRunStarted={onRunStarted}
+                  open={open && tab === 'promote'}
+                  orgSlug={orgSlug}
+                  projectId={projectId}
+                  toEnvironment={initialEnvSlug}
+                />
+              ) : (
+                <p className="border-secondary text-tertiary rounded-md border border-dashed p-4 text-sm">
+                  No upstream environment with a deployed version yet — deploy
+                  to an earlier env first.
+                </p>
+              )}
+            </TabsContent>
+          ) : null}
+        </Tabs>
       </DialogContent>
     </Dialog>
   )

--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -108,12 +108,21 @@ export function PromoteTab({
   })
   const [draft, setDraft] = useState<DraftReleaseNotesResponse | null>(null)
 
-  // Auto-draft on first open when we have a base + head.
+  // Skip the AI draft when there's nothing to release. We can't rely on
+  // ``lastTag !== selectedSha`` because the tag and the upstream SHA can be
+  // different strings that point at the same commit; trust the compare
+  // result instead — if the API returned zero commits, there's no diff to
+  // summarize and the model call would burn tokens for nothing.
+  const hasDiff = !!lastTag && !!selectedSha && commits.length > 0
+  // Auto-draft on first open when we have a base + head and a non-empty diff.
   useEffect(() => {
-    if (!open || draft || !lastTag || !selectedSha) return
-    draftMutation.mutate({ headSha: selectedSha }, { onSuccess: setDraft })
+    if (!open || draft || !hasDiff) return
+    draftMutation.mutate(
+      { headSha: selectedSha as string },
+      { onSuccess: setDraft },
+    )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, lastTag, selectedSha])
+  }, [open, hasDiff, selectedSha])
 
   const [tag, setTag] = useState<string>('')
   const [notes, setNotes] = useState<string>('')
@@ -332,6 +341,11 @@ export function PromoteTab({
                     <span className="text-tertiary"> (AI unavailable)</span>
                   ) : null}
                 </span>
+              ) : compareEnabled && !compareLoading && commits.length === 0 ? (
+                <span className="text-tertiary">
+                  No commits between the last tag and the upstream — nothing new
+                  to release.
+                </span>
               ) : (
                 <span className="text-tertiary">
                   No draft yet — pick a build above.
@@ -346,11 +360,11 @@ export function PromoteTab({
             {compare?.commits?.length ?? 0} commits considered
           </span>
           <Button
-            disabled={!selectedSha || draftMutation.isPending}
+            disabled={!hasDiff || draftMutation.isPending}
             onClick={() => {
-              if (!selectedSha) return
+              if (!hasDiff) return
               draftMutation.mutate(
-                { headSha: selectedSha },
+                { headSha: selectedSha as string },
                 {
                   onSuccess: (data) => {
                     setDraft(data)


### PR DESCRIPTION
## Summary
- Envs with both `can_deploy` and `can_promote` now open a single `ReleaseModal` whose tab strip doubles as the dialog header. Deploy / Promote are rendered as tabs and the active tab is driven by whether the URL is `/deploy/<env>` or `/promote/<env>`. When only one capability is supported, only that tab is shown.
- The Promote tab shows a placeholder when no upstream env has a deployed version yet, so navigating there from `/deploy/<env>` on a both-capable env never lands on a broken pane.
- Release-train chip cleanup: removed the CI-status icon and the colon between env name and version, and dropped the cross-fade `inline-grid` version slot so chips size to actual version length (versions render uniformly regardless of "v1.2.3" vs "abc1234" length).
- Chip tooltip now reflects only what the env can do: "Deploy", "Promote", or "Deploy / Promote".
- `PromoteTab`: skip the AI `draftReleaseNotes` call when the compare query returns zero commits. The previous `lastTag !== selectedSha` heuristic still fired the model when a tag and an upstream SHA were different strings pointing at the same commit. Empty-state copy waits for the compare query to settle so it doesn't flash while loading.
- Aligned the dialog close (X) icon with the tab-strip header.

## Test plan
- [ ] Click a release-train chip on an env that supports only `can_deploy` → modal opens on the Deploy tab; no Promote tab visible.
- [ ] Click a chip on an env that supports only `can_promote` → modal opens on the Promote tab; no Deploy tab visible.
- [ ] Click a chip on an env with both flags → modal opens on Deploy; switching to Promote works. Deep-linking to `/promote/<env>` opens the modal with the Promote tab active.
- [ ] Promote when the upstream env's tip equals the last tag (no diff) → no AI call is made; suggestion box says "No commits between the last tag and the upstream — nothing new to release."
- [ ] Regenerate-with-AI button is disabled when there are no commits.
- [ ] Release-train chip displays version uniformly: "Testing 1a9c610", "Staging 6.3.0", "Production 6.3.0" with consistent spacing.