### PR TITLE
Show the active underline on the Project Settings tab

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -31,7 +31,10 @@ const TabsTrigger = React.forwardRef<
       'hover:text-foreground',
       'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none',
       'disabled:pointer-events-none disabled:opacity-50',
-      'data-[state=active]:border-amber-500 data-[state=active]:text-amber-600',
+      // aria-selected, not data-state — TooltipTrigger (asChild) clobbers
+      // data-state with its own "open"/"closed" via Slot. aria-selected is
+      // set by Radix Tabs and isn't touched by the tooltip primitive.
+      'aria-selected:border-amber-500 aria-selected:text-amber-600',
       className,
     )}
     ref={ref}


### PR DESCRIPTION
## Summary
- `TooltipTrigger asChild` wrapping the Settings `TabsTrigger` passes its own `data-state="open"/"closed"` through the Radix Slot. The Slot spreads those props *after* `TabsTrigger` sets its own `data-state="active"`, so the rendered button always carries the tooltip's state and the active selector never matches.
- Switch the active-tab selector from `data-[state=active]` to `aria-selected` (set directly by Radix Tabs, untouched by the tooltip primitive). All other tabs continue to highlight identically since Radix sets both attributes.

## Test plan
- [ ] Navigate to `/projects/<id>/settings` — the gear icon shows the amber underline + text color
- [ ] Other tabs (Overview, Configuration, Dependencies, etc.) still show the active underline when selected
- [ ] Hover the Settings icon — tooltip still appears with "Project Settings"