### PR TITLE
Show Recompute Score when user has scoring_policy:rescore

### DIFF
--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -44,6 +44,8 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   const navigate = useNavigate()
   const { user } = useAuth()
   const isAdmin = user?.is_admin === true
+  const canRescore =
+    isAdmin || (user?.permissions ?? []).includes('scoring_policy:rescore')
   const { patch, scheduleScoreRefresh } = useProjectPatch(orgSlug, project.id)
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -185,21 +187,23 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
 
       <ProjectPluginsSection orgSlug={orgSlug} projectId={project.id} />
 
-      {isAdmin && (
+      {(canRescore || (isAdmin && deploymentPlugin)) && (
         <Card>
           <CardHeader>
             <CardTitle>Utility Functions</CardTitle>
           </CardHeader>
           <CardContent className="flex gap-2">
-            <Button
-              disabled={rescoreMutation.isPending}
-              onClick={() => rescoreMutation.mutate()}
-              size="sm"
-              variant="outline"
-            >
-              {rescoreMutation.isPending ? 'Enqueuing...' : 'Recompute Score'}
-            </Button>
-            {deploymentPlugin && (
+            {canRescore && (
+              <Button
+                disabled={rescoreMutation.isPending}
+                onClick={() => rescoreMutation.mutate()}
+                size="sm"
+                variant="outline"
+              >
+                {rescoreMutation.isPending ? 'Enqueuing...' : 'Recompute Score'}
+              </Button>
+            )}
+            {isAdmin && deploymentPlugin && (
               <Button
                 disabled={resyncMutation.isPending}
                 onClick={() => resyncMutation.mutate()}


### PR DESCRIPTION
## Summary

Pairs with AWeber-Imbi/imbi-api#329 which introduces a new `scoring_policy:rescore` permission for the single-project rescore path on `POST /scoring/rescore`. The project Settings → Utility Functions card was admin-only, so developers and default-role users couldn't trigger a rescore for their own project even after the API change lands.

## Changes

`src/components/ProjectSettingsTab.tsx`:
- Derive `canRescore = isAdmin || user.permissions.includes('scoring_policy:rescore')`.
- The card now renders when *either* button is available (it was gated on `isAdmin` alone before).
- The two buttons are gated independently:
  - **Recompute Score** → `canRescore`
  - **Sync Deployments** → `isAdmin && deploymentPlugin` (unchanged; the resync endpoint is still admin-only on the API side)

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [ ] Sign in as a developer-role user, open a project's Settings tab: "Recompute Score" should be visible; "Sync Deployments" should be hidden.
- [ ] Sign in as an admin: both buttons visible (when a deployment plugin is attached).

## Depends on

AWeber-Imbi/imbi-api#329 — without it, the button shows but the API returns 403.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>