### PR TITLE
Projects list: release surfaces, drift detection, and view-mode polish

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -20,6 +20,8 @@
       "file": "src/api/endpoints.ts",
       "exports": [
         "getMonthlyImprovement",
+        "getOrgPullRequests",
+        "getProjectPullRequests",
         "getScoreHistoryByTeam",
         "getScoreHistoryFeed",
         "getScoreRollup",

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -2087,7 +2087,12 @@ export const searchOrganization = (
 export const getProjectPullRequests = (
   orgSlug: string,
   projectId: string,
-  params?: { limit?: number; offset?: number; state?: 'closed' | 'open' },
+  params?: {
+    author?: string
+    limit?: number
+    offset?: number
+    state?: 'closed' | 'open'
+  },
   signal?: AbortSignal,
 ) =>
   apiClient.get<PullRequestListResponse>(
@@ -2098,7 +2103,12 @@ export const getProjectPullRequests = (
 
 export const getOrgPullRequests = (
   orgSlug: string,
-  params?: { limit?: number; offset?: number; state?: 'closed' | 'open' },
+  params?: {
+    author?: string
+    limit?: number
+    offset?: number
+    state?: 'closed' | 'open'
+  },
   signal?: AbortSignal,
 ) =>
   apiClient.get<PullRequestListResponse>(

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -72,6 +72,7 @@ import type {
   ProjectRelationshipsResponse,
   ProjectType,
   ProjectTypeCreate,
+  PullRequestListResponse,
   Role,
   RoleCreate,
   RoleDetail,
@@ -2080,5 +2081,28 @@ export const searchOrganization = (
   apiClient.get<SearchResult[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/search`,
     { limit: 20, threshold: 0.75, ...params, q },
+    signal,
+  )
+
+export const getProjectPullRequests = (
+  orgSlug: string,
+  projectId: string,
+  params?: { limit?: number; offset?: number; state?: 'closed' | 'open' },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<PullRequestListResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/pull-requests/`,
+    params,
+    signal,
+  )
+
+export const getOrgPullRequests = (
+  orgSlug: string,
+  params?: { limit?: number; offset?: number; state?: 'closed' | 'open' },
+  signal?: AbortSignal,
+) =>
+  apiClient.get<PullRequestListResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/pull-requests/`,
+    params,
     signal,
   )

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -376,6 +376,7 @@ function parseNextCursor(headers: Headers): string | undefined {
   }
 }
 
+// fallow-ignore-next-line complexity
 export const listOperationsLog = async (
   params: {
     cursor?: string
@@ -1736,6 +1737,7 @@ export const getProjectLogsHistogram = (
   )
 }
 
+// fallow-ignore-next-line complexity
 export const searchProjectLogs = (
   orgSlug: string,
   projectId: string,

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -22,7 +22,12 @@ import { CSS } from '@dnd-kit/utilities'
 import { useQuery } from '@tanstack/react-query'
 import { Settings } from 'lucide-react'
 
-import { getAdminPlugins, getMyIdentities, getProjects } from '@/api/endpoints'
+import {
+  getAdminPlugins,
+  getMyIdentities,
+  getOrgPullRequests,
+  getProjects,
+} from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useRecentDeployments } from '@/hooks/useRecentDeployments'
@@ -57,6 +62,7 @@ type WidgetId =
   | 'recent-activity'
   | 'recent-deployments'
   | 'stat-active-deployments'
+  | 'stat-open-prs'
   | 'stat-teams'
   | 'stat-total-projects'
   | 'team-activity'
@@ -87,6 +93,14 @@ const availableWidgets: WidgetConfig[] = [
     name: 'Teams',
   },
   {
+    category: 'stats',
+    columnSpan: 1,
+    description: 'Open pull requests across all projects',
+    icon: '🔀',
+    id: 'stat-open-prs',
+    name: 'Open PRs',
+  },
+  {
     category: 'activity',
     columnSpan: 2,
     description: 'Overview of team projects and deployments',
@@ -112,8 +126,8 @@ const availableWidgets: WidgetConfig[] = [
   },
   {
     category: 'development',
-    columnSpan: 2,
-    description: 'Your pending code reviews and PR status',
+    columnSpan: 1,
+    description: 'Your open and closed pull requests',
     icon: '🔀',
     id: 'my-pull-requests',
     name: 'My Pull Requests',
@@ -139,6 +153,7 @@ const WIDGET_IDS: ReadonlySet<WidgetId> = new Set<WidgetId>([
   'recent-activity',
   'recent-deployments',
   'stat-active-deployments',
+  'stat-open-prs',
   'stat-teams',
   'stat-total-projects',
   'team-activity',
@@ -152,6 +167,7 @@ interface SortableWidgetProps {
   id: string
 }
 
+// fallow-ignore-next-line complexity
 export function Dashboard({
   onProjectSelect,
   onUserSelect,
@@ -242,6 +258,18 @@ export function Dashboard({
     (d) => d.completed_at == null,
   ).length
 
+  const {
+    data: openPrsData,
+    isError: isOpenPrsError,
+    isLoading: isOpenPrsLoading,
+  } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) =>
+      getOrgPullRequests(orgSlug, { limit: 1, state: 'open' }, signal),
+    queryKey: ['org-prs', orgSlug, 'open'],
+    staleTime: 5 * 60 * 1000,
+  })
+
   // Persist selections
   useEffect(() => {
     localStorage.setItem(WIDGET_STORAGE_KEY, JSON.stringify(selectedWidgets))
@@ -273,9 +301,7 @@ export function Dashboard({
   }
 
   const widgetRegistry: Record<WidgetId, () => ReactElement> = {
-    'my-pull-requests': () => (
-      <MyPullRequestsWidget onUserSelect={onUserSelect} />
-    ),
+    'my-pull-requests': () => <MyPullRequestsWidget />,
     'outdated-components': () => (
       <OutdatedComponentsWidget onProjectSelect={onProjectSelect} />
     ),
@@ -297,6 +323,15 @@ export function Dashboard({
         value={activeDeploymentCount.toLocaleString()}
       />
     ),
+    'stat-open-prs': () => (
+      <StatWidget
+        icon="🔀"
+        isError={isOpenPrsError}
+        isLoading={isOpenPrsLoading}
+        title="Open PRs"
+        value={(openPrsData?.total ?? 0).toLocaleString()}
+      />
+    ),
     'stat-teams': () => (
       <StatWidget icon="👥" title="Teams" value={teamCount.toLocaleString()} />
     ),
@@ -312,9 +347,12 @@ export function Dashboard({
 
   const renderWidget = (widgetId: WidgetId) => widgetRegistry[widgetId]()
 
-  // Separate stat widgets from other widgets for layout
-  const statWidgets = selectedWidgets.filter((id) => id.startsWith('stat-'))
-  const otherWidgets = selectedWidgets.filter((id) => !id.startsWith('stat-'))
+  // columnSpan:1 widgets go in the narrow stat grid; everything else is masonry
+  const narrowWidgetIds = new Set(
+    availableWidgets.filter((w) => w.columnSpan === 1).map((w) => w.id),
+  )
+  const statWidgets = selectedWidgets.filter((id) => narrowWidgetIds.has(id))
+  const otherWidgets = selectedWidgets.filter((id) => !narrowWidgetIds.has(id))
 
   return (
     <div className="mx-auto max-w-[1400px] px-6 py-8">

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -20,7 +20,7 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useQuery } from '@tanstack/react-query'
-import { Settings } from 'lucide-react'
+import { GitPullRequest, Settings } from 'lucide-react'
 
 import {
   getAdminPlugins,
@@ -98,7 +98,7 @@ const availableWidgets: WidgetConfig[] = [
     description: 'Open pull requests across all projects',
     icon: '🔀',
     id: 'stat-open-prs',
-    name: 'Open PRs',
+    name: 'Total Open PRs',
   },
   {
     category: 'activity',
@@ -323,14 +323,35 @@ export function Dashboard({
         value={activeDeploymentCount.toLocaleString()}
       />
     ),
+    // fallow-ignore-next-line complexity
     'stat-open-prs': () => (
-      <StatWidget
-        icon="🔀"
-        isError={isOpenPrsError}
-        isLoading={isOpenPrsLoading}
-        title="Open PRs"
-        value={(openPrsData?.total ?? 0).toLocaleString()}
-      />
+      <div className="border-border bg-card rounded-lg border p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-secondary text-sm">Total Open PRs</p>
+            {isOpenPrsLoading ? (
+              <span
+                aria-label="Loading Total Open PRs"
+                className="bg-tertiary/40 mt-2 inline-block h-9 w-32 animate-pulse rounded"
+                role="status"
+              />
+            ) : isOpenPrsError ? (
+              <p className="text-danger mt-2 text-sm">Unavailable</p>
+            ) : (
+              <div className="mt-2 flex items-baseline gap-1.5">
+                <span className="text-primary text-3xl">
+                  {(openPrsData?.total ?? 0).toLocaleString()}
+                </span>
+                <span className="text-secondary text-sm">
+                  across {(openPrsData?.project_count ?? 0).toLocaleString()}{' '}
+                  projects
+                </span>
+              </div>
+            )}
+          </div>
+          <GitPullRequest className="text-tertiary size-9 shrink-0" />
+        </div>
+      </div>
     ),
     'stat-teams': () => (
       <StatWidget icon="👥" title="Teams" value={teamCount.toLocaleString()} />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -284,6 +284,7 @@ export function Dashboard({
     )
   }
 
+  // fallow-ignore-next-line complexity
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
 

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -96,6 +96,7 @@ type TabType = (typeof VALID_TABS)[number]
 
 const VALID_TAB_SET: Set<string> = new Set(VALID_TABS)
 
+// fallow-ignore-next-line complexity
 export function ProjectDetail({
   initialSubAction,
   initialSubId,
@@ -134,6 +135,7 @@ export function ProjectDetail({
   // placeholder for the version slot so versions don't pop in.
   const releasesLoading = releasesPending && !!orgSlug && !!project.id
 
+  // fallow-ignore-next-line complexity
   const deploymentStatus: Record<
     string,
     {
@@ -181,6 +183,7 @@ export function ProjectDetail({
   // the pipeline, *and* ``promote`` requires the upstream env to have a
   // deployed version (otherwise ``fromCommittish`` would be undefined
   // and the promote flow can't succeed).
+  // fallow-ignore-next-line complexity
   useEffect(() => {
     const isModalTab = initialTab === 'deploy' || initialTab === 'promote'
     if (initialTab && !VALID_TAB_SET.has(initialTab) && !isModalTab) {
@@ -415,6 +418,7 @@ export function ProjectDetail({
   // ``github-deployment-ec``). The fallback covers the case where the
   // project-type assignment didn't bind an identity plugin but a
   // matching one exists in the org's plugin catalog.
+  // fallow-ignore-next-line complexity
   const resolvedIdentityPlugin = useMemo(() => {
     if (!deploymentPlugin) return null
     const catalog = identityPlugins ?? []
@@ -460,9 +464,13 @@ export function ProjectDetail({
         : isUserConnectedToDeployment
           ? 'connected'
           : 'disconnected'
+  const isDeployable = (project.project_types ?? []).some(
+    (pt) => (pt as { deployable?: boolean }).deployable === true,
+  )
   const canTriggerDeployments =
-    !!deploymentPlugin && deploymentReadiness === 'connected'
+    isDeployable && !!deploymentPlugin && deploymentReadiness === 'connected'
 
+  // fallow-ignore-next-line complexity
   const deploymentConnectLabel = (() => {
     if (resolvedIdentityPlugin?.label) return resolvedIdentityPlugin.label
     if (deploymentIdentityPluginId) {
@@ -481,6 +489,7 @@ export function ProjectDetail({
   // resolve successfully before deciding — otherwise the empty default
   // during the initial fetch redirects every direct navigation to
   // /logs or /configuration.
+  // fallow-ignore-next-line complexity
   useEffect(() => {
     if (!projectPluginsFetched || !projectPluginsSuccess) return
     if (
@@ -717,7 +726,7 @@ export function ProjectDetail({
                   )
                 })}
             </div>
-            {deploymentPlugin && (
+            {isDeployable && deploymentPlugin && (
               <div className="text-tertiary flex items-center gap-1.5 text-xs italic">
                 <Info className="size-3.5" />
                 <span>
@@ -1091,6 +1100,7 @@ export function ProjectDetail({
   )
 }
 
+// fallow-ignore-next-line complexity
 function buildRecommendation(
   c: AttributeContribution,
   policy: ScoringPolicy,

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -140,20 +140,22 @@ export function ProjectDetail({
     string,
     {
       ciStatus: 'fail' | 'pass' | 'warn' | null
+      committish: string
       runUrl: null | string
       status: string
+      tag: null | string
       updated: string
-      version: string
     }
   > = useMemo(() => {
     const out: Record<
       string,
       {
         ciStatus: 'fail' | 'pass' | 'warn' | null
+        committish: string
         runUrl: null | string
         status: string
+        tag: null | string
         updated: string
-        version: string
       }
     > = {}
     for (const row of currentReleases) {
@@ -164,12 +166,13 @@ export function ProjectDetail({
         row.ci_status && row.ci_status !== 'unknown' ? row.ci_status : null
       out[row.environment.slug] = {
         ciStatus: ci,
+        committish: row.release.committish,
         runUrl: row.external_run_url,
         status: row.current_status ?? '',
+        tag: row.release.tag ?? null,
         updated: formatDistanceToNow(new Date(row.last_event_at), {
           addSuffix: true,
         }),
-        version: row.release.version,
       }
     }
     return out
@@ -210,8 +213,8 @@ export function ProjectDetail({
           return
         }
         const fromSlug = sortedEnvironments[idx - 1]?.slug
-        const fromVersion = fromSlug
-          ? deploymentStatus[fromSlug]?.version
+        const fromCommittish = fromSlug
+          ? deploymentStatus[fromSlug]?.committish
           : undefined
         // Wait for the releases query (drives ``deploymentStatus``) to
         // settle before deciding the upstream is empty. Use the
@@ -219,7 +222,7 @@ export function ProjectDetail({
         // genuinely zero releases would otherwise stay stuck here
         // without redirecting.
         if (releasesPending) return
-        if (!fromVersion) {
+        if (!fromCommittish) {
           navigate(`/projects/${project.id}`, { replace: true })
         }
       }
@@ -669,7 +672,9 @@ export function ProjectDetail({
                       ? 'Deploy / Promote'
                       : 'Deploy'
                   const versionSlot = deployment ? (
-                    <span className="font-mono">{deployment.version}</span>
+                    <span className="font-mono">
+                      {deployment.tag ?? deployment.committish}
+                    </span>
                   ) : releasesLoading ? (
                     <span
                       aria-hidden
@@ -1051,18 +1056,18 @@ export function ProjectDetail({
           // omit the Promote tab when prerequisites are unmet.
           const fromSlug =
             targetIdx > 0 ? sortedEnvironments[targetIdx - 1]?.slug : undefined
-          const fromVersion = fromSlug
-            ? deploymentStatus[fromSlug]?.version
+          const fromCommittish = fromSlug
+            ? deploymentStatus[fromSlug]?.committish
             : undefined
           const promoteAvailable =
-            canPromote && !!fromSlug && !!fromVersion && targetIdx > 0
+            canPromote && !!fromSlug && !!fromCommittish && targetIdx > 0
           if (!canDeploy && !promoteAvailable) return null
           return (
             <ReleaseModal
               canDeploy={canDeploy}
               canPromote={promoteAvailable}
               environments={sortedEnvironments}
-              fromCommittish={fromVersion}
+              fromCommittish={fromCommittish}
               fromEnvironment={fromSlug}
               initialAction={isPromoteModal ? 'promote' : 'deploy'}
               initialEnvSlug={initialSubId}

--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -10,7 +10,12 @@ type Environment = NonNullable<Project['environments']>[number]
 interface ProjectEnvironmentsCardProps {
   deploymentStatus: Record<
     string,
-    { status: string; updated: string; version: string }
+    {
+      committish: string
+      status: string
+      tag: null | string
+      updated: string
+    }
   >
   environments: Environment[]
 }
@@ -47,7 +52,9 @@ export function ProjectEnvironmentsCard({
                 </div>
                 <div className="w-28 shrink-0 text-right">
                   <span className="text-tertiary font-mono text-sm">
-                    {deployment?.version ?? ''}
+                    {deployment
+                      ? (deployment.tag ?? deployment.committish)
+                      : ''}
                   </span>
                 </div>
                 <div className="flex-1 text-right">

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -3,7 +3,14 @@ import { useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
-import { Grid3x3, List, Network, Plus, Search } from 'lucide-react'
+import {
+  GitPullRequest,
+  Grid3x3,
+  List,
+  Network,
+  Plus,
+  Search,
+} from 'lucide-react'
 import { matchSorter } from 'match-sorter'
 
 import { getProjects } from '@/api/endpoints'
@@ -211,6 +218,23 @@ export function ProjectsView() {
                     ))}
                   </div>
                 )}
+                {((project.open_pr_count ?? 0) > 0 ||
+                  (project.closed_pr_count ?? 0) > 0) && (
+                  <div className="mt-2 flex items-center gap-2">
+                    {(project.open_pr_count ?? 0) > 0 && (
+                      <span className="text-action flex items-center gap-1 text-xs font-medium">
+                        <GitPullRequest className="size-3" />
+                        {project.open_pr_count} open
+                      </span>
+                    )}
+                    {(project.closed_pr_count ?? 0) > 0 && (
+                      <span className="text-tertiary flex items-center gap-1 text-xs">
+                        <GitPullRequest className="size-3" />
+                        {project.closed_pr_count} closed
+                      </span>
+                    )}
+                  </div>
+                )}
               </Card>
             )
           })}
@@ -248,6 +272,13 @@ export function ProjectsView() {
                     }
                   >
                     Environments
+                  </TableHead>
+                  <TableHead
+                    className={
+                      'text-secondary px-6 py-3 text-left text-sm font-medium'
+                    }
+                  >
+                    PRs
                   </TableHead>
                   <TableHead
                     className={
@@ -293,6 +324,22 @@ export function ProjectsView() {
                               )}
                             </div>
                           )}
+                      </TableCell>
+                      <TableCell className="px-6 py-4">
+                        <div className="flex flex-col gap-0.5">
+                          {(project.open_pr_count ?? 0) > 0 && (
+                            <span className="text-action flex items-center gap-1 text-xs font-medium">
+                              <GitPullRequest className="size-3" />
+                              {project.open_pr_count} open
+                            </span>
+                          )}
+                          {(project.closed_pr_count ?? 0) > 0 && (
+                            <span className="text-tertiary flex items-center gap-1 text-xs">
+                              <GitPullRequest className="size-3" />
+                              {project.closed_pr_count} closed
+                            </span>
+                          )}
+                        </div>
                       </TableCell>
                       <TableCell className="px-6 py-4">
                         <ScoreBadge score={project.score} variant="circle" />

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -8,11 +8,11 @@ import {
   ChevronDown,
   ChevronsUpDown,
   ChevronUp,
+  CircleCheck,
   GitPullRequest,
   Grid3x3,
   List,
   ListFilter,
-  Network,
   Plus,
   Search,
   User,
@@ -24,21 +24,12 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { deriveChipColors } from '@/lib/chip-colors'
 
 import { NewProjectDialog } from './NewProjectDialog'
-import { ProjectGraphView } from './ProjectGraphView'
 import { Button } from './ui/button'
 import { Card } from './ui/card'
 import { Checkbox } from './ui/checkbox'
 import { Input } from './ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { ScoreBadge } from './ui/score-badge'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from './ui/table'
 
 interface FilterHeaderProps {
   activeFilters: Set<string>
@@ -66,6 +57,7 @@ type SortDir = 'asc' | 'desc'
 
 interface SortHeaderProps {
   children: React.ReactNode
+  className?: string
   onSort: () => void
   sortDir: SortDir
   sorted: boolean
@@ -81,17 +73,16 @@ export function ProjectsView() {
   const orgSlug = selectedOrganization?.slug || ''
 
   const rawView = searchParams.get('view')
-  const viewMode: 'graph' | 'grid' | 'list' =
-    rawView === 'grid' || rawView === 'list' || rawView === 'graph'
-      ? rawView
-      : 'grid'
+  const viewMode: 'grid' | 'list' =
+    rawView === 'grid' || rawView === 'list' ? rawView : 'grid'
   const searchQuery = searchParams.get('q') ?? ''
   const sortKey = searchParams.get('sort') as null | SortKey
   const sortDir = (searchParams.get('dir') ?? 'asc') as SortDir
   const teamsParam = searchParams.get('teams') ?? ''
   const typesParam = searchParams.get('types') ?? ''
+  const driftsParam = searchParams.get('drifts') ?? ''
 
-  const setViewMode = (v: 'graph' | 'grid' | 'list') =>
+  const setViewMode = (v: 'grid' | 'list') =>
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev)
@@ -189,6 +180,7 @@ export function ProjectsView() {
   const filteredProjects = useMemo(() => {
     const teamSet = new Set(teamsParam.split(',').filter(Boolean))
     const typeSet = new Set(typesParam.split(',').filter(Boolean))
+    const driftSet = new Set(driftsParam.split(',').filter(Boolean))
     let all = projects ?? []
 
     if (teamSet.size > 0) {
@@ -198,6 +190,9 @@ export function ProjectsView() {
       all = all.filter((p) =>
         (p.project_types ?? []).some((pt) => typeSet.has(pt.slug)),
       )
+    }
+    if (driftSet.size > 0) {
+      all = all.filter(() => driftSet.has('none'))
     }
     if (searchQuery) {
       return matchSorter(all, searchQuery, {
@@ -225,10 +220,20 @@ export function ProjectsView() {
       else if (sortKey === 'score') cmp = (a.score ?? 0) - (b.score ?? 0)
       return sortDir === 'asc' ? cmp : -cmp
     })
-  }, [projects, searchQuery, sortKey, sortDir, teamsParam, typesParam])
+  }, [
+    projects,
+    searchQuery,
+    sortKey,
+    sortDir,
+    teamsParam,
+    typesParam,
+    driftsParam,
+  ])
 
   const activeTeamSet = new Set(teamsParam.split(',').filter(Boolean))
   const activeTypeSet = new Set(typesParam.split(',').filter(Boolean))
+  const activeDriftSet = new Set(driftsParam.split(',').filter(Boolean))
+  const driftOptions = [{ label: 'None', slug: 'none' }]
 
   if (isLoading) {
     return (
@@ -281,31 +286,20 @@ export function ProjectsView() {
               </Button>
               <Button
                 aria-label="List view"
-                className={`rounded-none ${viewMode === 'list' ? 'bg-amber-bg text-amber-text' : ''}`}
+                className={`rounded-l-none ${viewMode === 'list' ? 'bg-amber-bg text-amber-text' : ''}`}
                 onClick={() => setViewMode('list')}
                 size="sm"
                 variant="ghost"
               >
                 <List className="size-4" />
               </Button>
-              <Button
-                aria-label="Graph view"
-                className={`rounded-l-none ${viewMode === 'graph' ? 'bg-amber-bg text-amber-text' : ''}`}
-                onClick={() => setViewMode('graph')}
-                size="sm"
-                variant="ghost"
-              >
-                <Network className="size-4" />
-              </Button>
             </div>
           </div>
         </Card>
       </div>
 
-      {/* Projects Graph/Grid/List */}
-      {viewMode === 'graph' ? (
-        <ProjectGraphView projects={filteredProjects} />
-      ) : viewMode === 'grid' ? (
+      {/* Projects Grid/List */}
+      {viewMode === 'grid' ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {/* fallow-ignore-next-line complexity */}
           {filteredProjects.map((project) => {
@@ -373,120 +367,130 @@ export function ProjectsView() {
         </div>
       ) : (
         <Card className="overflow-hidden">
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader className="border-tertiary bg-secondary border-b">
-                <TableRow>
-                  <FilterHeader
-                    activeFilters={activeTeamSet}
-                    centerFilter={{
-                      activeFilters: activeTeamSet,
-                      label: 'team',
-                      onToggle: (s) => toggleFilter('teams', s),
-                      options: teamOptions,
-                      title: 'Team',
-                    }}
-                    className="min-w-72"
-                    hideMainFilter
-                    label="team"
-                    onSort={() => setSort('name')}
-                    onToggle={(s) => toggleFilter('teams', s)}
-                    options={teamOptions}
-                    rightFilter={{
-                      activeFilters: activeTypeSet,
-                      label: 'type',
-                      onToggle: (s) => toggleFilter('types', s),
-                      options: typeOptions,
-                      title: 'Type',
-                    }}
-                    sortDir={sortDir}
-                    sorted={sortKey === 'name'}
-                  >
-                    Project
-                  </FilterHeader>
-                  <SortHeader
-                    onSort={() => setSort('prs')}
-                    sortDir={sortDir}
-                    sorted={sortKey === 'prs'}
-                  >
-                    PRs
-                  </SortHeader>
-                  <TableHead className="text-secondary w-px px-6 py-3 text-left text-sm font-medium whitespace-nowrap">
-                    Deployments
-                  </TableHead>
-                  <SortHeader
-                    onSort={() => setSort('score')}
-                    sortDir={sortDir}
-                    sorted={sortKey === 'score'}
-                  >
-                    Health
-                  </SortHeader>
-                </TableRow>
-              </TableHeader>
-              <TableBody className="divide-tertiary divide-y">
-                {/* fallow-ignore-next-line complexity */}
-                {filteredProjects.map((project) => {
-                  return (
-                    <TableRow
-                      className="hover:bg-secondary cursor-pointer transition-colors"
-                      key={`table-${project.id}`}
-                      onClick={() => handleProjectSelect(project.id)}
-                    >
-                      <TableCell className="min-w-72 px-6 py-4">
-                        <div>
-                          <p className="text-primary font-medium">
-                            {project.name}
-                          </p>
-                          {(project.project_types ?? []).length > 0 && (
-                            <p className="text-secondary text-xs">
-                              {project
-                                .project_types!.map((pt) => pt.name)
-                                .join(', ')}
-                            </p>
-                          )}
-                          <p className="text-tertiary text-xs">
-                            {project.team.name}
-                          </p>
-                        </div>
-                      </TableCell>
-                      <TableCell className="px-6 py-4">
-                        <div className="flex items-center gap-1.5">
-                          <span className="bg-secondary flex items-center gap-1 rounded-md px-1.5 py-0.5">
-                            <GitPullRequest className="text-action size-3.5" />
-                            <span className="text-action text-xs font-medium">
-                              {project.open_pr_count ?? 0}
-                            </span>
-                          </span>
-                          <span className="border-action flex items-center gap-1 rounded-md border px-1.5 py-0.5">
-                            <User className="text-action size-3.5" />
-                            <span className="text-action text-xs font-medium">
-                              {project.viewer_open_pr_count ?? 0}
-                            </span>
-                          </span>
-                        </div>
-                      </TableCell>
-                      <TableCell className="w-px items-center px-6 py-4 whitespace-nowrap">
-                        {project.environments &&
-                          project.environments.length > 0 && (
-                            <DeploymentCards
-                              environments={project.environments}
-                              releases={project.current_releases ?? {}}
-                            />
-                          )}
-                      </TableCell>
-                      <TableCell className="px-6 py-4">
-                        <ScoreBadge score={project.score} variant="circle" />
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
+          <div className="border-tertiary bg-secondary text-secondary flex items-stretch border-b text-sm font-medium">
+            <FilterHeader
+              activeFilters={activeTeamSet}
+              centerFilter={{
+                activeFilters: activeTeamSet,
+                label: 'team',
+                onToggle: (s) => toggleFilter('teams', s),
+                options: teamOptions,
+                title: 'Team',
+              }}
+              className="w-72 shrink-0"
+              hideMainFilter
+              label="team"
+              onSort={() => setSort('name')}
+              onToggle={(s) => toggleFilter('teams', s)}
+              options={teamOptions}
+              rightFilter={{
+                activeFilters: activeTypeSet,
+                label: 'type',
+                onToggle: (s) => toggleFilter('types', s),
+                options: typeOptions,
+                title: 'Type',
+              }}
+              sortDir={sortDir}
+              sorted={sortKey === 'name'}
+            >
+              Project
+            </FilterHeader>
+            <SortHeader
+              className="w-32 shrink-0"
+              onSort={() => setSort('prs')}
+              sortDir={sortDir}
+              sorted={sortKey === 'prs'}
+            >
+              PRs
+            </SortHeader>
+            <div className="w-24 shrink-0 px-2.5 py-3 text-center whitespace-nowrap">
+              <div className="flex items-center justify-center gap-1">
+                Drift
+                <FilterPopover
+                  activeFilters={activeDriftSet}
+                  label="drift"
+                  onToggle={(s) => toggleFilter('drifts', s)}
+                  options={driftOptions}
+                />
+              </div>
+            </div>
+            <div className="min-w-0 flex-1 px-6 py-3 text-center whitespace-nowrap">
+              Deployments
+            </div>
+            <SortHeader
+              className="w-28 shrink-0 text-right"
+              onSort={() => setSort('score')}
+              sortDir={sortDir}
+              sorted={sortKey === 'score'}
+            >
+              Health
+            </SortHeader>
+          </div>
+          <div
+            className="divide-tertiary divide-y overflow-y-auto"
+            style={{
+              maxHeight: 'calc(100vh - 330px - var(--assistant-height, 64px))',
+            }}
+          >
+            {/* fallow-ignore-next-line complexity */}
+            {filteredProjects.map((project) => (
+              <div
+                className="hover:bg-secondary flex cursor-pointer items-center transition-colors"
+                key={`row-${project.id}`}
+                onClick={() => handleProjectSelect(project.id)}
+              >
+                <div className="w-72 shrink-0 px-6 py-4">
+                  <p className="text-primary font-medium">{project.name}</p>
+                  {(project.project_types ?? []).length > 0 && (
+                    <p className="text-secondary text-xs">
+                      {project.project_types!.map((pt) => pt.name).join(', ')}
+                    </p>
+                  )}
+                  <p className="text-tertiary text-xs">{project.team.name}</p>
+                </div>
+                <div className="w-32 shrink-0 px-6 py-4">
+                  <div className="flex items-center gap-1.5">
+                    <span className="bg-secondary flex items-center gap-1 rounded-md px-1.5 py-0.5">
+                      <GitPullRequest className="text-action size-3.5" />
+                      <span className="text-action text-xs font-medium">
+                        {project.open_pr_count ?? 0}
+                      </span>
+                    </span>
+                    <span className="border-action flex items-center gap-1 rounded-md border px-1.5 py-0.5">
+                      <User className="text-action size-3.5" />
+                      <span className="text-action text-xs font-medium">
+                        {project.viewer_open_pr_count ?? 0}
+                      </span>
+                    </span>
+                  </div>
+                </div>
+                <div className="w-24 shrink-0 px-2.5 py-4 text-center whitespace-nowrap">
+                  <span className="text-success inline-flex items-center gap-1.5">
+                    <CircleCheck className="size-4 shrink-0" />
+                    <span className="text-xs font-medium">None</span>
+                  </span>
+                </div>
+                <div
+                  className="flex min-w-0 flex-1 overflow-x-auto px-6 py-4"
+                  style={{ justifyContent: 'safe center' }}
+                >
+                  {project.environments && project.environments.length > 0 && (
+                    <DeploymentCards
+                      environments={project.environments}
+                      releases={project.current_releases ?? {}}
+                    />
+                  )}
+                </div>
+                <div className="w-28 shrink-0 px-6 py-4 text-right">
+                  <ScoreBadge score={project.score} variant="circle" />
+                </div>
+              </div>
+            ))}
           </div>
         </Card>
       )}
 
-      {filteredProjects.length === 0 && viewMode !== 'graph' && (
+      {filteredProjects.length === 0 && (
         <div className="py-12 text-center">
           <p className="text-tertiary">
             No projects found matching your criteria
@@ -523,10 +527,8 @@ function DeploymentCards({
       (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.name.localeCompare(b.name),
   )
   return (
-    <div
-      className="flex w-fit items-start gap-2"
-      style={{ flexWrap: 'nowrap' }}
-    >
+    <div className="flex items-start gap-2" style={{ flexWrap: 'nowrap' }}>
+      {/* fallow-ignore-next-line complexity */}
       {sorted.map((env, idx) => {
         const release = releases[env.slug]
         const derived = env.label_color
@@ -544,38 +546,36 @@ function DeploymentCards({
               <ArrowRight className="text-tertiary mx-2 size-3.5 shrink-0" />
             )}
             <span className={cardClass} style={cardStyle}>
-              <p className="text-secondary mb-1.5 flex items-center justify-between gap-1.5 text-sm font-medium">
-                <span className="flex items-center gap-1.5">
-                  <span
-                    className="size-2 shrink-0 rounded-full"
-                    style={
-                      env.label_color
-                        ? { backgroundColor: env.label_color }
-                        : undefined
-                    }
-                  />
-                  {env.name}
-                </span>
-                {release && (
-                  <span className="text-tertiary text-xs font-normal">
-                    {timeAgo(release.deployed_at)}
+              <p className="text-secondary mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+                <span
+                  className="size-2 shrink-0 rounded-full"
+                  style={
+                    env.label_color
+                      ? { backgroundColor: env.label_color }
+                      : undefined
+                  }
+                />
+                {env.name}
+              </p>
+              <p className="font-mono text-base leading-tight font-bold">
+                {release ? (
+                  <span className="text-primary">{release.version}</span>
+                ) : (
+                  <span className="text-tertiary text-sm font-normal">
+                    Not deployed
                   </span>
                 )}
               </p>
-              {release ? (
-                <>
-                  <p className="text-primary font-mono text-base leading-tight font-bold">
-                    {release.version}
-                  </p>
-                  {release.performed_by && (
-                    <p className="text-tertiary mt-1 text-xs">
-                      {release.performed_by}
-                    </p>
-                  )}
-                </>
-              ) : (
-                <p className="text-tertiary font-mono text-sm">Not deployed</p>
-              )}
+              <p className="text-tertiary mt-1 flex items-center justify-between text-xs">
+                {release ? (
+                  <>
+                    <span>{release.performed_by ?? ''}</span>
+                    <span>{timeAgo(release.deployed_at)}</span>
+                  </>
+                ) : (
+                  <span className="invisible">—</span>
+                )}
+              </p>
             </span>
           </span>
         )
@@ -600,9 +600,7 @@ function FilterHeader({
   sorted,
 }: FilterHeaderProps) {
   return (
-    <TableHead
-      className={`text-secondary px-6 py-3 text-left text-sm font-medium ${className ? ` ${className}` : ''}`}
-    >
+    <div className={`px-6 py-3${className ? ` ${className}` : ''}`}>
       <div className="flex items-center justify-between gap-0.5">
         <div className="flex items-center gap-0.5">
           <button
@@ -632,7 +630,7 @@ function FilterHeader({
         </div>
         {centerFilter && (
           <div className="flex items-center gap-1">
-            <span className="text-tertiary/70 text-xs">
+            <span className="text-tertiary text-sm font-medium">
               {centerFilter.title}
             </span>
             <FilterPopover {...centerFilter} />
@@ -640,14 +638,14 @@ function FilterHeader({
         )}
         {rightFilter && (
           <div className="flex items-center gap-1">
-            <span className="text-tertiary/70 text-xs">
+            <span className="text-tertiary text-sm font-medium">
               {rightFilter.title}
             </span>
             <FilterPopover {...rightFilter} />
           </div>
         )}
       </div>
-    </TableHead>
+    </div>
   )
 }
 
@@ -698,10 +696,16 @@ function FilterPopover({
   )
 }
 
-function SortHeader({ children, onSort, sortDir, sorted }: SortHeaderProps) {
+function SortHeader({
+  children,
+  className,
+  onSort,
+  sortDir,
+  sorted,
+}: SortHeaderProps) {
   return (
-    <TableHead
-      className="text-secondary hover:text-primary cursor-pointer px-6 py-3 text-left text-sm font-medium select-none"
+    <div
+      className={`hover:text-primary cursor-pointer px-6 py-3 select-none ${className ? ` ${className}` : ''}`}
       onClick={onSort}
     >
       <span className="inline-flex items-center gap-1">
@@ -716,7 +720,7 @@ function SortHeader({ children, onSort, sortDir, sorted }: SortHeaderProps) {
           <ChevronsUpDown className="text-tertiary/50 size-3.5 shrink-0" />
         )}
       </span>
-    </TableHead>
+    </div>
   )
 }
 

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -34,6 +34,13 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from './ui/hover-card'
 import { Input } from './ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { ScoreBadge } from './ui/score-badge'
+
+interface DriftPair {
+  drifted: boolean
+  from: string
+  to: string
+  toLabelColor?: null | string
+}
 
 interface FilterHeaderProps {
   activeFilters: Set<string>
@@ -78,23 +85,20 @@ export function ProjectsView() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug || ''
 
+  const [storedView] = useState(() =>
+    typeof window === 'undefined'
+      ? null
+      : window.localStorage.getItem(VIEW_MODE_STORAGE_KEY),
+  )
   const rawView = searchParams.get('view')
-  const storedView =
-    typeof window !== 'undefined'
-      ? window.localStorage.getItem(VIEW_MODE_STORAGE_KEY)
-      : null
-  const viewMode: 'grid' | 'list' =
-    rawView === 'grid' || rawView === 'list'
-      ? rawView
-      : storedView === 'grid' || storedView === 'list'
-        ? storedView
-        : 'list'
+  const viewMode = resolveViewMode(rawView, storedView)
   const searchQuery = searchParams.get('q') ?? ''
   const sortKey = searchParams.get('sort') as null | SortKey
   const sortDir = (searchParams.get('dir') ?? 'asc') as SortDir
   const teamsParam = searchParams.get('teams') ?? ''
   const typesParam = searchParams.get('types') ?? ''
   const driftsParam = searchParams.get('drifts') ?? ''
+  const hasDrift = searchParams.get('has_drift') === '1'
   const hasOpenPRs = searchParams.get('has_open_prs') === '1'
   const hasMyOpenPRs = searchParams.get('has_my_open_prs') === '1'
 
@@ -111,16 +115,6 @@ export function ProjectsView() {
       { replace: true },
     )
   }
-
-  useEffect(() => {
-    if (
-      rawView !== 'grid' &&
-      rawView !== 'list' &&
-      typeof window !== 'undefined'
-    ) {
-      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode)
-    }
-  }, [rawView, viewMode])
 
   const setSearchQuery = (q: string) =>
     setSearchParams(
@@ -153,27 +147,19 @@ export function ProjectsView() {
       { replace: true },
     )
 
-  const toggleOpenPRs = () =>
+  const toggleBoolParam = (key: string) => () =>
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev)
-        if (prev.get('has_open_prs') === '1') next.delete('has_open_prs')
-        else next.set('has_open_prs', '1')
+        if (prev.get(key) === '1') next.delete(key)
+        else next.set(key, '1')
         return next
       },
       { replace: true },
     )
-
-  const toggleMyOpenPRs = () =>
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev)
-        if (prev.get('has_my_open_prs') === '1') next.delete('has_my_open_prs')
-        else next.set('has_my_open_prs', '1')
-        return next
-      },
-      { replace: true },
-    )
+  const toggleDrift = toggleBoolParam('has_drift')
+  const toggleOpenPRs = toggleBoolParam('has_open_prs')
+  const toggleMyOpenPRs = toggleBoolParam('has_my_open_prs')
 
   const toggleFilter = (param: string, slug: string) =>
     setSearchParams(
@@ -233,6 +219,13 @@ export function ProjectsView() {
     navigate(`/projects/${projectId}`)
   }
 
+  const driftedProjectIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const p of projects ?? []) if (projectHasDrift(p)) ids.add(p.id)
+    return ids
+  }, [projects])
+  const totalDriftProjects = driftedProjectIds.size
+
   // fallow-ignore-next-line complexity
   const filteredProjects = useMemo(() => {
     const teamSet = new Set(teamsParam.split(',').filter(Boolean))
@@ -256,6 +249,9 @@ export function ProjectsView() {
     }
     if (hasMyOpenPRs) {
       all = all.filter((p) => (p.viewer_open_pr_count ?? 0) > 0)
+    }
+    if (hasDrift) {
+      all = all.filter((p) => driftedProjectIds.has(p.id))
     }
     if (searchQuery) {
       return matchSorter(all, searchQuery, {
@@ -285,39 +281,35 @@ export function ProjectsView() {
     })
   }, [
     projects,
+    driftedProjectIds,
     searchQuery,
     sortKey,
     sortDir,
     teamsParam,
     typesParam,
     driftsParam,
+    hasDrift,
     hasOpenPRs,
     hasMyOpenPRs,
   ])
 
-  const totalOpenPRs = (projects ?? []).reduce(
-    (sum, p) => sum + (p.open_pr_count ?? 0),
-    0,
+  const totalOpenPRs = useMemo(
+    () => (projects ?? []).reduce((sum, p) => sum + (p.open_pr_count ?? 0), 0),
+    [projects],
   )
-  const totalMyOpenPRs = (projects ?? []).reduce(
-    (sum, p) => sum + (p.viewer_open_pr_count ?? 0),
-    0,
+  const totalMyOpenPRs = useMemo(
+    () =>
+      (projects ?? []).reduce(
+        (sum, p) => sum + (p.viewer_open_pr_count ?? 0),
+        0,
+      ),
+    [projects],
   )
 
   const activeTeamSet = new Set(teamsParam.split(',').filter(Boolean))
   const activeTypeSet = new Set(typesParam.split(',').filter(Boolean))
   const activeDriftSet = new Set(driftsParam.split(',').filter(Boolean))
   const driftOptions = [{ label: 'None', slug: 'none' }]
-
-  if (isLoading) {
-    return (
-      <div className="mx-auto max-w-screen-2xl px-6 py-8">
-        <div className="flex h-64 items-center justify-center">
-          <div className="text-lg">Loading projects...</div>
-        </div>
-      </div>
-    )
-  }
 
   return (
     <div className="mx-auto max-w-screen-2xl px-6 py-8">
@@ -326,6 +318,7 @@ export function ProjectsView() {
           <h1 className="text-primary text-2xl font-semibold">Projects</h1>
           <Button
             className="bg-action text-action-foreground hover:bg-action-hover"
+            disabled={isLoading}
             onClick={() => setNewProjectDialogOpen(true)}
             size="sm"
           >
@@ -341,6 +334,7 @@ export function ProjectsView() {
               <Search className="text-tertiary absolute top-1/2 left-3 size-4 -translate-y-1/2" />
               <Input
                 className="pl-9"
+                disabled={isLoading}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search projects..."
                 type="text"
@@ -349,31 +343,40 @@ export function ProjectsView() {
             </div>
 
             <div className="flex flex-1 items-center gap-2">
-              <StatBadge label="Healthy" value={0} variant="success" />
-              <StatBadge label="Deploying" value={0} variant="warning" />
-              <StatBadge label="Failed" value={0} variant="danger" />
+              <StatBadge hidden label="Healthy" value={0} variant="success" />
+              <StatBadge hidden label="Deploying" value={0} variant="warning" />
+              <StatBadge hidden label="Failed" value={0} variant="danger" />
               <StatBadge
                 active={hasOpenPRs}
+                disabled={isLoading}
                 label="Open PRs"
                 onClick={toggleOpenPRs}
                 value={totalOpenPRs}
                 variant="accent"
               />
-              <StatBadge label="Need Release" value={0} variant="amber" />
+              <StatBadge
+                active={hasDrift}
+                disabled={isLoading}
+                label="Need Release"
+                onClick={toggleDrift}
+                value={totalDriftProjects}
+                variant="amber"
+              />
               <StatBadge
                 active={hasMyOpenPRs}
+                disabled={isLoading}
                 label="My PRs"
                 onClick={toggleMyOpenPRs}
                 value={totalMyOpenPRs}
                 variant="info"
               />
-              <StatBadge label="My Commits" value={0} variant="teal" />
             </div>
 
             <div className="border-secondary flex items-center overflow-hidden rounded-lg border">
               <Button
                 aria-label="List view"
                 className={`rounded-r-none ${viewMode === 'list' ? 'bg-amber-bg text-amber-text' : ''}`}
+                disabled={isLoading}
                 onClick={() => setViewMode('list')}
                 size="sm"
                 variant="ghost"
@@ -383,6 +386,7 @@ export function ProjectsView() {
               <Button
                 aria-label="Grid view"
                 className={`rounded-l-none ${viewMode === 'grid' ? 'bg-amber-bg text-amber-text' : ''}`}
+                disabled={isLoading}
                 onClick={() => setViewMode('grid')}
                 size="sm"
                 variant="ghost"
@@ -394,7 +398,7 @@ export function ProjectsView() {
             <div className="border-secondary flex items-center overflow-hidden rounded-lg border">
               <Button
                 aria-label="Refresh"
-                disabled={isFetching}
+                disabled={isFetching || isLoading}
                 onClick={() => refetch()}
                 size="sm"
                 variant="ghost"
@@ -407,9 +411,11 @@ export function ProjectsView() {
           </div>
         </Card>
       </div>
-
-      {/* Projects Grid/List */}
-      {viewMode === 'grid' ? (
+      {isLoading ? (
+        <div className="flex h-64 items-center justify-center">
+          <div className="text-tertiary text-lg">Loading projects...</div>
+        </div>
+      ) : viewMode === 'grid' ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {/* fallow-ignore-next-line complexity */}
           {filteredProjects.map((project) => {
@@ -456,21 +462,17 @@ export function ProjectsView() {
                       className={`border-accent bg-accent text-accent inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs ${(project.open_pr_count ?? 0) > 0 ? '' : 'invisible'}`}
                     >
                       <GitPullRequest className="size-3.5" />
-                      <span className="font-medium">
-                        {project.open_pr_count ?? 0}
-                      </span>
+                      <span>{project.open_pr_count ?? 0}</span>
                     </span>
                     <span
                       className={`border-info bg-info text-info inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs ${(project.viewer_open_pr_count ?? 0) > 0 ? '' : 'invisible'}`}
                     >
                       <User className="size-3.5" />
-                      <span className="font-medium">
-                        {project.viewer_open_pr_count ?? 0}
-                      </span>
+                      <span>{project.viewer_open_pr_count ?? 0}</span>
                     </span>
-                    <span className="text-success text-xs font-medium">
-                      No drift
-                    </span>
+                    <div className="ml-auto flex flex-wrap items-center gap-2">
+                      <DriftCell inline project={project} />
+                    </div>
                     {isProjectDeployable(project) && envs.length > 0 && (
                       <div className="ml-auto flex flex-wrap items-center gap-2">
                         {envs.map((env) => (
@@ -500,7 +502,7 @@ export function ProjectsView() {
                 options: teamOptions,
                 title: 'Team',
               }}
-              className="w-72 shrink-0"
+              className="w-65 shrink-0"
               hideMainFilter
               label="team"
               onSort={() => setSort('name')}
@@ -526,8 +528,8 @@ export function ProjectsView() {
             >
               PRs
             </SortHeader>
-            <div className="w-24 shrink-0 px-2.5 py-3 text-center whitespace-nowrap">
-              <div className="flex items-center justify-center gap-1">
+            <div className="w-40 shrink-0 px-2.5 py-3 text-center whitespace-nowrap">
+              <div className="flex items-center justify-center gap-1 text-center">
                 Drift
                 <FilterPopover
                   activeFilters={activeDriftSet}
@@ -538,7 +540,7 @@ export function ProjectsView() {
               </div>
             </div>
             <div className="min-w-0 flex-1 px-6 py-3 text-center whitespace-nowrap">
-              Deployments
+              Current Deployments
             </div>
             <SortHeader
               className="w-40 shrink-0 text-center whitespace-nowrap"
@@ -562,7 +564,7 @@ export function ProjectsView() {
                 key={`row-${project.id}`}
                 onClick={() => handleProjectSelect(project.id)}
               >
-                <div className="w-72 shrink-0 px-6 py-4">
+                <div className="w-65 shrink-0 px-6 py-4">
                   <p className="text-primary font-medium">{project.name}</p>
                   {(project.project_types ?? []).length > 0 && (
                     <p className="text-secondary text-xs">
@@ -574,28 +576,21 @@ export function ProjectsView() {
                 <div className="w-40 shrink-0 px-6 py-4 whitespace-nowrap">
                   <div className="flex items-center justify-center gap-1.5">
                     {(project.open_pr_count ?? 0) > 0 && (
-                      <span className="border-accent bg-accent text-accent inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs">
+                      <span className="border-accent bg-accent text-accent inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs">
                         <GitPullRequest className="size-3.5" />
-                        <span className="font-medium">
-                          {project.open_pr_count}
-                        </span>
+                        <span>{project.open_pr_count}</span>
                       </span>
                     )}
                     {(project.viewer_open_pr_count ?? 0) > 0 && (
-                      <span className="border-info bg-info text-info inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs">
+                      <span className="border-info bg-info text-info inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs">
                         <User className="size-3.5" />
-                        <span className="font-medium">
-                          {project.viewer_open_pr_count}
-                        </span>
+                        <span>{project.viewer_open_pr_count}</span>
                       </span>
                     )}
                   </div>
                 </div>
-                <div className="w-24 shrink-0 px-2.5 py-4 text-center whitespace-nowrap">
-                  <span className="text-success inline-flex items-center gap-1.5">
-                    <CircleCheck className="size-4 shrink-0" />
-                    <span className="font-medium">None</span>
-                  </span>
+                <div className="flex w-40 shrink-0 items-center justify-center px-5 py-4">
+                  <DriftCell project={project} />
                 </div>
                 <div
                   className="flex min-w-0 flex-1 overflow-x-auto px-6 py-4"
@@ -622,15 +617,13 @@ export function ProjectsView() {
           </div>
         </Card>
       )}
-
-      {filteredProjects.length === 0 && (
+      {!isLoading && filteredProjects.length === 0 && (
         <div className="py-12 text-center">
           <p className="text-tertiary">
             No projects found matching your criteria
           </p>
         </div>
       )}
-
       <NewProjectDialog
         isOpen={newProjectDialogOpen}
         onClose={() => setNewProjectDialogOpen(false)}
@@ -638,6 +631,48 @@ export function ProjectsView() {
       />
     </div>
   )
+}
+
+function abbreviateEnvName(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return ''
+  if (parts.length === 1) return parts[0][0]!.toUpperCase()
+  return parts.map((w) => w[0]!.toUpperCase()).join('')
+}
+
+// fallow-ignore-next-line complexity
+function computeDriftPairs(
+  environments: {
+    label_color?: null | string
+    name: string
+    slug: string
+    sort_order?: null | number
+  }[],
+  releases: Record<string, { committish?: null | string; tag?: null | string }>,
+): DriftPair[] {
+  const sorted = [...environments].sort(
+    (a, b) =>
+      (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.name.localeCompare(b.name),
+  )
+  const pairs: DriftPair[] = []
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const a = sorted[i]
+    const b = sorted[i + 1]
+    const ra = releases[a.slug]
+    const rb = releases[b.slug]
+    const aTag = ra?.tag ?? null
+    const bTag = rb?.tag ?? null
+    const aSha = ra?.committish ?? null
+    const bSha = rb?.committish ?? null
+    const drifted = aTag !== bTag || aSha !== bSha
+    pairs.push({
+      drifted,
+      from: a.name,
+      to: b.name,
+      toLabelColor: b.label_color ?? null,
+    })
+  }
+  return pairs
 }
 
 function DeploymentCards({
@@ -673,8 +708,8 @@ function DeploymentCards({
           ? deriveChipColors(env.label_color, false)
           : null
         const cardClass = derived
-          ? `w-55 rounded-lg border p-3${!release ? ' border-dashed opacity-60' : ''}`
-          : `w-55 rounded-lg border p-3${release ? ' border-border bg-card' : ' border-tertiary/40 border-dashed opacity-60'}`
+          ? `w-50 rounded-lg border px-3 py-2${!release ? ' border-dashed opacity-60' : ''}`
+          : `w-50 rounded-lg border px-3 py-2${release ? ' border-border bg-card' : ' border-tertiary/40 border-dashed opacity-60'}`
         const cardStyle = derived
           ? { backgroundColor: derived.bg, borderColor: derived.border }
           : undefined
@@ -694,25 +729,26 @@ function DeploymentCards({
                   }
                 />
                 {env.name}
-                <CircleCheck className="text-success ml-auto size-4 shrink-0" />
               </p>
-              <p className="font-mono text-base leading-tight">
-                {release ? (
-                  <>
-                    <span className="text-primary">
-                      {release.tag ?? release.committish ?? '—'}
-                    </span>
-                    {release.tag && release.committish && (
-                      <span className="text-tertiary ml-2 text-xs font-normal">
-                        {release.committish}
+              <p className="flex items-center gap-2 font-mono text-base leading-tight">
+                <span className="min-w-0 flex-1">
+                  {release ? (
+                    <>
+                      <span className="text-primary">
+                        {release.tag ?? release.committish ?? '—'}
                       </span>
-                    )}
-                  </>
-                ) : (
-                  <span className="text-tertiary text-sm font-normal">
-                    Not deployed
-                  </span>
-                )}
+                      {release.tag && release.committish && (
+                        <span className="text-tertiary ml-2 text-xs font-normal">
+                          {release.committish}
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="text-tertiary text-sm font-normal">
+                      Not deployed
+                    </span>
+                  )}
+                </span>
               </p>
               <p className="text-tertiary mt-1 flex items-center justify-between text-xs">
                 {release ? (
@@ -725,6 +761,81 @@ function DeploymentCards({
                 )}
               </p>
             </span>
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function DriftCell({
+  inline,
+  project,
+}: {
+  inline?: boolean
+  project: {
+    current_releases?: null | Record<
+      string,
+      { committish?: null | string; tag?: null | string }
+    >
+    environments?:
+      | null
+      | {
+          label_color?: null | string
+          name: string
+          slug: string
+          sort_order?: null | number
+        }[]
+    project_types?: null | object[]
+  }
+}) {
+  const { isDarkMode } = useTheme()
+  if (!isProjectDeployable(project)) return null
+  const envs = project.environments ?? []
+  if (envs.length < 2) {
+    return null
+  }
+  const pairs = computeDriftPairs(envs, project.current_releases ?? {})
+  const drifted = pairs.filter((p) => p.drifted)
+  if (drifted.length === 0) {
+    return null
+  }
+  const containerCls = inline
+    ? 'flex flex-row flex-wrap items-center gap-1'
+    : 'flex flex-col items-center gap-1.5'
+  const badgeBaseCls = inline
+    ? 'inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-mono text-xs'
+    : 'inline-flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-xs'
+  const fallbackCls = 'border-amber-border bg-amber-bg text-amber-text border'
+  return (
+    <div className={containerCls}>
+      {drifted.map((p) => {
+        const derived = p.toLabelColor
+          ? deriveChipColors(p.toLabelColor, isDarkMode)
+          : null
+        return (
+          <span
+            className={
+              derived
+                ? `${badgeBaseCls} border`
+                : `${badgeBaseCls} ${fallbackCls}`
+            }
+            key={`${p.from}->${p.to}`}
+            style={
+              derived
+                ? {
+                    backgroundColor: derived.bg,
+                    borderColor: derived.border,
+                    color: derived.fg,
+                  }
+                : undefined
+            }
+          >
+            <span className="font-medium">Δ</span>
+            <span>{abbreviateEnvName(p.from)}</span>
+            <span>→</span>
+            <span>{abbreviateEnvName(p.to)}</span>
           </span>
         )
       })}
@@ -780,25 +891,27 @@ function EnvDeploymentHover({
               }
             />
             {env.name}
-            <CircleCheck className="text-success ml-auto size-4 shrink-0" />
           </p>
-          <p className="font-mono text-base leading-tight font-bold">
-            {release ? (
-              <>
-                <span className="text-primary">
-                  {release.tag ?? release.committish ?? '—'}
-                </span>
-                {release.tag && release.committish && (
-                  <span className="text-tertiary ml-2 text-xs font-normal">
-                    {release.committish}
+          <p className="flex items-center gap-2 font-mono text-base leading-tight font-bold">
+            <span className="min-w-0 flex-1">
+              {release ? (
+                <>
+                  <span className="text-primary">
+                    {release.tag ?? release.committish ?? '—'}
                   </span>
-                )}
-              </>
-            ) : (
-              <span className="text-tertiary text-sm font-normal">
-                Not deployed
-              </span>
-            )}
+                  {release.tag && release.committish && (
+                    <span className="text-tertiary ml-2 text-xs font-normal">
+                      {release.committish}
+                    </span>
+                  )}
+                </>
+              ) : (
+                <span className="text-tertiary text-sm font-normal">
+                  Not deployed
+                </span>
+              )}
+            </span>
+            <CircleCheck className="text-success size-4 shrink-0" />
           </p>
           <p className="text-tertiary mt-1 flex items-center justify-between text-xs">
             {release ? (
@@ -936,6 +1049,39 @@ function isProjectDeployable(project: {
   )
 }
 
+// fallow-ignore-next-line complexity
+function projectHasDrift(project: {
+  current_releases?: null | Record<
+    string,
+    { committish?: null | string; tag?: null | string }
+  >
+  environments?:
+    | null
+    | {
+        label_color?: null | string
+        name: string
+        slug: string
+        sort_order?: null | number
+      }[]
+  project_types?: null | object[]
+}): boolean {
+  if (!isProjectDeployable(project)) return false
+  const envs = project.environments ?? []
+  if (envs.length < 2) return false
+  const pairs = computeDriftPairs(envs, project.current_releases ?? {})
+  return pairs.some((p) => p.drifted)
+}
+
+// fallow-ignore-next-line complexity
+function resolveViewMode(
+  raw: null | string,
+  stored: null | string,
+): 'grid' | 'list' {
+  if (raw === 'grid' || raw === 'list') return raw
+  if (stored === 'grid' || stored === 'list') return stored
+  return 'list'
+}
+
 function SortHeader({
   children,
   className,
@@ -967,12 +1113,16 @@ function SortHeader({
 // fallow-ignore-next-line complexity
 function StatBadge({
   active,
+  disabled,
+  hidden,
   label,
   onClick,
   value,
   variant,
 }: {
   active?: boolean
+  disabled?: boolean
+  hidden?: boolean
   label: string
   onClick?: () => void
   value: number
@@ -985,6 +1135,7 @@ function StatBadge({
     | 'teal'
     | 'warning'
 }) {
+  if (hidden) return null
   const variantCls =
     variant === 'success'
       ? 'bg-success border-success text-success'
@@ -1002,7 +1153,9 @@ function StatBadge({
                   ? 'bg-amber-bg border-amber-border text-amber-text'
                   : 'border-secondary text-secondary'
   const interactiveCls = onClick
-    ? `cursor-pointer transition-shadow${active ? ' ring-2 ring-current ring-offset-2 ring-offset-background' : ' hover:ring-1 hover:ring-current hover:ring-offset-1 hover:ring-offset-background'}`
+    ? disabled
+      ? 'cursor-not-allowed opacity-50'
+      : `cursor-pointer transition-shadow${active ? ' ring-2 ring-current ring-offset-2 ring-offset-background' : ' hover:ring-1 hover:ring-current hover:ring-offset-1 hover:ring-offset-background'}`
     : ''
   const content = (
     <>
@@ -1018,6 +1171,7 @@ function StatBadge({
       <button
         aria-pressed={active}
         className={cls}
+        disabled={disabled}
         onClick={onClick}
         type="button"
       >

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -664,10 +664,17 @@ function SortHeader({ children, onSort, sortDir, sorted }: SortHeaderProps) {
   )
 }
 
+// fallow-ignore-next-line complexity
 function timeAgo(iso: string): string {
   const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000)
   if (mins < 60) return `${mins}m ago`
   const hours = Math.floor(mins / 60)
   if (hours < 24) return `${hours}h ago`
-  return `${Math.floor(hours / 24)}d ago`
+  const days = Math.floor(hours / 24)
+  if (days < 14) return `${days}d ago`
+  const months = Math.round(days / 30.44)
+  if (days < 365) return `${months}mo ago`
+  const years = days / 365.25
+  const rounded = Math.round(years * 10) / 10
+  return `${rounded}y ago`
 }

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -347,7 +347,7 @@ export function ProjectsView() {
                 )}
                 {((project.open_pr_count ?? 0) > 0 ||
                   (project.closed_pr_count ?? 0) > 0) && (
-                  <div className="mt-2 flex items-center gap-2">
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
                     {(project.open_pr_count ?? 0) > 0 && (
                       <span className="text-action flex items-center gap-1 text-xs font-medium">
                         <GitPullRequest className="size-3" />
@@ -358,6 +358,12 @@ export function ProjectsView() {
                       <span className="text-tertiary flex items-center gap-1 text-xs">
                         <GitPullRequest className="size-3" />
                         {project.closed_pr_count} closed
+                      </span>
+                    )}
+                    {(project.viewer_open_pr_count ?? 0) > 0 && (
+                      <span className="text-amber-text flex items-center gap-1 text-xs font-medium">
+                        <GitPullRequest className="size-3" />
+                        {project.viewer_open_pr_count} mine
                       </span>
                     )}
                   </div>
@@ -468,6 +474,12 @@ export function ProjectsView() {
                             <span className="text-tertiary flex items-center gap-1 text-xs">
                               <GitPullRequest className="size-3" />
                               {project.closed_pr_count} closed
+                            </span>
+                          )}
+                          {(project.viewer_open_pr_count ?? 0) > 0 && (
+                            <span className="text-amber-text flex items-center gap-1 text-xs font-medium">
+                              <GitPullRequest className="size-3" />
+                              {project.viewer_open_pr_count} mine
                             </span>
                           )}
                         </div>

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -628,7 +628,12 @@ function DeploymentCards({
   }[]
   releases: Record<
     string,
-    { deployed_at: string; performed_by?: null | string; version: string }
+    {
+      committish?: null | string
+      deployed_at: string
+      performed_by?: null | string
+      tag?: null | string
+    }
   >
 }) {
   const sorted = [...environments].sort(
@@ -669,7 +674,16 @@ function DeploymentCards({
               </p>
               <p className="font-mono text-base leading-tight">
                 {release ? (
-                  <span className="text-primary">{release.version}</span>
+                  <>
+                    <span className="text-primary">
+                      {release.tag ?? release.committish ?? '—'}
+                    </span>
+                    {release.tag && release.committish && (
+                      <span className="text-tertiary ml-2 text-xs font-normal">
+                        {release.committish}
+                      </span>
+                    )}
+                  </>
                 ) : (
                   <span className="text-tertiary text-sm font-normal">
                     Not deployed
@@ -706,9 +720,10 @@ function EnvDeploymentHover({
     sort_order?: null | number
   }
   release?: {
+    committish?: null | string
     deployed_at: string
     performed_by?: null | string
-    version: string
+    tag?: null | string
   }
 }) {
   const { isDarkMode } = useTheme()
@@ -745,7 +760,16 @@ function EnvDeploymentHover({
           </p>
           <p className="font-mono text-base leading-tight font-bold">
             {release ? (
-              <span className="text-primary">{release.version}</span>
+              <>
+                <span className="text-primary">
+                  {release.tag ?? release.committish ?? '—'}
+                </span>
+                {release.tag && release.committish && (
+                  <span className="text-tertiary ml-2 text-xs font-normal">
+                    {release.committish}
+                  </span>
+                )}
+              </>
             ) : (
               <span className="text-tertiary text-sm font-normal">
                 Not deployed

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -14,6 +14,7 @@ import {
   List,
   ListFilter,
   Plus,
+  RefreshCw,
   Search,
   User,
 } from 'lucide-react'
@@ -141,7 +142,12 @@ export function ProjectsView() {
 
   const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false)
 
-  const { data: projects, isLoading } = useQuery({
+  const {
+    data: projects,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => getProjects(orgSlug, signal),
     queryKey: ['projects', orgSlug],
@@ -263,15 +269,25 @@ export function ProjectsView() {
         {/* Search and Filters */}
         <Card className="p-4">
           <div className="flex items-center gap-3">
-            <div className="relative max-w-md flex-1">
+            <div className="relative w-80 shrink-0">
               <Search className="text-tertiary absolute top-1/2 left-3 size-4 -translate-y-1/2" />
               <Input
-                className={`pl-9 ${''}`}
+                className="pl-9"
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search projects..."
                 type="text"
                 value={searchQuery}
               />
+            </div>
+
+            <div className="flex flex-1 items-center gap-2">
+              <StatBadge label="Healthy" value={0} variant="success" />
+              <StatBadge label="Deploying" value={0} variant="warning" />
+              <StatBadge label="Failed" value={0} variant="danger" />
+              <StatBadge label="Open PRs" value={0} variant="accent" />
+              <StatBadge label="Need Release" value={0} variant="amber" />
+              <StatBadge label="My PRs" value={0} variant="info" />
+              <StatBadge label="My Commits" value={0} variant="teal" />
             </div>
 
             <div className="border-secondary flex items-center rounded-lg border">
@@ -292,6 +308,20 @@ export function ProjectsView() {
                 variant="ghost"
               >
                 <List className="size-4" />
+              </Button>
+            </div>
+
+            <div className="border-secondary flex items-center rounded-lg border">
+              <Button
+                aria-label="Refresh"
+                disabled={isFetching}
+                onClick={() => refetch()}
+                size="sm"
+                variant="ghost"
+              >
+                <RefreshCw
+                  className={`size-4${isFetching ? ' animate-spin' : ''}`}
+                />
               </Button>
             </div>
           </div>
@@ -323,7 +353,7 @@ export function ProjectsView() {
                   <div className="ml-3">
                     <ScoreBadge
                       score={project.score}
-                      size="md"
+                      size="lg"
                       variant="circle"
                     />
                   </div>
@@ -396,7 +426,7 @@ export function ProjectsView() {
               Project
             </FilterHeader>
             <SortHeader
-              className="w-32 shrink-0"
+              className="w-40 shrink-0 text-center whitespace-nowrap"
               onSort={() => setSort('prs')}
               sortDir={sortDir}
               sorted={sortKey === 'prs'}
@@ -418,12 +448,12 @@ export function ProjectsView() {
               Deployments
             </div>
             <SortHeader
-              className="w-28 shrink-0 text-right"
+              className="w-40 shrink-0 text-center whitespace-nowrap"
               onSort={() => setSort('score')}
               sortDir={sortDir}
               sorted={sortKey === 'score'}
             >
-              Health
+              Health Score
             </SortHeader>
           </div>
           <div
@@ -448,17 +478,17 @@ export function ProjectsView() {
                   )}
                   <p className="text-tertiary text-xs">{project.team.name}</p>
                 </div>
-                <div className="w-32 shrink-0 px-6 py-4">
-                  <div className="flex items-center gap-1.5">
-                    <span className="bg-secondary flex items-center gap-1 rounded-md px-1.5 py-0.5">
-                      <GitPullRequest className="text-action size-3.5" />
-                      <span className="text-action text-xs font-medium">
+                <div className="w-40 shrink-0 px-6 py-4 whitespace-nowrap">
+                  <div className="flex items-center justify-center gap-1.5">
+                    <span className="border-accent bg-accent text-accent inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs">
+                      <GitPullRequest className="size-3.5" />
+                      <span className="font-medium">
                         {project.open_pr_count ?? 0}
                       </span>
                     </span>
-                    <span className="border-action flex items-center gap-1 rounded-md border px-1.5 py-0.5">
-                      <User className="text-action size-3.5" />
-                      <span className="text-action text-xs font-medium">
+                    <span className="border-info bg-info text-info inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs">
+                      <User className="size-3.5" />
+                      <span className="font-medium">
                         {project.viewer_open_pr_count ?? 0}
                       </span>
                     </span>
@@ -467,7 +497,7 @@ export function ProjectsView() {
                 <div className="w-24 shrink-0 px-2.5 py-4 text-center whitespace-nowrap">
                   <span className="text-success inline-flex items-center gap-1.5">
                     <CircleCheck className="size-4 shrink-0" />
-                    <span className="text-xs font-medium">None</span>
+                    <span className="font-medium">None</span>
                   </span>
                 </div>
                 <div
@@ -481,8 +511,12 @@ export function ProjectsView() {
                     />
                   )}
                 </div>
-                <div className="w-28 shrink-0 px-6 py-4 text-right">
-                  <ScoreBadge score={project.score} variant="circle" />
+                <div className="flex w-40 shrink-0 justify-center px-6 py-4 whitespace-nowrap">
+                  <ScoreBadge
+                    score={project.score}
+                    size="md"
+                    variant="circle"
+                  />
                 </div>
               </div>
             ))}
@@ -721,6 +755,51 @@ function SortHeader({
         )}
       </span>
     </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function StatBadge({
+  label,
+  value,
+  variant,
+}: {
+  label: string
+  value: number
+  variant?:
+    | 'accent'
+    | 'amber'
+    | 'danger'
+    | 'info'
+    | 'success'
+    | 'teal'
+    | 'warning'
+}) {
+  const variantCls =
+    variant === 'success'
+      ? 'bg-success border-success text-success'
+      : variant === 'warning'
+        ? 'bg-warning border-warning text-warning'
+        : variant === 'danger'
+          ? 'bg-danger border-danger text-danger'
+          : variant === 'accent'
+            ? 'bg-accent border-accent text-accent'
+            : variant === 'info'
+              ? 'bg-info border-info text-info'
+              : variant === 'teal'
+                ? 'bg-teal border-teal text-teal'
+                : variant === 'amber'
+                  ? 'bg-amber-bg border-amber-border text-amber-text'
+                  : 'border-secondary text-secondary'
+  return (
+    <span
+      className={`inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs ${variantCls}`}
+    >
+      <span className={variant ? 'font-medium' : 'text-primary font-medium'}>
+        {value}
+      </span>
+      <span>{label}</span>
+    </span>
   )
 }
 

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -465,24 +465,18 @@ export function ProjectsView() {
                       </TableCell>
                       <TableCell className="px-6 py-4">
                         <div className="flex flex-col gap-0.5">
-                          {(project.open_pr_count ?? 0) > 0 && (
-                            <span className="text-action flex items-center gap-1 text-xs font-medium">
-                              <GitPullRequest className="size-3" />
-                              {project.open_pr_count} open
-                            </span>
-                          )}
-                          {(project.closed_pr_count ?? 0) > 0 && (
-                            <span className="text-tertiary flex items-center gap-1 text-xs">
-                              <GitPullRequest className="size-3" />
-                              {project.closed_pr_count} closed
-                            </span>
-                          )}
-                          {(project.viewer_open_pr_count ?? 0) > 0 && (
-                            <span className="text-amber-text flex items-center gap-1 text-xs font-medium">
-                              <GitPullRequest className="size-3" />
-                              {project.viewer_open_pr_count} mine
-                            </span>
-                          )}
+                          <span className="text-action flex items-center gap-1 text-xs font-medium">
+                            <GitPullRequest className="size-3" />
+                            {project.open_pr_count ?? 0} open
+                          </span>
+                          <span className="text-tertiary flex items-center gap-1 text-xs">
+                            <GitPullRequest className="size-3" />
+                            {project.closed_pr_count ?? 0} closed
+                          </span>
+                          <span className="text-amber-text flex items-center gap-1 text-xs font-medium">
+                            <GitPullRequest className="size-3" />
+                            {project.viewer_open_pr_count ?? 0} mine
+                          </span>
                         </div>
                       </TableCell>
                       <TableCell className="px-6 py-4">

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -381,6 +381,7 @@ export function ProjectsView() {
                   </FilterHeader>
                   <FilterHeader
                     activeFilters={activeTypeSet}
+                    className="min-w-48"
                     label="type"
                     onSort={() => setSort('type')}
                     onToggle={(s) => toggleFilter('types', s)}
@@ -428,7 +429,7 @@ export function ProjectsView() {
                           </p>
                         </div>
                       </TableCell>
-                      <TableCell className="text-secondary px-6 py-4">
+                      <TableCell className="text-secondary min-w-48 px-6 py-4">
                         {(project.project_types || [])
                           .map((pt) => pt.name)
                           .join(', ')}
@@ -525,26 +526,34 @@ function DeploymentCards({
               <ArrowRight className="text-tertiary mx-2 size-3.5 shrink-0" />
             )}
             <span className={cardClass} style={cardStyle}>
-              <p className="text-secondary mb-1.5 flex items-center gap-1.5 text-sm font-medium">
-                <span
-                  className="size-2 shrink-0 rounded-full"
-                  style={
-                    env.label_color
-                      ? { backgroundColor: env.label_color }
-                      : undefined
-                  }
-                />
-                {env.name}
+              <p className="text-secondary mb-1.5 flex items-center justify-between gap-1.5 text-sm font-medium">
+                <span className="flex items-center gap-1.5">
+                  <span
+                    className="size-2 shrink-0 rounded-full"
+                    style={
+                      env.label_color
+                        ? { backgroundColor: env.label_color }
+                        : undefined
+                    }
+                  />
+                  {env.name}
+                </span>
+                {release && (
+                  <span className="text-tertiary text-xs font-normal">
+                    {timeAgo(release.deployed_at)}
+                  </span>
+                )}
               </p>
               {release ? (
                 <>
                   <p className="text-primary font-mono text-base leading-tight font-bold">
                     {release.version}
                   </p>
-                  <p className="text-tertiary mt-1 text-xs">
-                    {release.performed_by ? `${release.performed_by} · ` : ''}
-                    {timeAgo(release.deployed_at)}
-                  </p>
+                  {release.performed_by && (
+                    <p className="text-tertiary mt-1 text-xs">
+                      {release.performed_by}
+                    </p>
+                  )}
                 </>
               ) : (
                 <p className="text-tertiary font-mono text-sm">Not deployed</p>

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -242,7 +242,9 @@ export function ProjectsView() {
       )
     }
     if (driftSet.size > 0) {
-      all = all.filter(() => driftSet.has('none'))
+      all = all.filter((p) =>
+        driftSet.has('none') ? !driftedProjectIds.has(p.id) : true,
+      )
     }
     if (hasOpenPRs) {
       all = all.filter((p) => (p.open_pr_count ?? 0) > 0)
@@ -664,7 +666,11 @@ function computeDriftPairs(
     const bTag = rb?.tag ?? null
     const aSha = ra?.committish ?? null
     const bSha = rb?.committish ?? null
-    const drifted = aTag !== bTag || aSha !== bSha
+    // When both envs have a SHA, compare them directly so that a tag-only
+    // difference on identical commits does not register as drift. Otherwise
+    // fall back to tag-or-SHA equality.
+    const drifted =
+      aSha && bSha ? aSha !== bSha : (aTag ?? aSha) !== (bTag ?? bSha)
     pairs.push({
       drifted,
       from: a.name,
@@ -911,7 +917,9 @@ function EnvDeploymentHover({
                 </span>
               )}
             </span>
-            <CircleCheck className="text-success size-4 shrink-0" />
+            {release && (
+              <CircleCheck className="text-success size-4 shrink-0" />
+            )}
           </p>
           <p className="text-tertiary mt-1 flex items-center justify-between text-xs">
             {release ? (

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
 import {
+  ArrowRight,
   ChevronDown,
   ChevronsUpDown,
   ChevronUp,
@@ -20,6 +21,8 @@ import { matchSorter } from 'match-sorter'
 
 import { getProjects } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useTheme } from '@/contexts/ThemeContext'
+import { deriveChipColors } from '@/lib/chip-colors'
 
 import { NewProjectDialog } from './NewProjectDialog'
 import { ProjectGraphView } from './ProjectGraphView'
@@ -28,7 +31,6 @@ import { Card } from './ui/card'
 import { Checkbox } from './ui/checkbox'
 import { Input } from './ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
-import { buildReleaseTrainStops, ReleaseTrain } from './ui/release-train'
 import { ScoreBadge } from './ui/score-badge'
 import {
   Table,
@@ -334,19 +336,14 @@ export function ProjectsView() {
                 </div>
 
                 {project.environments && project.environments.length > 0 && (
-                  <ReleaseTrain
-                    size="compact"
-                    stops={buildReleaseTrainStops(
-                      project.environments,
-                      new Map(
-                        Object.entries(project.current_releases ?? {}).map(
-                          ([slug, r]) => [slug, r.version],
-                        ),
-                      ),
-                    )}
-                  />
+                  <div className="mb-2">
+                    <DeploymentCards
+                      environments={project.environments}
+                      releases={project.current_releases ?? {}}
+                    />
+                  </div>
                 )}
-                <div className="mt-2 flex items-center gap-1.5">
+                <div className="flex items-center gap-1.5">
                   <span className="bg-secondary flex items-center gap-1 rounded-md px-1.5 py-0.5">
                     <GitPullRequest className="text-action size-3.5" />
                     <span className="text-action text-xs font-medium">
@@ -370,13 +367,17 @@ export function ProjectsView() {
             <Table>
               <TableHeader className="border-tertiary bg-secondary border-b">
                 <TableRow>
-                  <SortHeader
+                  <FilterHeader
+                    activeFilters={activeTeamSet}
+                    label="team"
                     onSort={() => setSort('name')}
+                    onToggle={(s) => toggleFilter('teams', s)}
+                    options={teamOptions}
                     sortDir={sortDir}
                     sorted={sortKey === 'name'}
                   >
                     Project
-                  </SortHeader>
+                  </FilterHeader>
                   <FilterHeader
                     activeFilters={activeTypeSet}
                     label="type"
@@ -388,20 +389,6 @@ export function ProjectsView() {
                   >
                     Type
                   </FilterHeader>
-                  <FilterHeader
-                    activeFilters={activeTeamSet}
-                    label="team"
-                    onSort={() => setSort('team')}
-                    onToggle={(s) => toggleFilter('teams', s)}
-                    options={teamOptions}
-                    sortDir={sortDir}
-                    sorted={sortKey === 'team'}
-                  >
-                    Team
-                  </FilterHeader>
-                  <TableHead className="text-secondary px-6 py-3 text-left text-sm font-medium">
-                    Environments
-                  </TableHead>
                   <SortHeader
                     onSort={() => setSort('prs')}
                     sortDir={sortDir}
@@ -409,6 +396,9 @@ export function ProjectsView() {
                   >
                     PRs
                   </SortHeader>
+                  <TableHead className="text-secondary px-6 py-3 text-left text-sm font-medium">
+                    Deployments
+                  </TableHead>
                   <SortHeader
                     onSort={() => setSort('score')}
                     sortDir={sortDir}
@@ -427,32 +417,20 @@ export function ProjectsView() {
                       key={`table-${project.id}`}
                       onClick={() => handleProjectSelect(project.id)}
                     >
-                      <TableCell className="text-primary px-6 py-4 font-medium">
-                        {project.name}
+                      <TableCell className="px-6 py-4">
+                        <div>
+                          <p className="text-primary font-medium">
+                            {project.name}
+                          </p>
+                          <p className="text-tertiary text-xs">
+                            {project.team.name}
+                          </p>
+                        </div>
                       </TableCell>
                       <TableCell className="text-secondary px-6 py-4">
                         {(project.project_types || [])
                           .map((pt) => pt.name)
                           .join(', ')}
-                      </TableCell>
-                      <TableCell className="text-secondary px-6 py-4">
-                        {project.team.name}
-                      </TableCell>
-                      <TableCell className="px-6 py-4">
-                        {project.environments &&
-                          project.environments.length > 0 && (
-                            <ReleaseTrain
-                              size="compact"
-                              stops={buildReleaseTrainStops(
-                                project.environments,
-                                new Map(
-                                  Object.entries(
-                                    project.current_releases ?? {},
-                                  ).map(([slug, r]) => [slug, r.version]),
-                                ),
-                              )}
-                            />
-                          )}
                       </TableCell>
                       <TableCell className="px-6 py-4">
                         <div className="flex items-center gap-1.5">
@@ -469,6 +447,15 @@ export function ProjectsView() {
                             </span>
                           </span>
                         </div>
+                      </TableCell>
+                      <TableCell className="px-6 py-4">
+                        {project.environments &&
+                          project.environments.length > 0 && (
+                            <DeploymentCards
+                              environments={project.environments}
+                              releases={project.current_releases ?? {}}
+                            />
+                          )}
                       </TableCell>
                       <TableCell className="px-6 py-4">
                         <ScoreBadge score={project.score} variant="circle" />
@@ -495,6 +482,73 @@ export function ProjectsView() {
         onClose={() => setNewProjectDialogOpen(false)}
         onProjectCreated={(id) => navigate(`/projects/${id}`)}
       />
+    </div>
+  )
+}
+
+function DeploymentCards({
+  environments,
+  releases,
+}: {
+  environments: {
+    label_color?: null | string
+    name: string
+    slug: string
+    sort_order?: null | number
+  }[]
+  releases: Record<
+    string,
+    { deployed_at: string; performed_by?: null | string; version: string }
+  >
+}) {
+  const { isDarkMode } = useTheme()
+  const sorted = [...environments].sort(
+    (a, b) =>
+      (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.name.localeCompare(b.name),
+  )
+  return (
+    <div className="flex items-start gap-2" style={{ flexWrap: 'nowrap' }}>
+      {sorted.map((env, idx) => {
+        const release = releases[env.slug]
+        const derived = env.label_color
+          ? deriveChipColors(env.label_color, isDarkMode)
+          : null
+        return (
+          <span className="flex shrink-0 items-center" key={env.slug}>
+            {idx > 0 && (
+              <ArrowRight className="text-tertiary mx-2 size-3.5 shrink-0" />
+            )}
+            <span
+              className={`min-w-35 rounded-lg p-3 ${
+                release
+                  ? 'border-border bg-card border'
+                  : 'border-tertiary/40 border border-dashed opacity-60'
+              }`}
+            >
+              <p className="text-secondary mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+                <span
+                  className="size-2 rounded-full"
+                  style={derived ? { backgroundColor: derived.fg } : undefined}
+                />
+                {env.name}
+              </p>
+              {release ? (
+                <>
+                  <p className="text-primary font-mono text-base leading-tight font-bold">
+                    {release.version}
+                  </p>
+                  <p className="text-tertiary mt-1 text-xs">
+                    {release.performed_by ? `${release.performed_by} · ` : ''}
+                    {timeAgo(release.deployed_at)}
+                  </p>
+                </>
+              ) : (
+                <p className="text-tertiary font-mono text-sm">Not deployed</p>
+              )}
+            </span>
+          </span>
+        )
+      })}
     </div>
   )
 }
@@ -592,4 +646,12 @@ function SortHeader({ children, onSort, sortDir, sorted }: SortHeaderProps) {
       </span>
     </TableHead>
   )
+}
+
+function timeAgo(iso: string): string {
+  const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
 }

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -450,7 +450,7 @@ export function ProjectsView() {
                           </span>
                         </div>
                       </TableCell>
-                      <TableCell className="px-6 py-4">
+                      <TableCell className="items-center px-6 py-4">
                         {project.environments &&
                           project.environments.length > 0 && (
                             <DeploymentCards
@@ -508,15 +508,18 @@ function DeploymentCards({
       (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.name.localeCompare(b.name),
   )
   return (
-    <div className="flex items-start gap-2" style={{ flexWrap: 'nowrap' }}>
+    <div
+      className="flex w-fit items-start gap-2"
+      style={{ flexWrap: 'nowrap' }}
+    >
       {sorted.map((env, idx) => {
         const release = releases[env.slug]
         const derived = env.label_color
           ? deriveChipColors(env.label_color, false)
           : null
         const cardClass = derived
-          ? `w-45 rounded-lg border p-3${!release ? ' border-dashed opacity-60' : ''}`
-          : `w-45 rounded-lg border p-3${release ? ' border-border bg-card' : ' border-tertiary/40 border-dashed opacity-60'}`
+          ? `w-55 rounded-lg border p-3${!release ? ' border-dashed opacity-60' : ''}`
+          : `w-55 rounded-lg border p-3${release ? ' border-border bg-card' : ' border-tertiary/40 border-dashed opacity-60'}`
         const cardStyle = derived
           ? { backgroundColor: derived.bg, borderColor: derived.border }
           : undefined

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -591,7 +591,7 @@ function DeploymentCards({
                 />
                 {env.name}
               </p>
-              <p className="font-mono text-base leading-tight font-bold">
+              <p className="font-mono text-base leading-tight">
                 {release ? (
                   <span className="text-primary">{release.version}</span>
                 ) : (

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -21,6 +21,7 @@ import { matchSorter } from 'match-sorter'
 
 import { getProjects } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { deriveChipColors } from '@/lib/chip-colors'
 
 import { NewProjectDialog } from './NewProjectDialog'
 import { ProjectGraphView } from './ProjectGraphView'
@@ -507,18 +508,21 @@ function DeploymentCards({
     <div className="flex items-start gap-2" style={{ flexWrap: 'nowrap' }}>
       {sorted.map((env, idx) => {
         const release = releases[env.slug]
+        const derived = env.label_color
+          ? deriveChipColors(env.label_color, false)
+          : null
+        const cardClass = derived
+          ? `w-45 rounded-lg border p-3${!release ? ' border-dashed opacity-60' : ''}`
+          : `w-45 rounded-lg border p-3${release ? ' border-border bg-card' : ' border-tertiary/40 border-dashed opacity-60'}`
+        const cardStyle = derived
+          ? { backgroundColor: derived.bg, borderColor: derived.border }
+          : undefined
         return (
           <span className="flex shrink-0 items-center" key={env.slug}>
             {idx > 0 && (
               <ArrowRight className="text-tertiary mx-2 size-3.5 shrink-0" />
             )}
-            <span
-              className={`w-45 rounded-lg p-3 ${
-                release
-                  ? 'border-border bg-card border'
-                  : 'border-tertiary/40 border border-dashed opacity-60'
-              }`}
-            >
+            <span className={cardClass} style={cardStyle}>
               <p className="text-secondary mb-1.5 flex items-center gap-1.5 text-sm font-medium">
                 <span
                   className="size-2 shrink-0 rounded-full"

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -21,8 +21,6 @@ import { matchSorter } from 'match-sorter'
 
 import { getProjects } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
-import { useTheme } from '@/contexts/ThemeContext'
-import { deriveChipColors } from '@/lib/chip-colors'
 
 import { NewProjectDialog } from './NewProjectDialog'
 import { ProjectGraphView } from './ProjectGraphView'
@@ -501,7 +499,6 @@ function DeploymentCards({
     { deployed_at: string; performed_by?: null | string; version: string }
   >
 }) {
-  const { isDarkMode } = useTheme()
   const sorted = [...environments].sort(
     (a, b) =>
       (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.name.localeCompare(b.name),
@@ -510,16 +507,13 @@ function DeploymentCards({
     <div className="flex items-start gap-2" style={{ flexWrap: 'nowrap' }}>
       {sorted.map((env, idx) => {
         const release = releases[env.slug]
-        const derived = env.label_color
-          ? deriveChipColors(env.label_color, isDarkMode)
-          : null
         return (
           <span className="flex shrink-0 items-center" key={env.slug}>
             {idx > 0 && (
               <ArrowRight className="text-tertiary mx-2 size-3.5 shrink-0" />
             )}
             <span
-              className={`min-w-35 rounded-lg p-3 ${
+              className={`w-40 rounded-lg p-3 ${
                 release
                   ? 'border-border bg-card border'
                   : 'border-tertiary/40 border border-dashed opacity-60'
@@ -527,8 +521,12 @@ function DeploymentCards({
             >
               <p className="text-secondary mb-1.5 flex items-center gap-1.5 text-sm font-medium">
                 <span
-                  className="size-2 rounded-full"
-                  style={derived ? { backgroundColor: derived.fg } : undefined}
+                  className="size-2 shrink-0 rounded-full"
+                  style={
+                    env.label_color
+                      ? { backgroundColor: env.label_color }
+                      : undefined
+                  }
                 />
                 {env.name}
               </p>

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -43,6 +43,7 @@ import {
 interface FilterHeaderProps {
   activeFilters: Set<string>
   children: React.ReactNode
+  className?: string
   label: string
   onSort: () => void
   onToggle: (slug: string) => void
@@ -368,6 +369,7 @@ export function ProjectsView() {
                 <TableRow>
                   <FilterHeader
                     activeFilters={activeTeamSet}
+                    className="min-w-72"
                     label="team"
                     onSort={() => setSort('name')}
                     onToggle={(s) => toggleFilter('teams', s)}
@@ -416,7 +418,7 @@ export function ProjectsView() {
                       key={`table-${project.id}`}
                       onClick={() => handleProjectSelect(project.id)}
                     >
-                      <TableCell className="px-6 py-4">
+                      <TableCell className="min-w-72 px-6 py-4">
                         <div>
                           <p className="text-primary font-medium">
                             {project.name}
@@ -559,6 +561,7 @@ function DeploymentCards({
 function FilterHeader({
   activeFilters,
   children,
+  className,
   label,
   onSort,
   onToggle,
@@ -567,7 +570,9 @@ function FilterHeader({
   sorted,
 }: FilterHeaderProps) {
   return (
-    <TableHead className="text-secondary px-6 py-3 text-left text-sm font-medium">
+    <TableHead
+      className={`text-secondary px-6 py-3 text-left text-sm font-medium ${className ? ` ${className}` : ''}`}
+    >
       <div className="flex items-center gap-0.5">
         <button
           className="hover:text-primary inline-flex items-center gap-1"

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -42,14 +42,24 @@ import {
 
 interface FilterHeaderProps {
   activeFilters: Set<string>
+  centerFilter?: FilterPopoverProps & { title: string }
   children: React.ReactNode
   className?: string
+  hideMainFilter?: boolean
   label: string
   onSort: () => void
   onToggle: (slug: string) => void
   options: { label: string; slug: string }[]
+  rightFilter?: FilterPopoverProps & { title: string }
   sortDir: SortDir
   sorted: boolean
+}
+
+interface FilterPopoverProps {
+  activeFilters: Set<string>
+  label: string
+  onToggle: (slug: string) => void
+  options: { label: string; slug: string }[]
 }
 
 type SortDir = 'asc' | 'desc'
@@ -369,27 +379,30 @@ export function ProjectsView() {
                 <TableRow>
                   <FilterHeader
                     activeFilters={activeTeamSet}
+                    centerFilter={{
+                      activeFilters: activeTeamSet,
+                      label: 'team',
+                      onToggle: (s) => toggleFilter('teams', s),
+                      options: teamOptions,
+                      title: 'Team',
+                    }}
                     className="min-w-72"
+                    hideMainFilter
                     label="team"
                     onSort={() => setSort('name')}
                     onToggle={(s) => toggleFilter('teams', s)}
                     options={teamOptions}
+                    rightFilter={{
+                      activeFilters: activeTypeSet,
+                      label: 'type',
+                      onToggle: (s) => toggleFilter('types', s),
+                      options: typeOptions,
+                      title: 'Type',
+                    }}
                     sortDir={sortDir}
                     sorted={sortKey === 'name'}
                   >
                     Project
-                  </FilterHeader>
-                  <FilterHeader
-                    activeFilters={activeTypeSet}
-                    className="min-w-48"
-                    label="type"
-                    onSort={() => setSort('type')}
-                    onToggle={(s) => toggleFilter('types', s)}
-                    options={typeOptions}
-                    sortDir={sortDir}
-                    sorted={sortKey === 'type'}
-                  >
-                    Type
                   </FilterHeader>
                   <SortHeader
                     onSort={() => setSort('prs')}
@@ -424,15 +437,17 @@ export function ProjectsView() {
                           <p className="text-primary font-medium">
                             {project.name}
                           </p>
+                          {(project.project_types ?? []).length > 0 && (
+                            <p className="text-secondary text-xs">
+                              {project
+                                .project_types!.map((pt) => pt.name)
+                                .join(', ')}
+                            </p>
+                          )}
                           <p className="text-tertiary text-xs">
                             {project.team.name}
                           </p>
                         </div>
-                      </TableCell>
-                      <TableCell className="text-secondary min-w-48 px-6 py-4">
-                        {(project.project_types || [])
-                          .map((pt) => pt.name)
-                          .join(', ')}
                       </TableCell>
                       <TableCell className="px-6 py-4">
                         <div className="flex items-center gap-1.5">
@@ -572,12 +587,15 @@ function DeploymentCards({
 // fallow-ignore-next-line complexity
 function FilterHeader({
   activeFilters,
+  centerFilter,
   children,
   className,
+  hideMainFilter,
   label,
   onSort,
   onToggle,
   options,
+  rightFilter,
   sortDir,
   sorted,
 }: FilterHeaderProps) {
@@ -585,63 +603,98 @@ function FilterHeader({
     <TableHead
       className={`text-secondary px-6 py-3 text-left text-sm font-medium ${className ? ` ${className}` : ''}`}
     >
-      <div className="flex items-center gap-0.5">
-        <button
-          className="hover:text-primary inline-flex items-center gap-1"
-          onClick={onSort}
-          type="button"
-        >
-          {children}
-          {sorted ? (
-            sortDir === 'asc' ? (
-              <ChevronUp className="size-3.5 shrink-0" />
+      <div className="flex items-center justify-between gap-0.5">
+        <div className="flex items-center gap-0.5">
+          <button
+            className="hover:text-primary inline-flex items-center gap-1"
+            onClick={onSort}
+            type="button"
+          >
+            {children}
+            {sorted ? (
+              sortDir === 'asc' ? (
+                <ChevronUp className="size-3.5 shrink-0" />
+              ) : (
+                <ChevronDown className="size-3.5 shrink-0" />
+              )
             ) : (
-              <ChevronDown className="size-3.5 shrink-0" />
-            )
-          ) : (
-            <ChevronsUpDown className="text-tertiary/50 size-3.5 shrink-0" />
+              <ChevronsUpDown className="text-tertiary/50 size-3.5 shrink-0" />
+            )}
+          </button>
+          {!hideMainFilter && (
+            <FilterPopover
+              activeFilters={activeFilters}
+              label={label}
+              onToggle={onToggle}
+              options={options}
+            />
           )}
-        </button>
-        <Popover>
-          <PopoverTrigger asChild>
-            <button
-              className={`flex items-center gap-0.5 rounded px-0.5 py-0.5 ${
-                activeFilters.size > 0
-                  ? 'text-action'
-                  : 'text-tertiary/50 hover:text-secondary'
-              }`}
-              type="button"
-            >
-              <ListFilter className="size-3.5" />
-              {activeFilters.size > 0 && (
-                <span className="text-xs leading-none">
-                  {activeFilters.size}
-                </span>
-              )}
-            </button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-48 p-2">
-            <p className="text-secondary mb-2 px-1 text-xs font-medium tracking-wide uppercase">
-              Filter by {label}
-            </p>
-            <div className="space-y-0.5">
-              {options.map((opt) => (
-                <label
-                  className="hover:bg-secondary flex cursor-pointer items-center gap-2 rounded px-1 py-1.5"
-                  key={opt.slug}
-                >
-                  <Checkbox
-                    checked={activeFilters.has(opt.slug)}
-                    onCheckedChange={() => onToggle(opt.slug)}
-                  />
-                  <span className="text-primary text-sm">{opt.label}</span>
-                </label>
-              ))}
-            </div>
-          </PopoverContent>
-        </Popover>
+        </div>
+        {centerFilter && (
+          <div className="flex items-center gap-1">
+            <span className="text-tertiary/70 text-xs">
+              {centerFilter.title}
+            </span>
+            <FilterPopover {...centerFilter} />
+          </div>
+        )}
+        {rightFilter && (
+          <div className="flex items-center gap-1">
+            <span className="text-tertiary/70 text-xs">
+              {rightFilter.title}
+            </span>
+            <FilterPopover {...rightFilter} />
+          </div>
+        )}
       </div>
     </TableHead>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function FilterPopover({
+  activeFilters,
+  label,
+  onToggle,
+  options,
+}: FilterPopoverProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className={`flex items-center gap-0.5 rounded px-0.5 py-0.5 ${
+            activeFilters.size > 0
+              ? 'text-action'
+              : 'text-tertiary/50 hover:text-secondary'
+          }`}
+          type="button"
+        >
+          <ListFilter className="size-3.5" />
+          {activeFilters.size > 0 && (
+            <span className="text-xs leading-none">{activeFilters.size}</span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-48 p-2">
+        <p className="text-secondary mb-2 px-1 text-xs font-medium tracking-wide uppercase">
+          Filter by {label}
+        </p>
+        <div className="space-y-0.5">
+          {options.map((opt) => (
+            <label
+              className="hover:bg-secondary flex cursor-pointer items-center gap-2 rounded px-1 py-1.5"
+              key={opt.slug}
+            >
+              <Checkbox
+                checked={activeFilters.has(opt.slug)}
+                onCheckedChange={() => onToggle(opt.slug)}
+              />
+              <span className="text-primary text-sm">{opt.label}</span>
+            </label>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -14,21 +14,21 @@ import {
   Network,
   Plus,
   Search,
+  User,
 } from 'lucide-react'
 import { matchSorter } from 'match-sorter'
 
 import { getProjects } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
-import { sortEnvironments } from '@/lib/utils'
 
 import { NewProjectDialog } from './NewProjectDialog'
 import { ProjectGraphView } from './ProjectGraphView'
 import { Button } from './ui/button'
 import { Card } from './ui/card'
 import { Checkbox } from './ui/checkbox'
-import { EnvironmentBadge } from './ui/environment-badge'
 import { Input } from './ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
+import { buildReleaseTrainStops, ReleaseTrain } from './ui/release-train'
 import { ScoreBadge } from './ui/score-badge'
 import {
   Table,
@@ -334,40 +334,32 @@ export function ProjectsView() {
                 </div>
 
                 {project.environments && project.environments.length > 0 && (
-                  <div className="flex flex-wrap items-center gap-2">
-                    {sortEnvironments(project.environments || []).map((env) => (
-                      <EnvironmentBadge
-                        key={env.slug}
-                        label_color={env.label_color}
-                        name={env.name}
-                        slug={env.slug}
-                      />
-                    ))}
-                  </div>
+                  <ReleaseTrain
+                    size="compact"
+                    stops={buildReleaseTrainStops(
+                      project.environments,
+                      new Map(
+                        Object.entries(project.current_releases ?? {}).map(
+                          ([slug, r]) => [slug, r.version],
+                        ),
+                      ),
+                    )}
+                  />
                 )}
-                {((project.open_pr_count ?? 0) > 0 ||
-                  (project.closed_pr_count ?? 0) > 0) && (
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    {(project.open_pr_count ?? 0) > 0 && (
-                      <span className="text-action flex items-center gap-1 text-xs font-medium">
-                        <GitPullRequest className="size-3" />
-                        {project.open_pr_count} open
-                      </span>
-                    )}
-                    {(project.closed_pr_count ?? 0) > 0 && (
-                      <span className="text-tertiary flex items-center gap-1 text-xs">
-                        <GitPullRequest className="size-3" />
-                        {project.closed_pr_count} closed
-                      </span>
-                    )}
-                    {(project.viewer_open_pr_count ?? 0) > 0 && (
-                      <span className="text-amber-text flex items-center gap-1 text-xs font-medium">
-                        <GitPullRequest className="size-3" />
-                        {project.viewer_open_pr_count} mine
-                      </span>
-                    )}
-                  </div>
-                )}
+                <div className="mt-2 flex items-center gap-1.5">
+                  <span className="bg-secondary flex items-center gap-1 rounded-md px-1.5 py-0.5">
+                    <GitPullRequest className="text-action size-3.5" />
+                    <span className="text-action text-xs font-medium">
+                      {project.open_pr_count ?? 0}
+                    </span>
+                  </span>
+                  <span className="border-action flex items-center gap-1 rounded-md border px-1.5 py-0.5">
+                    <User className="text-action size-3.5" />
+                    <span className="text-action text-xs font-medium">
+                      {project.viewer_open_pr_count ?? 0}
+                    </span>
+                  </span>
+                </div>
               </Card>
             )
           })}
@@ -449,33 +441,32 @@ export function ProjectsView() {
                       <TableCell className="px-6 py-4">
                         {project.environments &&
                           project.environments.length > 0 && (
-                            <div className="flex flex-wrap items-center gap-2">
-                              {sortEnvironments(project.environments || []).map(
-                                (env) => (
-                                  <EnvironmentBadge
-                                    key={env.slug}
-                                    label_color={env.label_color}
-                                    name={env.name}
-                                    slug={env.slug}
-                                  />
+                            <ReleaseTrain
+                              size="compact"
+                              stops={buildReleaseTrainStops(
+                                project.environments,
+                                new Map(
+                                  Object.entries(
+                                    project.current_releases ?? {},
+                                  ).map(([slug, r]) => [slug, r.version]),
                                 ),
                               )}
-                            </div>
+                            />
                           )}
                       </TableCell>
                       <TableCell className="px-6 py-4">
-                        <div className="flex flex-col gap-0.5">
-                          <span className="text-action flex items-center gap-1 text-xs font-medium">
-                            <GitPullRequest className="size-3" />
-                            {project.open_pr_count ?? 0} open
+                        <div className="flex items-center gap-1.5">
+                          <span className="bg-secondary flex items-center gap-1 rounded-md px-1.5 py-0.5">
+                            <GitPullRequest className="text-action size-3.5" />
+                            <span className="text-action text-xs font-medium">
+                              {project.open_pr_count ?? 0}
+                            </span>
                           </span>
-                          <span className="text-tertiary flex items-center gap-1 text-xs">
-                            <GitPullRequest className="size-3" />
-                            {project.closed_pr_count ?? 0} closed
-                          </span>
-                          <span className="text-amber-text flex items-center gap-1 text-xs font-medium">
-                            <GitPullRequest className="size-3" />
-                            {project.viewer_open_pr_count ?? 0} mine
+                          <span className="border-action flex items-center gap-1 rounded-md border px-1.5 py-0.5">
+                            <User className="text-action size-3.5" />
+                            <span className="text-action text-xs font-medium">
+                              {project.viewer_open_pr_count ?? 0}
+                            </span>
                           </span>
                         </div>
                       </TableCell>

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -222,7 +222,7 @@ export function ProjectsView() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-7xl px-6 py-8">
+      <div className="mx-auto max-w-screen-2xl px-6 py-8">
         <div className="flex h-64 items-center justify-center">
           <div className="text-lg">Loading projects...</div>
         </div>
@@ -231,7 +231,7 @@ export function ProjectsView() {
   }
 
   return (
-    <div className="mx-auto max-w-7xl px-6 py-8">
+    <div className="mx-auto max-w-screen-2xl px-6 py-8">
       <div className="mb-6">
         <div className="mb-4 flex items-center justify-between">
           <h1 className="text-primary text-2xl font-semibold">Projects</h1>

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -69,6 +69,8 @@ interface SortHeaderProps {
 
 type SortKey = 'name' | 'prs' | 'score' | 'team' | 'type'
 
+const VIEW_MODE_STORAGE_KEY = 'imbi.projects.view-mode'
+
 // fallow-ignore-next-line complexity
 export function ProjectsView() {
   const navigate = useNavigate()
@@ -77,8 +79,16 @@ export function ProjectsView() {
   const orgSlug = selectedOrganization?.slug || ''
 
   const rawView = searchParams.get('view')
+  const storedView =
+    typeof window !== 'undefined'
+      ? window.localStorage.getItem(VIEW_MODE_STORAGE_KEY)
+      : null
   const viewMode: 'grid' | 'list' =
-    rawView === 'grid' || rawView === 'list' ? rawView : 'grid'
+    rawView === 'grid' || rawView === 'list'
+      ? rawView
+      : storedView === 'grid' || storedView === 'list'
+        ? storedView
+        : 'list'
   const searchQuery = searchParams.get('q') ?? ''
   const sortKey = searchParams.get('sort') as null | SortKey
   const sortDir = (searchParams.get('dir') ?? 'asc') as SortDir
@@ -88,7 +98,10 @@ export function ProjectsView() {
   const hasOpenPRs = searchParams.get('has_open_prs') === '1'
   const hasMyOpenPRs = searchParams.get('has_my_open_prs') === '1'
 
-  const setViewMode = (v: 'grid' | 'list') =>
+  const setViewMode = (v: 'grid' | 'list') => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, v)
+    }
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev)
@@ -97,6 +110,17 @@ export function ProjectsView() {
       },
       { replace: true },
     )
+  }
+
+  useEffect(() => {
+    if (
+      rawView !== 'grid' &&
+      rawView !== 'list' &&
+      typeof window !== 'undefined'
+    ) {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode)
+    }
+  }, [rawView, viewMode])
 
   const setSearchQuery = (q: string) =>
     setSearchParams(
@@ -348,22 +372,22 @@ export function ProjectsView() {
 
             <div className="border-secondary flex items-center overflow-hidden rounded-lg border">
               <Button
-                aria-label="Grid view"
-                className={`rounded-r-none ${viewMode === 'grid' ? 'bg-amber-bg text-amber-text' : ''}`}
-                onClick={() => setViewMode('grid')}
-                size="sm"
-                variant="ghost"
-              >
-                <Grid3x3 className="size-4" />
-              </Button>
-              <Button
                 aria-label="List view"
-                className={`rounded-l-none ${viewMode === 'list' ? 'bg-amber-bg text-amber-text' : ''}`}
+                className={`rounded-r-none ${viewMode === 'list' ? 'bg-amber-bg text-amber-text' : ''}`}
                 onClick={() => setViewMode('list')}
                 size="sm"
                 variant="ghost"
               >
                 <List className="size-4" />
+              </Button>
+              <Button
+                aria-label="Grid view"
+                className={`rounded-l-none ${viewMode === 'grid' ? 'bg-amber-bg text-amber-text' : ''}`}
+                onClick={() => setViewMode('grid')}
+                size="sm"
+                variant="ghost"
+              >
+                <Grid3x3 className="size-4" />
               </Button>
             </div>
 

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -513,7 +513,7 @@ function DeploymentCards({
               <ArrowRight className="text-tertiary mx-2 size-3.5 shrink-0" />
             )}
             <span
-              className={`w-40 rounded-lg p-3 ${
+              className={`w-45 rounded-lg p-3 ${
                 release
                   ? 'border-border bg-card border'
                   : 'border-tertiary/40 border border-dashed opacity-60'

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -294,8 +294,8 @@ export function ProjectsView() {
       {viewMode === 'graph' ? (
         <ProjectGraphView projects={filteredProjects} />
       ) : viewMode === 'grid' ? (
-        // fallow-ignore-next-line complexity
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {/* fallow-ignore-next-line complexity */}
           {filteredProjects.map((project) => {
             return (
               <Card
@@ -427,6 +427,7 @@ export function ProjectsView() {
                 </TableRow>
               </TableHeader>
               <TableBody className="divide-tertiary divide-y">
+                {/* fallow-ignore-next-line complexity */}
                 {filteredProjects.map((project) => {
                   return (
                     <TableRow

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -398,7 +398,7 @@ export function ProjectsView() {
                   >
                     PRs
                   </SortHeader>
-                  <TableHead className="text-secondary px-6 py-3 text-left text-sm font-medium">
+                  <TableHead className="text-secondary w-px px-6 py-3 text-left text-sm font-medium whitespace-nowrap">
                     Deployments
                   </TableHead>
                   <SortHeader
@@ -450,7 +450,7 @@ export function ProjectsView() {
                           </span>
                         </div>
                       </TableCell>
-                      <TableCell className="items-center px-6 py-4">
+                      <TableCell className="w-px items-center px-6 py-4 whitespace-nowrap">
                         {project.environments &&
                           project.environments.length > 0 && (
                             <DeploymentCards

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -4,9 +4,13 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
 import {
+  ChevronDown,
+  ChevronsUpDown,
+  ChevronUp,
   GitPullRequest,
   Grid3x3,
   List,
+  ListFilter,
   Network,
   Plus,
   Search,
@@ -21,8 +25,10 @@ import { NewProjectDialog } from './NewProjectDialog'
 import { ProjectGraphView } from './ProjectGraphView'
 import { Button } from './ui/button'
 import { Card } from './ui/card'
+import { Checkbox } from './ui/checkbox'
 import { EnvironmentBadge } from './ui/environment-badge'
 import { Input } from './ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { ScoreBadge } from './ui/score-badge'
 import {
   Table,
@@ -33,6 +39,29 @@ import {
   TableRow,
 } from './ui/table'
 
+interface FilterHeaderProps {
+  activeFilters: Set<string>
+  children: React.ReactNode
+  label: string
+  onSort: () => void
+  onToggle: (slug: string) => void
+  options: { label: string; slug: string }[]
+  sortDir: SortDir
+  sorted: boolean
+}
+
+type SortDir = 'asc' | 'desc'
+
+interface SortHeaderProps {
+  children: React.ReactNode
+  onSort: () => void
+  sortDir: SortDir
+  sorted: boolean
+}
+
+type SortKey = 'name' | 'prs' | 'score' | 'team' | 'type'
+
+// fallow-ignore-next-line complexity
 export function ProjectsView() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -45,6 +74,10 @@ export function ProjectsView() {
       ? rawView
       : 'grid'
   const searchQuery = searchParams.get('q') ?? ''
+  const sortKey = searchParams.get('sort') as null | SortKey
+  const sortDir = (searchParams.get('dir') ?? 'asc') as SortDir
+  const teamsParam = searchParams.get('teams') ?? ''
+  const typesParam = searchParams.get('types') ?? ''
 
   const setViewMode = (v: 'graph' | 'grid' | 'list') =>
     setSearchParams(
@@ -67,6 +100,42 @@ export function ProjectsView() {
       { replace: true },
     )
 
+  const setSort = (key: SortKey) =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        if (prev.get('sort') === key) {
+          if ((prev.get('dir') ?? 'asc') === 'asc') {
+            next.set('dir', 'desc')
+          } else {
+            next.delete('sort')
+            next.delete('dir')
+          }
+        } else {
+          next.set('sort', key)
+          next.set('dir', 'asc')
+        }
+        return next
+      },
+      { replace: true },
+    )
+
+  const toggleFilter = (param: string, slug: string) =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        const current = new Set(
+          prev.get(param)?.split(',').filter(Boolean) ?? [],
+        )
+        if (current.has(slug)) current.delete(slug)
+        else current.add(slug)
+        if (current.size > 0) next.set(param, [...current].sort().join(','))
+        else next.delete(param)
+        return next
+      },
+      { replace: true },
+    )
+
   const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false)
 
   const { data: projects, isLoading } = useQuery({
@@ -75,22 +144,79 @@ export function ProjectsView() {
     queryKey: ['projects', orgSlug],
   })
 
+  const teamOptions = useMemo(
+    () =>
+      Array.from(
+        new Map(
+          (projects ?? []).map((p) => [p.team.slug, p.team.name]),
+        ).entries(),
+      )
+        .map(([slug, label]) => ({ label, slug }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [projects],
+  )
+
+  // fallow-ignore-next-line complexity
+  const typeOptions = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const p of projects ?? []) {
+      for (const pt of p.project_types ?? []) {
+        map.set(pt.slug, pt.name)
+      }
+    }
+    return Array.from(map.entries())
+      .map(([slug, label]) => ({ label, slug }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [projects])
+
   const handleProjectSelect = (projectId: string) => {
     navigate(`/projects/${projectId}`)
   }
 
+  // fallow-ignore-next-line complexity
   const filteredProjects = useMemo(() => {
-    const all = projects || []
-    if (!searchQuery) return all
-    return matchSorter(all, searchQuery, {
-      keys: [
-        'name',
-        'description',
-        'team.name',
-        { key: (p) => (p.project_types || []).map((pt) => pt.name) },
-      ],
+    const teamSet = new Set(teamsParam.split(',').filter(Boolean))
+    const typeSet = new Set(typesParam.split(',').filter(Boolean))
+    let all = projects ?? []
+
+    if (teamSet.size > 0) {
+      all = all.filter((p) => teamSet.has(p.team.slug))
+    }
+    if (typeSet.size > 0) {
+      all = all.filter((p) =>
+        (p.project_types ?? []).some((pt) => typeSet.has(pt.slug)),
+      )
+    }
+    if (searchQuery) {
+      return matchSorter(all, searchQuery, {
+        keys: [
+          'name',
+          'description',
+          'team.name',
+          { key: (p) => (p.project_types || []).map((pt) => pt.name) },
+        ],
+      })
+    }
+    if (!sortKey) return all
+
+    // fallow-ignore-next-line complexity
+    return [...all].sort((a, b) => {
+      let cmp = 0
+      if (sortKey === 'name') cmp = a.name.localeCompare(b.name)
+      else if (sortKey === 'team') cmp = a.team.name.localeCompare(b.team.name)
+      else if (sortKey === 'type') {
+        const aType = (a.project_types ?? [])[0]?.name ?? ''
+        const bType = (b.project_types ?? [])[0]?.name ?? ''
+        cmp = aType.localeCompare(bType)
+      } else if (sortKey === 'prs')
+        cmp = (a.open_pr_count ?? 0) - (b.open_pr_count ?? 0)
+      else if (sortKey === 'score') cmp = (a.score ?? 0) - (b.score ?? 0)
+      return sortDir === 'asc' ? cmp : -cmp
     })
-  }, [projects, searchQuery])
+  }, [projects, searchQuery, sortKey, sortDir, teamsParam, typesParam])
+
+  const activeTeamSet = new Set(teamsParam.split(',').filter(Boolean))
+  const activeTypeSet = new Set(typesParam.split(',').filter(Boolean))
 
   if (isLoading) {
     return (
@@ -168,6 +294,7 @@ export function ProjectsView() {
       {viewMode === 'graph' ? (
         <ProjectGraphView projects={filteredProjects} />
       ) : viewMode === 'grid' ? (
+        // fallow-ignore-next-line complexity
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filteredProjects.map((project) => {
             return (
@@ -245,48 +372,52 @@ export function ProjectsView() {
             <Table>
               <TableHeader className="border-tertiary bg-secondary border-b">
                 <TableRow>
-                  <TableHead
-                    className={
-                      'text-secondary px-6 py-3 text-left text-sm font-medium'
-                    }
+                  <SortHeader
+                    onSort={() => setSort('name')}
+                    sortDir={sortDir}
+                    sorted={sortKey === 'name'}
                   >
                     Project
-                  </TableHead>
-                  <TableHead
-                    className={
-                      'text-secondary px-6 py-3 text-left text-sm font-medium'
-                    }
+                  </SortHeader>
+                  <FilterHeader
+                    activeFilters={activeTypeSet}
+                    label="type"
+                    onSort={() => setSort('type')}
+                    onToggle={(s) => toggleFilter('types', s)}
+                    options={typeOptions}
+                    sortDir={sortDir}
+                    sorted={sortKey === 'type'}
                   >
                     Type
-                  </TableHead>
-                  <TableHead
-                    className={
-                      'text-secondary px-6 py-3 text-left text-sm font-medium'
-                    }
+                  </FilterHeader>
+                  <FilterHeader
+                    activeFilters={activeTeamSet}
+                    label="team"
+                    onSort={() => setSort('team')}
+                    onToggle={(s) => toggleFilter('teams', s)}
+                    options={teamOptions}
+                    sortDir={sortDir}
+                    sorted={sortKey === 'team'}
                   >
                     Team
-                  </TableHead>
-                  <TableHead
-                    className={
-                      'text-secondary px-6 py-3 text-left text-sm font-medium'
-                    }
-                  >
+                  </FilterHeader>
+                  <TableHead className="text-secondary px-6 py-3 text-left text-sm font-medium">
                     Environments
                   </TableHead>
-                  <TableHead
-                    className={
-                      'text-secondary px-6 py-3 text-left text-sm font-medium'
-                    }
+                  <SortHeader
+                    onSort={() => setSort('prs')}
+                    sortDir={sortDir}
+                    sorted={sortKey === 'prs'}
                   >
                     PRs
-                  </TableHead>
-                  <TableHead
-                    className={
-                      'text-secondary px-6 py-3 text-left text-sm font-medium'
-                    }
+                  </SortHeader>
+                  <SortHeader
+                    onSort={() => setSort('score')}
+                    sortDir={sortDir}
+                    sorted={sortKey === 'score'}
                   >
                     Health
-                  </TableHead>
+                  </SortHeader>
                 </TableRow>
               </TableHeader>
               <TableBody className="divide-tertiary divide-y">
@@ -367,5 +498,100 @@ export function ProjectsView() {
         onProjectCreated={(id) => navigate(`/projects/${id}`)}
       />
     </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function FilterHeader({
+  activeFilters,
+  children,
+  label,
+  onSort,
+  onToggle,
+  options,
+  sortDir,
+  sorted,
+}: FilterHeaderProps) {
+  return (
+    <TableHead className="text-secondary px-6 py-3 text-left text-sm font-medium">
+      <div className="flex items-center gap-0.5">
+        <button
+          className="hover:text-primary inline-flex items-center gap-1"
+          onClick={onSort}
+          type="button"
+        >
+          {children}
+          {sorted ? (
+            sortDir === 'asc' ? (
+              <ChevronUp className="size-3.5 shrink-0" />
+            ) : (
+              <ChevronDown className="size-3.5 shrink-0" />
+            )
+          ) : (
+            <ChevronsUpDown className="text-tertiary/50 size-3.5 shrink-0" />
+          )}
+        </button>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              className={`flex items-center gap-0.5 rounded px-0.5 py-0.5 ${
+                activeFilters.size > 0
+                  ? 'text-action'
+                  : 'text-tertiary/50 hover:text-secondary'
+              }`}
+              type="button"
+            >
+              <ListFilter className="size-3.5" />
+              {activeFilters.size > 0 && (
+                <span className="text-xs leading-none">
+                  {activeFilters.size}
+                </span>
+              )}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-48 p-2">
+            <p className="text-secondary mb-2 px-1 text-xs font-medium tracking-wide uppercase">
+              Filter by {label}
+            </p>
+            <div className="space-y-0.5">
+              {options.map((opt) => (
+                <label
+                  className="hover:bg-secondary flex cursor-pointer items-center gap-2 rounded px-1 py-1.5"
+                  key={opt.slug}
+                >
+                  <Checkbox
+                    checked={activeFilters.has(opt.slug)}
+                    onCheckedChange={() => onToggle(opt.slug)}
+                  />
+                  <span className="text-primary text-sm">{opt.label}</span>
+                </label>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </TableHead>
+  )
+}
+
+function SortHeader({ children, onSort, sortDir, sorted }: SortHeaderProps) {
+  return (
+    <TableHead
+      className="text-secondary hover:text-primary cursor-pointer px-6 py-3 text-left text-sm font-medium select-none"
+      onClick={onSort}
+    >
+      <span className="inline-flex items-center gap-1">
+        {children}
+        {sorted ? (
+          sortDir === 'asc' ? (
+            <ChevronUp className="size-3.5 shrink-0" />
+          ) : (
+            <ChevronDown className="size-3.5 shrink-0" />
+          )
+        ) : (
+          <ChevronsUpDown className="text-tertiary/50 size-3.5 shrink-0" />
+        )}
+      </span>
+    </TableHead>
   )
 }

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -22,12 +22,15 @@ import { matchSorter } from 'match-sorter'
 
 import { getProjects } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useTheme } from '@/contexts/ThemeContext'
 import { deriveChipColors } from '@/lib/chip-colors'
 
 import { NewProjectDialog } from './NewProjectDialog'
 import { Button } from './ui/button'
 import { Card } from './ui/card'
 import { Checkbox } from './ui/checkbox'
+import { EnvironmentBadge } from './ui/environment-badge'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from './ui/hover-card'
 import { Input } from './ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { ScoreBadge } from './ui/score-badge'
@@ -82,6 +85,8 @@ export function ProjectsView() {
   const teamsParam = searchParams.get('teams') ?? ''
   const typesParam = searchParams.get('types') ?? ''
   const driftsParam = searchParams.get('drifts') ?? ''
+  const hasOpenPRs = searchParams.get('has_open_prs') === '1'
+  const hasMyOpenPRs = searchParams.get('has_my_open_prs') === '1'
 
   const setViewMode = (v: 'grid' | 'list') =>
     setSearchParams(
@@ -119,6 +124,28 @@ export function ProjectsView() {
           next.set('sort', key)
           next.set('dir', 'asc')
         }
+        return next
+      },
+      { replace: true },
+    )
+
+  const toggleOpenPRs = () =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        if (prev.get('has_open_prs') === '1') next.delete('has_open_prs')
+        else next.set('has_open_prs', '1')
+        return next
+      },
+      { replace: true },
+    )
+
+  const toggleMyOpenPRs = () =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        if (prev.get('has_my_open_prs') === '1') next.delete('has_my_open_prs')
+        else next.set('has_my_open_prs', '1')
         return next
       },
       { replace: true },
@@ -200,6 +227,12 @@ export function ProjectsView() {
     if (driftSet.size > 0) {
       all = all.filter(() => driftSet.has('none'))
     }
+    if (hasOpenPRs) {
+      all = all.filter((p) => (p.open_pr_count ?? 0) > 0)
+    }
+    if (hasMyOpenPRs) {
+      all = all.filter((p) => (p.viewer_open_pr_count ?? 0) > 0)
+    }
     if (searchQuery) {
       return matchSorter(all, searchQuery, {
         keys: [
@@ -234,7 +267,18 @@ export function ProjectsView() {
     teamsParam,
     typesParam,
     driftsParam,
+    hasOpenPRs,
+    hasMyOpenPRs,
   ])
+
+  const totalOpenPRs = (projects ?? []).reduce(
+    (sum, p) => sum + (p.open_pr_count ?? 0),
+    0,
+  )
+  const totalMyOpenPRs = (projects ?? []).reduce(
+    (sum, p) => sum + (p.viewer_open_pr_count ?? 0),
+    0,
+  )
 
   const activeTeamSet = new Set(teamsParam.split(',').filter(Boolean))
   const activeTypeSet = new Set(typesParam.split(',').filter(Boolean))
@@ -284,13 +328,25 @@ export function ProjectsView() {
               <StatBadge label="Healthy" value={0} variant="success" />
               <StatBadge label="Deploying" value={0} variant="warning" />
               <StatBadge label="Failed" value={0} variant="danger" />
-              <StatBadge label="Open PRs" value={0} variant="accent" />
+              <StatBadge
+                active={hasOpenPRs}
+                label="Open PRs"
+                onClick={toggleOpenPRs}
+                value={totalOpenPRs}
+                variant="accent"
+              />
               <StatBadge label="Need Release" value={0} variant="amber" />
-              <StatBadge label="My PRs" value={0} variant="info" />
+              <StatBadge
+                active={hasMyOpenPRs}
+                label="My PRs"
+                onClick={toggleMyOpenPRs}
+                value={totalMyOpenPRs}
+                variant="info"
+              />
               <StatBadge label="My Commits" value={0} variant="teal" />
             </div>
 
-            <div className="border-secondary flex items-center rounded-lg border">
+            <div className="border-secondary flex items-center overflow-hidden rounded-lg border">
               <Button
                 aria-label="Grid view"
                 className={`rounded-r-none ${viewMode === 'grid' ? 'bg-amber-bg text-amber-text' : ''}`}
@@ -311,7 +367,7 @@ export function ProjectsView() {
               </Button>
             </div>
 
-            <div className="border-secondary flex items-center rounded-lg border">
+            <div className="border-secondary flex items-center overflow-hidden rounded-lg border">
               <Button
                 aria-label="Refresh"
                 disabled={isFetching}
@@ -333,63 +389,76 @@ export function ProjectsView() {
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {/* fallow-ignore-next-line complexity */}
           {filteredProjects.map((project) => {
+            const typeNames = (project.project_types ?? [])
+              .map((pt) => pt.name)
+              .join(', ')
+            const meta = [typeNames, project.team.name]
+              .filter(Boolean)
+              .join(' · ')
+            const envs = [...(project.environments ?? [])].sort(
+              (a, b) =>
+                (a.sort_order ?? 0) - (b.sort_order ?? 0) ||
+                a.name.localeCompare(b.name),
+            )
             return (
               <Card
-                className={`cursor-pointer p-5 transition-shadow hover:shadow-md ${''}`}
+                className="flex min-h-56 cursor-pointer flex-col p-5 transition-shadow hover:shadow-md"
                 key={`card-${project.id}`}
                 onClick={() => handleProjectSelect(project.id)}
               >
-                <div className="mb-3 flex items-start justify-between">
+                <div className="mb-3 flex items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <h3 className="text-primary mb-1 truncate font-medium">
                       {project.name}
                     </h3>
-                    <p className="text-tertiary text-sm">
-                      {(project.project_types || [])
-                        .map((pt) => pt.name)
-                        .join(', ')}
-                    </p>
+                    <p className="text-tertiary text-sm">{meta}</p>
                   </div>
-                  <div className="ml-3">
-                    <ScoreBadge
-                      score={project.score}
-                      size="lg"
-                      variant="circle"
-                    />
-                  </div>
+                  <ScoreBadge
+                    score={project.score}
+                    size="md"
+                    variant="circle"
+                  />
                 </div>
 
                 {project.description && (
-                  <p className="text-secondary mb-3 line-clamp-2 text-sm">
+                  <p className="text-secondary line-clamp-2 text-sm">
                     {project.description}
                   </p>
                 )}
 
-                <div className="mb-3">
-                  <p className="text-tertiary text-xs">{project.team.name}</p>
-                </div>
-
-                {project.environments && project.environments.length > 0 && (
-                  <div className="mb-2">
-                    <DeploymentCards
-                      environments={project.environments}
-                      releases={project.current_releases ?? {}}
-                    />
+                <div className="border-tertiary mt-auto border-t pt-[18px]">
+                  <div className="flex min-h-8 flex-wrap items-center gap-2">
+                    <span
+                      className={`border-accent bg-accent text-accent inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs ${(project.open_pr_count ?? 0) > 0 ? '' : 'invisible'}`}
+                    >
+                      <GitPullRequest className="size-3.5" />
+                      <span className="font-medium">
+                        {project.open_pr_count ?? 0}
+                      </span>
+                    </span>
+                    <span
+                      className={`border-info bg-info text-info inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs ${(project.viewer_open_pr_count ?? 0) > 0 ? '' : 'invisible'}`}
+                    >
+                      <User className="size-3.5" />
+                      <span className="font-medium">
+                        {project.viewer_open_pr_count ?? 0}
+                      </span>
+                    </span>
+                    <span className="text-success text-xs font-medium">
+                      No drift
+                    </span>
+                    {isProjectDeployable(project) && envs.length > 0 && (
+                      <div className="ml-auto flex flex-wrap items-center gap-2">
+                        {envs.map((env) => (
+                          <EnvDeploymentHover
+                            env={env}
+                            key={env.slug}
+                            release={(project.current_releases ?? {})[env.slug]}
+                          />
+                        ))}
+                      </div>
+                    )}
                   </div>
-                )}
-                <div className="flex items-center gap-1.5">
-                  <span className="bg-secondary flex items-center gap-1 rounded-md px-1.5 py-0.5">
-                    <GitPullRequest className="text-action size-3.5" />
-                    <span className="text-action text-xs font-medium">
-                      {project.open_pr_count ?? 0}
-                    </span>
-                  </span>
-                  <span className="border-action flex items-center gap-1 rounded-md border px-1.5 py-0.5">
-                    <User className="text-action size-3.5" />
-                    <span className="text-action text-xs font-medium">
-                      {project.viewer_open_pr_count ?? 0}
-                    </span>
-                  </span>
                 </div>
               </Card>
             )
@@ -480,18 +549,22 @@ export function ProjectsView() {
                 </div>
                 <div className="w-40 shrink-0 px-6 py-4 whitespace-nowrap">
                   <div className="flex items-center justify-center gap-1.5">
-                    <span className="border-accent bg-accent text-accent inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs">
-                      <GitPullRequest className="size-3.5" />
-                      <span className="font-medium">
-                        {project.open_pr_count ?? 0}
+                    {(project.open_pr_count ?? 0) > 0 && (
+                      <span className="border-accent bg-accent text-accent inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs">
+                        <GitPullRequest className="size-3.5" />
+                        <span className="font-medium">
+                          {project.open_pr_count}
+                        </span>
                       </span>
-                    </span>
-                    <span className="border-info bg-info text-info inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs">
-                      <User className="size-3.5" />
-                      <span className="font-medium">
-                        {project.viewer_open_pr_count ?? 0}
+                    )}
+                    {(project.viewer_open_pr_count ?? 0) > 0 && (
+                      <span className="border-info bg-info text-info inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs">
+                        <User className="size-3.5" />
+                        <span className="font-medium">
+                          {project.viewer_open_pr_count}
+                        </span>
                       </span>
-                    </span>
+                    )}
                   </div>
                 </div>
                 <div className="w-24 shrink-0 px-2.5 py-4 text-center whitespace-nowrap">
@@ -504,12 +577,14 @@ export function ProjectsView() {
                   className="flex min-w-0 flex-1 overflow-x-auto px-6 py-4"
                   style={{ justifyContent: 'safe center' }}
                 >
-                  {project.environments && project.environments.length > 0 && (
-                    <DeploymentCards
-                      environments={project.environments}
-                      releases={project.current_releases ?? {}}
-                    />
-                  )}
+                  {isProjectDeployable(project) &&
+                    project.environments &&
+                    project.environments.length > 0 && (
+                      <DeploymentCards
+                        environments={project.environments}
+                        releases={project.current_releases ?? {}}
+                      />
+                    )}
                 </div>
                 <div className="flex w-40 shrink-0 justify-center px-6 py-4 whitespace-nowrap">
                   <ScoreBadge
@@ -590,6 +665,7 @@ function DeploymentCards({
                   }
                 />
                 {env.name}
+                <CircleCheck className="text-success ml-auto size-4 shrink-0" />
               </p>
               <p className="font-mono text-base leading-tight">
                 {release ? (
@@ -615,6 +691,80 @@ function DeploymentCards({
         )
       })}
     </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function EnvDeploymentHover({
+  env,
+  release,
+}: {
+  env: {
+    label_color?: null | string
+    name: string
+    slug: string
+    sort_order?: null | number
+  }
+  release?: {
+    deployed_at: string
+    performed_by?: null | string
+    version: string
+  }
+}) {
+  const { isDarkMode } = useTheme()
+  const derived = env.label_color
+    ? deriveChipColors(env.label_color, isDarkMode)
+    : null
+  const cardStyle = derived
+    ? { backgroundColor: derived.bg, borderColor: derived.border }
+    : undefined
+  return (
+    <HoverCard openDelay={150}>
+      <HoverCardTrigger asChild>
+        <span>
+          <EnvironmentBadge
+            label_color={env.label_color}
+            name={env.name}
+            slug={env.slug}
+          />
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent align="center" className="w-55 overflow-hidden p-0">
+        <div className="p-3" style={cardStyle}>
+          <p className="text-secondary mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+            <span
+              className="size-2 shrink-0 rounded-full"
+              style={
+                env.label_color
+                  ? { backgroundColor: env.label_color }
+                  : undefined
+              }
+            />
+            {env.name}
+            <CircleCheck className="text-success ml-auto size-4 shrink-0" />
+          </p>
+          <p className="font-mono text-base leading-tight font-bold">
+            {release ? (
+              <span className="text-primary">{release.version}</span>
+            ) : (
+              <span className="text-tertiary text-sm font-normal">
+                Not deployed
+              </span>
+            )}
+          </p>
+          <p className="text-tertiary mt-1 flex items-center justify-between text-xs">
+            {release ? (
+              <>
+                <span>{release.performed_by ?? ''}</span>
+                <span>{timeAgo(release.deployed_at)}</span>
+              </>
+            ) : (
+              <span className="invisible">—</span>
+            )}
+          </p>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
   )
 }
 
@@ -730,6 +880,14 @@ function FilterPopover({
   )
 }
 
+function isProjectDeployable(project: {
+  project_types?: null | object[]
+}): boolean {
+  return (project.project_types ?? []).some(
+    (pt) => (pt as { deployable?: boolean }).deployable === true,
+  )
+}
+
 function SortHeader({
   children,
   className,
@@ -760,11 +918,15 @@ function SortHeader({
 
 // fallow-ignore-next-line complexity
 function StatBadge({
+  active,
   label,
+  onClick,
   value,
   variant,
 }: {
+  active?: boolean
   label: string
+  onClick?: () => void
   value: number
   variant?:
     | 'accent'
@@ -791,16 +953,31 @@ function StatBadge({
                 : variant === 'amber'
                   ? 'bg-amber-bg border-amber-border text-amber-text'
                   : 'border-secondary text-secondary'
-  return (
-    <span
-      className={`inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs ${variantCls}`}
-    >
+  const interactiveCls = onClick
+    ? `cursor-pointer transition-shadow${active ? ' ring-2 ring-current ring-offset-2 ring-offset-background' : ' hover:ring-1 hover:ring-current hover:ring-offset-1 hover:ring-offset-background'}`
+    : ''
+  const content = (
+    <>
       <span className={variant ? 'font-medium' : 'text-primary font-medium'}>
         {value}
       </span>
       <span>{label}</span>
-    </span>
+    </>
   )
+  const cls = `inline-flex h-10 items-center gap-1.5 rounded-md border p-3 text-xs ${variantCls} ${interactiveCls}`
+  if (onClick) {
+    return (
+      <button
+        aria-pressed={active}
+        className={cls}
+        onClick={onClick}
+        type="button"
+      >
+        {content}
+      </button>
+    )
+  }
+  return <span className={cls}>{content}</span>
 }
 
 // fallow-ignore-next-line complexity

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -13,6 +13,7 @@ import {
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { PROJECT_TYPE_BASE_FIELDS_SET } from '@/lib/constants'
@@ -27,6 +28,7 @@ interface ProjectTypeFormProps {
   projectType: null | ProjectType
 }
 
+// fallow-ignore-next-line complexity
 export function ProjectTypeForm({
   error,
   isLoading = false,
@@ -41,6 +43,9 @@ export function ProjectTypeForm({
   const [slug, setSlug] = useState(projectType?.slug || '')
   const [description, setDescription] = useState(projectType?.description || '')
   const [icon, setIcon] = useState(projectType?.icon || '')
+  const [deployable, setDeployable] = useState<boolean>(
+    (projectType as null | { deployable?: boolean })?.deployable ?? false,
+  )
   const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [orgSlug, setOrgSlug] = useState(
     projectType?.organization.slug || selectedOrganization?.slug || '',
@@ -60,6 +65,7 @@ export function ProjectTypeForm({
     staleTime: 5 * 60 * 1000,
   })
 
+  // fallow-ignore-next-line complexity
   const validate = () => {
     const newErrors: Record<string, string> = {}
     if (!name.trim()) newErrors.name = 'Project type name is required'
@@ -84,6 +90,7 @@ export function ProjectTypeForm({
     if (!validate()) return
 
     onSave(orgSlug, {
+      deployable,
       description: description.trim() || null,
       icon: icon.trim() || null,
       name: name.trim(),
@@ -250,6 +257,29 @@ export function ProjectTypeForm({
                 rows={3}
                 value={description}
               />
+            </div>
+
+            <div>
+              <div className="border-input flex items-start justify-between gap-3 rounded-lg border p-3">
+                <div>
+                  <label
+                    className="text-foreground text-sm font-medium"
+                    htmlFor="project-type-deployable"
+                  >
+                    Deployable
+                  </label>
+                  <p className="text-tertiary text-xs">
+                    Enable deployment tracking and release-train features for
+                    projects of this type.
+                  </p>
+                </div>
+                <Switch
+                  checked={deployable}
+                  disabled={isLoading}
+                  id="project-type-deployable"
+                  onCheckedChange={setDeployable}
+                />
+              </div>
             </div>
 
             <div>

--- a/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
@@ -1,158 +1,93 @@
-import { CheckCircle, Clock, GitPullRequest, MessageSquare } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 
-import { Badge, type BadgeProps } from '@/components/ui/badge'
-import { Card } from '@/components/ui/card'
+import { getMyIdentities, getOrgPullRequests } from '@/api/endpoints'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import type { IdentityConnectionResponse } from '@/types'
 
-interface MyPullRequestsWidgetProps {
-  onUserSelect?: (userName: string) => void
-}
+const GITHUB_PR_PLUGIN_SLUG = 'github-enterprise-cloud'
 
-export function MyPullRequestsWidget({
-  onUserSelect,
-}: MyPullRequestsWidgetProps) {
-  const pullRequests = [
-    {
-      author: 'You',
-      branch: 'feature/health-tracking',
-      comments: 3,
-      createdAt: '2 hours ago',
-      id: 1,
-      repo: 'frontend-applications/navigation',
-      reviewers: ['Scott Miller', 'Dave Shawley'],
-      status: 'ready' as const,
-      title: 'Add health score tracking to dashboard',
-    },
-    {
-      author: 'You',
-      branch: 'bugfix/status-indicator',
-      comments: 0,
-      createdAt: '5 hours ago',
-      id: 2,
-      repo: 'platform/deployment-service',
-      reviewers: ['Gavin Roy'],
-      status: 'pending' as const,
-      title: 'Fix deployment status indicator',
-    },
-    {
-      author: 'You',
-      branch: 'feature/oauth-updates',
-      comments: 7,
-      createdAt: '1 day ago',
-      id: 3,
-      repo: 'security/auth-service',
-      reviewers: ['Jim Fitzpatrick', 'Scott Miller'],
-      status: 'changes-requested' as const,
-      title: 'Update authentication flow',
-    },
-    {
-      author: 'You',
-      branch: 'perf/query-optimization',
-      comments: 2,
-      createdAt: '2 days ago',
-      id: 4,
-      repo: 'backend/analytics',
-      reviewers: ['Dave Shawley'],
-      status: 'approved' as const,
-      title: 'Optimize database queries for reports',
-    },
-  ]
+// fallow-ignore-next-line complexity
+export function MyPullRequestsWidget() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
 
-  const statusConfig = {
-    approved: { color: 'green' as const, icon: CheckCircle, label: 'Approved' },
-    'changes-requested': {
-      color: 'red' as const,
-      icon: MessageSquare,
-      label: 'Changes Requested',
-    },
-    pending: { color: 'yellow' as const, icon: Clock, label: 'Pending Review' },
-    ready: {
-      color: 'blue' as const,
-      icon: GitPullRequest,
-      label: 'Ready for Review',
-    },
-  }
+  const { data: identities, isLoading: identitiesLoading } = useQuery({
+    queryFn: ({ signal }) => getMyIdentities(signal),
+    queryKey: ['me-identities'],
+    staleTime: 0,
+  })
+
+  const login = identities ? githubLogin(identities) : undefined
+  const hasIdentity = !identitiesLoading && !!login
+
+  const { data: openData, isLoading: openLoading } = useQuery({
+    enabled: hasIdentity && !!orgSlug,
+    queryFn: ({ signal }) =>
+      getOrgPullRequests(
+        orgSlug,
+        { author: login, limit: 1, state: 'open' },
+        signal,
+      ),
+    queryKey: ['my-prs', orgSlug, login, 'open'],
+    staleTime: 60 * 1000,
+  })
+
+  const { data: closedData, isLoading: closedLoading } = useQuery({
+    enabled: hasIdentity && !!orgSlug,
+    queryFn: ({ signal }) =>
+      getOrgPullRequests(
+        orgSlug,
+        { author: login, limit: 1, state: 'closed' },
+        signal,
+      ),
+    queryKey: ['my-prs', orgSlug, login, 'closed'],
+    staleTime: 60 * 1000,
+  })
+
+  const isLoading = identitiesLoading || openLoading || closedLoading
+  const notConnected = !identitiesLoading && !login
 
   return (
-    <Card className="p-6">
-      <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-primary text-lg">My Pull Requests</h3>
-        <span className="text-secondary text-sm">
-          {pullRequests.length} open
-        </span>
+    <div className="border-border bg-card rounded-lg border p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-secondary text-sm">My Pull Requests</p>
+          {isLoading ? (
+            <span
+              aria-label="Loading My Pull Requests"
+              className="bg-tertiary/40 mt-2 inline-block h-8 w-20 animate-pulse rounded"
+              role="status"
+            />
+          ) : notConnected ? (
+            <>
+              <p className="text-tertiary mt-2 text-3xl">—</p>
+              <a
+                className="text-action mt-1 block text-xs hover:underline"
+                href="/settings/connections"
+              >
+                Connect GitHub
+              </a>
+            </>
+          ) : (
+            <>
+              <p className="text-action mt-2 text-3xl">
+                {openData?.total ?? 0}
+              </p>
+              <p className="text-tertiary mt-1 text-xs">
+                {closedData?.total ?? 0} closed
+              </p>
+            </>
+          )}
+        </div>
+        <div className="text-4xl">🔀</div>
       </div>
-
-      <div className="space-y-3">
-        {pullRequests.map((pr) => {
-          const config = statusConfig[pr.status]
-          const StatusIcon = config.icon
-
-          return (
-            <div
-              className="border-input bg-background hover:border-secondary rounded-lg border p-4 transition-colors"
-              key={pr.id}
-            >
-              <div className="flex items-start gap-3">
-                <GitPullRequest className="text-tertiary mt-0.5 size-5 shrink-0" />
-                <div className="min-w-0 flex-1">
-                  <div className="text-primary mb-1 font-medium">
-                    {pr.title}
-                  </div>
-                  <div className="text-secondary mb-2 text-sm">
-                    {pr.repo} • {pr.branch}
-                  </div>
-
-                  <div className="flex flex-wrap items-center gap-3">
-                    <Badge
-                      className="gap-1.5 rounded-full"
-                      variant={
-                        ({
-                          blue: 'info',
-                          red: 'danger',
-                          yellow: 'warning',
-                        }[config.color as string] ??
-                          'success') as BadgeProps['variant']
-                      }
-                    >
-                      <StatusIcon className="size-3" />
-                      {config.label}
-                    </Badge>
-
-                    {pr.comments > 0 && (
-                      <span className="flex items-center gap-1 text-xs text-gray-500">
-                        <MessageSquare className="size-3" />
-                        {pr.comments}
-                      </span>
-                    )}
-
-                    <span className="text-xs text-gray-500">
-                      {pr.createdAt}
-                    </span>
-                  </div>
-
-                  {pr.reviewers.length > 0 && (
-                    <div className="mt-2 text-xs text-gray-500">
-                      Reviewers:{' '}
-                      {pr.reviewers.map((reviewer, idx) => (
-                        <button
-                          className={`text-info hover:text-info/80 ${
-                            idx > 0 ? 'ml-1' : ''
-                          }`}
-                          key={idx}
-                          onClick={() => onUserSelect?.(reviewer)}
-                          type="button"
-                        >
-                          {reviewer}
-                          {idx < pr.reviewers.length - 1 ? ',' : ''}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </Card>
+    </div>
   )
+}
+
+function githubLogin(
+  identities: IdentityConnectionResponse[],
+): string | undefined {
+  return identities.find((i) => i.plugin_slug === GITHUB_PR_PLUGIN_SLUG)
+    ?.subject
 }

--- a/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
@@ -12,7 +12,11 @@ export function MyPullRequestsWidget() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug ?? ''
 
-  const { data: identities, isLoading: identitiesLoading } = useQuery({
+  const {
+    data: identities,
+    isError: identitiesError,
+    isLoading: identitiesLoading,
+  } = useQuery({
     queryFn: ({ signal }) => getMyIdentities(signal),
     queryKey: ['me-identities'],
     staleTime: 0,
@@ -21,7 +25,11 @@ export function MyPullRequestsWidget() {
   const login = identities ? githubLogin(identities) : undefined
   const hasIdentity = !identitiesLoading && !!login
 
-  const { data: openData, isLoading: openLoading } = useQuery({
+  const {
+    data: openData,
+    isError: openError,
+    isLoading: openLoading,
+  } = useQuery({
     enabled: hasIdentity && !!orgSlug,
     queryFn: ({ signal }) =>
       getOrgPullRequests(
@@ -33,7 +41,11 @@ export function MyPullRequestsWidget() {
     staleTime: 60 * 1000,
   })
 
-  const { data: closedData, isLoading: closedLoading } = useQuery({
+  const {
+    data: closedData,
+    isError: closedError,
+    isLoading: closedLoading,
+  } = useQuery({
     enabled: hasIdentity && !!orgSlug,
     queryFn: ({ signal }) =>
       getOrgPullRequests(
@@ -46,6 +58,7 @@ export function MyPullRequestsWidget() {
   })
 
   const isLoading = identitiesLoading || openLoading || closedLoading
+  const isError = identitiesError || openError || closedError
   const notConnected = !identitiesLoading && !login
   const openCount = openData?.total ?? 0
   const closedCount = closedData?.total ?? 0
@@ -61,6 +74,8 @@ export function MyPullRequestsWidget() {
               className="bg-tertiary/40 mt-2 inline-block h-9 w-32 animate-pulse rounded"
               role="status"
             />
+          ) : isError ? (
+            <p className="text-danger mt-2 text-sm">Unavailable</p>
           ) : notConnected ? (
             <>
               <p className="text-tertiary mt-2 text-3xl">—</p>

--- a/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { GitMerge } from 'lucide-react'
 
 import { getMyIdentities, getOrgPullRequests } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -46,6 +47,8 @@ export function MyPullRequestsWidget() {
 
   const isLoading = identitiesLoading || openLoading || closedLoading
   const notConnected = !identitiesLoading && !login
+  const openCount = openData?.total ?? 0
+  const closedCount = closedData?.total ?? 0
 
   return (
     <div className="border-border bg-card rounded-lg border p-6">
@@ -55,7 +58,7 @@ export function MyPullRequestsWidget() {
           {isLoading ? (
             <span
               aria-label="Loading My Pull Requests"
-              className="bg-tertiary/40 mt-2 inline-block h-8 w-20 animate-pulse rounded"
+              className="bg-tertiary/40 mt-2 inline-block h-9 w-32 animate-pulse rounded"
               role="status"
             />
           ) : notConnected ? (
@@ -69,17 +72,20 @@ export function MyPullRequestsWidget() {
               </a>
             </>
           ) : (
-            <>
-              <p className="text-action mt-2 text-3xl">
-                {openData?.total ?? 0}
-              </p>
-              <p className="text-tertiary mt-1 text-xs">
-                {closedData?.total ?? 0} closed
-              </p>
-            </>
+            <div className="mt-2 flex items-baseline gap-1.5">
+              <span className="text-primary text-3xl">
+                {openCount.toLocaleString()}
+              </span>
+              <span className="text-secondary text-sm">Open</span>
+              <span className="text-tertiary text-sm">/</span>
+              <span className="text-tertiary text-3xl">
+                {closedCount.toLocaleString()}
+              </span>
+              <span className="text-secondary text-sm">Closed</span>
+            </div>
           )}
         </div>
-        <div className="text-4xl">🔀</div>
+        <GitMerge className="text-tertiary size-9 shrink-0" />
       </div>
     </div>
   )

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -169,17 +169,20 @@ export function DeployTab({
   }, [envSlug])
 
   // For first-env (commit-based) deployments, ``selected.label`` is the
-  // branch name (e.g. ``main``), so compare against ``selected.sha``.
-  // For tag-based envs ``selected.label`` is the tag and matches
-  // ``current.release.version``.
+  // branch name (e.g. ``main``), so compare against ``selected.sha`` via
+  // the release's ``committish``. For tag-based envs ``selected.label`` is
+  // the tag and matches ``current.release.tag``.
+  const currentCommittish = current?.release?.committish ?? null
+  const currentTag = current?.release?.tag ?? null
   const isRedeploy =
     !!current?.release &&
     !!selected &&
     (isFirstEnv
-      ? current.release.version === selected.sha ||
-        selected.sha.startsWith(current.release.version) ||
-        current.release.version.startsWith(selected.sha)
-      : current.release.version === selected.label)
+      ? !!currentCommittish &&
+        (currentCommittish === selected.sha ||
+          selected.sha.startsWith(currentCommittish) ||
+          currentCommittish.startsWith(selected.sha))
+      : currentTag === selected.label)
 
   const queryClient = useQueryClient()
   const mutation = useMutation({
@@ -261,7 +264,9 @@ export function DeployTab({
           <div className="text-tertiary mt-1 text-xs">
             {current?.release ? (
               <>
-                <span className="font-mono">{current.release.version}</span>
+                <span className="font-mono">
+                  {current.release.tag ?? current.release.committish}
+                </span>
                 {current.last_event_at ? (
                   <>
                     {' · '}
@@ -304,7 +309,9 @@ export function DeployTab({
         </div>
         {!isFirstEnv ? (
           <TagList
-            current={current?.release?.version ?? null}
+            current={
+              current?.release?.tag ?? current?.release?.committish ?? null
+            }
             onSelect={(r) => setSelected({ label: r.name, sha: r.sha })}
             selectedSha={selected?.sha ?? null}
             tags={tagOptions}
@@ -316,7 +323,9 @@ export function DeployTab({
             branchesLoading={branchesLoading}
             commits={activeBranchCommits}
             commitsLoading={activeBranchLoading}
-            current={current?.release?.version ?? null}
+            current={
+              current?.release?.tag ?? current?.release?.committish ?? null
+            }
             onBranchSelect={(name) => {
               setActiveBranch(name)
               setSelected(null)
@@ -332,7 +341,9 @@ export function DeployTab({
         ) : (
           <CommitList
             commits={branchCommits}
-            current={current?.release?.version ?? null}
+            current={
+              current?.release?.tag ?? current?.release?.committish ?? null
+            }
             isLoading={commitsLoading}
             onSelect={(c) =>
               setSelected({ label: defaultBranchName, sha: c.sha })
@@ -345,7 +356,7 @@ export function DeployTab({
       {/* Diff summary */}
       {selected && current?.release ? (
         <DiffSummary
-          base={current.release.version}
+          base={current.release.committish}
           head={selected.label ?? selected.sha}
           orgSlug={orgSlug}
           projectId={projectId}

--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -63,8 +63,8 @@ export function PromoteTab({
     return currentReleases.find((r) => r.environment.slug === toEnvironment)
   }, [currentReleases, toEnvironment])
 
-  const lastTag = toCurrent?.release?.version ?? null
-  const fromTipSha = fromCommittish ?? fromCurrent?.release?.version ?? null
+  const lastTag = toCurrent?.release?.tag ?? null
+  const fromTipSha = fromCommittish ?? fromCurrent?.release?.committish ?? null
 
   // Compare last_tag → fromTipSha to enumerate the commits in flight.
   const compareEnabled =

--- a/src/components/reports/ProjectsGraphReport.tsx
+++ b/src/components/reports/ProjectsGraphReport.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { getProjects } from '@/api/endpoints'
+import { ProjectGraphView } from '@/components/ProjectGraphView'
+import { useOrganization } from '@/contexts/OrganizationContext'
+
+export function ProjectsGraphReport() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
+
+  const { data: projects, isLoading } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => getProjects(orgSlug, signal),
+    queryKey: ['projects', orgSlug],
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="text-tertiary text-sm">Loading projects…</div>
+      </div>
+    )
+  }
+
+  return <ProjectGraphView projects={projects ?? []} />
+}

--- a/src/components/reports/ProjectsGraphReport.tsx
+++ b/src/components/reports/ProjectsGraphReport.tsx
@@ -4,6 +4,7 @@ import { getProjects } from '@/api/endpoints'
 import { ProjectGraphView } from '@/components/ProjectGraphView'
 import { useOrganization } from '@/contexts/OrganizationContext'
 
+// fallow-ignore-next-line complexity
 export function ProjectsGraphReport() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug ?? ''

--- a/src/components/reports/ProjectsGraphReport.tsx
+++ b/src/components/reports/ProjectsGraphReport.tsx
@@ -9,11 +9,26 @@ export function ProjectsGraphReport() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug ?? ''
 
-  const { data: projects, isLoading } = useQuery({
+  const {
+    data: projects,
+    error,
+    isLoading,
+  } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => getProjects(orgSlug, signal),
     queryKey: ['projects', orgSlug],
   })
+
+  if (error) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="text-danger text-sm">
+          Failed to load projects:{' '}
+          {error instanceof Error ? error.message : 'Unknown error'}
+        </div>
+      </div>
+    )
+  }
 
   if (isLoading) {
     return (

--- a/src/components/ui/score-badge.tsx
+++ b/src/components/ui/score-badge.tsx
@@ -1,11 +1,12 @@
 interface ScoreBadgeProps {
   score?: null | number
-  /** sm = compact table cell; md = card with ring; lg = detail sidebar */
-  size?: 'lg' | 'md' | 'sm'
+  /** sm = compact table cell; md = card with ring; lg = detail sidebar; xl = prominent list cell */
+  size?: 'lg' | 'md' | 'sm' | 'xl'
   /** circle: rounded-full (projects list); square: rounded-lg (project detail) */
   variant?: 'circle' | 'square'
 }
 
+// fallow-ignore-next-line complexity
 export function ScoreBadge({
   score,
   size = 'sm',
@@ -15,14 +16,16 @@ export function ScoreBadge({
 
   if (score == null || !Number.isFinite(score)) {
     const dims =
-      size === 'lg'
-        ? 'h-16 w-16 text-2xl'
-        : size === 'md'
-          ? 'h-12 w-12 text-sm'
-          : 'h-10 w-10 text-sm'
+      size === 'xl'
+        ? 'h-20 w-20 text-[1.5rem]'
+        : size === 'lg'
+          ? 'h-16 w-16 text-2xl'
+          : size === 'md'
+            ? 'h-12 w-12 text-sm'
+            : 'h-10 w-10 text-sm'
     return (
       <div
-        className={`text-tertiary flex shrink-0 items-center justify-center font-medium ${rounded} ${dims}`}
+        className={`border-tertiary text-tertiary flex shrink-0 items-center justify-center border-[0.25px] font-medium ${rounded} ${dims}`}
       >
         —
       </div>
@@ -30,12 +33,22 @@ export function ScoreBadge({
   }
 
   const display = Math.round(score)
-  const { bg, ring, text } = scoreClasses(display)
+  const { bg, border, ring, text } = scoreClasses(display)
+
+  if (size === 'xl') {
+    return (
+      <div
+        className={`flex size-20 shrink-0 items-center justify-center border-[0.25px] text-[1.5rem] font-medium ${rounded} ${bg} ${border} ${text}`}
+      >
+        {display}
+      </div>
+    )
+  }
 
   if (size === 'lg') {
     return (
       <div
-        className={`flex size-16 shrink-0 items-center justify-center text-2xl font-medium ${rounded} ${bg} ${text}`}
+        className={`flex size-16 shrink-0 items-center justify-center border-[0.25px] text-2xl font-medium ${rounded} ${bg} ${border} ${text}`}
       >
         {display}
       </div>
@@ -45,7 +58,7 @@ export function ScoreBadge({
   if (size === 'md') {
     return (
       <div
-        className={`flex size-12 shrink-0 items-center justify-center ring-4 ${rounded} ${bg} ${text} ${ring}`}
+        className={`flex size-12 shrink-0 items-center justify-center border-[0.25px] ring-4 ${rounded} ${bg} ${border} ${text} ${ring}`}
       >
         <span className="text-sm font-semibold">{display}</span>
       </div>
@@ -54,7 +67,7 @@ export function ScoreBadge({
 
   return (
     <div
-      className={`inline-flex size-10 items-center justify-center ${rounded} ${bg} ${text}`}
+      className={`inline-flex size-10 items-center justify-center border-[0.25px] ${rounded} ${bg} ${border} ${text}`}
     >
       <span className="text-sm font-semibold">{display}</span>
     </div>
@@ -63,20 +76,28 @@ export function ScoreBadge({
 
 function scoreClasses(score: number): {
   bg: string
+  border: string
   ring: string
   text: string
 } {
   if (score >= 80)
     return {
       bg: 'bg-success',
+      border: 'border-success',
       ring: 'ring-success',
       text: 'text-success',
     }
   if (score >= 70)
     return {
       bg: 'bg-warning',
+      border: 'border-warning',
       ring: 'ring-warning',
       text: 'text-warning',
     }
-  return { bg: 'bg-danger', ring: 'ring-danger', text: 'text-danger' }
+  return {
+    bg: 'bg-danger',
+    border: 'border-danger',
+    ring: 'ring-danger',
+    text: 'text-danger',
+  }
 }

--- a/src/components/ui/score-badge.tsx
+++ b/src/components/ui/score-badge.tsx
@@ -58,7 +58,7 @@ export function ScoreBadge({
   if (size === 'md') {
     return (
       <div
-        className={`flex size-12 shrink-0 items-center justify-center ring-2 ${rounded} ${bg} ${border} ${text} ${ring}`}
+        className={`flex size-12 shrink-0 items-center justify-center ring-2 ${rounded} ${bg} ${text} ${ring}`}
       >
         <span className="text-sm font-semibold">{display}</span>
       </div>

--- a/src/components/ui/score-badge.tsx
+++ b/src/components/ui/score-badge.tsx
@@ -58,7 +58,7 @@ export function ScoreBadge({
   if (size === 'md') {
     return (
       <div
-        className={`flex size-12 shrink-0 items-center justify-center border-[0.25px] ring-4 ${rounded} ${bg} ${border} ${text} ${ring}`}
+        className={`flex size-12 shrink-0 items-center justify-center ring-2 ${rounded} ${bg} ${border} ${text} ${ring}`}
       >
         <span className="text-sm font-semibold">{display}</span>
       </div>
@@ -67,7 +67,7 @@ export function ScoreBadge({
 
   return (
     <div
-      className={`inline-flex size-10 items-center justify-center border-[0.25px] ${rounded} ${bg} ${border} ${text}`}
+      className={`inline-flex size-10 items-center justify-center border ${rounded} ${bg} ${border} ${text}`}
     >
       <span className="text-sm font-semibold">{display}</span>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -68,6 +68,7 @@
   --background-color-success: var(--ds-bg-success);
   --background-color-warning: var(--ds-bg-warning);
   --background-color-accent: var(--ds-bg-accent);
+  --background-color-teal: var(--ds-bg-teal);
   --background-color-action: var(--ds-action-bg);
   --background-color-action-hover: var(--ds-action-bg-hover);
 
@@ -79,6 +80,7 @@
   --text-color-success: var(--ds-text-success);
   --text-color-warning: var(--ds-text-warning);
   --text-color-accent: var(--ds-text-accent);
+  --text-color-teal: var(--ds-text-teal);
   --text-color-action: var(--ds-action-bg);
   --text-color-action-foreground: var(--ds-action-fg);
 
@@ -90,6 +92,7 @@
   --border-color-success: var(--ds-border-success);
   --border-color-warning: var(--ds-border-warning);
   --border-color-accent: var(--ds-border-accent);
+  --border-color-teal: var(--ds-border-teal);
   --border-color-action: var(--ds-action-bg);
 
   --ring-color-primary: var(--ds-border-primary);
@@ -100,6 +103,7 @@
   --ring-color-success: var(--ds-border-success);
   --ring-color-warning: var(--ds-border-warning);
   --ring-color-accent: var(--ds-border-accent);
+  --ring-color-teal: var(--ds-border-teal);
   --ring-color-action: var(--ds-action-bg);
 
   --divide-color-primary: var(--ds-border-primary);
@@ -217,24 +221,27 @@
   --ds-bg-success: #eaf3de;
   --ds-bg-warning: #faeeda;
   --ds-bg-accent: #eeedfe;
+  --ds-bg-teal: #d6efea;
 
   --ds-text-primary: #1a1a18;
   --ds-text-secondary: #5f5e5a;
   --ds-text-tertiary: #888780;
   --ds-text-info: #185fa5;
-  --ds-text-danger: #a32d2d;
+  --ds-text-danger: #c86b5e;
   --ds-text-success: #6b9a3f;
   --ds-text-warning: #7c5900;
   --ds-text-accent: #3c3489;
+  --ds-text-teal: #0f7164;
 
   --ds-border-tertiary: rgba(26, 26, 24, 0.15);
   --ds-border-secondary: rgba(26, 26, 24, 0.3);
   --ds-border-primary: rgba(26, 26, 24, 0.4);
   --ds-border-info: #185fa5;
-  --ds-border-danger: #f5b4b4;
-  --ds-border-success: #b4d99a;
+  --ds-border-danger: #c86b5e;
+  --ds-border-success: #6b9a3f;
   --ds-border-warning: #e6c77a;
-  --ds-border-accent: #c8c4f1;
+  --ds-border-accent: #3c3489;
+  --ds-border-teal: #0f7164;
 
   --ds-action-bg: #b8860b;
   --ds-action-bg-hover: #8f6a09;
@@ -251,6 +258,7 @@
   --ds-bg-success: #1c2e12;
   --ds-bg-warning: #3d2e12;
   --ds-bg-accent: #20204a;
+  --ds-bg-teal: #0f2e28;
 
   --ds-text-primary: #e8e7e3;
   --ds-text-secondary: #a0a09a;
@@ -260,15 +268,17 @@
   --ds-text-success: #7cbf4a;
   --ds-text-warning: #e0a830;
   --ds-text-accent: #9d95e8;
+  --ds-text-teal: #5fc9b4;
 
   --ds-border-tertiary: rgba(232, 231, 227, 0.15);
   --ds-border-secondary: rgba(232, 231, 227, 0.25);
   --ds-border-primary: rgba(232, 231, 227, 0.35);
   --ds-border-info: #6db3f2;
-  --ds-border-danger: #8a3030;
-  --ds-border-success: #4a7a1a;
+  --ds-border-danger: #f08a8a;
+  --ds-border-success: #7cbf4a;
   --ds-border-warning: #7a5818;
-  --ds-border-accent: #3a3570;
+  --ds-border-accent: #9d95e8;
+  --ds-border-teal: #5fc9b4;
 
   --ds-action-bg: #fbce39;
   --ds-action-bg-hover: #e0b525;

--- a/src/index.css
+++ b/src/index.css
@@ -284,6 +284,15 @@
   --ds-action-bg-hover: #e0b525;
   --ds-action-fg: #1a1a18;
 
+  /* WorkerBee amber brand tokens — dim the cream backdrop and brighten
+     the text so highlighted "selected" surfaces (StatBadge amber, active
+     nav, etc.) carry the same visual weight as the other --ds-bg-*
+     tinted variants in dark mode. Border/ring stay brand-orange. */
+  --background-color-amber-bg: #3d2e12;
+  --text-color-amber-text: #e0a830;
+  --text-color-amber-text-mid: #d1962a;
+  --border-color-amber-text: #e0a830;
+
   --color-background: hsl(40 5% 11%);
   --color-foreground: hsl(40 4% 90%);
   --color-primary: hsl(38 90% 50%);

--- a/src/index.css
+++ b/src/index.css
@@ -223,7 +223,7 @@
   --ds-text-tertiary: #888780;
   --ds-text-info: #185fa5;
   --ds-text-danger: #a32d2d;
-  --ds-text-success: #27500a;
+  --ds-text-success: #6b9a3f;
   --ds-text-warning: #7c5900;
   --ds-text-accent: #3c3489;
 

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,10 +1,16 @@
 import { useNavigate, useParams } from 'react-router-dom'
 
-import { BarChart3, GitCommitHorizontal, TrendingUp } from 'lucide-react'
+import {
+  BarChart3,
+  GitCommitHorizontal,
+  Network,
+  TrendingUp,
+} from 'lucide-react'
 
 import { CommandBar } from '@/components/CommandBar'
 import { Navigation } from '@/components/Navigation'
 import { MonthlyImprovementReport } from '@/components/reports/MonthlyImprovementReport'
+import { ProjectsGraphReport } from '@/components/reports/ProjectsGraphReport'
 import { ScoreHistoryReport } from '@/components/reports/ScoreHistoryReport'
 import { TeamKPIReport } from '@/components/reports/TeamKPIReport'
 import { usePageTitle } from '@/hooks/usePageTitle'
@@ -20,13 +26,19 @@ const REPORTS: Report[] = [
   {
     description: 'Month-over-month score delta',
     id: 'monthly-improvement',
-    label: 'Monthly improvement',
+    label: 'Monthly Improvement',
     subtitle: 'Score improvement by team for a selected month',
+  },
+  {
+    description: 'Service dependency graph',
+    id: 'projects-graph',
+    label: 'Projects Graph',
+    subtitle: 'Project relationships across the org',
   },
   {
     description: 'Score trends over time per team',
     id: 'score-history',
-    label: 'Score history',
+    label: 'Score History',
     subtitle: 'Avg score trend per team over time',
   },
   {
@@ -40,6 +52,7 @@ const REPORTS: Report[] = [
 const DEFAULT_REPORT = REPORTS[0].id
 const VALID_IDS = new Set(REPORTS.map((r) => r.id))
 
+// fallow-ignore-next-line complexity
 export function ReportsPage() {
   usePageTitle('Reports')
   const { reportId } = useParams<{ reportId?: string }>()
@@ -70,6 +83,7 @@ export function ReportsPage() {
                 </div>
               </div>
               <div className="space-y-1 p-2">
+                {/* fallow-ignore-next-line complexity */}
                 {REPORTS.map((r) => {
                   const isActive = r.id === activeId
                   return (
@@ -86,6 +100,8 @@ export function ReportsPage() {
                         <BarChart3 className="mt-0.5 size-3.5 shrink-0" />
                       ) : r.id === 'score-history' ? (
                         <GitCommitHorizontal className="mt-0.5 size-3.5 shrink-0" />
+                      ) : r.id === 'projects-graph' ? (
+                        <Network className="mt-0.5 size-3.5 shrink-0" />
                       ) : (
                         <TrendingUp className="mt-0.5 size-3.5 shrink-0" />
                       )}
@@ -113,6 +129,7 @@ export function ReportsPage() {
             {activeId === 'team-kpi' && <TeamKPIReport />}
             {activeId === 'monthly-improvement' && <MonthlyImprovementReport />}
             {activeId === 'score-history' && <ScoreHistoryReport />}
+            {activeId === 'projects-graph' && <ProjectsGraphReport />}
           </div>
         </div>
       </main>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,7 @@ export interface Project {
   [key: string]: unknown
   archived?: boolean
   archived_at?: null | string
+  closed_pr_count?: number
   created_at?: null | string
   description?: null | string
   environments?: Environment[]
@@ -137,6 +138,7 @@ export interface Project {
   identifiers?: Record<string, number | string>
   links?: Record<string, string>
   name: string
+  open_pr_count?: number
   project_type?: {
     name: string
     organization: {
@@ -215,6 +217,29 @@ export interface ProjectTypeCreate {
   icon?: null | string
   name: string
   slug: string
+}
+
+export interface PullRequest {
+  additions: number
+  author: string
+  changed_files: number
+  created_at: string
+  deletions: number
+  draft: boolean
+  merged: boolean
+  merged_at: null | string
+  pr_id: string
+  pr_number: number
+  project_id: string
+  state: string
+  title: string
+  updated_at: string
+  url: string
+}
+
+export interface PullRequestListResponse {
+  data: PullRequest[]
+  total: number
 }
 
 export type RelationshipLink = Schemas['RelationshipLink']

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -216,6 +216,7 @@ export type ProjectType = Schemas['ProjectTypeResponse']
 // mounts project-type creation via the generic org scoped endpoint.
 export interface ProjectTypeCreate {
   [key: string]: unknown
+  deployable?: boolean
   description?: null | string
   icon?: null | string
   name: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -250,9 +250,10 @@ export interface PullRequestListResponse {
 export type RelationshipLink = Schemas['RelationshipLink']
 
 export interface ReleaseInfo {
+  committish?: null | string
   deployed_at: string
   performed_by?: null | string
-  version: string
+  tag?: null | string
 }
 
 // Scoring policy types — discriminated union on `category`. See
@@ -937,15 +938,16 @@ export type ProjectRelationshipsResponse =
   Schemas['ProjectRelationshipsResponse']
 
 export interface Release {
+  committish: string
   created_at: string
   created_by: string
   description?: null | string
   id: string
   links: ReleaseLink[]
   project_id: string
+  tag?: null | string
   title: string
   updated_at?: null | string
-  version: string
 }
 export interface ReleaseLink {
   label?: null | string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -250,6 +250,7 @@ export type RelationshipLink = Schemas['RelationshipLink']
 
 export interface ReleaseInfo {
   deployed_at: string
+  performed_by?: null | string
   version: string
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -239,6 +239,7 @@ export interface PullRequest {
 
 export interface PullRequestListResponse {
   data: PullRequest[]
+  project_count: number
   total: number
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,6 +131,7 @@ export interface Project {
   archived_at?: null | string
   closed_pr_count?: number
   created_at?: null | string
+  current_releases?: Record<string, ReleaseInfo>
   description?: null | string
   environments?: Environment[]
   icon?: null | string
@@ -174,6 +175,8 @@ export interface Project {
     slug: string
   }
   updated_at?: null | string
+  viewer_closed_pr_count?: number
+  viewer_open_pr_count?: number
 }
 
 // `ProjectCreate` stays hand-written: the UI sends `environment_slugs` (a
@@ -244,6 +247,11 @@ export interface PullRequestListResponse {
 }
 
 export type RelationshipLink = Schemas['RelationshipLink']
+
+export interface ReleaseInfo {
+  deployed_at: string
+  version: string
+}
 
 // Scoring policy types — discriminated union on `category`. See
 // imbi-common/scoring/models.py for the canonical shape.


### PR DESCRIPTION
## Summary
- Migrate project list release surfaces to the new tag/committish model
- Add drift detection between consecutive environments with themed badges in both list and grid views
- Surface drift in a clickable "Need Release" stat badge that filters the list
- Reshape the deployment cards (label-color theming, env name + version layout, check icon moved to the version line)
- Default Projects to list view, persist the user's last choice in localStorage
- Disable header controls during the initial fetch instead of replacing the page with a spinner

## Test plan
- [ ] Verify the Projects page opens in list view on first load, then remembers grid/list across reloads
- [ ] Confirm the Drift column shows abbreviated `Δ <from> → <to>` badges colored by the destination env's `label_color`
- [ ] Confirm the grid cards show the same drift badges inline alongside PR badges
- [ ] Toggle the "Need Release" stat badge and verify it filters to projects with drift, and the count matches the filtered set
- [ ] Toggle "Open PRs" and "My PRs" stat badges and verify they continue to work
- [ ] Confirm the deployment cards render the green check on the version line (right-aligned) and not on the env-name line
- [ ] Hover an environment chip in the grid card and confirm the popover renders the same way
- [ ] Confirm the page does not produce a horizontal page-level scrollbar with multiple deployment cards