### PR TITLE
Use vite:preloadError event for chunk-load recovery

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -13,16 +13,6 @@ interface ErrorBoundaryState {
   error: Error | null
 }
 
-// Matches the various ways browsers report a failed dynamic `import()` for a
-// hashed chunk that no longer exists on the server (typically after a redeploy
-// while the user has a stale tab open). The MIME-type variant fires when the
-// SPA's index.html is served as a fallback for the missing JS file.
-const CHUNK_LOAD_ERROR_RE =
-  /Loading chunk|Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|Expected a JavaScript-or-Wasm module/i
-
-const RELOAD_GUARD_KEY = 'imbi:error-boundary-reloaded-at'
-const RELOAD_GUARD_WINDOW_MS = 10_000
-
 export class ErrorBoundary extends Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
@@ -35,17 +25,6 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
     console.error('[ErrorBoundary] Render error:', error, info)
-    if (CHUNK_LOAD_ERROR_RE.test(error.message) && this.shouldAutoReload()) {
-      try {
-        window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
-      } catch {
-        // Ignore storage failures (quota, disabled, privacy mode) and still
-        // attempt the reload — recovery matters more than the loop guard, and
-        // a broken `setItem` usually means `getItem` is broken too, which
-        // makes `shouldAutoReload` return false on the next pass anyway.
-      }
-      window.location.reload()
-    }
   }
 
   render(): ReactNode {
@@ -86,20 +65,5 @@ export class ErrorBoundary extends Component<
 
   reset = (): void => {
     this.setState({ error: null })
-  }
-
-  private shouldAutoReload(): boolean {
-    // Guard against infinite reload loops: only auto-reload if we haven't
-    // already reloaded in the last RELOAD_GUARD_WINDOW_MS. If a fresh
-    // index.html still references missing chunks the user falls through to
-    // the manual fallback UI.
-    try {
-      const last = Number(
-        window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? '0',
-      )
-      return Date.now() - last > RELOAD_GUARD_WINDOW_MS
-    } catch {
-      return false
-    }
   }
 }

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -7,24 +7,10 @@ function Boom({ message }: { message: string }): never {
   throw new Error(message)
 }
 
-const RELOAD_GUARD_KEY = 'imbi:error-boundary-reloaded-at'
-
 describe('ErrorBoundary', () => {
-  let reloadSpy: ReturnType<typeof vi.fn>
-  let originalLocation: Location
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    window.sessionStorage.clear()
-    originalLocation = window.location
-    reloadSpy = vi.fn()
-    // jsdom marks `window.location.reload` as non-configurable, so we replace
-    // the whole `location` object for the duration of the test.
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { ...originalLocation, reload: reloadSpy },
-      writable: true,
-    })
     // React 18 logs the caught error to console.error in addition to our
     // boundary's own logging — silence the noise so the test output stays
     // readable.
@@ -32,72 +18,16 @@ describe('ErrorBoundary', () => {
   })
 
   afterEach(() => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: originalLocation,
-      writable: true,
-    })
     consoleErrorSpy.mockRestore()
   })
 
-  it('auto-reloads when a dynamic import fails after a redeploy', () => {
-    render(
-      <ErrorBoundary>
-        <Boom message="Failed to fetch dynamically imported module: https://example.com/assets/Page.abc.js" />
-      </ErrorBoundary>,
-    )
-
-    expect(reloadSpy).toHaveBeenCalledTimes(1)
-  })
-
-  it('auto-reloads when the server returns text/html for a chunk', () => {
-    render(
-      <ErrorBoundary>
-        <Boom message='Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".' />
-      </ErrorBoundary>,
-    )
-
-    expect(reloadSpy).toHaveBeenCalled()
-  })
-
-  it('shows the fallback UI for ordinary render errors', () => {
+  it('shows the fallback UI for render errors', () => {
     render(
       <ErrorBoundary>
         <Boom message="Cannot read properties of undefined (reading 'foo')" />
       </ErrorBoundary>,
     )
 
-    expect(reloadSpy).not.toHaveBeenCalled()
     expect(screen.getByText('Something went wrong')).toBeInTheDocument()
-  })
-
-  it('does not loop: a recent reload disables auto-reload until the guard window passes', () => {
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
-
-    render(
-      <ErrorBoundary>
-        <Boom message="Failed to fetch dynamically imported module" />
-      </ErrorBoundary>,
-    )
-
-    expect(reloadSpy).not.toHaveBeenCalled()
-    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
-  })
-
-  it('still reloads when sessionStorage.setItem throws', () => {
-    const setItemSpy = vi
-      .spyOn(Storage.prototype, 'setItem')
-      .mockImplementation(() => {
-        throw new Error('QuotaExceededError')
-      })
-
-    render(
-      <ErrorBoundary>
-        <Boom message="Failed to fetch dynamically imported module" />
-      </ErrorBoundary>,
-    )
-
-    expect(reloadSpy).toHaveBeenCalledTimes(1)
-    setItemSpy.mockRestore()
   })
 })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,39 @@ import { queryClient } from '@/lib/queryClient'
 import App from './App.tsx'
 import './index.css'
 
+// Vite emits `vite:preloadError` when a dynamic `import()` for a hashed chunk
+// fails — typically when a redeploy has rotated the chunk hashes while the
+// user has a stale tab open. Reload the SPA so the fresh index.html can fetch
+// the new chunks. A short sessionStorage guard prevents an infinite reload
+// loop if the freshly-loaded index.html still references missing chunks.
+const RELOAD_GUARD_KEY = 'imbi:preload-error-reloaded-at'
+const RELOAD_GUARD_WINDOW_MS = 10_000
+
+function withinReloadGuardWindow(): boolean {
+  try {
+    const last = Number(window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? '0')
+    return Date.now() - last <= RELOAD_GUARD_WINDOW_MS
+  } catch {
+    // If storage is unreadable we can't tell whether we just reloaded; treat
+    // as in-window so we don't risk a loop.
+    return true
+  }
+}
+
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault()
+  if (withinReloadGuardWindow()) {
+    return
+  }
+  try {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+  } catch {
+    // Storage write failures (quota, disabled, privacy mode) shouldn't block
+    // recovery — fall through to the reload.
+  }
+  window.location.reload()
+})
+
 // Cache the root on the container so Vite HMR re-evaluating this module
 // doesn't call createRoot() twice on the same node, which produces a
 // React warning and a cascade of removeChild errors during dev reloads.


### PR DESCRIPTION
## Summary
Switch the SPA's "reload on stale chunk" recovery from a regex-based check in `ErrorBoundary.componentDidCatch` to a `vite:preloadError` window listener registered in `main.tsx`.

## Problem
PR #284 added auto-reload logic to `ErrorBoundary` that matched chunk-load errors with a regex (`/Loading chunk|Failed to fetch dynamically imported module|.../i`). The regex is fragile — the wording of these errors varies by browser and changes between Vite versions — and recovery only kicks in *after* React's render has failed, so the user momentarily sees the error UI before the page reloads.

Vite exposes a `vite:preloadError` event from its `__vitePreload` helper precisely for this case. It fires at the preload step (before the failure bubbles into React) and carries a structured payload, so we don't have to regex error messages.

## Solution
- Add a `vite:preloadError` listener in `main.tsx` that calls `event.preventDefault()` and reloads the SPA.
- Move the 10s sessionStorage reload-loop guard with it (new key: `imbi:preload-error-reloaded-at`). If the freshly-loaded `index.html` still references missing chunks, the second event is ignored and the user falls through to whatever surface the failure reaches (typically the error boundary's fallback UI).
- Strip the chunk-detection regex, the `RELOAD_GUARD_KEY` constants, and the `shouldAutoReload()` branch from `ErrorBoundary`. The boundary keeps its broader "show fallback UI on render error" role unchanged — only the chunk-specific path is removed.
- Drop the now-obsolete chunk-load test cases and the `window.location.reload` mock boilerplate from `ErrorBoundary.test.tsx`; keep the "renders fallback UI" test.

## Impact
- Users on stale tabs after a redeploy no longer see a flash of the "Something went wrong" UI before the reload — the listener fires earlier in the failure path.
- Recovery no longer depends on matching error-message wording, so it should be resilient across browser and Vite-version changes.
- The error boundary's general-purpose fallback UI is unchanged; non-chunk render errors behave exactly as before.
- Verified with `npm run lint`, `npm run build`, and `npx vitest run src/components/__tests__/ErrorBoundary.test.tsx`.