### PR TITLE
Fetch projects-list with the slim API payload

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -134,6 +134,56 @@ export const getProjects = async (
   return Array.isArray(response) ? response : []
 }
 
+// Slim variant: returns a trimmed ``ProjectListItem`` payload (just
+// the fields the projects-list view reads). Used by the projects
+// page to keep the cached array compact in memory; other callers
+// can opt in once their consumers are audited.
+export interface ProjectListItem {
+  archived: boolean
+  closed_pr_count: number
+  current_releases: Record<
+    string,
+    {
+      committish?: null | string
+      deployed_at: string
+      performed_by?: null | string
+      tag?: null | string
+    }
+  >
+  description: null | string
+  environments: {
+    label_color?: null | string
+    name: string
+    slug: string
+    sort_order: number
+  }[]
+  id: string
+  name: string
+  open_pr_count: number
+  project_types: {
+    deployable: boolean
+    name: string
+    slug: string
+  }[]
+  score: null | number
+  slug: string
+  team: { name: string; slug: string }
+  viewer_closed_pr_count: number
+  viewer_open_pr_count: number
+}
+
+export const getProjectsSlim = async (
+  orgSlug: string,
+  signal?: AbortSignal,
+): Promise<ProjectListItem[]> => {
+  const response = await apiClient.get<ProjectListItem[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/?slim=true`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
 export const getProject = (
   orgSlug: string,
   projectId: string,

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lucide-react'
 import { matchSorter } from 'match-sorter'
 
-import { getProjects } from '@/api/endpoints'
+import { getProjectsSlim } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useDebouncedValue } from '@/hooks/useDebouncedValue'
@@ -211,7 +211,7 @@ export function ProjectsView() {
     refetch,
   } = useQuery({
     enabled: !!orgSlug,
-    queryFn: ({ signal }) => getProjects(orgSlug, signal),
+    queryFn: ({ signal }) => getProjectsSlim(orgSlug, signal),
     queryKey: ['projects', orgSlug],
   })
 

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react'
-import { useDeferredValue, useEffect, useMemo, useState } from 'react'
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -239,9 +245,14 @@ export function ProjectsView() {
       .sort((a, b) => a.label.localeCompare(b.label))
   }, [projects])
 
-  const handleProjectSelect = (projectId: string) => {
-    navigate(`/projects/${projectId}`)
-  }
+  // Stable ref so the memoized ``ProjectListRow`` can actually skip
+  // re-renders when only the parent's input/filter state changes.
+  const handleProjectSelect = useCallback(
+    (projectId: string) => {
+      navigate(`/projects/${projectId}`)
+    },
+    [navigate],
+  )
 
   const driftedProjectIds = useMemo(() => {
     const ids = new Set<string>()

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -21,12 +21,11 @@ import {
 } from 'lucide-react'
 import { matchSorter } from 'match-sorter'
 
-import { getProjectsSlim } from '@/api/endpoints'
+import { getProjectsSlim, type ProjectListItem } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { deriveChipColors } from '@/lib/chip-colors'
-import type { Project } from '@/types'
 
 import { NewProjectDialog } from './NewProjectDialog'
 import { Button } from './ui/button'
@@ -69,7 +68,7 @@ interface FilterPopoverProps {
 
 interface ProjectListRowProps {
   onSelect: (id: string) => void
-  project: Project
+  project: ProjectListItem
 }
 
 type SortDir = 'asc' | 'desc'
@@ -212,7 +211,7 @@ export function ProjectsView() {
   } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => getProjectsSlim(orgSlug, signal),
-    queryKey: ['projects', orgSlug],
+    queryKey: ['projects', orgSlug, 'slim'],
   })
 
   const teamOptions = useMemo(


### PR DESCRIPTION
## Summary

The Projects page caches ~3MB of `Project[]` in browser memory on large orgs. Most of that is fields the page never reads — `links`, `identifiers`, embedded organizations on team / project_types / environments, blueprint dynamic fields, `DEPLOYED_IN` edge properties, and the hypermedia `relationships` block.

AWeber-Imbi/imbi-api#330 adds `?slim=true` returning a `ProjectListItem` with just what the page reads. This PR flips the projects-list fetch to use it.

## Changes

- New `getProjectsSlim` + `ProjectListItem` interface in `api/endpoints.ts` (single new function; no behavior change to `getProjects`).
- `ProjectsView` switches to `getProjectsSlim`. Same fields render the same UI — the slim shape is a strict subset of `Project` for the keys the page actually reads.
- Other callers of `getProjects` (Dashboard, OperationsLog, EditRelationshipsDialog, NewOpsLogDialog) keep the full payload until each is audited; they may not need the heavier fields either.

## Expected payoff

- Per-project: ~kilobytes → ~hundreds of bytes (varies by blueprint count / env count).
- Network: smaller initial fetch.
- Memory: smaller cached array in React Query + JS heap.
- JSON parse on initial load: faster.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [ ] Smoke test against a deployed env: open `/projects`, verify the list renders identically, name/team/types/envs/PR counts/score all show, search still works.
- [ ] Verify in browser devtools network tab that the response no longer includes `links`, `identifiers`, `relationships`, embedded `organization` on team/project_types/environments.

## Depends on

AWeber-Imbi/imbi-api#330 — without it, `?slim=true` is ignored and the full payload still comes back (the page would still work, no win).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>