### PR TITLE
Make project search responsive on big project lists

### DIFF
--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react'
+import * as React from 'react'
+import { useDeferredValue, useEffect, useMemo, useState } from 'react'
 
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -23,7 +24,9 @@ import { matchSorter } from 'match-sorter'
 import { getProjects } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { deriveChipColors } from '@/lib/chip-colors'
+import type { Project } from '@/types'
 
 import { NewProjectDialog } from './NewProjectDialog'
 import { Button } from './ui/button'
@@ -64,6 +67,11 @@ interface FilterPopoverProps {
   options: { label: string; slug: string }[]
 }
 
+interface ProjectListRowProps {
+  onSelect: (id: string) => void
+  project: Project
+}
+
 type SortDir = 'asc' | 'desc'
 
 interface SortHeaderProps {
@@ -77,6 +85,12 @@ interface SortHeaderProps {
 type SortKey = 'name' | 'prs' | 'score' | 'team' | 'type'
 
 const VIEW_MODE_STORAGE_KEY = 'imbi.projects.view-mode'
+
+// Trails the user by ~one settle so the URL ``?q=`` write (and the
+// downstream filter+render pass) doesn't fire on every keystroke.
+// 200ms is short enough to feel synchronous for the common
+// type-pause-look pattern.
+const SEARCH_DEBOUNCE_MS = 200
 
 // fallow-ignore-next-line complexity
 export function ProjectsView() {
@@ -92,7 +106,19 @@ export function ProjectsView() {
   )
   const rawView = searchParams.get('view')
   const viewMode = resolveViewMode(rawView, storedView)
-  const searchQuery = searchParams.get('q') ?? ''
+  // ``inputQuery`` drives the controlled <Input>; ``debouncedQuery``
+  // is what gets persisted to the URL and consumed by the filter
+  // pipeline. Local input state keeps typing responsive even though
+  // filtering hundreds of rows is expensive; the URL sync trails the
+  // user by ``SEARCH_DEBOUNCE_MS`` so back-buttoning still works.
+  const urlQuery = searchParams.get('q') ?? ''
+  const [inputQuery, setInputQuery] = useState(urlQuery)
+  const debouncedQuery = useDebouncedValue(inputQuery, SEARCH_DEBOUNCE_MS)
+  // ``useDeferredValue`` lets React render the stale filtered list
+  // first (so the input never freezes), then reconcile to the new
+  // ``debouncedQuery`` at a lower priority. Cheap to add and
+  // additive to the debounce.
+  const deferredQuery = useDeferredValue(debouncedQuery)
   const sortKey = (searchParams.get('sort') ?? 'name') as SortKey
   const sortDir = (searchParams.get('dir') ?? 'asc') as SortDir
   const teamsParam = searchParams.get('teams') ?? ''
@@ -116,16 +142,32 @@ export function ProjectsView() {
     )
   }
 
-  const setSearchQuery = (q: string) =>
+  // Sync the debounced query → URL. Skip the write when the value
+  // already matches what's in the URL (covers back/forward and the
+  // initial mount where ``inputQuery === urlQuery`` by construction).
+  useEffect(() => {
+    if (debouncedQuery === urlQuery) return
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev)
-        if (q) next.set('q', q)
+        if (debouncedQuery) next.set('q', debouncedQuery)
         else next.delete('q')
         return next
       },
       { replace: true },
     )
+  }, [debouncedQuery, urlQuery, setSearchParams])
+
+  // Honor external URL changes (back/forward, deep links) by
+  // resyncing the input. Compares against the *current* input so
+  // typing isn't clobbered by the debounced URL write that just
+  // landed.
+  useEffect(() => {
+    if (urlQuery !== inputQuery && urlQuery !== debouncedQuery) {
+      setInputQuery(urlQuery)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlQuery])
 
   const setSort = (key: SortKey) =>
     setSearchParams((prev) => nextSortParams(prev, key), { replace: true })
@@ -238,8 +280,8 @@ export function ProjectsView() {
     if (hasDrift) {
       all = all.filter((p) => driftedProjectIds.has(p.id))
     }
-    if (searchQuery) {
-      return matchSorter(all, searchQuery, {
+    if (deferredQuery) {
+      return matchSorter(all, deferredQuery, {
         keys: [
           'name',
           'description',
@@ -273,7 +315,7 @@ export function ProjectsView() {
   }, [
     projects,
     driftedProjectIds,
-    searchQuery,
+    deferredQuery,
     sortKey,
     sortDir,
     teamsParam,
@@ -326,10 +368,10 @@ export function ProjectsView() {
               <Input
                 className="pl-9"
                 disabled={isLoading}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => setInputQuery(e.target.value)}
                 placeholder="Search projects..."
                 type="text"
-                value={searchQuery}
+                value={inputQuery}
               />
             </div>
 
@@ -548,62 +590,12 @@ export function ProjectsView() {
               maxHeight: 'calc(100vh - 330px - var(--assistant-height, 64px))',
             }}
           >
-            {/* fallow-ignore-next-line complexity */}
             {filteredProjects.map((project) => (
-              <div
-                className="hover:bg-secondary flex cursor-pointer items-center transition-colors"
+              <ProjectListRow
                 key={`row-${project.id}`}
-                onClick={() => handleProjectSelect(project.id)}
-              >
-                <div className="w-65 shrink-0 px-6 py-4">
-                  <p className="text-primary font-medium">{project.name}</p>
-                  {(project.project_types ?? []).length > 0 && (
-                    <p className="text-secondary text-xs">
-                      {project.project_types!.map((pt) => pt.name).join(', ')}
-                    </p>
-                  )}
-                  <p className="text-tertiary text-xs">{project.team.name}</p>
-                </div>
-                <div className="w-40 shrink-0 px-6 py-4 whitespace-nowrap">
-                  <div className="flex items-center justify-center gap-1.5">
-                    {(project.open_pr_count ?? 0) > 0 && (
-                      <span className="border-accent bg-accent text-accent inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs">
-                        <GitPullRequest className="size-3.5" />
-                        <span>{project.open_pr_count}</span>
-                      </span>
-                    )}
-                    {(project.viewer_open_pr_count ?? 0) > 0 && (
-                      <span className="border-info bg-info text-info inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs">
-                        <User className="size-3.5" />
-                        <span>{project.viewer_open_pr_count}</span>
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div className="flex w-40 shrink-0 items-center justify-center px-5 py-4">
-                  <DriftCell project={project} />
-                </div>
-                <div
-                  className="flex min-w-0 flex-1 overflow-x-auto px-6 py-4"
-                  style={{ justifyContent: 'safe center' }}
-                >
-                  {isProjectDeployable(project) &&
-                    project.environments &&
-                    project.environments.length > 0 && (
-                      <DeploymentCards
-                        environments={project.environments}
-                        releases={project.current_releases ?? {}}
-                      />
-                    )}
-                </div>
-                <div className="flex w-40 shrink-0 justify-center px-6 py-4 whitespace-nowrap">
-                  <ScoreBadge
-                    score={project.score}
-                    size="md"
-                    variant="circle"
-                  />
-                </div>
-              </div>
+                onSelect={handleProjectSelect}
+                project={project}
+              />
             ))}
           </div>
         </Card>
@@ -1207,3 +1199,66 @@ function timeAgo(iso: string): string {
   const rounded = Math.round(years * 10) / 10
   return `${rounded}y ago`
 }
+
+// Memoized list-mode row so a parent re-render (e.g. an ``inputQuery``
+// keystroke) doesn't redo the JSX for every row in the table. The
+// ``project`` reference comes from a memoized filter pipeline, so as
+// long as the underlying object identity is stable (it is — React Query
+// returns the same array between renders), the row skips its render.
+// fallow-ignore-next-line complexity
+const ProjectListRow = React.memo(function ProjectListRow({
+  onSelect,
+  project,
+}: ProjectListRowProps) {
+  return (
+    <div
+      className="hover:bg-secondary flex cursor-pointer items-center transition-colors"
+      onClick={() => onSelect(project.id)}
+    >
+      <div className="w-65 shrink-0 px-6 py-4">
+        <p className="text-primary font-medium">{project.name}</p>
+        {(project.project_types ?? []).length > 0 && (
+          <p className="text-secondary text-xs">
+            {project.project_types!.map((pt) => pt.name).join(', ')}
+          </p>
+        )}
+        <p className="text-tertiary text-xs">{project.team.name}</p>
+      </div>
+      <div className="w-40 shrink-0 px-6 py-4 whitespace-nowrap">
+        <div className="flex items-center justify-center gap-1.5">
+          {(project.open_pr_count ?? 0) > 0 && (
+            <span className="border-accent bg-accent text-accent inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs">
+              <GitPullRequest className="size-3.5" />
+              <span>{project.open_pr_count}</span>
+            </span>
+          )}
+          {(project.viewer_open_pr_count ?? 0) > 0 && (
+            <span className="border-info bg-info text-info inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs">
+              <User className="size-3.5" />
+              <span>{project.viewer_open_pr_count}</span>
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="flex w-40 shrink-0 items-center justify-center px-5 py-4">
+        <DriftCell project={project} />
+      </div>
+      <div
+        className="flex min-w-0 flex-1 overflow-x-auto px-6 py-4"
+        style={{ justifyContent: 'safe center' }}
+      >
+        {isProjectDeployable(project) &&
+          project.environments &&
+          project.environments.length > 0 && (
+            <DeploymentCards
+              environments={project.environments}
+              releases={project.current_releases ?? {}}
+            />
+          )}
+      </div>
+      <div className="flex w-40 shrink-0 justify-center px-6 py-4 whitespace-nowrap">
+        <ScoreBadge score={project.score} size="md" variant="circle" />
+      </div>
+    </div>
+  )
+})

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+// Returns ``value`` after it has remained unchanged for ``delayMs``
+// milliseconds. Useful for keeping a snappy input state separate from
+// a downstream consumer that's expensive to recompute (URL sync,
+// network call, big filter+render pass).
+//
+// ``delayMs`` of ``0`` short-circuits and returns ``value`` directly,
+// which lets a caller turn debouncing off (e.g. for tests) without
+// branching the hook out.
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    if (delayMs <= 0) {
+      setDebounced(value)
+      return
+    }
+    const timer = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+  return debounced
+}

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -18,5 +18,5 @@ export function useDebouncedValue<T>(value: T, delayMs: number): T {
     const timer = setTimeout(() => setDebounced(value), delayMs)
     return () => clearTimeout(timer)
   }, [value, delayMs])
-  return debounced
+  return delayMs <= 0 ? value : debounced
 }


### PR DESCRIPTION
## Summary

Search on the Projects page was freezing the input for 500ms-2s on large orgs. The cause was three things compounding, not the payload size:

1. `setSearchQuery` wrote the URL `?q=` on every keystroke (`ProjectsView.tsx:120`), triggering a top-level re-render → `filteredProjects` `useMemo` re-evaluated `matchSorter` over the whole array → every row in the list re-rendered (each row mounts `DeploymentCards`, `DriftCell`, `ScoreBadge`).
2. No debounce — every character paid the full filter+render cost.
3. The row JSX lives inline in the `filteredProjects.map(...)` so React redoes the entire row tree even when only the search string changed.

## Changes

- **Local input state + debounced URL sync** (`useDebouncedValue` hook, 200ms). The controlled `<Input>` binds to `inputQuery`; the URL write trails the user.
- **`useDeferredValue`** on the debounced query so React renders the stale filtered list first, then reconciles to the new result at a lower priority.
- **`React.memo`'d `ProjectListRow`**. Extracted the inline list-row JSX. With stable `project` references from the memoized filter pipeline, rows skip their render when only the search string changed.
- URL reconciliation goes both ways: typed input → debounced URL write; external URL change (back/forward, deep link) → input state, guarded so the typed value isn't clobbered by the debounced write that just landed.

## Not in scope (follow-ups)

- Slimmer `GET /organizations/{org}/projects/` payload — 3MB cached in memory today, dropping unused fields (`links`, `identifiers`, embedded `organization` on team/project_types/environments, blueprint dynamic fields, edge props) cuts memory + network without changing the page. Will be a separate API+UI PR.
- List virtualization (`@tanstack/react-virtual` is already a transitive dep). Useful past ~150 rows; defer until we see if the above is enough.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 248/248
- [ ] Type fast on the search box with a large project list; input should stay responsive
- [ ] Pause typing → URL `?q=` updates ~200ms later; back-button restores prior query
- [ ] Deep link `/?q=foo` populates the input on mount

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>