### PR TITLE
Button cursor style tweaks

### DIFF
--- a/src/components/documents/DocumentsFilterRail.tsx
+++ b/src/components/documents/DocumentsFilterRail.tsx
@@ -1,5 +1,6 @@
 import { Search } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 import type { TagRef } from '@/types'
@@ -58,13 +59,14 @@ export function DocumentsFilterRail({
             {activeCount} filter{activeCount > 1 ? 's' : ''} · {totalFiltered}{' '}
             documents
           </span>
-          <button
-            className="text-warning cursor-pointer border-0 bg-transparent p-0 text-[11.5px] hover:underline"
+          <Button
+            className="text-warning text-[11.5px]"
             onClick={onClear}
-            type="button"
+            size="sm"
+            variant="link"
           >
             Clear
-          </button>
+          </Button>
         </div>
       )}
 

--- a/src/components/documents/DocumentsPinboardNew.tsx
+++ b/src/components/documents/DocumentsPinboardNew.tsx
@@ -124,14 +124,10 @@ export function DocumentsPinboardNew({
       <div>
         {/* Toolbar */}
         <div className="mb-3.5 flex flex-wrap items-center gap-2.5">
-          <button
-            className="text-secondary hover:bg-secondary hover:text-primary inline-flex cursor-pointer items-center gap-1.5 rounded border-0 bg-transparent px-1.5 py-1 text-xs"
-            onClick={onDiscard}
-            type="button"
-          >
+          <Button onClick={onDiscard} size="sm" variant="ghost">
             <ArrowLeft className="size-3" />
             All documents
-          </button>
+          </Button>
           <span className="text-tertiary">/</span>
           <span className="text-primary text-xs font-medium">
             {isEditing ? 'Edit document' : 'New document'}

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -100,14 +100,10 @@ export function DocumentsPinboardReader({
       <div>
         <div className="mb-3.5 grid grid-cols-[minmax(0,1fr)_260px] items-start gap-5">
           <div className="flex flex-wrap items-center gap-2.5">
-            <button
-              className="text-secondary hover:bg-secondary hover:text-primary inline-flex cursor-pointer items-center gap-1.5 rounded border-0 bg-transparent px-1.5 py-1 text-xs"
-              onClick={onBack}
-              type="button"
-            >
+            <Button onClick={onBack} size="sm" variant="ghost">
               <ArrowLeft className="size-3" />
               All documents
-            </button>
+            </Button>
             <div className="ml-auto flex items-center gap-1">
               <Button
                 className="gap-1.5"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex cursor-pointer items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     defaultVariants: {
       size: 'default',


### PR DESCRIPTION
- `Button` was rendering with the browser-default arrow cursor instead of
    the hand cursor users expect. Adds `cursor-pointer` to `buttonVariants`
    and replaces `disabled:pointer-events-none` with `disabled:cursor-not-allowed`
    so disabled buttons communicate their state rather than silently reverting
    to an arrow.
- Removing `pointer-events-none` means disabled buttons wrapped in tooltips
    will now show their tooltip on hover. All such instances in the codebase
    use generic action-label tooltips ("Refresh", "Rotate key", etc.), so this
    is an improvement — not a regression.
- Three raw `<button>` elements in the Documents feature (two "All documents"
    back nav buttons, one "Clear" filter link) were not using the `Button`
    component. Migrated to `variant="ghost"` and `variant="link"` respectively.
    Three other custom `<button>` elements in the same area were intentionally
    left as-is (22px icon button, document card link, tab chip) since they have
    custom sizing/layout that doesn't map to a `Button` variant; `cursor-pointer`
    is set explicitly on those.