### PR TITLE
Use shared formatRelativeDate in projects list (fix 0mo ago)

### DIFF
--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -26,6 +26,7 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { deriveChipColors } from '@/lib/chip-colors'
+import { formatRelativeDate } from '@/lib/formatDate'
 import type { Project } from '@/types'
 
 import { NewProjectDialog } from './NewProjectDialog'
@@ -724,7 +725,7 @@ function DeploymentCards({
                 {release ? (
                   <>
                     <span>{release.performed_by ?? ''}</span>
-                    <span>{timeAgo(release.deployed_at)}</span>
+                    <span>{formatRelativeDate(release.deployed_at)}</span>
                   </>
                 ) : (
                   <span className="invisible">—</span>
@@ -872,7 +873,7 @@ function EnvDeploymentHover({
             {release ? (
               <>
                 <span>{release.performed_by ?? ''}</span>
-                <span>{timeAgo(release.deployed_at)}</span>
+                <span>{formatRelativeDate(release.deployed_at)}</span>
               </>
             ) : (
               <span className="invisible">—</span>
@@ -1183,21 +1184,6 @@ function StatBadge({
     )
   }
   return <span className={cls}>{content}</span>
-}
-
-// fallow-ignore-next-line complexity
-function timeAgo(iso: string): string {
-  const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000)
-  if (mins < 60) return `${mins}m ago`
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 14) return `${days}d ago`
-  const months = Math.round(days / 30.44)
-  if (days < 365) return `${months}mo ago`
-  const years = days / 365.25
-  const rounded = Math.round(years * 10) / 10
-  return `${rounded}y ago`
 }
 
 // Memoized list-mode row so a parent re-render (e.g. an ``inputQuery``

--- a/src/lib/__tests__/formatDate.test.ts
+++ b/src/lib/__tests__/formatDate.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDate, formatRelativeDate, relTime } from '@/lib/formatDate'
+
+// Fixed reference instant so relative-time math stays deterministic
+// across CI clocks. Picked as a Wednesday afternoon so day-of-week
+// rollovers (if anything starts depending on them) don't surprise us.
+const NOW = Date.parse('2026-05-20T12:00:00Z')
+const sec = 1_000
+const min = 60 * sec
+const hour = 60 * min
+const day = 24 * hour
+
+describe('formatDate', () => {
+  it('formats a localized short date', () => {
+    // Use a Z-suffixed instant and only assert structural pieces so
+    // the test passes in any timezone CI runs under (toLocaleDateString
+    // formats in the local zone).
+    const out = formatDate('2026-03-17T12:00:00Z')
+    expect(out).toMatch(/2026/)
+    expect(out).toMatch(/Mar/)
+    expect(out).not.toBe('—')
+  })
+
+  it('returns em-dash for null', () => {
+    expect(formatDate(null)).toBe('—')
+  })
+
+  it('returns em-dash for undefined', () => {
+    expect(formatDate(undefined)).toBe('—')
+  })
+
+  it('returns em-dash for empty string', () => {
+    expect(formatDate('')).toBe('—')
+  })
+})
+
+describe('relTime', () => {
+  // --- m / h / d / w / mo / y unit transitions -----------------------
+
+  it('returns "now" for under one minute', () => {
+    expect(relTime(NOW - 30 * sec, NOW)).toBe('now')
+  })
+
+  it('returns minutes for 1m to 59m', () => {
+    expect(relTime(NOW - 1 * min, NOW)).toBe('1m')
+    expect(relTime(NOW - 59 * min, NOW)).toBe('59m')
+  })
+
+  it('returns hours for 1h to 23h', () => {
+    expect(relTime(NOW - 60 * min, NOW)).toBe('1h')
+    expect(relTime(NOW - 23 * hour, NOW)).toBe('23h')
+  })
+
+  it('returns days for 1d to 6d', () => {
+    expect(relTime(NOW - 1 * day, NOW)).toBe('1d')
+    expect(relTime(NOW - 6 * day, NOW)).toBe('6d')
+  })
+
+  it('returns weeks for 7d to 29d', () => {
+    // This is the bug-regression slot. ``ProjectsView``'s broken
+    // local copy previously fell through to "0mo ago" anywhere from
+    // 14-15 days. Lock down every week of the range:
+    expect(relTime(NOW - 7 * day, NOW)).toBe('1w')
+    expect(relTime(NOW - 13 * day, NOW)).toBe('1w')
+    expect(relTime(NOW - 14 * day, NOW)).toBe('2w')
+    expect(relTime(NOW - 15 * day, NOW)).toBe('2w')
+    expect(relTime(NOW - 20 * day, NOW)).toBe('2w')
+    expect(relTime(NOW - 21 * day, NOW)).toBe('3w')
+    expect(relTime(NOW - 29 * day, NOW)).toBe('4w')
+  })
+
+  it('returns months for 30d to 364d', () => {
+    expect(relTime(NOW - 30 * day, NOW)).toBe('1mo')
+    expect(relTime(NOW - 59 * day, NOW)).toBe('1mo')
+    expect(relTime(NOW - 60 * day, NOW)).toBe('2mo')
+    expect(relTime(NOW - 364 * day, NOW)).toBe('12mo')
+  })
+
+  it('returns years for 365d and beyond', () => {
+    expect(relTime(NOW - 365 * day, NOW)).toBe('1y')
+    expect(relTime(NOW - 700 * day, NOW)).toBe('1y')
+    expect(relTime(NOW - 730 * day, NOW)).toBe('2y')
+  })
+
+  it('never returns "0mo"', () => {
+    // Sweep every day from 14 to 29 — these used to round to "0mo"
+    // in the buggy local copy. Now they must all render as a week
+    // count, not months.
+    for (let d = 14; d < 30; d++) {
+      const out = relTime(NOW - d * day, NOW)
+      expect(out).not.toBe('0mo')
+      expect(out).toMatch(/^\dw$/)
+    }
+  })
+
+  // --- input shapes -------------------------------------------------
+
+  it('accepts a millisecond timestamp', () => {
+    expect(relTime(NOW - 2 * hour, NOW)).toBe('2h')
+  })
+
+  it('accepts an ISO string', () => {
+    const iso = new Date(NOW - 2 * hour).toISOString()
+    expect(relTime(iso, NOW)).toBe('2h')
+  })
+
+  // --- defensive edge cases ----------------------------------------
+
+  it('clamps future timestamps to "now"', () => {
+    // Clock skew on either end shouldn't render as "-3m"; the
+    // function clamps negative diffs to 0.
+    expect(relTime(NOW + 5 * min, NOW)).toBe('now')
+  })
+
+  it('returns "now" for an unparseable input', () => {
+    expect(relTime('not-a-date', NOW)).toBe('now')
+  })
+
+  it('defaults ``now`` to wall-clock when omitted', () => {
+    // Just smoke-test the no-arg path; the value isn't asserted
+    // exactly because Date.now() ticks during execution.
+    const out = relTime(Date.now() - 10 * min)
+    expect(out).toMatch(/^(now|\d+m)$/)
+  })
+})
+
+describe('formatRelativeDate', () => {
+  it('appends " ago" to a non-now relTime result', () => {
+    const iso = new Date(NOW - 2 * day).toISOString()
+    // formatRelativeDate calls Date.now() internally — we can't
+    // pin the "now" anchor, so assert on the shape + suffix only.
+    expect(formatRelativeDate(iso)).toMatch(/^\d+(mo|m|h|d|w|y) ago$/)
+  })
+
+  it('uses "just now" instead of "now ago"', () => {
+    const iso = new Date(Date.now()).toISOString()
+    expect(formatRelativeDate(iso)).toBe('just now')
+  })
+
+  it('returns em-dash for null', () => {
+    expect(formatRelativeDate(null)).toBe('—')
+  })
+
+  it('returns em-dash for undefined', () => {
+    expect(formatRelativeDate(undefined)).toBe('—')
+  })
+
+  it('returns em-dash for empty string', () => {
+    expect(formatRelativeDate('')).toBe('—')
+  })
+})


### PR DESCRIPTION
## Summary

The Projects page deployment chips were showing "0mo ago" for any deployment 14–15 days old (see screenshot in chat). `ProjectsView` had its own copy of `timeAgo` that diverged from the shared `formatRelativeDate` already used by `RoleManagement`, `ProjectTypeManagement`, and `EnvironmentManagement`.

Two bugs in the local copy:
- `days < 14` switched to months at 14 days, leaving a 14–29 day gap with no week tier (admin tables use a `< 30` cutoff with a week tier).
- `months = Math.round(days / 30.44)` rounded values < 0.5 to `0`, so days 14–15 rendered as "0mo ago".

The shared `relTime` in `src/lib/formatDate.ts` has been correct all along (`d < 30 → ${Math.floor(d / 7)}w`).

## Changes

- Drop the local `timeAgo` from `ProjectsView`; route both call sites through `formatRelativeDate`. Output goes from "0mo ago" → "2w ago" / "3w ago" / etc. on the 14–29 day range.
- Add `src/lib/__tests__/formatDate.test.ts` — 22 tests, no prior coverage on `formatDate.ts`.

## Test cases (since you asked)

For `relTime`:
- "now" for under one minute
- `1m`–`59m` (minutes)
- `1h`–`23h` (hours)
- `1d`–`6d` (days)
- `1w`–`4w` (weeks) — including the bug-regression sweep across days 14–29
- `1mo`–`12mo` (months) — 30d → "1mo", 60d → "2mo", 364d → "12mo"
- `1y` / `2y` (years)
- never returns "0mo" for any day in 14–29
- ms timestamp + ISO string inputs
- clamps future timestamps to "now" (clock-skew defense)
- "now" for unparseable input
- default `now = Date.now()` when omitted

For `formatRelativeDate`:
- " ago" suffix on non-now results
- "just now" instead of "now ago"
- em-dash for null / undefined / empty

For `formatDate`:
- localized short date with month abbreviation
- em-dash for null / undefined / empty

All 22 tests pass. Build + lint clean.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>