### PR TITLE
Add pull request count display to project index

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -20,6 +20,8 @@
       "file": "src/api/endpoints.ts",
       "exports": [
         "getMonthlyImprovement",
+        "getOrgPullRequests",
+        "getProjectPullRequests",
         "getScoreHistoryByTeam",
         "getScoreHistoryFeed",
         "getScoreRollup",

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -2087,7 +2087,12 @@ export const searchOrganization = (
 export const getProjectPullRequests = (
   orgSlug: string,
   projectId: string,
-  params?: { limit?: number; offset?: number; state?: 'closed' | 'open' },
+  params?: {
+    author?: string
+    limit?: number
+    offset?: number
+    state?: 'closed' | 'open'
+  },
   signal?: AbortSignal,
 ) =>
   apiClient.get<PullRequestListResponse>(
@@ -2098,7 +2103,12 @@ export const getProjectPullRequests = (
 
 export const getOrgPullRequests = (
   orgSlug: string,
-  params?: { limit?: number; offset?: number; state?: 'closed' | 'open' },
+  params?: {
+    author?: string
+    limit?: number
+    offset?: number
+    state?: 'closed' | 'open'
+  },
   signal?: AbortSignal,
 ) =>
   apiClient.get<PullRequestListResponse>(

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -72,6 +72,7 @@ import type {
   ProjectRelationshipsResponse,
   ProjectType,
   ProjectTypeCreate,
+  PullRequestListResponse,
   Role,
   RoleCreate,
   RoleDetail,
@@ -2080,5 +2081,28 @@ export const searchOrganization = (
   apiClient.get<SearchResult[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/search`,
     { limit: 20, threshold: 0.75, ...params, q },
+    signal,
+  )
+
+export const getProjectPullRequests = (
+  orgSlug: string,
+  projectId: string,
+  params?: { limit?: number; offset?: number; state?: 'closed' | 'open' },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<PullRequestListResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/pull-requests/`,
+    params,
+    signal,
+  )
+
+export const getOrgPullRequests = (
+  orgSlug: string,
+  params?: { limit?: number; offset?: number; state?: 'closed' | 'open' },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<PullRequestListResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/pull-requests/`,
+    params,
     signal,
   )

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -22,7 +22,12 @@ import { CSS } from '@dnd-kit/utilities'
 import { useQuery } from '@tanstack/react-query'
 import { Settings } from 'lucide-react'
 
-import { getAdminPlugins, getMyIdentities, getProjects } from '@/api/endpoints'
+import {
+  getAdminPlugins,
+  getMyIdentities,
+  getOrgPullRequests,
+  getProjects,
+} from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useRecentDeployments } from '@/hooks/useRecentDeployments'
@@ -57,6 +62,7 @@ type WidgetId =
   | 'recent-activity'
   | 'recent-deployments'
   | 'stat-active-deployments'
+  | 'stat-open-prs'
   | 'stat-teams'
   | 'stat-total-projects'
   | 'team-activity'
@@ -87,6 +93,14 @@ const availableWidgets: WidgetConfig[] = [
     name: 'Teams',
   },
   {
+    category: 'stats',
+    columnSpan: 1,
+    description: 'Open pull requests across all projects',
+    icon: '🔀',
+    id: 'stat-open-prs',
+    name: 'Open PRs',
+  },
+  {
     category: 'activity',
     columnSpan: 2,
     description: 'Overview of team projects and deployments',
@@ -112,8 +126,8 @@ const availableWidgets: WidgetConfig[] = [
   },
   {
     category: 'development',
-    columnSpan: 2,
-    description: 'Your pending code reviews and PR status',
+    columnSpan: 1,
+    description: 'Your open and closed pull requests',
     icon: '🔀',
     id: 'my-pull-requests',
     name: 'My Pull Requests',
@@ -139,6 +153,7 @@ const WIDGET_IDS: ReadonlySet<WidgetId> = new Set<WidgetId>([
   'recent-activity',
   'recent-deployments',
   'stat-active-deployments',
+  'stat-open-prs',
   'stat-teams',
   'stat-total-projects',
   'team-activity',
@@ -152,6 +167,7 @@ interface SortableWidgetProps {
   id: string
 }
 
+// fallow-ignore-next-line complexity
 export function Dashboard({
   onProjectSelect,
   onUserSelect,
@@ -242,6 +258,18 @@ export function Dashboard({
     (d) => d.completed_at == null,
   ).length
 
+  const {
+    data: openPrsData,
+    isError: isOpenPrsError,
+    isLoading: isOpenPrsLoading,
+  } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) =>
+      getOrgPullRequests(orgSlug, { limit: 1, state: 'open' }, signal),
+    queryKey: ['org-prs', orgSlug, 'open'],
+    staleTime: 5 * 60 * 1000,
+  })
+
   // Persist selections
   useEffect(() => {
     localStorage.setItem(WIDGET_STORAGE_KEY, JSON.stringify(selectedWidgets))
@@ -273,9 +301,7 @@ export function Dashboard({
   }
 
   const widgetRegistry: Record<WidgetId, () => ReactElement> = {
-    'my-pull-requests': () => (
-      <MyPullRequestsWidget onUserSelect={onUserSelect} />
-    ),
+    'my-pull-requests': () => <MyPullRequestsWidget />,
     'outdated-components': () => (
       <OutdatedComponentsWidget onProjectSelect={onProjectSelect} />
     ),
@@ -297,6 +323,15 @@ export function Dashboard({
         value={activeDeploymentCount.toLocaleString()}
       />
     ),
+    'stat-open-prs': () => (
+      <StatWidget
+        icon="🔀"
+        isError={isOpenPrsError}
+        isLoading={isOpenPrsLoading}
+        title="Open PRs"
+        value={(openPrsData?.total ?? 0).toLocaleString()}
+      />
+    ),
     'stat-teams': () => (
       <StatWidget icon="👥" title="Teams" value={teamCount.toLocaleString()} />
     ),
@@ -312,9 +347,12 @@ export function Dashboard({
 
   const renderWidget = (widgetId: WidgetId) => widgetRegistry[widgetId]()
 
-  // Separate stat widgets from other widgets for layout
-  const statWidgets = selectedWidgets.filter((id) => id.startsWith('stat-'))
-  const otherWidgets = selectedWidgets.filter((id) => !id.startsWith('stat-'))
+  // columnSpan:1 widgets go in the narrow stat grid; everything else is masonry
+  const narrowWidgetIds = new Set(
+    availableWidgets.filter((w) => w.columnSpan === 1).map((w) => w.id),
+  )
+  const statWidgets = selectedWidgets.filter((id) => narrowWidgetIds.has(id))
+  const otherWidgets = selectedWidgets.filter((id) => !narrowWidgetIds.has(id))
 
   return (
     <div className="mx-auto max-w-[1400px] px-6 py-8">

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -3,7 +3,14 @@ import { useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
-import { Grid3x3, List, Network, Plus, Search } from 'lucide-react'
+import {
+  GitPullRequest,
+  Grid3x3,
+  List,
+  Network,
+  Plus,
+  Search,
+} from 'lucide-react'
 import { matchSorter } from 'match-sorter'
 
 import { getProjects } from '@/api/endpoints'
@@ -211,6 +218,23 @@ export function ProjectsView() {
                     ))}
                   </div>
                 )}
+                {((project.open_pr_count ?? 0) > 0 ||
+                  (project.closed_pr_count ?? 0) > 0) && (
+                  <div className="mt-2 flex items-center gap-2">
+                    {(project.open_pr_count ?? 0) > 0 && (
+                      <span className="text-action flex items-center gap-1 text-xs font-medium">
+                        <GitPullRequest className="size-3" />
+                        {project.open_pr_count} open
+                      </span>
+                    )}
+                    {(project.closed_pr_count ?? 0) > 0 && (
+                      <span className="text-tertiary flex items-center gap-1 text-xs">
+                        <GitPullRequest className="size-3" />
+                        {project.closed_pr_count} closed
+                      </span>
+                    )}
+                  </div>
+                )}
               </Card>
             )
           })}
@@ -248,6 +272,13 @@ export function ProjectsView() {
                     }
                   >
                     Environments
+                  </TableHead>
+                  <TableHead
+                    className={
+                      'text-secondary px-6 py-3 text-left text-sm font-medium'
+                    }
+                  >
+                    PRs
                   </TableHead>
                   <TableHead
                     className={
@@ -293,6 +324,22 @@ export function ProjectsView() {
                               )}
                             </div>
                           )}
+                      </TableCell>
+                      <TableCell className="px-6 py-4">
+                        <div className="flex flex-col gap-0.5">
+                          {(project.open_pr_count ?? 0) > 0 && (
+                            <span className="text-action flex items-center gap-1 text-xs font-medium">
+                              <GitPullRequest className="size-3" />
+                              {project.open_pr_count} open
+                            </span>
+                          )}
+                          {(project.closed_pr_count ?? 0) > 0 && (
+                            <span className="text-tertiary flex items-center gap-1 text-xs">
+                              <GitPullRequest className="size-3" />
+                              {project.closed_pr_count} closed
+                            </span>
+                          )}
+                        </div>
                       </TableCell>
                       <TableCell className="px-6 py-4">
                         <ScoreBadge score={project.score} variant="circle" />

--- a/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
@@ -1,158 +1,93 @@
-import { CheckCircle, Clock, GitPullRequest, MessageSquare } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 
-import { Badge, type BadgeProps } from '@/components/ui/badge'
-import { Card } from '@/components/ui/card'
+import { getMyIdentities, getOrgPullRequests } from '@/api/endpoints'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import type { IdentityConnectionResponse } from '@/types'
 
-interface MyPullRequestsWidgetProps {
-  onUserSelect?: (userName: string) => void
-}
+const GITHUB_PR_PLUGIN_SLUG = 'github-enterprise-cloud'
 
-export function MyPullRequestsWidget({
-  onUserSelect,
-}: MyPullRequestsWidgetProps) {
-  const pullRequests = [
-    {
-      author: 'You',
-      branch: 'feature/health-tracking',
-      comments: 3,
-      createdAt: '2 hours ago',
-      id: 1,
-      repo: 'frontend-applications/navigation',
-      reviewers: ['Scott Miller', 'Dave Shawley'],
-      status: 'ready' as const,
-      title: 'Add health score tracking to dashboard',
-    },
-    {
-      author: 'You',
-      branch: 'bugfix/status-indicator',
-      comments: 0,
-      createdAt: '5 hours ago',
-      id: 2,
-      repo: 'platform/deployment-service',
-      reviewers: ['Gavin Roy'],
-      status: 'pending' as const,
-      title: 'Fix deployment status indicator',
-    },
-    {
-      author: 'You',
-      branch: 'feature/oauth-updates',
-      comments: 7,
-      createdAt: '1 day ago',
-      id: 3,
-      repo: 'security/auth-service',
-      reviewers: ['Jim Fitzpatrick', 'Scott Miller'],
-      status: 'changes-requested' as const,
-      title: 'Update authentication flow',
-    },
-    {
-      author: 'You',
-      branch: 'perf/query-optimization',
-      comments: 2,
-      createdAt: '2 days ago',
-      id: 4,
-      repo: 'backend/analytics',
-      reviewers: ['Dave Shawley'],
-      status: 'approved' as const,
-      title: 'Optimize database queries for reports',
-    },
-  ]
+// fallow-ignore-next-line complexity
+export function MyPullRequestsWidget() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
 
-  const statusConfig = {
-    approved: { color: 'green' as const, icon: CheckCircle, label: 'Approved' },
-    'changes-requested': {
-      color: 'red' as const,
-      icon: MessageSquare,
-      label: 'Changes Requested',
-    },
-    pending: { color: 'yellow' as const, icon: Clock, label: 'Pending Review' },
-    ready: {
-      color: 'blue' as const,
-      icon: GitPullRequest,
-      label: 'Ready for Review',
-    },
-  }
+  const { data: identities, isLoading: identitiesLoading } = useQuery({
+    queryFn: ({ signal }) => getMyIdentities(signal),
+    queryKey: ['me-identities'],
+    staleTime: 0,
+  })
+
+  const login = identities ? githubLogin(identities) : undefined
+  const hasIdentity = !identitiesLoading && !!login
+
+  const { data: openData, isLoading: openLoading } = useQuery({
+    enabled: hasIdentity && !!orgSlug,
+    queryFn: ({ signal }) =>
+      getOrgPullRequests(
+        orgSlug,
+        { author: login, limit: 1, state: 'open' },
+        signal,
+      ),
+    queryKey: ['my-prs', orgSlug, login, 'open'],
+    staleTime: 60 * 1000,
+  })
+
+  const { data: closedData, isLoading: closedLoading } = useQuery({
+    enabled: hasIdentity && !!orgSlug,
+    queryFn: ({ signal }) =>
+      getOrgPullRequests(
+        orgSlug,
+        { author: login, limit: 1, state: 'closed' },
+        signal,
+      ),
+    queryKey: ['my-prs', orgSlug, login, 'closed'],
+    staleTime: 60 * 1000,
+  })
+
+  const isLoading = identitiesLoading || openLoading || closedLoading
+  const notConnected = !identitiesLoading && !login
 
   return (
-    <Card className="p-6">
-      <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-primary text-lg">My Pull Requests</h3>
-        <span className="text-secondary text-sm">
-          {pullRequests.length} open
-        </span>
+    <div className="border-border bg-card rounded-lg border p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-secondary text-sm">My Pull Requests</p>
+          {isLoading ? (
+            <span
+              aria-label="Loading My Pull Requests"
+              className="bg-tertiary/40 mt-2 inline-block h-8 w-20 animate-pulse rounded"
+              role="status"
+            />
+          ) : notConnected ? (
+            <>
+              <p className="text-tertiary mt-2 text-3xl">—</p>
+              <a
+                className="text-action mt-1 block text-xs hover:underline"
+                href="/settings/connections"
+              >
+                Connect GitHub
+              </a>
+            </>
+          ) : (
+            <>
+              <p className="text-action mt-2 text-3xl">
+                {openData?.total ?? 0}
+              </p>
+              <p className="text-tertiary mt-1 text-xs">
+                {closedData?.total ?? 0} closed
+              </p>
+            </>
+          )}
+        </div>
+        <div className="text-4xl">🔀</div>
       </div>
-
-      <div className="space-y-3">
-        {pullRequests.map((pr) => {
-          const config = statusConfig[pr.status]
-          const StatusIcon = config.icon
-
-          return (
-            <div
-              className="border-input bg-background hover:border-secondary rounded-lg border p-4 transition-colors"
-              key={pr.id}
-            >
-              <div className="flex items-start gap-3">
-                <GitPullRequest className="text-tertiary mt-0.5 size-5 shrink-0" />
-                <div className="min-w-0 flex-1">
-                  <div className="text-primary mb-1 font-medium">
-                    {pr.title}
-                  </div>
-                  <div className="text-secondary mb-2 text-sm">
-                    {pr.repo} • {pr.branch}
-                  </div>
-
-                  <div className="flex flex-wrap items-center gap-3">
-                    <Badge
-                      className="gap-1.5 rounded-full"
-                      variant={
-                        ({
-                          blue: 'info',
-                          red: 'danger',
-                          yellow: 'warning',
-                        }[config.color as string] ??
-                          'success') as BadgeProps['variant']
-                      }
-                    >
-                      <StatusIcon className="size-3" />
-                      {config.label}
-                    </Badge>
-
-                    {pr.comments > 0 && (
-                      <span className="flex items-center gap-1 text-xs text-gray-500">
-                        <MessageSquare className="size-3" />
-                        {pr.comments}
-                      </span>
-                    )}
-
-                    <span className="text-xs text-gray-500">
-                      {pr.createdAt}
-                    </span>
-                  </div>
-
-                  {pr.reviewers.length > 0 && (
-                    <div className="mt-2 text-xs text-gray-500">
-                      Reviewers:{' '}
-                      {pr.reviewers.map((reviewer, idx) => (
-                        <button
-                          className={`text-info hover:text-info/80 ${
-                            idx > 0 ? 'ml-1' : ''
-                          }`}
-                          key={idx}
-                          onClick={() => onUserSelect?.(reviewer)}
-                          type="button"
-                        >
-                          {reviewer}
-                          {idx < pr.reviewers.length - 1 ? ',' : ''}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </Card>
+    </div>
   )
+}
+
+function githubLogin(
+  identities: IdentityConnectionResponse[],
+): string | undefined {
+  return identities.find((i) => i.plugin_slug === GITHUB_PR_PLUGIN_SLUG)
+    ?.subject
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,7 @@ export interface Project {
   [key: string]: unknown
   archived?: boolean
   archived_at?: null | string
+  closed_pr_count?: number
   created_at?: null | string
   description?: null | string
   environments?: Environment[]
@@ -137,6 +138,7 @@ export interface Project {
   identifiers?: Record<string, number | string>
   links?: Record<string, string>
   name: string
+  open_pr_count?: number
   project_type?: {
     name: string
     organization: {
@@ -215,6 +217,29 @@ export interface ProjectTypeCreate {
   icon?: null | string
   name: string
   slug: string
+}
+
+export interface PullRequest {
+  additions: number
+  author: string
+  changed_files: number
+  created_at: string
+  deletions: number
+  draft: boolean
+  merged: boolean
+  merged_at: null | string
+  pr_id: string
+  pr_number: number
+  project_id: string
+  state: string
+  title: string
+  updated_at: string
+  url: string
+}
+
+export interface PullRequestListResponse {
+  data: PullRequest[]
+  total: number
 }
 
 export type RelationshipLink = Schemas['RelationshipLink']


### PR DESCRIPTION
## Summary

- Adds `closed_pr_count` and `open_pr_count` optional fields to the `Project` type to match the new API response fields from [imbi-api#313](https://github.com/AWeber-Imbi/imbi-api/pull/313)
- Adds `PullRequest` and `PullRequestListResponse` types to `src/types/index.ts`
- Adds `getProjectPullRequests` and `getOrgPullRequests` endpoint functions to `src/api/endpoints.ts`
- Updates `ProjectsView` to display PR counts per project:
  - **Grid view**: shows open (amber) and closed (muted) PR counts with a `GitPullRequest` icon below the environment badges when counts are non-zero
  - **List view**: adds a "PRs" column with the same display

## Dependencies

Requires [imbi-api#313](https://github.com/AWeber-Imbi/imbi-api/pull/313) which adds `open_pr_count` / `closed_pr_count` to the project list response, and [imbi-common#115](https://github.com/AWeber-Imbi/imbi-common/pull/115) which adds the ClickHouse `pull_requests` table.

## Test plan

- [ ] Projects with pull request data show open/closed counts on the project index (grid and list views)
- [ ] Projects with no PR data show nothing (counts default to 0, badges are hidden)
- [ ] TypeScript compiles without errors (`npm run build`)
- [ ] `getProjectPullRequests` and `getOrgPullRequests` are available for future consumers