### PR TITLE
Bump version to 2.6.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imbi-ui-v2",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imbi-ui-v2",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imbi-ui-v2",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 import { OrganizationProvider } from './contexts/OrganizationContext'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { useAuth } from './hooks/useAuth'
+import { useVersionCheck } from './hooks/useVersionCheck'
 
 const DashboardPage = lazy(() =>
   import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })),
@@ -73,6 +74,7 @@ function AdminProtectedRoute({ children }: { children: React.ReactNode }) {
 }
 
 function App() {
+  useVersionCheck()
   return (
     <ThemeProvider>
       <Toaster position="top-right" richColors />

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react'
+
+import { toast } from 'sonner'
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000
+const CURRENT_VERSION = __APP_VERSION__
+
+export function useVersionCheck(intervalMs = DEFAULT_INTERVAL_MS) {
+  const notifiedRef = useRef(false)
+
+  useEffect(() => {
+    if (import.meta.env.DEV) return
+
+    const check = async () => {
+      if (notifiedRef.current || document.hidden) return
+      const remote = await fetchRemoteVersion()
+      if (!isStale(remote)) return
+      notifiedRef.current = true
+      notifyNewVersion()
+    }
+
+    const id = window.setInterval(check, intervalMs)
+    const onVisibility = () => {
+      if (!document.hidden) void check()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      window.clearInterval(id)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [intervalMs])
+}
+
+async function fetchRemoteVersion(): Promise<null | string> {
+  try {
+    const res = await fetch('/version.json', { cache: 'no-store' })
+    if (!res.ok) return null
+    const { version } = (await res.json()) as { version?: string }
+    return version ?? null
+  } catch {
+    return null
+  }
+}
+
+function isStale(remote: null | string): boolean {
+  return remote !== null && remote !== CURRENT_VERSION
+}
+
+function notifyNewVersion() {
+  toast('A new version of Imbi is available', {
+    action: {
+      label: 'Reload',
+      onClick: () => window.location.reload(),
+    },
+    duration: Infinity,
+  })
+}

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -51,11 +51,14 @@ function isStale(remote: null | string): boolean {
   return remote !== null && remote !== CURRENT_VERSION
 }
 
-function shouldCheck(
-  notifiedRef: MutableRefObject<boolean>,
-  inFlightRef: MutableRefObject<boolean>,
-): boolean {
-  return !notifiedRef.current && !inFlightRef.current && !document.hidden
+function notifyNewVersion() {
+  toast('A new version of Imbi is available', {
+    action: {
+      label: 'Reload',
+      onClick: () => window.location.reload(),
+    },
+    duration: Infinity,
+  })
 }
 
 async function runCheck(
@@ -67,12 +70,9 @@ async function runCheck(
   notifyNewVersion()
 }
 
-function notifyNewVersion() {
-  toast('A new version of Imbi is available', {
-    action: {
-      label: 'Reload',
-      onClick: () => window.location.reload(),
-    },
-    duration: Infinity,
-  })
+function shouldCheck(
+  notifiedRef: MutableRefObject<boolean>,
+  inFlightRef: MutableRefObject<boolean>,
+): boolean {
+  return !notifiedRef.current && !inFlightRef.current && !document.hidden
 }

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import type { MutableRefObject } from 'react'
 
 import { toast } from 'sonner'
 
@@ -7,16 +8,19 @@ const CURRENT_VERSION = __APP_VERSION__
 
 export function useVersionCheck(intervalMs = DEFAULT_INTERVAL_MS) {
   const notifiedRef = useRef(false)
+  const inFlightRef = useRef(false)
 
   useEffect(() => {
     if (import.meta.env.DEV) return
 
     const check = async () => {
-      if (notifiedRef.current || document.hidden) return
-      const remote = await fetchRemoteVersion()
-      if (!isStale(remote)) return
-      notifiedRef.current = true
-      notifyNewVersion()
+      if (!shouldCheck(notifiedRef, inFlightRef)) return
+      inFlightRef.current = true
+      try {
+        await runCheck(notifiedRef)
+      } finally {
+        inFlightRef.current = false
+      }
     }
 
     const id = window.setInterval(check, intervalMs)
@@ -45,6 +49,22 @@ async function fetchRemoteVersion(): Promise<null | string> {
 
 function isStale(remote: null | string): boolean {
   return remote !== null && remote !== CURRENT_VERSION
+}
+
+function shouldCheck(
+  notifiedRef: MutableRefObject<boolean>,
+  inFlightRef: MutableRefObject<boolean>,
+): boolean {
+  return !notifiedRef.current && !inFlightRef.current && !document.hidden
+}
+
+async function runCheck(
+  notifiedRef: MutableRefObject<boolean>,
+): Promise<void> {
+  const remote = await fetchRemoteVersion()
+  if (!isStale(remote)) return
+  notifiedRef.current = true
+  notifyNewVersion()
 }
 
 function notifyNewVersion() {

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -61,9 +61,7 @@ function notifyNewVersion() {
   })
 }
 
-async function runCheck(
-  notifiedRef: MutableRefObject<boolean>,
-): Promise<void> {
+async function runCheck(notifiedRef: MutableRefObject<boolean>): Promise<void> {
   const remote = await fetchRemoteVersion()
   if (!isStale(remote)) return
   notifiedRef.current = true

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string
+
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,25 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
+import { execSync } from 'child_process'
 import path from 'path'
 import { defineConfig, type Plugin, type ViteDevServer } from 'vite'
+
+function resolveBuildId(): string {
+  const fromEnv = process.env.VITE_GIT_REF?.trim()
+  if (fromEnv && fromEnv !== 'latest') return fromEnv
+  try {
+    return execSync('git describe --tags --always --dirty', {
+      cwd: __dirname,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+  } catch {
+    return Date.now().toString()
+  }
+}
+
+const BUILD_ID = resolveBuildId()
 
 function requestLogger(): Plugin {
   return {
@@ -12,6 +30,20 @@ function requestLogger(): Plugin {
       })
     },
     name: 'request-logger',
+  }
+}
+
+function versionManifest(): Plugin {
+  return {
+    apply: 'build',
+    generateBundle() {
+      this.emitFile({
+        fileName: 'version.json',
+        source: JSON.stringify({ version: BUILD_ID }),
+        type: 'asset',
+      })
+    },
+    name: 'version-manifest',
   }
 }
 
@@ -36,6 +68,9 @@ export default defineConfig({
     },
     sourcemap: true,
   },
+  define: {
+    __APP_VERSION__: JSON.stringify(BUILD_ID),
+  },
   esbuild: {
     // Preserve console.error / console.warn so auth-failure diagnostics
     // (see useAuth.ts) survive in prod; strip the noisy levels only via
@@ -43,7 +78,7 @@ export default defineConfig({
     // breakpoint statements in source, so a `drop` list is unnecessary.)
     pure: ['console.log', 'console.debug', 'console.info'],
   },
-  plugins: [tailwindcss(), react(), requestLogger()],
+  plugins: [tailwindcss(), react(), requestLogger(), versionManifest()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

Release 2.6.0 — new features + perf + fixes since 2.5.1.

### Changes

- #295 — Default log envs to the project's own environments (fix)
- #296 — Make project search responsive on big project lists (perf)
- #297 — Show Recompute Score when user has scoring_policy:rescore (feature)
- #298 — Fetch projects-list with the slim API payload (perf/data)
- #299 — Use shared formatRelativeDate in projects list (fix 0mo ago) + new test coverage
- #294 — Edit per-project plugin option overrides (feature)

### Bump

- ``package.json``: 2.5.1 → 2.6.0
- ``package-lock.json``: root version refs updated to match