### PR TITLE
Fix ops-log template rendering and improve activity feed

### DIFF
--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -196,6 +196,7 @@ function dayLabel(d: Date): string {
     .toUpperCase()
 }
 
+// fallow-ignore-next-line complexity
 function diffObjects(
   oldObj: Record<string, unknown>,
   newObj: Record<string, unknown>,
@@ -335,6 +336,37 @@ function isProjectChangePayload(
   return typeof payload.field === 'string'
 }
 
+// fallow-ignore-next-line complexity
+function KeyChangeItem({ change }: { change: KeyChange }) {
+  return (
+    <li className="text-secondary text-xs">
+      <span className="text-tertiary">{change.kind}</span>{' '}
+      <ValueChip>{change.key}</ValueChip>
+      {change.kind === 'changed' && (
+        <>
+          {': '}
+          <ValueChip>{change.oldValue}</ValueChip>
+          {' → '}
+          <ValueChip>{change.newValue}</ValueChip>
+        </>
+      )}
+      {change.kind === 'added' && change.newValue !== '' && (
+        <>
+          {': '}
+          <ValueChip>{change.newValue}</ValueChip>
+        </>
+      )}
+      {change.kind === 'removed' && change.oldValue !== '' && (
+        <>
+          {': '}
+          <ValueChip>{change.oldValue}</ValueChip>
+        </>
+      )}
+    </li>
+  )
+}
+
+// fallow-ignore-next-line complexity
 function OpsEntry({
   displayNames,
   envMap,
@@ -411,30 +443,7 @@ function renderProjectChangeBody(
           changed {field}
           <ul className="mt-1 space-y-0.5">
             {changes.map((c) => (
-              <li className="text-secondary text-xs" key={c.key}>
-                <span className="text-tertiary">{c.kind}</span>{' '}
-                <ValueChip>{c.key}</ValueChip>
-                {c.kind === 'changed' && (
-                  <>
-                    {': '}
-                    <ValueChip>{c.oldValue}</ValueChip>
-                    {' → '}
-                    <ValueChip>{c.newValue}</ValueChip>
-                  </>
-                )}
-                {c.kind === 'added' && c.newValue !== '' && (
-                  <>
-                    {': '}
-                    <ValueChip>{c.newValue}</ValueChip>
-                  </>
-                )}
-                {c.kind === 'removed' && c.oldValue !== '' && (
-                  <>
-                    {': '}
-                    <ValueChip>{c.oldValue}</ValueChip>
-                  </>
-                )}
-              </li>
+              <KeyChangeItem change={c} key={c.key} />
             ))}
           </ul>
         </span>

--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -11,6 +11,7 @@ import {
   listProjectEvents,
 } from '@/api/endpoints'
 import type { EventRecord } from '@/api/endpoints'
+import { renderEntryLabel } from '@/components/operations-log/renderEntryLabel'
 import { EnvironmentBadge } from '@/components/ui/environment-badge'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
@@ -19,6 +20,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { usePluginOpsLogTemplates } from '@/hooks/usePluginOpsLogTemplates'
+import type { PluginOpsLogTemplateMap } from '@/hooks/usePluginOpsLogTemplates'
 import { formatFieldKey } from '@/lib/project-field-formatting'
 import type { Environment, OperationsLogRecord } from '@/types'
 
@@ -48,7 +51,15 @@ const DOT_CLASS = {
   warning: 'bg-[#ef9f27]',
 }
 
+interface KeyChange {
+  key: string
+  kind: 'added' | 'changed' | 'removed'
+  newValue?: string
+  oldValue?: string
+}
+
 export function ProjectActivityLog({ orgSlug, projectId, projectSlug }: Props) {
+  const { templates } = usePluginOpsLogTemplates()
   const { data: eventsPage, isPending: eventsPending } = useQuery({
     enabled: Boolean(orgSlug) && Boolean(projectId),
     queryFn: ({ signal }) =>
@@ -160,6 +171,7 @@ export function ProjectActivityLog({ orgSlug, projectId, projectSlug }: Props) {
                       envMap={envMap}
                       item={item}
                       key={`ops-${item.data.id}-${i}`}
+                      templates={templates}
                     />
                   ),
                 )}
@@ -182,6 +194,31 @@ function dayLabel(d: Date): string {
   return d
     .toLocaleDateString('en-US', { day: 'numeric', month: 'short' })
     .toUpperCase()
+}
+
+function diffObjects(
+  oldObj: Record<string, unknown>,
+  newObj: Record<string, unknown>,
+): KeyChange[] {
+  const keys = new Set([...Object.keys(oldObj), ...Object.keys(newObj)])
+  const changes: KeyChange[] = []
+  for (const key of keys) {
+    const hasOld = key in oldObj
+    const hasNew = key in newObj
+    if (!hasOld && hasNew) {
+      changes.push({ key, kind: 'added', newValue: formatValue(newObj[key]) })
+    } else if (hasOld && !hasNew) {
+      changes.push({ key, kind: 'removed', oldValue: formatValue(oldObj[key]) })
+    } else if (formatValue(oldObj[key]) !== formatValue(newObj[key])) {
+      changes.push({
+        key,
+        kind: 'changed',
+        newValue: formatValue(newObj[key]),
+        oldValue: formatValue(oldObj[key]),
+      })
+    }
+  }
+  return changes.sort((a, b) => a.key.localeCompare(b.key))
 }
 
 function EntryRow({
@@ -248,31 +285,9 @@ function EventEntry({
     entry.type === 'project-change' &&
     isProjectChangePayload(entry.payload)
   ) {
-    const field = formatFieldKey(entry.payload.field)
-    const oldStr = formatValue(entry.payload.old)
-    const newStr = formatValue(entry.payload.new)
-    body = (
-      <span>
-        changed {field}
-        {oldStr ? (
-          <>
-            {' '}
-            <ValueChip>{oldStr}</ValueChip>
-            {' → '}
-            <ValueChip>{newStr}</ValueChip>
-          </>
-        ) : (
-          <>
-            {' to '}
-            <ValueChip>{newStr}</ValueChip>
-          </>
-        )}
-      </span>
-    )
+    body = renderProjectChangeBody(entry.payload)
   } else {
-    body = (
-      <span className="text-tertiary">{entry.type.replace(/-/g, ' ')}</span>
-    )
+    body = renderGenericEventBody(entry)
   }
 
   return (
@@ -301,6 +316,19 @@ function getDisplayName(
   return displayNames.get(email) ?? email.split('@')[0] ?? email
 }
 
+function humanizeEventType(type: string): string {
+  return type.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}
+
 function isProjectChangePayload(
   payload: Record<string, unknown>,
 ): payload is ProjectChangePayload {
@@ -311,28 +339,34 @@ function OpsEntry({
   displayNames,
   envMap,
   item,
+  templates,
 }: {
   displayNames: Map<string, string>
   envMap: Map<string, Environment>
   item: ActivityItem & { kind: 'ops' }
+  templates: PluginOpsLogTemplateMap
 }) {
   const op = item.data
   const actor = op.performed_by ?? op.recorded_by
   const name = getDisplayName(actor, displayNames)
   const color: AvatarColor =
     op.entry_type === 'Deployed' ? 'warning' : 'neutral'
+  const env = envMap.get(op.environment_slug)
+  const label = renderEntryLabel(op, {
+    environment: env,
+    performerDisplayName: name,
+    templates,
+  })
 
   const body = (
     <span>
-      {op.entry_type.toLowerCase()}
-      {op.version && (
+      {label || op.entry_type.toLowerCase()}
+      {env && (
         <>
-          {' '}
-          <ValueChip>{op.version}</ValueChip>
+          {' on '}
+          <EnvChip env={env} />
         </>
       )}
-      {' to '}
-      <EnvChip env={envMap.get(op.environment_slug)} />
     </span>
   )
 
@@ -344,6 +378,88 @@ function OpsEntry({
       name={name}
       ts={item.ts}
     />
+  )
+}
+
+function renderGenericEventBody(entry: EventRecord): React.ReactNode {
+  const label = humanizeEventType(entry.type)
+  return (
+    <span>
+      <span className="text-secondary">{label}</span>
+      {entry.third_party_service && (
+        <span className="text-tertiary"> via {entry.third_party_service}</span>
+      )}
+    </span>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function renderProjectChangeBody(
+  payload: ProjectChangePayload,
+): React.ReactNode {
+  const field = formatFieldKey(payload.field)
+  const oldIsObj = isPlainObject(payload.old)
+  const newIsObj = isPlainObject(payload.new)
+  if (oldIsObj || newIsObj) {
+    const changes = diffObjects(
+      oldIsObj ? (payload.old as Record<string, unknown>) : {},
+      newIsObj ? (payload.new as Record<string, unknown>) : {},
+    )
+    if (changes.length > 0) {
+      return (
+        <span>
+          changed {field}
+          <ul className="mt-1 space-y-0.5">
+            {changes.map((c) => (
+              <li className="text-secondary text-xs" key={c.key}>
+                <span className="text-tertiary">{c.kind}</span>{' '}
+                <ValueChip>{c.key}</ValueChip>
+                {c.kind === 'changed' && (
+                  <>
+                    {': '}
+                    <ValueChip>{c.oldValue}</ValueChip>
+                    {' → '}
+                    <ValueChip>{c.newValue}</ValueChip>
+                  </>
+                )}
+                {c.kind === 'added' && c.newValue !== '' && (
+                  <>
+                    {': '}
+                    <ValueChip>{c.newValue}</ValueChip>
+                  </>
+                )}
+                {c.kind === 'removed' && c.oldValue !== '' && (
+                  <>
+                    {': '}
+                    <ValueChip>{c.oldValue}</ValueChip>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        </span>
+      )
+    }
+  }
+  const oldStr = formatValue(payload.old)
+  const newStr = formatValue(payload.new)
+  return (
+    <span>
+      changed {field}
+      {oldStr ? (
+        <>
+          {' '}
+          <ValueChip>{oldStr}</ValueChip>
+          {' → '}
+          <ValueChip>{newStr}</ValueChip>
+        </>
+      ) : (
+        <>
+          {' to '}
+          <ValueChip>{newStr}</ValueChip>
+        </>
+      )}
+    </span>
   )
 }
 

--- a/src/components/operations-log/OperationsLogReleaseCard.tsx
+++ b/src/components/operations-log/OperationsLogReleaseCard.tsx
@@ -14,19 +14,15 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useTheme } from '@/contexts/ThemeContext'
+import { usePluginOpsLogTemplates } from '@/hooks/usePluginOpsLogTemplates'
 import { deriveChipColors } from '@/lib/chip-colors'
 import { cn } from '@/lib/utils'
 import type { Environment, Project } from '@/types'
 
 import { OperationsLogEntryDetails } from './OperationsLogEntryDetails'
-import {
-  absTime,
-  cleanDescription,
-  cleanName,
-  type ReleaseGroup,
-  relTime,
-} from './opsLogHelpers'
+import { absTime, cleanName, type ReleaseGroup, relTime } from './opsLogHelpers'
 import { OPS_ROW_GRID, OPS_ROW_PAD } from './opsRowLayout'
+import { renderEntryLabel } from './renderEntryLabel'
 
 interface Props {
   environmentsBySlug: Map<string, Environment>
@@ -48,11 +44,17 @@ export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
   project,
 }: Props) {
   const { isDarkMode } = useTheme()
+  const { templates } = usePluginOpsLogTemplates()
   const latest = group.latestEntry
   const performer = latest.performed_by ?? latest.recorded_by
   const displayName = performerDisplayNames.get(performer) ?? performer
   const version = group.stops[0]?.entry.version ?? latest.version ?? ''
-  const desc = cleanDescription(group.description, version)
+  const desc = renderEntryLabel(latest, {
+    environment: environmentsBySlug.get(latest.environment_slug),
+    performerDisplayName: displayName,
+    project,
+    templates,
+  })
   const projectLabel = project?.name ?? group.project_slug
 
   // Pipeline = this project's own environments, unioned with any

--- a/src/components/operations-log/renderEntryLabel.ts
+++ b/src/components/operations-log/renderEntryLabel.ts
@@ -1,0 +1,41 @@
+import type { PluginOpsLogTemplateMap } from '@/hooks/usePluginOpsLogTemplates'
+import type { Environment, OperationsLogRecord, Project } from '@/types'
+
+import { cleanDescription } from './opsLogHelpers'
+import { parseDescription } from './parseDescription'
+import { renderOpsLogLabel } from './renderOpsLogTemplate'
+
+export interface RenderEntryLabelContext {
+  environment?: Environment
+  performerDisplayName?: string
+  project?: Project
+  templates: PluginOpsLogTemplateMap
+}
+
+// fallow-ignore-next-line complexity
+export function renderEntryLabel(
+  entry: OperationsLogRecord,
+  ctx: RenderEntryLabelContext,
+): string {
+  const parsed = parseDescription(entry)
+  if (parsed.kind !== 'plugin') {
+    return cleanDescription(entry.description, entry.version)
+  }
+  const template = ctx.templates.get(entry.plugin_slug ?? '', parsed.action)
+  if (!template) {
+    return (
+      parsed.summary ??
+      `${entry.plugin_slug ?? ''}${parsed.action ? ` · ${parsed.action}` : ''}`
+    )
+  }
+  const performer = entry.performed_by ?? entry.recorded_by
+  return renderOpsLogLabel(template, {
+    display: {
+      environment: ctx.environment?.name ?? entry.environment_slug,
+      performer: ctx.performerDisplayName ?? performer,
+      project: ctx.project?.name ?? entry.project_slug,
+    },
+    entry,
+    payload: parsed.payload,
+  })
+}

--- a/src/lib/project-field-formatting.ts
+++ b/src/lib/project-field-formatting.ts
@@ -19,6 +19,7 @@ const WORD_OVERRIDES: Record<string, string> = {
   ci: 'CI',
   github: 'GitHub',
   gitlab: 'GitLab',
+  openapi: 'OpenAPI',
   sonarqube: 'SonarQube',
 }
 


### PR DESCRIPTION
## Summary
- **Operations log**: release-grouped rows previously rendered `cleanDescription()` on the group's stored JSON string and never consulted the plugin template registry, so deploys/promotes that landed as a single release-train stop showed raw `{action,plugin_slug,…}` payloads. Added a `renderEntryLabel` helper covering the `parseDescription → template lookup → fallback` chain and wired the release card through it.
- **Project activity feed** (`ProjectActivityLog`): `OpsEntry` now applies plugin-template rendering via `renderEntryLabel`. `project-change` events with object-valued old/new now render an added/removed/changed key list instead of one chip containing the full `JSON.stringify` output (e.g. the "changed Links" entry). Bare third-party events (`deployment_status`, etc.) are humanized and tagged with the originating `third_party_service`.
- **Configuration tab**: bumped the resizable left panel to `minSize 30` / `maxSize 60` and invalidated the persisted layout id (`v2`) so the previously-stored ~10 % width is discarded.
- **Field labels**: add `OpenAPI` to `WORD_OVERRIDES` in `project-field-formatting.ts`.

## Test plan
- [ ] Open an operations log with release-grouped rows; the release card renders the plugin template label (e.g. "Promoted testing to staging as 6.3.0.") instead of raw JSON.
- [ ] Open a project's Recent Activity panel — entries from plugins like aws-ssm render their template label, not their JSON.
- [ ] `project-change` event whose old/new values are objects (e.g. `links`) renders as a list of changed keys with chips per key.
- [ ] Configuration tab list/detail split is wider on first load (30 % minimum) and clamps at 60 %.
- [ ] An `openapi` project field renders as "OpenAPI", not "Openapi".