### PR TITLE
Auto-refresh on release + npm 7-day holdback

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 import { OrganizationProvider } from './contexts/OrganizationContext'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { useAuth } from './hooks/useAuth'
+import { useVersionCheck } from './hooks/useVersionCheck'
 
 const DashboardPage = lazy(() =>
   import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })),
@@ -73,6 +74,7 @@ function AdminProtectedRoute({ children }: { children: React.ReactNode }) {
 }
 
 function App() {
+  useVersionCheck()
   return (
     <ThemeProvider>
       <Toaster position="top-right" richColors />

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react'
+
+import { toast } from 'sonner'
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000
+const CURRENT_VERSION = __APP_VERSION__
+
+export function useVersionCheck(intervalMs = DEFAULT_INTERVAL_MS) {
+  const notifiedRef = useRef(false)
+
+  useEffect(() => {
+    if (import.meta.env.DEV) return
+
+    const check = async () => {
+      if (notifiedRef.current || document.hidden) return
+      const remote = await fetchRemoteVersion()
+      if (!isStale(remote)) return
+      notifiedRef.current = true
+      notifyNewVersion()
+    }
+
+    const id = window.setInterval(check, intervalMs)
+    const onVisibility = () => {
+      if (!document.hidden) void check()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      window.clearInterval(id)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [intervalMs])
+}
+
+async function fetchRemoteVersion(): Promise<null | string> {
+  try {
+    const res = await fetch('/version.json', { cache: 'no-store' })
+    if (!res.ok) return null
+    const { version } = (await res.json()) as { version?: string }
+    return version ?? null
+  } catch {
+    return null
+  }
+}
+
+function isStale(remote: null | string): boolean {
+  return remote !== null && remote !== CURRENT_VERSION
+}
+
+function notifyNewVersion() {
+  toast('A new version of Imbi is available', {
+    action: {
+      label: 'Reload',
+      onClick: () => window.location.reload(),
+    },
+    duration: Infinity,
+  })
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string
+
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,25 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
+import { execSync } from 'child_process'
 import path from 'path'
 import { defineConfig, type Plugin, type ViteDevServer } from 'vite'
+
+function resolveBuildId(): string {
+  const fromEnv = process.env.VITE_GIT_REF?.trim()
+  if (fromEnv && fromEnv !== 'latest') return fromEnv
+  try {
+    return execSync('git describe --tags --always --dirty', {
+      cwd: __dirname,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+  } catch {
+    return Date.now().toString()
+  }
+}
+
+const BUILD_ID = resolveBuildId()
 
 function requestLogger(): Plugin {
   return {
@@ -12,6 +30,20 @@ function requestLogger(): Plugin {
       })
     },
     name: 'request-logger',
+  }
+}
+
+function versionManifest(): Plugin {
+  return {
+    apply: 'build',
+    generateBundle() {
+      this.emitFile({
+        fileName: 'version.json',
+        source: JSON.stringify({ version: BUILD_ID }),
+        type: 'asset',
+      })
+    },
+    name: 'version-manifest',
   }
 }
 
@@ -36,10 +68,13 @@ export default defineConfig({
     },
     sourcemap: true,
   },
+  define: {
+    __APP_VERSION__: JSON.stringify(BUILD_ID),
+  },
   esbuild: {
     drop: ['console'],
   },
-  plugins: [tailwindcss(), react(), requestLogger()],
+  plugins: [tailwindcss(), react(), requestLogger(), versionManifest()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

Two supply-chain / release-quality improvements bundled together.

**Auto-refresh on release.** Vite now emits `dist/version.json` containing the build ID (preferring `VITE_GIT_REF`, falling back to `git describe` or `Date.now()`), and the same value is exposed in the bundle as `__APP_VERSION__`. A new `useVersionCheck` hook polls the manifest every 5 minutes (visibility-gated, skipped in dev) and surfaces a sonner toast with a Reload action when a mismatch is seen — so users on long-lived sessions don't get stuck on stale UI after a deploy. Pairs with the Caddy `no-cache` headers in [AWeber-Imbi/imbi](https://github.com/AWeber-Imbi/imbi).

**npm holdback.** `.npmrc` adds `min-release-age=7` so freshly-published npm packages are deferred for a week — supply-chain hardening against the recent wave of compromised npm releases. Requires npm ≥ 11.5; current local version is 11.12.1.

## Test plan
- [ ] `npm run build` produces `dist/version.json` with a real build ID
- [ ] `npm run dev` does not poll (`useVersionCheck` no-ops via `import.meta.env.DEV`)
- [ ] After a fresh build, hand-edit `dist/version.json` to a new value, run `npm run preview`, confirm toast appears within 5 minutes
- [ ] `npm install` respects the holdback (try installing a freshly-published package)