### PR TITLE
Polish search tray UI

### DIFF
--- a/src/components/search/SearchResultsPanel.tsx
+++ b/src/components/search/SearchResultsPanel.tsx
@@ -11,7 +11,10 @@ import {
 } from '@/api/search'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
-import { useSearchEnrichment } from '@/hooks/useSearchEnrichment'
+import {
+  type EnrichedInfo,
+  useSearchEnrichment,
+} from '@/hooks/useSearchEnrichment'
 import { deriveChipColors } from '@/lib/chip-colors'
 
 interface SearchResultsPanelProps {
@@ -138,7 +141,7 @@ const CONFIDENCE_STYLES: Record<
 }
 
 interface ResultCardProps {
-  enrichment: Map<string, { breadcrumb?: string; name?: string }>
+  enrichment: Map<string, EnrichedInfo>
   nameByNodeId: Map<string, string>
   onNavigate: (path: string) => void
   query: string

--- a/src/components/search/SearchResultsPanel.tsx
+++ b/src/components/search/SearchResultsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useNavigate } from 'react-router-dom'
 
@@ -10,7 +10,9 @@ import {
   type SearchResult,
 } from '@/api/search'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useTheme } from '@/contexts/ThemeContext'
 import { useSearchEnrichment } from '@/hooks/useSearchEnrichment'
+import { deriveChipColors } from '@/lib/chip-colors'
 
 interface SearchResultsPanelProps {
   isLoading: boolean
@@ -24,78 +26,91 @@ interface SearchResultsPanelProps {
 
 const ENTITY_STYLES: Record<
   string,
-  { dot: string; label: string; round?: boolean; text: string }
+  { dot: string; hex: string; label: string; round?: boolean; text: string }
 > = {
   Blueprint: {
-    dot: 'bg-cyan-500',
+    dot: 'bg-[#8C82D4]',
+    hex: '#8C82D4',
     label: 'Blueprint',
     round: true,
-    text: 'text-cyan-600 dark:text-cyan-400',
+    text: 'text-[#8C82D4]',
   },
   Document: {
-    dot: 'bg-slate-500',
+    dot: 'bg-[#D98847]',
+    hex: '#D98847',
     label: 'Document',
-    text: 'text-slate-600 dark:text-slate-400',
+    text: 'text-[#D98847]',
   },
   DocumentTemplate: {
-    dot: 'bg-slate-400',
+    dot: 'bg-[#7A7873]',
+    hex: '#7A7873',
     label: 'Doc Template',
-    text: 'text-slate-500 dark:text-slate-400',
+    text: 'text-[#7A7873]',
   },
   Environment: {
-    dot: 'bg-indigo-500',
+    dot: 'bg-[#7A7873]',
+    hex: '#7A7873',
     label: 'Environment',
-    text: 'text-indigo-600 dark:text-indigo-400',
+    text: 'text-[#7A7873]',
   },
   LinkDefinition: {
-    dot: 'bg-purple-500',
+    dot: 'bg-[#8C82D4]',
+    hex: '#8C82D4',
     label: 'Link Definition',
     round: true,
-    text: 'text-purple-600 dark:text-purple-400',
+    text: 'text-[#8C82D4]',
   },
   Organization: {
-    dot: 'bg-amber-500',
+    dot: 'bg-[#C86B5E]',
+    hex: '#C86B5E',
     label: 'Organization',
-    text: 'text-amber-600 dark:text-amber-400',
+    text: 'text-[#C86B5E]',
   },
   Project: {
-    dot: 'bg-blue-500',
+    dot: 'bg-[#5A89C9]',
+    hex: '#5A89C9',
     label: 'Project',
-    text: 'text-blue-600 dark:text-blue-400',
+    text: 'text-[#5A89C9]',
   },
   ProjectType: {
-    dot: 'bg-violet-500',
+    dot: 'bg-[#8C82D4]',
+    hex: '#8C82D4',
     label: 'Project Type',
-    text: 'text-violet-600 dark:text-violet-400',
+    text: 'text-[#8C82D4]',
   },
   Release: {
-    dot: 'bg-orange-500',
+    dot: 'bg-[#C86B5E]',
+    hex: '#C86B5E',
     label: 'Release',
     round: true,
-    text: 'text-orange-600 dark:text-orange-400',
+    text: 'text-[#C86B5E]',
   },
   Tag: {
-    dot: 'bg-green-500',
+    dot: 'bg-[#C86B5E]',
+    hex: '#C86B5E',
     label: 'Tag',
     round: true,
-    text: 'text-green-600 dark:text-green-400',
+    text: 'text-[#C86B5E]',
   },
   Team: {
-    dot: 'bg-teal-500',
+    dot: 'bg-[#7A7873]',
+    hex: '#7A7873',
     label: 'Team',
     round: true,
-    text: 'text-teal-600 dark:text-teal-400',
+    text: 'text-[#7A7873]',
   },
   ThirdPartyService: {
-    dot: 'bg-emerald-500',
+    dot: 'bg-[#7A7873]',
+    hex: '#7A7873',
     label: '3rd-Party Service',
     round: true,
-    text: 'text-emerald-600 dark:text-emerald-400',
+    text: 'text-[#7A7873]',
   },
 }
 
 const DEFAULT_ENTITY = {
   dot: 'bg-muted-foreground',
+  hex: '',
   label: '',
   round: false,
   text: 'text-muted-foreground',
@@ -116,9 +131,9 @@ const CONFIDENCE_STYLES: Record<
     text: 'text-orange-500 dark:text-orange-400',
   },
   Strong: {
-    bar: 'bg-green-500',
-    dot: 'bg-green-500',
-    text: 'text-green-600 dark:text-green-400',
+    bar: 'bg-[#6B9A3F]',
+    dot: 'bg-[#6B9A3F]',
+    text: 'text-[#6B9A3F]',
   },
 }
 
@@ -144,6 +159,21 @@ export function SearchResultsPanel({
   const { selectedOrganization } = useOrganization()
   const [labelFilter, setLabelFilter] = useState<null | string>(null)
   const [refineOpen, setRefineOpen] = useState(false)
+  const queryStartRef = useRef<null | number>(null)
+  const [elapsedMs, setElapsedMs] = useState<null | number>(null)
+
+  useEffect(() => {
+    queryStartRef.current = Date.now()
+    setElapsedMs(null)
+  }, [query])
+
+  useEffect(() => {
+    if (!isLoading && queryStartRef.current !== null && results.length > 0) {
+      setElapsedMs(Date.now() - queryStartRef.current)
+      queryStartRef.current = null
+    }
+  }, [isLoading, results])
+
   const enrichment = useSearchEnrichment(
     results,
     selectedOrganization?.slug ?? null,
@@ -219,10 +249,10 @@ export function SearchResultsPanel({
     const style = ENTITY_STYLES[nodeLabel] ?? DEFAULT_ENTITY
     return (
       <button
-        className={`flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-0.5 font-mono text-[11px] transition-colors ${
+        className={`flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-0.5 font-mono text-xs transition-colors ${
           labelFilter === nodeLabel
-            ? 'border-border bg-card text-foreground'
-            : 'text-muted-foreground hover:text-foreground border-transparent'
+            ? 'bg-foreground text-background dark:bg-[#FBCE39] dark:text-black'
+            : 'text-muted-foreground hover:text-foreground'
         }`}
         key={nodeLabel}
         onClick={() =>
@@ -241,26 +271,23 @@ export function SearchResultsPanel({
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Summary header */}
-      <div className="border-border text-muted-foreground flex items-center gap-2 border-b px-4 py-2 text-[11px]">
+      <div className="border-border text-muted-foreground flex items-center gap-2 border-b px-4 py-2 text-xs">
         <span className="font-mono">
           {navigableResults.length} results for{' '}
           <span className="text-foreground">"{query}"</span>
-        </span>
-        {topLabel && (
-          <>
-            <span>·</span>
-            <span className="flex items-center gap-1">
-              <span
-                className={`size-1.5 rounded-full ${CONFIDENCE_STYLES[topLabel].dot}`}
-              />
+          {elapsedMs !== null && <> in {(elapsedMs / 1000).toFixed(3)}s</>}
+          {topLabel && elapsedMs !== null && (
+            <>
+              {' '}
+              &ndash;{' '}
               <span className={CONFIDENCE_STYLES[topLabel].text}>
                 {topLabel} top match
               </span>
-            </span>
-          </>
-        )}
+            </>
+          )}
+        </span>
         <button
-          className={`border-border ml-auto flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] transition-colors ${
+          className={`border-border ml-auto flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs transition-colors ${
             refineOpen
               ? 'bg-foreground text-background'
               : 'text-muted-foreground hover:text-foreground'
@@ -278,17 +305,17 @@ export function SearchResultsPanel({
       {refineOpen && (
         <div className="border-border bg-muted/40 border-b px-4 py-3">
           <div className="mb-3 flex items-baseline gap-2">
-            <span className="text-foreground text-[12px] font-medium">
+            <span className="text-foreground text-xs font-medium">
               Refine search
             </span>
-            <span className="text-muted-foreground text-[11px]">
+            <span className="text-muted-foreground text-xs">
               These advanced controls map to the /search API. Most users
               shouldn't need them.
             </span>
           </div>
           <div className="grid grid-cols-2 gap-6">
             <div>
-              <label className="text-muted-foreground mb-1.5 block text-[11px]">
+              <label className="text-muted-foreground mb-1.5 block text-xs">
                 Similarity threshold
               </label>
               <input
@@ -300,12 +327,12 @@ export function SearchResultsPanel({
                 type="range"
                 value={threshold}
               />
-              <span className="text-muted-foreground mt-1 block font-mono text-[11px]">
+              <span className="text-muted-foreground mt-1 block font-mono text-xs">
                 {threshold.toFixed(2)} cosine
               </span>
             </div>
             <div>
-              <label className="text-muted-foreground mb-1.5 block text-[11px]">
+              <label className="text-muted-foreground mb-1.5 block text-xs">
                 Max results
               </label>
               <input
@@ -317,7 +344,7 @@ export function SearchResultsPanel({
                 type="range"
                 value={limit}
               />
-              <span className="text-muted-foreground mt-1 block font-mono text-[11px]">
+              <span className="text-muted-foreground mt-1 block font-mono text-xs">
                 {limit}
               </span>
             </div>
@@ -328,9 +355,9 @@ export function SearchResultsPanel({
       {/* Filter pills */}
       <div className="border-border flex items-center gap-1 overflow-x-auto border-b px-3 py-2">
         <button
-          className={`flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 font-mono text-[11px] font-medium transition-colors ${
+          className={`flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 font-mono text-xs font-medium transition-colors ${
             labelFilter === null
-              ? 'bg-foreground text-background'
+              ? 'bg-foreground text-background dark:bg-[#FBCE39] dark:text-black'
               : 'text-muted-foreground hover:text-foreground'
           }`}
           onClick={() => setLabelFilter(null)}
@@ -379,7 +406,7 @@ function highlightKeywords(text: string, query: string): React.ReactNode {
       {parts.map((part, i) =>
         i % 2 === 1 ? (
           <mark
-            className="rounded-sm bg-amber-200/80 px-0.5 dark:bg-amber-800/50"
+            className="rounded-sm bg-amber-200/80 px-0.5 dark:bg-[#FBCE39]"
             key={i}
           >
             {part}
@@ -403,6 +430,10 @@ function ResultCard({
   const label = getConfidenceLabel(result.distance)!
   const entityStyle = ENTITY_STYLES[result.node_label] ?? DEFAULT_ENTITY
   const confStyle = CONFIDENCE_STYLES[label]
+  const { isDarkMode } = useTheme()
+  const chipColors = entityStyle.hex
+    ? deriveChipColors(entityStyle.hex, isDarkMode)
+    : null
   const path = getResultPath(result)
   const similarity = Math.round((1 - result.distance) * 100)
 
@@ -417,9 +448,11 @@ function ResultCard({
         (result.chunk_text.length > 72 ? '…' : ''))
   const snippet = isNameAttr || enriched?.name ? null : result.chunk_text
 
+  const centerText = enriched?.description ?? snippet
+
   return (
     <button
-      className={`group border-border flex w-full items-start gap-3 border-b px-4 py-3 text-left transition-colors ${
+      className={`group border-border flex w-full items-center gap-3 border-b px-4 py-2.5 text-left transition-colors ${
         path ? 'hover:bg-muted/30 cursor-pointer' : 'cursor-default'
       }`}
       onClick={() => {
@@ -427,41 +460,56 @@ function ResultCard({
       }}
       type="button"
     >
+      {/* Badge */}
       <div
-        className={`bg-muted/60 mt-0.5 flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium dark:bg-white/8 ${entityStyle.text}`}
+        className="shrink-0 rounded px-2 py-0.5 text-xs font-medium whitespace-nowrap"
+        style={
+          chipColors
+            ? {
+                backgroundColor: chipColors.bg,
+                border: `1px solid ${chipColors.border}`,
+                color: chipColors.fg,
+              }
+            : undefined
+        }
       >
-        <span
-          className={`size-1.5 shrink-0 ${entityStyle.round ? 'rounded-full' : 'rounded-[2px]'} ${entityStyle.dot}`}
-        />
         {entityStyle.label || result.node_label}
       </div>
 
-      <div className="min-w-0 flex-1">
+      {/* Title + breadcrumb */}
+      <div className="min-w-0 flex-[0_0_15%]">
         <div className="flex flex-wrap items-baseline gap-1.5">
-          <span className="text-foreground text-[13.5px] leading-snug font-semibold">
+          <span className="text-foreground text-sm leading-snug font-semibold">
             {highlightKeywords(title, query)}
           </span>
           {!isNameAttr && !enriched?.name && (
-            <span className="bg-muted/60 text-muted-foreground shrink-0 rounded px-1 py-px font-mono text-[10px] dark:bg-white/8">
+            <span className="bg-muted/60 text-muted-foreground shrink-0 rounded px-1 py-px font-mono text-xs dark:bg-white/8">
               {result.attribute}
             </span>
           )}
         </div>
         {enriched?.breadcrumb && (
-          <p className="text-muted-foreground/60 mt-0.5 font-mono text-[10px]">
+          <p className="text-muted-foreground truncate text-sm">
             {enriched.breadcrumb}
-          </p>
-        )}
-        {snippet && (
-          <p className="text-muted-foreground mt-1 line-clamp-2 text-[12px] leading-relaxed">
-            {highlightKeywords(snippet, query)}
           </p>
         )}
       </div>
 
-      <div className="flex shrink-0 flex-col items-end gap-1 pt-0.5">
+      {/* Description / snippet — center column */}
+      <div className="min-w-0 flex-1">
+        {centerText && (
+          <p className="text-muted-foreground truncate text-sm">
+            {snippet && !enriched?.description
+              ? highlightKeywords(snippet, query)
+              : centerText}
+          </p>
+        )}
+      </div>
+
+      {/* Confidence */}
+      <div className="flex shrink-0 flex-col items-end gap-1">
         <span
-          className={`flex items-center gap-1 font-mono text-[11px] ${confStyle.text}`}
+          className={`flex items-center gap-1 font-mono text-xs ${confStyle.text}`}
         >
           <span className={`size-1.5 rounded-full ${confStyle.dot}`} />
           {label}

--- a/src/hooks/useSearchEnrichment.ts
+++ b/src/hooks/useSearchEnrichment.ts
@@ -12,6 +12,7 @@ import type { SearchResult } from '@/api/search'
 
 export interface EnrichedInfo {
   breadcrumb?: string
+  description?: null | string
   name?: string
 }
 
@@ -82,6 +83,7 @@ export function useSearchEnrichment(
       const p = q.data
       map.set(p.id, {
         breadcrumb: projectBreadcrumb(p),
+        description: p.description,
         name: p.name,
       })
     }
@@ -132,5 +134,5 @@ function projectBreadcrumb(p: {
   team: { name: string }
 }): string {
   const ptName = p.project_types?.[0]?.name ?? p.project_type?.name
-  return ptName ? `${ptName} › ${p.team.name}` : p.team.name
+  return ptName ?? p.team.name
 }


### PR DESCRIPTION
## Summary

- Entity type labels replaced with chip-style badges using `deriveChipColors` and a fixed hex palette (Project `#5A89C9`, Document `#D98847`, with `#C86B5E`, `#8C82D4`, `#7A7873` for other types)
- Result rows restructured as a 3-column flex layout: badge | title 15% | description flex-1 | confidence; description column shows project description or matched snippet with keyword highlighting
- Summary header now shows query timing (`in 0.123s`) and top confidence label (`– Strong top match`) measured from query change to result arrival
- Filter pill selected state uses brand amber (`#FBCE39`) in dark mode, foreground-inverse in light mode
- Breadcrumb simplified to project type only (removed "Team ›" prefix)
- Strong confidence color updated to `#6B9A3F`; keyword highlight mark in dark mode uses `#FBCE39`

## Test plan

- [ ] Open search tray, run a query — result rows show entity chip badges with correct colors
- [ ] Summary header shows `N results for "query" in X.XXXs – Strong/Close/Related top match` after results load
- [ ] Selecting a filter pill highlights it with amber (dark mode) / inverse (light mode)
- [ ] Project results show description in center column; breadcrumb shows only project type

🤖 Generated with [Claude Code](https://claude.ai/claude-code)