### PR TITLE
Use match-sorter for fuzzy project search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "js-yaml": "^4.1.1",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.469.0",
+        "match-sorter": "^8.3.0",
         "md5": "^2.3.0",
         "react": "^19.2.4",
         "react-day-picker": "^9.4.4",
@@ -7546,6 +7547,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-8.3.0.tgz",
+      "integrity": "sha512-8Py1GbZi5zsclYSFcPAH4H5xfTbeD0bOREA7qP/t8bW4MbOSlPl8sbqHOedEV7O+Bxyvxm6xs/v6BXJGe+JDNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.8",
+        "remove-accents": "0.5.0"
+      }
+    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -9332,6 +9343,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "js-yaml": "^4.1.1",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.469.0",
+    "match-sorter": "^8.3.0",
     "md5": "^2.3.0",
     "react": "^19.2.4",
     "react-day-picker": "^9.4.4",

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
 import { Grid3x3, List, Network, Plus, Search } from 'lucide-react'
+import { matchSorter } from 'match-sorter'
 
 import { getProjects } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -74,16 +75,13 @@ export function ProjectsView() {
   const filteredProjects = useMemo(() => {
     const all = projects || []
     if (!searchQuery) return all
-    const query = searchQuery.toLowerCase()
-    return all.filter((p) => {
-      return (
-        p.name.toLowerCase().includes(query) ||
-        p.description?.toLowerCase().includes(query) ||
-        p.team.name.toLowerCase().includes(query) ||
-        (p.project_types || []).some((pt) =>
-          pt.name.toLowerCase().includes(query),
-        )
-      )
+    return matchSorter(all, searchQuery, {
+      keys: [
+        'name',
+        'description',
+        'team.name',
+        { key: (p) => (p.project_types || []).map((pt) => pt.name) },
+      ],
     })
   }, [projects, searchQuery])
 


### PR DESCRIPTION
Replaces substring filter with match-sorter so queries like "message editor" match "message-editor" and results are ranked by match quality.