### PR TITLE
Add Sentry browser SDK with runtime DSN injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <title>Imbi</title>
     <script>
       window.__IMBI_API_URL__ = '{{env "VITE_API_URL"}}'
+      window.__IMBI_SENTRY_DSN__ = '{{env "VITE_SENTRY_DSN"}}'
     </script>
     <script>
       (function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.6",
+        "@sentry/react": "^10.53.1",
         "@tabler/icons-react": "^3.41.1",
         "@tanstack/react-query": "^5.66.1",
         "@tanstack/react-virtual": "^3.13.24",
@@ -3924,6 +3925,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.53.1.tgz",
+      "integrity": "sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.53.1.tgz",
+      "integrity": "sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.53.1.tgz",
+      "integrity": "sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.53.1.tgz",
+      "integrity": "sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.53.1.tgz",
+      "integrity": "sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry-internal/feedback": "10.53.1",
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry-internal/replay-canvas": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
+      "integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.53.1.tgz",
+      "integrity": "sha512-lrwNq5T/zW84l60894TpKHPcvFuc1I/Hnohecc0TfYVpIcYYuw2orCHoU4v4wgkFaJUpegVetbgdOphViyLVjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.6",
+    "@sentry/react": "^10.53.1",
     "@tabler/icons-react": "^3.41.1",
     "@tanstack/react-query": "^5.66.1",
     "@tanstack/react-virtual": "^3.13.24",

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,21 @@
+import * as Sentry from '@sentry/react'
+
+export function initSentry(): void {
+  const dsn = resolveDsn()
+  if (!dsn) return
+
+  Sentry.init({
+    dsn,
+    integrations: [Sentry.browserTracingIntegration()],
+    sendDefaultPii: false,
+    tracesSampleRate: 0.1,
+  })
+}
+
+function resolveDsn(): string | undefined {
+  const runtime = window.__IMBI_SENTRY_DSN__
+  if (runtime && !runtime.includes('{{')) {
+    return runtime
+  }
+  return import.meta.env.VITE_SENTRY_DSN
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,12 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import ReactDOM from 'react-dom/client'
 
 import { queryClient } from '@/lib/queryClient'
+import { initSentry } from '@/lib/sentry'
 
 import App from './App.tsx'
 import './index.css'
+
+initSentry()
 
 // Vite emits `vite:preloadError` when a dynamic `import()` for a hashed chunk
 // fails — typically when a redeploy has rotated the chunk hashes while the

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,8 +9,10 @@ interface ImportMetaEnv {
   readonly VITE_API_URL: string
   readonly VITE_OAUTH_CLIENT_ID?: string
   readonly VITE_OAUTH_REDIRECT_URI?: string
+  readonly VITE_SENTRY_DSN?: string
 }
 
 interface Window {
   __IMBI_API_URL__?: string
+  __IMBI_SENTRY_DSN__?: string
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         },
       },
     },
+    sourcemap: true,
   },
   esbuild: {
     drop: ['console'],


### PR DESCRIPTION
## Summary

- Install `@sentry/react` with `browserTracingIntegration`
- `index.html` injects `window.__IMBI_SENTRY_DSN__` via Caddy template (`{{env "VITE_SENTRY_DSN"}}`)
- `src/lib/sentry.ts` resolves the DSN at runtime (Caddy injection first, falls back to `import.meta.env.VITE_SENTRY_DSN` for local dev)
- `main.tsx` calls `initSentry()` before React renders
- `vite.config.ts` enables source maps so stack traces in Sentry are symbolicated
- `vite-env.d.ts` adds `Window.__IMBI_SENTRY_DSN__` and `ImportMetaEnv.VITE_SENTRY_DSN`

## Problem

No Sentry error reporting in the UI. Stack traces in production were unsymbolicated.

## Solution

Follows the same runtime injection pattern as `VITE_API_URL`: Caddy substitutes the env var into a `window.__IMBI_*__` global at request time, with a Vite `import.meta.env` fallback for local development. Sentry is a no-op if `VITE_SENTRY_DSN` is unset.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Source maps present in `dist/assets/`
- [ ] No Sentry init without `VITE_SENTRY_DSN`
- [ ] Errors captured when `VITE_SENTRY_DSN` is set