### PR TITLE
Add reload button to Step 1 of the promote dialog

### DIFF
--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -69,7 +69,12 @@ export function PromoteTab({
   // Compare last_tag → fromTipSha to enumerate the commits in flight.
   const compareEnabled =
     open && !!lastTag && !!fromTipSha && lastTag !== fromTipSha
-  const { data: compare, isLoading: compareLoading } = useQuery({
+  const {
+    data: compare,
+    isFetching: compareFetching,
+    isLoading: compareLoading,
+    refetch: refetchCompare,
+  } = useQuery({
     enabled: compareEnabled,
     queryFn: ({ signal }) =>
       compareDeploymentRefs(
@@ -254,9 +259,24 @@ export function PromoteTab({
 
       {/* Step 1 — pick the build */}
       <section>
-        <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
-          Step 1 — Build to promote
-        </p>
+        <div className="mb-2 flex items-center justify-between">
+          <p className="text-tertiary text-xs tracking-wider uppercase">
+            Step 1 — Build to promote
+          </p>
+          <button
+            aria-label="Reload commits"
+            className="text-tertiary hover:text-primary rounded p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!compareEnabled || compareFetching}
+            onClick={() => {
+              void refetchCompare()
+            }}
+            type="button"
+          >
+            <RefreshCw
+              className={cn('size-3.5', compareFetching && 'animate-spin')}
+            />
+          </button>
+        </div>
         {compareEnabled && compareLoading ? (
           <LoadingState label="Loading commits…" />
         ) : !compareEnabled ? (


### PR DESCRIPTION
## Summary
- Adds a reload icon button on the right side of the "Step 1 — Build to promote" row in the promote dialog
- Refetches the commit comparison so operators can pick up new commits landed after the dialog opened without closing and reopening it
- Spins while fetching and is disabled when there's no compare to run

## Test plan
- [ ] Open the promote dialog for a project with a delta between the last tag and the upstream tip
- [ ] Click the reload icon — list refreshes, icon spins, button disables briefly
- [ ] Confirm the icon is disabled when there is no prior release / no delta