### PR TITLE
Fix Configuration tab sidebar width and resize handle

### DIFF
--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -158,7 +158,9 @@ export function ConfigurationTab({
   })
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: 'imbi:config-tab:split',
+    // v2 key — the prior id stored layouts whose sizes were interpreted as
+    // pixels by react-resizable-panels v4, locking the list pane to ~28px.
+    id: 'imbi:config-tab:split:v2',
     panelIds: ['list', 'detail'],
     storage: typeof window === 'undefined' ? undefined : window.localStorage,
   })
@@ -593,10 +595,10 @@ export function ConfigurationTab({
         {/* LEFT pane: filter + key list */}
         <Panel
           className="border-primary bg-secondary flex min-h-0 flex-col"
-          defaultSize={28}
+          defaultSize="28%"
           id="list"
-          maxSize={55}
-          minSize={18}
+          maxSize="55%"
+          minSize="18%"
         >
           <div className="border-primary flex h-14 shrink-0 items-center border-b px-3.5">
             <div className="relative flex w-full items-center">
@@ -636,13 +638,13 @@ export function ConfigurationTab({
           )}
         </Panel>
 
-        <Separator className="bg-primary hover:bg-amber-border focus-visible:bg-amber-border w-px transition-colors outline-none" />
+        <Separator className="bg-primary hover:bg-amber-border focus-visible:bg-amber-border w-1.5 cursor-col-resize transition-colors outline-none" />
 
         {/* RIGHT pane */}
         <Panel
           className="bg-primary flex min-h-0 flex-col"
           id="detail"
-          minSize={30}
+          minSize="30%"
         >
           {mode === 'create' ? (
             <DetailPane
@@ -1244,7 +1246,7 @@ function ParamList({
         return (
           <button
             className={cn(
-              'flex w-full items-center gap-2.5 border-b border-primary px-3.5 py-2.5 text-left transition-colors',
+              'flex w-full items-center gap-2.5 border-b border-primary px-3.5 py-2.5 text-left transition-colors last:border-b-0',
               isSelected ? 'bg-amber-bg' : 'hover:bg-tertiary',
             )}
             key={p.key}

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -638,7 +638,7 @@ export function ConfigurationTab({
           )}
         </Panel>
 
-        <Separator className="bg-primary hover:bg-amber-border focus-visible:bg-amber-border w-1.5 cursor-col-resize transition-colors outline-none" />
+        <Separator className="hover:after:bg-amber-border focus-visible:after:bg-amber-border relative w-1.5 cursor-col-resize bg-transparent outline-none after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-(--ds-border-primary) after:transition-colors" />
 
         {/* RIGHT pane */}
         <Panel


### PR DESCRIPTION
## Summary
- Quote the list/detail Panel sizes as percentage strings — `react-resizable-panels` v4 interprets numeric values as pixels, which collapsed the list pane to ~28px and capped it at 55px (defaultSize 28%, minSize 18%, maxSize 55%; detail minSize 30%).
- Bump the `useDefaultLayout` storage id to `imbi:config-tab:split:v2` so previously-saved pixel layouts in localStorage don't override the new defaults.
- Widen the Separator from `w-px` to `w-1.5` and set `cursor-col-resize` so the drag handle is actually grabbable.
- Drop the bottom border on the last list item.

## Test plan
- [ ] Open a project's Configuration tab — left pane defaults to ~28% width
- [ ] Drag the divider; it resizes and clamps within 18–55% (right pane keeps ≥30%)
- [ ] Refresh the page; saved layout restores correctly
- [ ] Last parameter row has no trailing divider line