### PR TITLE
Reload SPA when error boundary catches chunk load error

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -13,6 +13,16 @@ interface ErrorBoundaryState {
   error: Error | null
 }
 
+// Matches the various ways browsers report a failed dynamic `import()` for a
+// hashed chunk that no longer exists on the server (typically after a redeploy
+// while the user has a stale tab open). The MIME-type variant fires when the
+// SPA's index.html is served as a fallback for the missing JS file.
+const CHUNK_LOAD_ERROR_RE =
+  /Loading chunk|Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|Expected a JavaScript-or-Wasm module/i
+
+const RELOAD_GUARD_KEY = 'imbi:error-boundary-reloaded-at'
+const RELOAD_GUARD_WINDOW_MS = 10_000
+
 export class ErrorBoundary extends Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
@@ -25,6 +35,10 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
     console.error('[ErrorBoundary] Render error:', error, info)
+    if (CHUNK_LOAD_ERROR_RE.test(error.message) && this.shouldAutoReload()) {
+      window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+      window.location.reload()
+    }
   }
 
   render(): ReactNode {
@@ -65,5 +79,20 @@ export class ErrorBoundary extends Component<
 
   reset = (): void => {
     this.setState({ error: null })
+  }
+
+  private shouldAutoReload(): boolean {
+    // Guard against infinite reload loops: only auto-reload if we haven't
+    // already reloaded in the last RELOAD_GUARD_WINDOW_MS. If a fresh
+    // index.html still references missing chunks the user falls through to
+    // the manual fallback UI.
+    try {
+      const last = Number(
+        window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? '0',
+      )
+      return Date.now() - last > RELOAD_GUARD_WINDOW_MS
+    } catch {
+      return false
+    }
   }
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -36,7 +36,14 @@ export class ErrorBoundary extends Component<
   componentDidCatch(error: Error, info: ErrorInfo): void {
     console.error('[ErrorBoundary] Render error:', error, info)
     if (CHUNK_LOAD_ERROR_RE.test(error.message) && this.shouldAutoReload()) {
-      window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+      try {
+        window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+      } catch {
+        // Ignore storage failures (quota, disabled, privacy mode) and still
+        // attempt the reload — recovery matters more than the loop guard, and
+        // a broken `setItem` usually means `getItem` is broken too, which
+        // makes `shouldAutoReload` return false on the next pass anyway.
+      }
       window.location.reload()
     }
   }

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -83,4 +83,21 @@ describe('ErrorBoundary', () => {
     expect(reloadSpy).not.toHaveBeenCalled()
     expect(screen.getByText('Something went wrong')).toBeInTheDocument()
   })
+
+  it('still reloads when sessionStorage.setItem throws', () => {
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+
+    render(
+      <ErrorBoundary>
+        <Boom message="Failed to fetch dynamically imported module" />
+      </ErrorBoundary>,
+    )
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    setItemSpy.mockRestore()
+  })
 })

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ErrorBoundary } from '../ErrorBoundary'
+
+function Boom({ message }: { message: string }): never {
+  throw new Error(message)
+}
+
+const RELOAD_GUARD_KEY = 'imbi:error-boundary-reloaded-at'
+
+describe('ErrorBoundary', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>
+  let originalLocation: Location
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    window.sessionStorage.clear()
+    originalLocation = window.location
+    reloadSpy = vi.fn()
+    // jsdom marks `window.location.reload` as non-configurable, so we replace
+    // the whole `location` object for the duration of the test.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+      writable: true,
+    })
+    // React 18 logs the caught error to console.error in addition to our
+    // boundary's own logging — silence the noise so the test output stays
+    // readable.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+      writable: true,
+    })
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('auto-reloads when a dynamic import fails after a redeploy', () => {
+    render(
+      <ErrorBoundary>
+        <Boom message="Failed to fetch dynamically imported module: https://example.com/assets/Page.abc.js" />
+      </ErrorBoundary>,
+    )
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('auto-reloads when the server returns text/html for a chunk', () => {
+    render(
+      <ErrorBoundary>
+        <Boom message='Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".' />
+      </ErrorBoundary>,
+    )
+
+    expect(reloadSpy).toHaveBeenCalled()
+  })
+
+  it('shows the fallback UI for ordinary render errors', () => {
+    render(
+      <ErrorBoundary>
+        <Boom message="Cannot read properties of undefined (reading 'foo')" />
+      </ErrorBoundary>,
+    )
+
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+  })
+
+  it('does not loop: a recent reload disables auto-reload until the guard window passes', () => {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+
+    render(
+      <ErrorBoundary>
+        <Boom message="Failed to fetch dynamically imported module" />
+      </ErrorBoundary>,
+    )
+
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

When the app is left open across a redeploy, `React.lazy()` route imports point at hashed chunk filenames that no longer exist on the server. The server serves the SPA fallback `index.html` for those URLs, the browser refuses it as a JS module ("Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of `text/html`"), and the `ErrorBoundary` catches the failure. Clicking **Try again** only clears boundary state — the underlying module specifier is still rejected in the browser's module loader, so React re-awaits the same failed promise with **no new network request** and the user is stuck.

This PR makes the boundary self-heal by calling `window.location.reload()` from `componentDidCatch` when the caught error matches a chunk-load failure pattern, with a `sessionStorage` guard to prevent reload loops if the fresh `index.html` still references missing chunks.

## Problem

- Stale-tab users get a permanent "Something went wrong" screen after every deploy.
- "Try again" produces zero feedback (no network activity, no new console error) because the module loader caches the rejected dynamic import.
- Users have to know to hit the **Reload** button, refresh the page manually, or close the tab.

## Solution

`src/components/ErrorBoundary.tsx`

- Add a regex matching the various browser phrasings for a failed dynamic `import()` plus the MIME-type-mismatch case.
- In `componentDidCatch`, if the error matches and we haven't auto-reloaded within the last 10 s, stamp `sessionStorage['imbi:error-boundary-reloaded-at']` and call `window.location.reload()`.
- The 10 s guard prevents an infinite loop if the freshly fetched `index.html` still references missing chunks — the user falls through to the existing manual fallback UI.

`src/components/__tests__/ErrorBoundary.test.tsx`

- Auto-reload on `Failed to fetch dynamically imported module`.
- Auto-reload on the `Expected a JavaScript-or-Wasm module` MIME-mismatch message.
- Ordinary render errors still render the fallback UI (no reload).
- A recent sessionStorage timestamp suppresses auto-reload (loop guard).

## Test plan

- [x] `npm test` — 251 tests pass, including the 4 new `ErrorBoundary` cases.
- [x] `npm run lint` — no new errors on the touched files (pre-existing Tailwind class-order warnings/errors elsewhere are unchanged).
- [x] `npm run format:check` — clean.
- [x] `npm run build` — TypeScript + Vite build succeeds.
- [ ] Manual: deploy app → leave tab open → redeploy with new chunk hashes → navigate or interact so a lazy chunk loads → page should auto-reload to the new bundle without a "Try again" dead end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)