### PR TITLE
Add Open PRs report

### DIFF
--- a/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import type { InfiniteData } from '@tanstack/react-query'
 import {
   ChevronRight,
@@ -9,13 +9,14 @@ import {
   GitPullRequestClosed,
 } from 'lucide-react'
 
-import { getOrgPullRequests, getProjects } from '@/api/endpoints'
+import { getOrgPullRequests, type ProjectListItem } from '@/api/endpoints'
 import { Card } from '@/components/ui/card'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useGithubLogin } from '@/hooks/useGithubLogin'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
+import { useProjectsSlimMap } from '@/hooks/useProjectsSlimMap'
 import { relTime } from '@/lib/formatDate'
-import type { Project, PullRequest, PullRequestListResponse } from '@/types'
+import type { PullRequest, PullRequestListResponse } from '@/types'
 
 const PAGE_SIZE = 20
 const FILTER_KEY = 'imbi-my-prs-filter'
@@ -81,17 +82,7 @@ export function MyPullRequestsWidget() {
     staleTime: 60_000,
   })
 
-  const { data: projects } = useQuery({
-    enabled: !!orgSlug,
-    queryFn: ({ signal }) => getProjects(orgSlug, signal),
-    queryKey: ['projects', orgSlug],
-  })
-
-  const projectsById = useMemo(() => {
-    const m = new Map<string, Project>()
-    for (const p of projects ?? []) m.set(p.id, p)
-    return m
-  }, [projects])
+  const { projectsById } = useProjectsSlimMap(orgSlug)
 
   // fallow-ignore-next-line complexity
   const prs = useMemo(() => {
@@ -206,7 +197,7 @@ function PrRow({
   projectsById,
 }: {
   pr: PullRequest
-  projectsById: Map<string, Project>
+  projectsById: Map<string, ProjectListItem>
 }) {
   const project = projectsById.get(pr.project_id)
   const repoLabel = project ? `${project.team.slug}/${project.slug}` : undefined

--- a/src/components/project/ProjectPullRequestsTab.tsx
+++ b/src/components/project/ProjectPullRequestsTab.tsx
@@ -10,10 +10,11 @@ import {
 } from 'lucide-react'
 
 import { getProjectPullRequests } from '@/api/endpoints'
+import { DiffBar } from '@/components/pull-requests/DiffBar'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
 import { UserDisplay } from '@/components/ui/user-display'
-import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
+import { useLoginToEmail } from '@/hooks/useLoginToEmail'
 import { relTime } from '@/lib/formatDate'
 import type { PullRequest } from '@/types'
 
@@ -65,18 +66,7 @@ export function ProjectPullRequestsTab({ orgSlug, projectId }: Props) {
     staleTime: 60_000,
   })
 
-  const { displayNames, users } = useUserDisplayNames()
-
-  // GitHub login → email: heuristic match on email local-part
-  const loginToEmail = useMemo(() => {
-    const m = new Map<string, string>()
-    for (const u of users) {
-      if (!u.email) continue
-      const local = u.email.split('@')[0]
-      if (local) m.set(local, u.email)
-    }
-    return m
-  }, [users])
+  const { displayNames, loginToEmail } = useLoginToEmail()
 
   const isLoading = openFetching || closedFetching
   const hasError = openError || closedError
@@ -274,44 +264,6 @@ export function ProjectPullRequestsTab({ orgSlug, projectId }: Props) {
         </table>
       </div>
     </Card>
-  )
-}
-
-function DiffBar({
-  additions,
-  deletions,
-}: {
-  additions: number
-  deletions: number
-}) {
-  const total = additions + deletions
-  if (total === 0) return <span className="text-tertiary text-xs">—</span>
-  const addBlocks = Math.round((additions / total) * 5)
-  const delBlocks = 5 - addBlocks
-  return (
-    <div className="flex flex-col items-center gap-1">
-      <div className="text-xs">
-        <span className="text-success">+{additions.toLocaleString()}</span>
-        <span className="text-tertiary"> · </span>
-        <span className="text-danger">-{deletions.toLocaleString()}</span>
-      </div>
-      <div className="flex gap-0.5">
-        {Array.from({ length: addBlocks }).map((_, i) => (
-          <div
-            className="h-2 w-3.5"
-            key={`a${i}`}
-            style={{ backgroundColor: 'var(--text-color-success)' }}
-          />
-        ))}
-        {Array.from({ length: delBlocks }).map((_, i) => (
-          <div
-            className="h-2 w-3.5"
-            key={`d${i}`}
-            style={{ backgroundColor: 'var(--text-color-danger)' }}
-          />
-        ))}
-      </div>
-    </div>
   )
 }
 

--- a/src/components/pull-requests/DiffBar.tsx
+++ b/src/components/pull-requests/DiffBar.tsx
@@ -1,0 +1,37 @@
+export function DiffBar({
+  additions,
+  deletions,
+}: {
+  additions: number
+  deletions: number
+}) {
+  const total = additions + deletions
+  if (total === 0) return <span className="text-tertiary text-xs">—</span>
+  const addBlocks = Math.round((additions / total) * 5)
+  const delBlocks = 5 - addBlocks
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="text-xs">
+        <span className="text-success">+{additions.toLocaleString()}</span>
+        <span className="text-tertiary"> · </span>
+        <span className="text-danger">-{deletions.toLocaleString()}</span>
+      </div>
+      <div className="flex gap-0.5">
+        {Array.from({ length: addBlocks }).map((_, i) => (
+          <div
+            className="h-2 w-3.5"
+            key={`a${i}`}
+            style={{ backgroundColor: 'var(--text-color-success)' }}
+          />
+        ))}
+        {Array.from({ length: delBlocks }).map((_, i) => (
+          <div
+            className="h-2 w-3.5"
+            key={`d${i}`}
+            style={{ backgroundColor: 'var(--text-color-danger)' }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -1,0 +1,424 @@
+import { useMemo, useState } from 'react'
+
+import { useNavigate } from 'react-router-dom'
+
+import { useQuery } from '@tanstack/react-query'
+import { ExternalLink, GitPullRequest, RefreshCw } from 'lucide-react'
+
+import {
+  getOrgPullRequests,
+  getProjectsSlim,
+  type ProjectListItem,
+} from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { UserDisplay } from '@/components/ui/user-display'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
+import { relTime } from '@/lib/formatDate'
+import type { PullRequest } from '@/types'
+
+interface EnrichedPR extends PullRequest {
+  project_name: string
+  project_slug: string
+  project_types: { name: string; slug: string }[]
+  team_name: string
+  team_slug: string
+}
+
+const ALL = '__all__'
+
+// fallow-ignore-next-line complexity
+export function OpenPullRequestsReport() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
+  const navigate = useNavigate()
+
+  const [teamFilter, setTeamFilter] = useState<string>(ALL)
+  const [projectTypeFilter, setProjectTypeFilter] = useState<string>(ALL)
+  const [search, setSearch] = useState('')
+
+  const {
+    data: prData,
+    isError: prsError,
+    isFetching: prsFetching,
+    refetch: refetchPrs,
+  } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) =>
+      getOrgPullRequests(orgSlug, { limit: 500, state: 'open' }, signal),
+    queryKey: ['org-prs', orgSlug, 'open'],
+    staleTime: 60_000,
+  })
+
+  const {
+    data: projects,
+    isError: projectsError,
+    isFetching: projectsFetching,
+    refetch: refetchProjects,
+  } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => getProjectsSlim(orgSlug, signal),
+    queryKey: ['projects-slim', orgSlug],
+    staleTime: 120_000,
+  })
+
+  const { displayNames, users } = useUserDisplayNames()
+
+  const loginToEmail = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const u of users) {
+      if (!u.email) continue
+      const local = u.email.split('@')[0]
+      if (local) m.set(local, u.email)
+    }
+    return m
+  }, [users])
+
+  const projectsById = useMemo(() => {
+    const m = new Map<string, ProjectListItem>()
+    for (const p of projects ?? []) m.set(p.id, p)
+    return m
+  }, [projects])
+
+  const enriched = useMemo<EnrichedPR[]>(() => {
+    const prs = prData?.data ?? []
+    const out: EnrichedPR[] = []
+    for (const pr of prs) {
+      if (pr.draft) continue
+      if (pr.state !== 'open') continue
+      const p = projectsById.get(pr.project_id)
+      if (!p) continue
+      if (p.archived) continue
+      out.push({
+        ...pr,
+        project_name: p.name,
+        project_slug: p.slug,
+        project_types: p.project_types,
+        team_name: p.team.name,
+        team_slug: p.team.slug,
+      })
+    }
+    out.sort(
+      (a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    )
+    return out
+  }, [prData, projectsById])
+
+  const teamOptions = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const pr of enriched) map.set(pr.team_slug, pr.team_name)
+    return [...map.entries()]
+      .map(([slug, name]) => ({ name, slug }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [enriched])
+
+  const projectTypeOptions = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const pr of enriched) {
+      for (const pt of pr.project_types) map.set(pt.slug, pt.name)
+    }
+    return [...map.entries()]
+      .map(([slug, name]) => ({ name, slug }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [enriched])
+
+  // fallow-ignore-next-line complexity
+  const filtered = useMemo(() => {
+    let rows = enriched
+    if (teamFilter !== ALL) {
+      rows = rows.filter((r) => r.team_slug === teamFilter)
+    }
+    if (projectTypeFilter !== ALL) {
+      rows = rows.filter((r) =>
+        r.project_types.some((pt) => pt.slug === projectTypeFilter),
+      )
+    }
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      rows = rows.filter(
+        (r) =>
+          r.title.toLowerCase().includes(q) ||
+          r.author.toLowerCase().includes(q) ||
+          r.project_name.toLowerCase().includes(q) ||
+          String(r.pr_number).includes(q),
+      )
+    }
+    return rows
+  }, [enriched, teamFilter, projectTypeFilter, search])
+
+  const isLoading = prsFetching || projectsFetching
+  const hasError = prsError || projectsError
+  const total = enriched.length
+
+  function refreshAll() {
+    void refetchPrs()
+    void refetchProjects()
+  }
+
+  return (
+    <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
+      {/* Toolbar */}
+      <div className="border-tertiary flex flex-wrap items-center gap-3 border-b px-4 py-3">
+        <div className="flex items-center gap-2">
+          <label className="text-tertiary text-xs">Team</label>
+          <Select onValueChange={setTeamFilter} value={teamFilter}>
+            <SelectTrigger className="h-8 w-44 text-xs">
+              <SelectValue placeholder="All teams" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>All teams</SelectItem>
+              {teamOptions.map((t) => (
+                <SelectItem key={t.slug} value={t.slug}>
+                  {t.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-tertiary text-xs">Project type</label>
+          <Select
+            onValueChange={setProjectTypeFilter}
+            value={projectTypeFilter}
+          >
+            <SelectTrigger className="h-8 w-44 text-xs">
+              <SelectValue placeholder="All types" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>All types</SelectItem>
+              {projectTypeOptions.map((pt) => (
+                <SelectItem key={pt.slug} value={pt.slug}>
+                  {pt.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-1 items-center justify-end gap-2">
+          <input
+            className="border-input bg-background text-primary focus:ring-action h-8 w-64 rounded border px-3 text-sm focus:ring-1 focus:outline-none"
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filter by title, author, project, or #"
+            type="text"
+            value={search}
+          />
+          <span className="text-tertiary text-xs">
+            {filtered.length} of {total}
+          </span>
+          <button
+            aria-label="Refresh"
+            className="text-tertiary hover:text-primary rounded p-1.5 transition-colors"
+            disabled={isLoading}
+            onClick={refreshAll}
+            type="button"
+          >
+            <RefreshCw
+              className={`size-4 ${isLoading ? 'animate-spin' : ''}`}
+            />
+          </button>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-tertiary border-b">
+              <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                Team
+              </th>
+              <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                Project Type
+              </th>
+              <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                Project
+              </th>
+              <th className="text-tertiary w-16 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                #
+              </th>
+              <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                Title
+              </th>
+              <th className="text-tertiary w-40 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
+                Author
+              </th>
+              <th className="text-tertiary w-14 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
+                Files
+              </th>
+              <th className="text-tertiary w-36 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
+                Diff
+              </th>
+              <th className="text-tertiary w-20 px-4 py-2 text-right text-xs font-medium tracking-wide uppercase">
+                Updated
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {hasError ? (
+              <tr>
+                <td className="px-4 py-8 text-center" colSpan={9}>
+                  <div className="text-danger text-sm">
+                    Failed to load pull requests.
+                  </div>
+                  <button
+                    className="text-action mt-2 text-xs hover:underline"
+                    onClick={refreshAll}
+                    type="button"
+                  >
+                    Retry
+                  </button>
+                </td>
+              </tr>
+            ) : isLoading && enriched.length === 0 ? (
+              Array.from({ length: 6 }).map((_, i) => (
+                <tr className="border-tertiary border-b" key={i}>
+                  <td className="px-4 py-3" colSpan={9}>
+                    <div className="bg-tertiary/30 h-4 animate-pulse rounded" />
+                  </td>
+                </tr>
+              ))
+            ) : filtered.length === 0 ? (
+              <tr>
+                <td
+                  className="text-tertiary px-4 py-12 text-center"
+                  colSpan={9}
+                >
+                  No open pull requests match the current filters.
+                </td>
+              </tr>
+            ) : (
+              filtered.map((pr) => (
+                <PrRow
+                  displayNames={displayNames}
+                  key={pr.pr_id}
+                  loginToEmail={loginToEmail}
+                  onOpenProject={() => navigate(`/projects/${pr.project_id}`)}
+                  pr={pr}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function DiffBar({
+  additions,
+  deletions,
+}: {
+  additions: number
+  deletions: number
+}) {
+  const total = additions + deletions
+  if (total === 0) return <span className="text-tertiary text-xs">—</span>
+  const addBlocks = Math.round((additions / total) * 5)
+  const delBlocks = 5 - addBlocks
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="text-xs">
+        <span className="text-success">+{additions.toLocaleString()}</span>
+        <span className="text-tertiary"> · </span>
+        <span className="text-danger">-{deletions.toLocaleString()}</span>
+      </div>
+      <div className="flex gap-0.5">
+        {Array.from({ length: addBlocks }).map((_, i) => (
+          <div
+            className="h-2 w-3.5"
+            key={`a${i}`}
+            style={{ backgroundColor: 'var(--text-color-success)' }}
+          />
+        ))}
+        {Array.from({ length: delBlocks }).map((_, i) => (
+          <div
+            className="h-2 w-3.5"
+            key={`d${i}`}
+            style={{ backgroundColor: 'var(--text-color-danger)' }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function PrRow({
+  displayNames,
+  loginToEmail,
+  onOpenProject,
+  pr,
+}: {
+  displayNames: Map<string, string>
+  loginToEmail: Map<string, string>
+  onOpenProject: () => void
+  pr: EnrichedPR
+}) {
+  const email = loginToEmail.get(pr.author)
+
+  return (
+    <tr className="border-tertiary hover:bg-secondary/30 border-b transition-colors last:border-b-0">
+      <td className="text-secondary px-4 py-3 text-xs">{pr.team_name}</td>
+      <td className="px-4 py-3">
+        <div className="flex flex-wrap gap-1">
+          {pr.project_types.map((pt) => (
+            <Badge key={pt.slug} variant="neutral">
+              {pt.name}
+            </Badge>
+          ))}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <button
+          className="text-primary hover:text-action text-left text-sm font-medium transition-colors"
+          onClick={onOpenProject}
+          type="button"
+        >
+          {pr.project_name}
+        </button>
+      </td>
+      <td className="px-4 py-3">
+        <span className="text-tertiary flex items-center gap-1.5 text-xs">
+          <GitPullRequest className="text-success size-3.5 shrink-0" />
+          {pr.pr_number}
+        </span>
+      </td>
+      <td className="max-w-0 px-4 py-3">
+        <a
+          className="text-primary hover:text-action inline-flex max-w-full items-center gap-1.5 transition-colors"
+          href={pr.url}
+          rel="noreferrer"
+          target="_blank"
+        >
+          <span className="truncate">{pr.title}</span>
+          <ExternalLink className="text-tertiary size-3 shrink-0" />
+        </a>
+      </td>
+      <td className="px-4 py-3 text-center">
+        <UserDisplay
+          displayNames={email ? displayNames : undefined}
+          email={email ?? pr.author}
+          linkToProfile={!!email}
+          textClassName="text-sm"
+        />
+      </td>
+      <td className="text-secondary px-4 py-3 text-center">
+        {pr.changed_files}
+      </td>
+      <td className="px-4 py-3 text-center">
+        <DiffBar additions={pr.additions} deletions={pr.deletions} />
+      </td>
+      <td className="text-tertiary px-4 py-3 text-right text-xs tabular-nums">
+        {relTime(pr.updated_at)}
+      </td>
+    </tr>
+  )
+}

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -5,11 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ExternalLink, GitPullRequest, RefreshCw } from 'lucide-react'
 
-import {
-  getOrgPullRequests,
-  getProjectsSlim,
-  type ProjectListItem,
-} from '@/api/endpoints'
+import { getOrgPullRequests, type ProjectListItem } from '@/api/endpoints'
 import { DiffBar } from '@/components/pull-requests/DiffBar'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -28,8 +24,16 @@ import {
 import { UserDisplay } from '@/components/ui/user-display'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useLoginToEmail } from '@/hooks/useLoginToEmail'
+import { useProjectsSlimMap } from '@/hooks/useProjectsSlimMap'
 import { relTime } from '@/lib/formatDate'
 import type { PullRequest } from '@/types'
+
+interface AuthorInfo {
+  displayNamesForUser: Map<string, string> | undefined
+  emailOrAuthor: string
+  linkToProfile: boolean
+  tooltip: string
+}
 
 interface EnrichedPR extends PullRequest {
   project_name: string
@@ -39,19 +43,22 @@ interface EnrichedPR extends PullRequest {
   team_slug: string
 }
 
-interface ReportToolbarProps {
-  filteredCount: number
+interface ReportData {
+  enriched: EnrichedPR[]
+  hasError: boolean
   isLoading: boolean
-  onRefresh: () => void
-  onSearchChange: (v: string) => void
-  onTeamChange: (v: string) => void
-  onTypeChange: (v: string) => void
-  projectTypeFilter: string
   projectTypeOptions: SlugName[]
-  search: string
-  teamFilter: string
+  refreshAll: () => void
   teamOptions: SlugName[]
-  total: number
+}
+
+interface ReportFilters {
+  projectTypeFilter: string
+  search: string
+  setProjectTypeFilter: (v: string) => void
+  setSearch: (v: string) => void
+  setTeamFilter: (v: string) => void
+  teamFilter: string
 }
 
 interface SlugName {
@@ -88,65 +95,51 @@ export function OpenPullRequestsReport() {
   const orgSlug = selectedOrganization?.slug ?? ''
   const navigate = useNavigate()
 
-  const [teamFilter, setTeamFilter] = useState<string>(ALL)
-  const [projectTypeFilter, setProjectTypeFilter] = useState<string>(ALL)
-  const [search, setSearch] = useState('')
-
-  const {
-    enriched,
-    hasError,
-    isLoading,
-    projectTypeOptions,
-    refreshAll,
-    teamOptions,
-  } = useOpenPrReportData(orgSlug)
-
+  const filters = useReportFilters()
+  const data = useOpenPrReportData(orgSlug)
   const { displayNames, loginToEmail } = useLoginToEmail()
-
   const filtered = useOpenPrFilters(
-    enriched,
-    teamFilter,
-    projectTypeFilter,
-    search,
+    data.enriched,
+    filters.teamFilter,
+    filters.projectTypeFilter,
+    filters.search,
   )
 
   return (
     <TooltipProvider delayDuration={200}>
       <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
         <ReportToolbar
+          data={data}
           filteredCount={filtered.length}
-          isLoading={isLoading}
-          onRefresh={refreshAll}
-          onSearchChange={setSearch}
-          onTeamChange={setTeamFilter}
-          onTypeChange={setProjectTypeFilter}
-          projectTypeFilter={projectTypeFilter}
-          projectTypeOptions={projectTypeOptions}
-          search={search}
-          teamFilter={teamFilter}
-          teamOptions={teamOptions}
-          total={enriched.length}
+          filters={filters}
         />
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <ReportTableHead />
-            <tbody>
-              <ReportTableBody
-                displayNames={displayNames}
-                enrichedCount={enriched.length}
-                filtered={filtered}
-                hasError={hasError}
-                isLoading={isLoading}
-                loginToEmail={loginToEmail}
-                onOpenProject={(id) => navigate(`/projects/${id}`)}
-                onRetry={refreshAll}
-              />
-            </tbody>
-          </table>
-        </div>
+        <ReportTable
+          data={data}
+          displayNames={displayNames}
+          filtered={filtered}
+          loginToEmail={loginToEmail}
+          onOpenProject={(id) => navigate(`/projects/${id}`)}
+        />
       </div>
     </TooltipProvider>
   )
+}
+
+function bodyStatus({
+  enrichedCount,
+  filtered,
+  hasError,
+  isLoading,
+}: {
+  enrichedCount: number
+  filtered: EnrichedPR[]
+  hasError: boolean
+  isLoading: boolean
+}): 'empty' | 'error' | 'loading' | 'ready' {
+  if (hasError) return 'error'
+  if (isLoading && enrichedCount === 0) return 'loading'
+  if (filtered.length === 0) return 'empty'
+  return 'ready'
 }
 
 function deriveSlugNameOptions(
@@ -262,16 +255,7 @@ function matchesSearch(r: EnrichedPR, q: string): boolean {
   )
 }
 
-function PrAuthorCell({
-  author,
-  displayNames,
-  email,
-}: {
-  author: string
-  displayNames: Map<string, string>
-  email: string | undefined
-}) {
-  const tooltip = email ? (displayNames.get(email) ?? author) : author
+function PrAuthorCell({ info }: { info: AuthorInfo }) {
   return (
     <td className="px-4 py-3">
       <div className="flex justify-center">
@@ -279,15 +263,15 @@ function PrAuthorCell({
           <TooltipTrigger asChild>
             <span className="inline-flex">
               <UserDisplay
-                displayNames={email ? displayNames : undefined}
-                email={email ?? author}
+                displayNames={info.displayNamesForUser}
+                email={info.emailOrAuthor}
                 hideName
-                linkToProfile={!!email}
+                linkToProfile={info.linkToProfile}
                 title=""
               />
             </span>
           </TooltipTrigger>
-          <TooltipContent>{tooltip}</TooltipContent>
+          <TooltipContent>{info.tooltip}</TooltipContent>
         </Tooltip>
       </div>
     </td>
@@ -353,7 +337,7 @@ function PrRow({
   onOpenProject: () => void
   pr: EnrichedPR
 }) {
-  const email = loginToEmail.get(pr.author)
+  const authorInfo = resolveAuthorInfo(pr.author, loginToEmail, displayNames)
   return (
     <tr className="border-tertiary hover:bg-secondary/30 border-b transition-colors last:border-b-0">
       <td className="text-secondary px-4 py-3 font-mono text-xs">
@@ -363,11 +347,7 @@ function PrRow({
       <PrProjectCell name={pr.project_name} onOpen={onOpenProject} />
       <PrNumberCell number={pr.pr_number} />
       <PrTitleCell title={pr.title} url={pr.url} />
-      <PrAuthorCell
-        author={pr.author}
-        displayNames={displayNames}
-        email={email}
-      />
+      <PrAuthorCell info={authorInfo} />
       <td className="text-secondary px-4 py-3 text-center">
         {pr.changed_files}
       </td>
@@ -378,6 +358,32 @@ function PrRow({
         {relTime(pr.updated_at)}
       </td>
     </tr>
+  )
+}
+
+function PrRows({
+  displayNames,
+  filtered,
+  loginToEmail,
+  onOpenProject,
+}: {
+  displayNames: Map<string, string>
+  filtered: EnrichedPR[]
+  loginToEmail: Map<string, string>
+  onOpenProject: (id: string) => void
+}) {
+  return (
+    <>
+      {filtered.map((pr) => (
+        <PrRow
+          displayNames={displayNames}
+          key={pr.pr_id}
+          loginToEmail={loginToEmail}
+          onOpenProject={() => onOpenProject(pr.project_id)}
+          pr={pr}
+        />
+      ))}
+    </>
   )
 }
 
@@ -402,6 +408,40 @@ function PrTitleCell({ title, url }: { title: string; url: string }) {
   )
 }
 
+function ReportTable({
+  data,
+  displayNames,
+  filtered,
+  loginToEmail,
+  onOpenProject,
+}: {
+  data: ReportData
+  displayNames: Map<string, string>
+  filtered: EnrichedPR[]
+  loginToEmail: Map<string, string>
+  onOpenProject: (id: string) => void
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <ReportTableHead />
+        <tbody>
+          <ReportTableBody
+            displayNames={displayNames}
+            enrichedCount={data.enriched.length}
+            filtered={filtered}
+            hasError={data.hasError}
+            isLoading={data.isLoading}
+            loginToEmail={loginToEmail}
+            onOpenProject={onOpenProject}
+            onRetry={data.refreshAll}
+          />
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 function ReportTableBody({
   displayNames,
   enrichedCount,
@@ -421,21 +461,17 @@ function ReportTableBody({
   onOpenProject: (id: string) => void
   onRetry: () => void
 }) {
-  if (hasError) return <ErrorRow onRetry={onRetry} />
-  if (isLoading && enrichedCount === 0) return <SkeletonRows />
-  if (filtered.length === 0) return <EmptyRow />
+  const status = bodyStatus({ enrichedCount, filtered, hasError, isLoading })
+  if (status === 'error') return <ErrorRow onRetry={onRetry} />
+  if (status === 'loading') return <SkeletonRows />
+  if (status === 'empty') return <EmptyRow />
   return (
-    <>
-      {filtered.map((pr) => (
-        <PrRow
-          displayNames={displayNames}
-          key={pr.pr_id}
-          loginToEmail={loginToEmail}
-          onOpenProject={() => onOpenProject(pr.project_id)}
-          pr={pr}
-        />
-      ))}
-    </>
+    <PrRows
+      displayNames={displayNames}
+      filtered={filtered}
+      loginToEmail={loginToEmail}
+      onOpenProject={onOpenProject}
+    />
   )
 }
 
@@ -457,58 +493,77 @@ function ReportTableHead() {
 }
 
 function ReportToolbar({
+  data,
   filteredCount,
-  isLoading,
-  onRefresh,
-  onSearchChange,
-  onTeamChange,
-  onTypeChange,
-  projectTypeFilter,
-  projectTypeOptions,
-  search,
-  teamFilter,
-  teamOptions,
-  total,
-}: ReportToolbarProps) {
+  filters,
+}: {
+  data: ReportData
+  filteredCount: number
+  filters: ReportFilters
+}) {
   return (
     <div className="border-tertiary flex flex-wrap items-center gap-3 border-b px-4 py-3">
       <FilterSelect
         label="Team"
-        onValueChange={onTeamChange}
-        options={teamOptions}
+        onValueChange={filters.setTeamFilter}
+        options={data.teamOptions}
         placeholder="All teams"
-        value={teamFilter}
+        value={filters.teamFilter}
       />
       <FilterSelect
         label="Project type"
-        onValueChange={onTypeChange}
-        options={projectTypeOptions}
+        onValueChange={filters.setProjectTypeFilter}
+        options={data.projectTypeOptions}
         placeholder="All types"
-        value={projectTypeFilter}
+        value={filters.projectTypeFilter}
       />
       <div className="flex flex-1 items-center justify-end gap-2">
         <input
           className="border-input bg-background text-primary focus:ring-action h-8 w-64 rounded border px-3 text-sm focus:ring-1 focus:outline-none"
-          onChange={(e) => onSearchChange(e.target.value)}
+          onChange={(e) => filters.setSearch(e.target.value)}
           placeholder="Filter by title, author, project, or #"
           type="text"
-          value={search}
+          value={filters.search}
         />
         <span className="text-tertiary text-xs">
-          {filteredCount} of {total}
+          {filteredCount} of {data.enriched.length}
         </span>
         <button
           aria-label="Refresh"
           className="text-tertiary hover:text-primary rounded p-1.5 transition-colors"
-          disabled={isLoading}
-          onClick={onRefresh}
+          disabled={data.isLoading}
+          onClick={data.refreshAll}
           type="button"
         >
-          <RefreshCw className={`size-4 ${isLoading ? 'animate-spin' : ''}`} />
+          <RefreshCw
+            className={`size-4 ${data.isLoading ? 'animate-spin' : ''}`}
+          />
         </button>
       </div>
     </div>
   )
+}
+
+function resolveAuthorInfo(
+  author: string,
+  loginToEmail: Map<string, string>,
+  displayNames: Map<string, string>,
+): AuthorInfo {
+  const email = loginToEmail.get(author)
+  if (!email) {
+    return {
+      displayNamesForUser: undefined,
+      emailOrAuthor: author,
+      linkToProfile: false,
+      tooltip: author,
+    }
+  }
+  return {
+    displayNamesForUser: displayNames,
+    emailOrAuthor: email,
+    linkToProfile: true,
+    tooltip: displayNames.get(email) ?? author,
+  }
 }
 
 function SkeletonRows() {
@@ -562,41 +617,18 @@ function useOpenPrReportData(orgSlug: string) {
   })
 
   const {
-    data: projects,
     isError: projectsError,
     isFetching: projectsFetching,
+    projectsById,
     refetch: refetchProjects,
-  } = useQuery({
-    enabled: !!orgSlug,
-    queryFn: ({ signal }) => getProjectsSlim(orgSlug, signal),
-    queryKey: ['projects-slim', orgSlug],
-    staleTime: 120_000,
-  })
-
-  const projectsById = useMemo(() => {
-    const m = new Map<string, ProjectListItem>()
-    for (const p of projects ?? []) m.set(p.id, p)
-    return m
-  }, [projects])
+  } = useProjectsSlimMap(orgSlug)
 
   const enriched = useMemo(
     () => enrichPullRequests(prData?.data ?? [], projectsById),
     [prData, projectsById],
   )
 
-  const teamOptions = useMemo(
-    () =>
-      deriveSlugNameOptions(enriched, (pr) => [[pr.team_slug, pr.team_name]]),
-    [enriched],
-  )
-
-  const projectTypeOptions = useMemo(
-    () =>
-      deriveSlugNameOptions(enriched, (pr) =>
-        pr.project_types.map((pt) => [pt.slug, pt.name] as const),
-      ),
-    [enriched],
-  )
+  const { projectTypeOptions, teamOptions } = useReportOptions(enriched)
 
   function refreshAll() {
     void refetchPrs()
@@ -611,4 +643,34 @@ function useOpenPrReportData(orgSlug: string) {
     refreshAll,
     teamOptions,
   }
+}
+
+function useReportFilters(): ReportFilters {
+  const [teamFilter, setTeamFilter] = useState<string>(ALL)
+  const [projectTypeFilter, setProjectTypeFilter] = useState<string>(ALL)
+  const [search, setSearch] = useState('')
+  return {
+    projectTypeFilter,
+    search,
+    setProjectTypeFilter,
+    setSearch,
+    setTeamFilter,
+    teamFilter,
+  }
+}
+
+function useReportOptions(enriched: EnrichedPR[]) {
+  const teamOptions = useMemo(
+    () =>
+      deriveSlugNameOptions(enriched, (pr) => [[pr.team_slug, pr.team_name]]),
+    [enriched],
+  )
+  const projectTypeOptions = useMemo(
+    () =>
+      deriveSlugNameOptions(enriched, (pr) =>
+        pr.project_types.map((pt) => [pt.slug, pt.name] as const),
+      ),
+    [enriched],
+  )
+  return { projectTypeOptions, teamOptions }
 }

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -232,13 +232,13 @@ export function OpenPullRequestsReport() {
         <table className="w-full text-sm">
           <thead>
             <tr className="border-tertiary border-b">
-              <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+              <th className="text-tertiary w-20 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
                 Team
               </th>
-              <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+              <th className="text-tertiary w-32 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
                 Project Type
               </th>
-              <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+              <th className="text-tertiary w-44 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
                 Project
               </th>
               <th className="text-tertiary w-16 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
@@ -378,10 +378,11 @@ function PrRow({
           ))}
         </div>
       </td>
-      <td className="px-4 py-3">
+      <td className="max-w-44 px-4 py-3">
         <button
-          className="text-primary hover:text-action text-left text-sm font-medium transition-colors"
+          className="text-primary hover:text-action block w-full truncate text-left text-sm font-medium transition-colors"
           onClick={onOpenProject}
+          title={pr.project_name}
           type="button"
         >
           {pr.project_name}

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -126,18 +126,16 @@ export function OpenPullRequestsReport() {
 }
 
 function bodyStatus({
-  enrichedCount,
   filtered,
   hasError,
-  isLoading,
+  showSkeleton,
 }: {
-  enrichedCount: number
   filtered: EnrichedPR[]
   hasError: boolean
-  isLoading: boolean
+  showSkeleton: boolean
 }): 'empty' | 'error' | 'loading' | 'ready' {
   if (hasError) return 'error'
-  if (isLoading && enrichedCount === 0) return 'loading'
+  if (showSkeleton) return 'loading'
   if (filtered.length === 0) return 'empty'
   return 'ready'
 }
@@ -421,6 +419,7 @@ function ReportTable({
   loginToEmail: Map<string, string>
   onOpenProject: (id: string) => void
 }) {
+  const showSkeleton = data.isLoading && data.enriched.length === 0
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
@@ -428,13 +427,12 @@ function ReportTable({
         <tbody>
           <ReportTableBody
             displayNames={displayNames}
-            enrichedCount={data.enriched.length}
             filtered={filtered}
             hasError={data.hasError}
-            isLoading={data.isLoading}
             loginToEmail={loginToEmail}
             onOpenProject={onOpenProject}
             onRetry={data.refreshAll}
+            showSkeleton={showSkeleton}
           />
         </tbody>
       </table>
@@ -444,24 +442,22 @@ function ReportTable({
 
 function ReportTableBody({
   displayNames,
-  enrichedCount,
   filtered,
   hasError,
-  isLoading,
   loginToEmail,
   onOpenProject,
   onRetry,
+  showSkeleton,
 }: {
   displayNames: Map<string, string>
-  enrichedCount: number
   filtered: EnrichedPR[]
   hasError: boolean
-  isLoading: boolean
   loginToEmail: Map<string, string>
   onOpenProject: (id: string) => void
   onRetry: () => void
+  showSkeleton: boolean
 }) {
-  const status = bodyStatus({ enrichedCount, filtered, hasError, isLoading })
+  const status = bodyStatus({ filtered, hasError, showSkeleton })
   if (status === 'error') return <ErrorRow onRetry={onRetry} />
   if (status === 'loading') return <SkeletonRows />
   if (status === 'empty') return <EmptyRow />

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -247,7 +247,7 @@ export function OpenPullRequestsReport() {
               <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
                 Title
               </th>
-              <th className="text-tertiary w-40 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
+              <th className="text-tertiary w-10 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
                 Author
               </th>
               <th className="text-tertiary w-14 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
@@ -404,13 +404,16 @@ function PrRow({
           <ExternalLink className="text-tertiary size-3 shrink-0" />
         </a>
       </td>
-      <td className="px-4 py-3 text-center">
-        <UserDisplay
-          displayNames={email ? displayNames : undefined}
-          email={email ?? pr.author}
-          linkToProfile={!!email}
-          textClassName="text-sm"
-        />
+      <td className="px-4 py-3">
+        <div className="flex justify-center">
+          <UserDisplay
+            displayNames={email ? displayNames : undefined}
+            email={email ?? pr.author}
+            hideName
+            linkToProfile={!!email}
+            title={email ? (displayNames.get(email) ?? pr.author) : pr.author}
+          />
+        </div>
       </td>
       <td className="text-secondary px-4 py-3 text-center">
         {pr.changed_files}

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -18,6 +18,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { UserDisplay } from '@/components/ui/user-display'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
@@ -164,151 +170,153 @@ export function OpenPullRequestsReport() {
   }
 
   return (
-    <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
-      {/* Toolbar */}
-      <div className="border-tertiary flex flex-wrap items-center gap-3 border-b px-4 py-3">
-        <div className="flex items-center gap-2">
-          <label className="text-tertiary text-xs">Team</label>
-          <Select onValueChange={setTeamFilter} value={teamFilter}>
-            <SelectTrigger className="h-8 w-44 text-xs">
-              <SelectValue placeholder="All teams" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL}>All teams</SelectItem>
-              {teamOptions.map((t) => (
-                <SelectItem key={t.slug} value={t.slug}>
-                  {t.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex items-center gap-2">
-          <label className="text-tertiary text-xs">Project type</label>
-          <Select
-            onValueChange={setProjectTypeFilter}
-            value={projectTypeFilter}
-          >
-            <SelectTrigger className="h-8 w-44 text-xs">
-              <SelectValue placeholder="All types" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL}>All types</SelectItem>
-              {projectTypeOptions.map((pt) => (
-                <SelectItem key={pt.slug} value={pt.slug}>
-                  {pt.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-1 items-center justify-end gap-2">
-          <input
-            className="border-input bg-background text-primary focus:ring-action h-8 w-64 rounded border px-3 text-sm focus:ring-1 focus:outline-none"
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Filter by title, author, project, or #"
-            type="text"
-            value={search}
-          />
-          <span className="text-tertiary text-xs">
-            {filtered.length} of {total}
-          </span>
-          <button
-            aria-label="Refresh"
-            className="text-tertiary hover:text-primary rounded p-1.5 transition-colors"
-            disabled={isLoading}
-            onClick={refreshAll}
-            type="button"
-          >
-            <RefreshCw
-              className={`size-4 ${isLoading ? 'animate-spin' : ''}`}
+    <TooltipProvider delayDuration={200}>
+      <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
+        {/* Toolbar */}
+        <div className="border-tertiary flex flex-wrap items-center gap-3 border-b px-4 py-3">
+          <div className="flex items-center gap-2">
+            <label className="text-tertiary text-xs">Team</label>
+            <Select onValueChange={setTeamFilter} value={teamFilter}>
+              <SelectTrigger className="h-8 w-44 text-xs">
+                <SelectValue placeholder="All teams" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL}>All teams</SelectItem>
+                {teamOptions.map((t) => (
+                  <SelectItem key={t.slug} value={t.slug}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-tertiary text-xs">Project type</label>
+            <Select
+              onValueChange={setProjectTypeFilter}
+              value={projectTypeFilter}
+            >
+              <SelectTrigger className="h-8 w-44 text-xs">
+                <SelectValue placeholder="All types" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL}>All types</SelectItem>
+                {projectTypeOptions.map((pt) => (
+                  <SelectItem key={pt.slug} value={pt.slug}>
+                    {pt.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-1 items-center justify-end gap-2">
+            <input
+              className="border-input bg-background text-primary focus:ring-action h-8 w-64 rounded border px-3 text-sm focus:ring-1 focus:outline-none"
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Filter by title, author, project, or #"
+              type="text"
+              value={search}
             />
-          </button>
+            <span className="text-tertiary text-xs">
+              {filtered.length} of {total}
+            </span>
+            <button
+              aria-label="Refresh"
+              className="text-tertiary hover:text-primary rounded p-1.5 transition-colors"
+              disabled={isLoading}
+              onClick={refreshAll}
+              type="button"
+            >
+              <RefreshCw
+                className={`size-4 ${isLoading ? 'animate-spin' : ''}`}
+              />
+            </button>
+          </div>
         </div>
-      </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-tertiary border-b">
-              <th className="text-tertiary w-20 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                Team
-              </th>
-              <th className="text-tertiary w-32 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                Project Type
-              </th>
-              <th className="text-tertiary w-44 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                Project
-              </th>
-              <th className="text-tertiary w-16 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                #
-              </th>
-              <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                Title
-              </th>
-              <th className="text-tertiary w-10 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
-                Author
-              </th>
-              <th className="text-tertiary w-14 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
-                Files
-              </th>
-              <th className="text-tertiary w-36 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
-                Diff
-              </th>
-              <th className="text-tertiary w-20 px-4 py-2 text-right text-xs font-medium tracking-wide uppercase">
-                Updated
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {hasError ? (
-              <tr>
-                <td className="px-4 py-8 text-center" colSpan={9}>
-                  <div className="text-danger text-sm">
-                    Failed to load pull requests.
-                  </div>
-                  <button
-                    className="text-action mt-2 text-xs hover:underline"
-                    onClick={refreshAll}
-                    type="button"
-                  >
-                    Retry
-                  </button>
-                </td>
+        {/* Table */}
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-tertiary border-b">
+                <th className="text-tertiary w-20 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                  Team
+                </th>
+                <th className="text-tertiary w-32 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                  Project Type
+                </th>
+                <th className="text-tertiary w-44 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                  Project
+                </th>
+                <th className="text-tertiary w-16 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                  #
+                </th>
+                <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
+                  Title
+                </th>
+                <th className="text-tertiary w-10 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
+                  Author
+                </th>
+                <th className="text-tertiary w-14 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
+                  Files
+                </th>
+                <th className="text-tertiary w-36 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
+                  Diff
+                </th>
+                <th className="text-tertiary w-20 px-4 py-2 text-right text-xs font-medium tracking-wide uppercase">
+                  Updated
+                </th>
               </tr>
-            ) : isLoading && enriched.length === 0 ? (
-              Array.from({ length: 6 }).map((_, i) => (
-                <tr className="border-tertiary border-b" key={i}>
-                  <td className="px-4 py-3" colSpan={9}>
-                    <div className="bg-tertiary/30 h-4 animate-pulse rounded" />
+            </thead>
+            <tbody>
+              {hasError ? (
+                <tr>
+                  <td className="px-4 py-8 text-center" colSpan={9}>
+                    <div className="text-danger text-sm">
+                      Failed to load pull requests.
+                    </div>
+                    <button
+                      className="text-action mt-2 text-xs hover:underline"
+                      onClick={refreshAll}
+                      type="button"
+                    >
+                      Retry
+                    </button>
                   </td>
                 </tr>
-              ))
-            ) : filtered.length === 0 ? (
-              <tr>
-                <td
-                  className="text-tertiary px-4 py-12 text-center"
-                  colSpan={9}
-                >
-                  No open pull requests match the current filters.
-                </td>
-              </tr>
-            ) : (
-              filtered.map((pr) => (
-                <PrRow
-                  displayNames={displayNames}
-                  key={pr.pr_id}
-                  loginToEmail={loginToEmail}
-                  onOpenProject={() => navigate(`/projects/${pr.project_id}`)}
-                  pr={pr}
-                />
-              ))
-            )}
-          </tbody>
-        </table>
+              ) : isLoading && enriched.length === 0 ? (
+                Array.from({ length: 6 }).map((_, i) => (
+                  <tr className="border-tertiary border-b" key={i}>
+                    <td className="px-4 py-3" colSpan={9}>
+                      <div className="bg-tertiary/30 h-4 animate-pulse rounded" />
+                    </td>
+                  </tr>
+                ))
+              ) : filtered.length === 0 ? (
+                <tr>
+                  <td
+                    className="text-tertiary px-4 py-12 text-center"
+                    colSpan={9}
+                  >
+                    No open pull requests match the current filters.
+                  </td>
+                </tr>
+              ) : (
+                filtered.map((pr) => (
+                  <PrRow
+                    displayNames={displayNames}
+                    key={pr.pr_id}
+                    loginToEmail={loginToEmail}
+                    onOpenProject={() => navigate(`/projects/${pr.project_id}`)}
+                    pr={pr}
+                  />
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   )
 }
 
@@ -379,14 +387,18 @@ function PrRow({
         </div>
       </td>
       <td className="max-w-44 px-4 py-3">
-        <button
-          className="text-primary hover:text-action block w-full truncate text-left text-sm font-medium transition-colors"
-          onClick={onOpenProject}
-          title={pr.project_name}
-          type="button"
-        >
-          {pr.project_name}
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className="text-primary hover:text-action block w-full truncate text-left text-sm font-medium transition-colors"
+              onClick={onOpenProject}
+              type="button"
+            >
+              {pr.project_name}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{pr.project_name}</TooltipContent>
+        </Tooltip>
       </td>
       <td className="px-4 py-3">
         <span className="text-tertiary flex items-center gap-1.5 text-xs">
@@ -407,13 +419,22 @@ function PrRow({
       </td>
       <td className="px-4 py-3">
         <div className="flex justify-center">
-          <UserDisplay
-            displayNames={email ? displayNames : undefined}
-            email={email ?? pr.author}
-            hideName
-            linkToProfile={!!email}
-            title={email ? (displayNames.get(email) ?? pr.author) : pr.author}
-          />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <UserDisplay
+                  displayNames={email ? displayNames : undefined}
+                  email={email ?? pr.author}
+                  hideName
+                  linkToProfile={!!email}
+                  title=""
+                />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {email ? (displayNames.get(email) ?? pr.author) : pr.author}
+            </TooltipContent>
+          </Tooltip>
         </div>
       </td>
       <td className="text-secondary px-4 py-3 text-center">

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -10,6 +10,7 @@ import {
   getProjectsSlim,
   type ProjectListItem,
 } from '@/api/endpoints'
+import { DiffBar } from '@/components/pull-requests/DiffBar'
 import { Badge } from '@/components/ui/badge'
 import {
   Select,
@@ -26,7 +27,7 @@ import {
 } from '@/components/ui/tooltip'
 import { UserDisplay } from '@/components/ui/user-display'
 import { useOrganization } from '@/contexts/OrganizationContext'
-import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
+import { useLoginToEmail } from '@/hooks/useLoginToEmail'
 import { relTime } from '@/lib/formatDate'
 import type { PullRequest } from '@/types'
 
@@ -38,9 +39,50 @@ interface EnrichedPR extends PullRequest {
   team_slug: string
 }
 
+interface ReportToolbarProps {
+  filteredCount: number
+  isLoading: boolean
+  onRefresh: () => void
+  onSearchChange: (v: string) => void
+  onTeamChange: (v: string) => void
+  onTypeChange: (v: string) => void
+  projectTypeFilter: string
+  projectTypeOptions: SlugName[]
+  search: string
+  teamFilter: string
+  teamOptions: SlugName[]
+  total: number
+}
+
+interface SlugName {
+  name: string
+  slug: string
+}
+
 const ALL = '__all__'
 
-// fallow-ignore-next-line complexity
+const COLUMN_ALIGN: Record<'center' | 'left' | 'right', string> = {
+  center: 'text-center',
+  left: 'text-left',
+  right: 'text-right',
+}
+
+const COLUMNS: {
+  align: 'center' | 'left' | 'right'
+  label: string
+  width?: string
+}[] = [
+  { align: 'left', label: 'Team', width: 'w-20' },
+  { align: 'left', label: 'Project Type', width: 'w-32' },
+  { align: 'left', label: 'Project', width: 'w-44' },
+  { align: 'left', label: '#', width: 'w-16' },
+  { align: 'left', label: 'Title' },
+  { align: 'center', label: 'Author', width: 'w-10' },
+  { align: 'center', label: 'Files', width: 'w-14' },
+  { align: 'center', label: 'Diff', width: 'w-36' },
+  { align: 'right', label: 'Updated', width: 'w-20' },
+]
+
 export function OpenPullRequestsReport() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug ?? ''
@@ -50,6 +92,462 @@ export function OpenPullRequestsReport() {
   const [projectTypeFilter, setProjectTypeFilter] = useState<string>(ALL)
   const [search, setSearch] = useState('')
 
+  const {
+    enriched,
+    hasError,
+    isLoading,
+    projectTypeOptions,
+    refreshAll,
+    teamOptions,
+  } = useOpenPrReportData(orgSlug)
+
+  const { displayNames, loginToEmail } = useLoginToEmail()
+
+  const filtered = useOpenPrFilters(
+    enriched,
+    teamFilter,
+    projectTypeFilter,
+    search,
+  )
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
+        <ReportToolbar
+          filteredCount={filtered.length}
+          isLoading={isLoading}
+          onRefresh={refreshAll}
+          onSearchChange={setSearch}
+          onTeamChange={setTeamFilter}
+          onTypeChange={setProjectTypeFilter}
+          projectTypeFilter={projectTypeFilter}
+          projectTypeOptions={projectTypeOptions}
+          search={search}
+          teamFilter={teamFilter}
+          teamOptions={teamOptions}
+          total={enriched.length}
+        />
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <ReportTableHead />
+            <tbody>
+              <ReportTableBody
+                displayNames={displayNames}
+                enrichedCount={enriched.length}
+                filtered={filtered}
+                hasError={hasError}
+                isLoading={isLoading}
+                loginToEmail={loginToEmail}
+                onOpenProject={(id) => navigate(`/projects/${id}`)}
+                onRetry={refreshAll}
+              />
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </TooltipProvider>
+  )
+}
+
+function deriveSlugNameOptions(
+  rows: EnrichedPR[],
+  getPairs: (pr: EnrichedPR) => readonly (readonly [string, string])[],
+): SlugName[] {
+  const map = new Map<string, string>()
+  for (const pr of rows) {
+    for (const [slug, name] of getPairs(pr)) map.set(slug, name)
+  }
+  return [...map.entries()]
+    .map(([slug, name]) => ({ name, slug }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function EmptyRow() {
+  return (
+    <tr>
+      <td className="text-tertiary px-4 py-12 text-center" colSpan={9}>
+        No open pull requests match the current filters.
+      </td>
+    </tr>
+  )
+}
+
+function enrichPullRequests(
+  prs: PullRequest[],
+  projectsById: Map<string, ProjectListItem>,
+): EnrichedPR[] {
+  const out: EnrichedPR[] = []
+  for (const pr of prs) {
+    const p = projectsById.get(pr.project_id)
+    if (!p || !includePr(pr, p)) continue
+    out.push({
+      ...pr,
+      project_name: p.name,
+      project_slug: p.slug,
+      project_types: p.project_types,
+      team_name: p.team.name,
+      team_slug: p.team.slug,
+    })
+  }
+  out.sort(
+    (a, b) =>
+      new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+  )
+  return out
+}
+
+function ErrorRow({ onRetry }: { onRetry: () => void }) {
+  return (
+    <tr>
+      <td className="px-4 py-8 text-center" colSpan={9}>
+        <div className="text-danger text-sm">Failed to load pull requests.</div>
+        <button
+          className="text-action mt-2 text-xs hover:underline"
+          onClick={onRetry}
+          type="button"
+        >
+          Retry
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+function FilterSelect({
+  label,
+  onValueChange,
+  options,
+  placeholder,
+  value,
+}: {
+  label: string
+  onValueChange: (v: string) => void
+  options: SlugName[]
+  placeholder: string
+  value: string
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <label className="text-tertiary text-xs">{label}</label>
+      <Select onValueChange={onValueChange} value={value}>
+        <SelectTrigger className="h-8 w-44 text-xs">
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>{placeholder}</SelectItem>
+          {options.map((o) => (
+            <SelectItem key={o.slug} value={o.slug}>
+              {o.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function includePr(pr: PullRequest, p: ProjectListItem): boolean {
+  if (pr.draft) return false
+  if (pr.state !== 'open') return false
+  if (p.archived) return false
+  return true
+}
+
+function matchesSearch(r: EnrichedPR, q: string): boolean {
+  return (
+    r.title.toLowerCase().includes(q) ||
+    r.author.toLowerCase().includes(q) ||
+    r.project_name.toLowerCase().includes(q) ||
+    String(r.pr_number).includes(q)
+  )
+}
+
+function PrAuthorCell({
+  author,
+  displayNames,
+  email,
+}: {
+  author: string
+  displayNames: Map<string, string>
+  email: string | undefined
+}) {
+  const tooltip = email ? (displayNames.get(email) ?? author) : author
+  return (
+    <td className="px-4 py-3">
+      <div className="flex justify-center">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
+              <UserDisplay
+                displayNames={email ? displayNames : undefined}
+                email={email ?? author}
+                hideName
+                linkToProfile={!!email}
+                title=""
+              />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{tooltip}</TooltipContent>
+        </Tooltip>
+      </div>
+    </td>
+  )
+}
+
+function PrNumberCell({ number }: { number: number }) {
+  return (
+    <td className="px-4 py-3">
+      <span className="text-tertiary flex items-center gap-1.5 text-xs">
+        <GitPullRequest className="text-success size-3.5 shrink-0" />
+        {number}
+      </span>
+    </td>
+  )
+}
+
+function PrProjectCell({ name, onOpen }: { name: string; onOpen: () => void }) {
+  return (
+    <td className="max-w-44 px-4 py-3">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className="text-primary hover:text-action block w-full truncate text-left text-sm font-medium transition-colors"
+            onClick={onOpen}
+            type="button"
+          >
+            {name}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{name}</TooltipContent>
+      </Tooltip>
+    </td>
+  )
+}
+
+function PrProjectTypesCell({
+  types,
+}: {
+  types: { name: string; slug: string }[]
+}) {
+  return (
+    <td className="px-4 py-3">
+      <div className="flex flex-wrap gap-1">
+        {types.map((pt) => (
+          <Badge key={pt.slug} variant="neutral">
+            {pt.slug}
+          </Badge>
+        ))}
+      </div>
+    </td>
+  )
+}
+
+function PrRow({
+  displayNames,
+  loginToEmail,
+  onOpenProject,
+  pr,
+}: {
+  displayNames: Map<string, string>
+  loginToEmail: Map<string, string>
+  onOpenProject: () => void
+  pr: EnrichedPR
+}) {
+  const email = loginToEmail.get(pr.author)
+  return (
+    <tr className="border-tertiary hover:bg-secondary/30 border-b transition-colors last:border-b-0">
+      <td className="text-secondary px-4 py-3 font-mono text-xs">
+        {pr.team_slug}
+      </td>
+      <PrProjectTypesCell types={pr.project_types} />
+      <PrProjectCell name={pr.project_name} onOpen={onOpenProject} />
+      <PrNumberCell number={pr.pr_number} />
+      <PrTitleCell title={pr.title} url={pr.url} />
+      <PrAuthorCell
+        author={pr.author}
+        displayNames={displayNames}
+        email={email}
+      />
+      <td className="text-secondary px-4 py-3 text-center">
+        {pr.changed_files}
+      </td>
+      <td className="px-4 py-3 text-center">
+        <DiffBar additions={pr.additions} deletions={pr.deletions} />
+      </td>
+      <td className="text-tertiary px-4 py-3 text-right text-xs tabular-nums">
+        {relTime(pr.updated_at)}
+      </td>
+    </tr>
+  )
+}
+
+function PrTitleCell({ title, url }: { title: string; url: string }) {
+  return (
+    <td className="max-w-0 px-4 py-3">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <a
+            className="text-primary hover:text-action inline-flex max-w-full items-center gap-1.5 transition-colors"
+            href={url}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <span className="truncate">{title}</span>
+            <ExternalLink className="text-tertiary size-3 shrink-0" />
+          </a>
+        </TooltipTrigger>
+        <TooltipContent>{title}</TooltipContent>
+      </Tooltip>
+    </td>
+  )
+}
+
+function ReportTableBody({
+  displayNames,
+  enrichedCount,
+  filtered,
+  hasError,
+  isLoading,
+  loginToEmail,
+  onOpenProject,
+  onRetry,
+}: {
+  displayNames: Map<string, string>
+  enrichedCount: number
+  filtered: EnrichedPR[]
+  hasError: boolean
+  isLoading: boolean
+  loginToEmail: Map<string, string>
+  onOpenProject: (id: string) => void
+  onRetry: () => void
+}) {
+  if (hasError) return <ErrorRow onRetry={onRetry} />
+  if (isLoading && enrichedCount === 0) return <SkeletonRows />
+  if (filtered.length === 0) return <EmptyRow />
+  return (
+    <>
+      {filtered.map((pr) => (
+        <PrRow
+          displayNames={displayNames}
+          key={pr.pr_id}
+          loginToEmail={loginToEmail}
+          onOpenProject={() => onOpenProject(pr.project_id)}
+          pr={pr}
+        />
+      ))}
+    </>
+  )
+}
+
+function ReportTableHead() {
+  return (
+    <thead>
+      <tr className="border-tertiary border-b">
+        {COLUMNS.map((c) => (
+          <th
+            className={`text-tertiary px-4 py-2 text-xs font-medium tracking-wide uppercase ${COLUMN_ALIGN[c.align]} ${c.width ?? ''}`}
+            key={c.label}
+          >
+            {c.label}
+          </th>
+        ))}
+      </tr>
+    </thead>
+  )
+}
+
+function ReportToolbar({
+  filteredCount,
+  isLoading,
+  onRefresh,
+  onSearchChange,
+  onTeamChange,
+  onTypeChange,
+  projectTypeFilter,
+  projectTypeOptions,
+  search,
+  teamFilter,
+  teamOptions,
+  total,
+}: ReportToolbarProps) {
+  return (
+    <div className="border-tertiary flex flex-wrap items-center gap-3 border-b px-4 py-3">
+      <FilterSelect
+        label="Team"
+        onValueChange={onTeamChange}
+        options={teamOptions}
+        placeholder="All teams"
+        value={teamFilter}
+      />
+      <FilterSelect
+        label="Project type"
+        onValueChange={onTypeChange}
+        options={projectTypeOptions}
+        placeholder="All types"
+        value={projectTypeFilter}
+      />
+      <div className="flex flex-1 items-center justify-end gap-2">
+        <input
+          className="border-input bg-background text-primary focus:ring-action h-8 w-64 rounded border px-3 text-sm focus:ring-1 focus:outline-none"
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Filter by title, author, project, or #"
+          type="text"
+          value={search}
+        />
+        <span className="text-tertiary text-xs">
+          {filteredCount} of {total}
+        </span>
+        <button
+          aria-label="Refresh"
+          className="text-tertiary hover:text-primary rounded p-1.5 transition-colors"
+          disabled={isLoading}
+          onClick={onRefresh}
+          type="button"
+        >
+          <RefreshCw className={`size-4 ${isLoading ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <tr className="border-tertiary border-b" key={i}>
+          <td className="px-4 py-3" colSpan={9}>
+            <div className="bg-tertiary/30 h-4 animate-pulse rounded" />
+          </td>
+        </tr>
+      ))}
+    </>
+  )
+}
+
+function useOpenPrFilters(
+  enriched: EnrichedPR[],
+  teamFilter: string,
+  projectTypeFilter: string,
+  search: string,
+): EnrichedPR[] {
+  return useMemo(() => {
+    let rows = enriched
+    if (teamFilter !== ALL) {
+      rows = rows.filter((r) => r.team_slug === teamFilter)
+    }
+    if (projectTypeFilter !== ALL) {
+      rows = rows.filter((r) =>
+        r.project_types.some((pt) => pt.slug === projectTypeFilter),
+      )
+    }
+    const q = search.trim().toLowerCase()
+    if (q) rows = rows.filter((r) => matchesSearch(r, q))
+    return rows
+  }, [enriched, teamFilter, projectTypeFilter, search])
+}
+
+function useOpenPrReportData(orgSlug: string) {
   const {
     data: prData,
     isError: prsError,
@@ -75,382 +573,42 @@ export function OpenPullRequestsReport() {
     staleTime: 120_000,
   })
 
-  const { displayNames, users } = useUserDisplayNames()
-
-  const loginToEmail = useMemo(() => {
-    const m = new Map<string, string>()
-    for (const u of users) {
-      if (!u.email) continue
-      const local = u.email.split('@')[0]
-      if (local) m.set(local, u.email)
-    }
-    return m
-  }, [users])
-
   const projectsById = useMemo(() => {
     const m = new Map<string, ProjectListItem>()
     for (const p of projects ?? []) m.set(p.id, p)
     return m
   }, [projects])
 
-  const enriched = useMemo<EnrichedPR[]>(() => {
-    const prs = prData?.data ?? []
-    const out: EnrichedPR[] = []
-    for (const pr of prs) {
-      if (pr.draft) continue
-      if (pr.state !== 'open') continue
-      const p = projectsById.get(pr.project_id)
-      if (!p) continue
-      if (p.archived) continue
-      out.push({
-        ...pr,
-        project_name: p.name,
-        project_slug: p.slug,
-        project_types: p.project_types,
-        team_name: p.team.name,
-        team_slug: p.team.slug,
-      })
-    }
-    out.sort(
-      (a, b) =>
-        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
-    )
-    return out
-  }, [prData, projectsById])
+  const enriched = useMemo(
+    () => enrichPullRequests(prData?.data ?? [], projectsById),
+    [prData, projectsById],
+  )
 
-  const teamOptions = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const pr of enriched) map.set(pr.team_slug, pr.team_name)
-    return [...map.entries()]
-      .map(([slug, name]) => ({ name, slug }))
-      .sort((a, b) => a.name.localeCompare(b.name))
-  }, [enriched])
+  const teamOptions = useMemo(
+    () =>
+      deriveSlugNameOptions(enriched, (pr) => [[pr.team_slug, pr.team_name]]),
+    [enriched],
+  )
 
-  const projectTypeOptions = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const pr of enriched) {
-      for (const pt of pr.project_types) map.set(pt.slug, pt.name)
-    }
-    return [...map.entries()]
-      .map(([slug, name]) => ({ name, slug }))
-      .sort((a, b) => a.name.localeCompare(b.name))
-  }, [enriched])
-
-  // fallow-ignore-next-line complexity
-  const filtered = useMemo(() => {
-    let rows = enriched
-    if (teamFilter !== ALL) {
-      rows = rows.filter((r) => r.team_slug === teamFilter)
-    }
-    if (projectTypeFilter !== ALL) {
-      rows = rows.filter((r) =>
-        r.project_types.some((pt) => pt.slug === projectTypeFilter),
-      )
-    }
-    if (search.trim()) {
-      const q = search.toLowerCase()
-      rows = rows.filter(
-        (r) =>
-          r.title.toLowerCase().includes(q) ||
-          r.author.toLowerCase().includes(q) ||
-          r.project_name.toLowerCase().includes(q) ||
-          String(r.pr_number).includes(q),
-      )
-    }
-    return rows
-  }, [enriched, teamFilter, projectTypeFilter, search])
-
-  const isLoading = prsFetching || projectsFetching
-  const hasError = prsError || projectsError
-  const total = enriched.length
+  const projectTypeOptions = useMemo(
+    () =>
+      deriveSlugNameOptions(enriched, (pr) =>
+        pr.project_types.map((pt) => [pt.slug, pt.name] as const),
+      ),
+    [enriched],
+  )
 
   function refreshAll() {
     void refetchPrs()
     void refetchProjects()
   }
 
-  return (
-    <TooltipProvider delayDuration={200}>
-      <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
-        {/* Toolbar */}
-        <div className="border-tertiary flex flex-wrap items-center gap-3 border-b px-4 py-3">
-          <div className="flex items-center gap-2">
-            <label className="text-tertiary text-xs">Team</label>
-            <Select onValueChange={setTeamFilter} value={teamFilter}>
-              <SelectTrigger className="h-8 w-44 text-xs">
-                <SelectValue placeholder="All teams" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>All teams</SelectItem>
-                {teamOptions.map((t) => (
-                  <SelectItem key={t.slug} value={t.slug}>
-                    {t.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex items-center gap-2">
-            <label className="text-tertiary text-xs">Project type</label>
-            <Select
-              onValueChange={setProjectTypeFilter}
-              value={projectTypeFilter}
-            >
-              <SelectTrigger className="h-8 w-44 text-xs">
-                <SelectValue placeholder="All types" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>All types</SelectItem>
-                {projectTypeOptions.map((pt) => (
-                  <SelectItem key={pt.slug} value={pt.slug}>
-                    {pt.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex flex-1 items-center justify-end gap-2">
-            <input
-              className="border-input bg-background text-primary focus:ring-action h-8 w-64 rounded border px-3 text-sm focus:ring-1 focus:outline-none"
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Filter by title, author, project, or #"
-              type="text"
-              value={search}
-            />
-            <span className="text-tertiary text-xs">
-              {filtered.length} of {total}
-            </span>
-            <button
-              aria-label="Refresh"
-              className="text-tertiary hover:text-primary rounded p-1.5 transition-colors"
-              disabled={isLoading}
-              onClick={refreshAll}
-              type="button"
-            >
-              <RefreshCw
-                className={`size-4 ${isLoading ? 'animate-spin' : ''}`}
-              />
-            </button>
-          </div>
-        </div>
-
-        {/* Table */}
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-tertiary border-b">
-                <th className="text-tertiary w-20 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                  Team
-                </th>
-                <th className="text-tertiary w-32 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                  Project Type
-                </th>
-                <th className="text-tertiary w-44 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                  Project
-                </th>
-                <th className="text-tertiary w-16 px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                  #
-                </th>
-                <th className="text-tertiary px-4 py-2 text-left text-xs font-medium tracking-wide uppercase">
-                  Title
-                </th>
-                <th className="text-tertiary w-10 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
-                  Author
-                </th>
-                <th className="text-tertiary w-14 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
-                  Files
-                </th>
-                <th className="text-tertiary w-36 px-4 py-2 text-center text-xs font-medium tracking-wide uppercase">
-                  Diff
-                </th>
-                <th className="text-tertiary w-20 px-4 py-2 text-right text-xs font-medium tracking-wide uppercase">
-                  Updated
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {hasError ? (
-                <tr>
-                  <td className="px-4 py-8 text-center" colSpan={9}>
-                    <div className="text-danger text-sm">
-                      Failed to load pull requests.
-                    </div>
-                    <button
-                      className="text-action mt-2 text-xs hover:underline"
-                      onClick={refreshAll}
-                      type="button"
-                    >
-                      Retry
-                    </button>
-                  </td>
-                </tr>
-              ) : isLoading && enriched.length === 0 ? (
-                Array.from({ length: 6 }).map((_, i) => (
-                  <tr className="border-tertiary border-b" key={i}>
-                    <td className="px-4 py-3" colSpan={9}>
-                      <div className="bg-tertiary/30 h-4 animate-pulse rounded" />
-                    </td>
-                  </tr>
-                ))
-              ) : filtered.length === 0 ? (
-                <tr>
-                  <td
-                    className="text-tertiary px-4 py-12 text-center"
-                    colSpan={9}
-                  >
-                    No open pull requests match the current filters.
-                  </td>
-                </tr>
-              ) : (
-                filtered.map((pr) => (
-                  <PrRow
-                    displayNames={displayNames}
-                    key={pr.pr_id}
-                    loginToEmail={loginToEmail}
-                    onOpenProject={() => navigate(`/projects/${pr.project_id}`)}
-                    pr={pr}
-                  />
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </TooltipProvider>
-  )
-}
-
-function DiffBar({
-  additions,
-  deletions,
-}: {
-  additions: number
-  deletions: number
-}) {
-  const total = additions + deletions
-  if (total === 0) return <span className="text-tertiary text-xs">—</span>
-  const addBlocks = Math.round((additions / total) * 5)
-  const delBlocks = 5 - addBlocks
-  return (
-    <div className="flex flex-col items-center gap-1">
-      <div className="text-xs">
-        <span className="text-success">+{additions.toLocaleString()}</span>
-        <span className="text-tertiary"> · </span>
-        <span className="text-danger">-{deletions.toLocaleString()}</span>
-      </div>
-      <div className="flex gap-0.5">
-        {Array.from({ length: addBlocks }).map((_, i) => (
-          <div
-            className="h-2 w-3.5"
-            key={`a${i}`}
-            style={{ backgroundColor: 'var(--text-color-success)' }}
-          />
-        ))}
-        {Array.from({ length: delBlocks }).map((_, i) => (
-          <div
-            className="h-2 w-3.5"
-            key={`d${i}`}
-            style={{ backgroundColor: 'var(--text-color-danger)' }}
-          />
-        ))}
-      </div>
-    </div>
-  )
-}
-
-// fallow-ignore-next-line complexity
-function PrRow({
-  displayNames,
-  loginToEmail,
-  onOpenProject,
-  pr,
-}: {
-  displayNames: Map<string, string>
-  loginToEmail: Map<string, string>
-  onOpenProject: () => void
-  pr: EnrichedPR
-}) {
-  const email = loginToEmail.get(pr.author)
-
-  return (
-    <tr className="border-tertiary hover:bg-secondary/30 border-b transition-colors last:border-b-0">
-      <td className="text-secondary px-4 py-3 font-mono text-xs">
-        {pr.team_slug}
-      </td>
-      <td className="px-4 py-3">
-        <div className="flex flex-wrap gap-1">
-          {pr.project_types.map((pt) => (
-            <Badge key={pt.slug} variant="neutral">
-              {pt.slug}
-            </Badge>
-          ))}
-        </div>
-      </td>
-      <td className="max-w-44 px-4 py-3">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              className="text-primary hover:text-action block w-full truncate text-left text-sm font-medium transition-colors"
-              onClick={onOpenProject}
-              type="button"
-            >
-              {pr.project_name}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>{pr.project_name}</TooltipContent>
-        </Tooltip>
-      </td>
-      <td className="px-4 py-3">
-        <span className="text-tertiary flex items-center gap-1.5 text-xs">
-          <GitPullRequest className="text-success size-3.5 shrink-0" />
-          {pr.pr_number}
-        </span>
-      </td>
-      <td className="max-w-0 px-4 py-3">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <a
-              className="text-primary hover:text-action inline-flex max-w-full items-center gap-1.5 transition-colors"
-              href={pr.url}
-              rel="noreferrer"
-              target="_blank"
-            >
-              <span className="truncate">{pr.title}</span>
-              <ExternalLink className="text-tertiary size-3 shrink-0" />
-            </a>
-          </TooltipTrigger>
-          <TooltipContent>{pr.title}</TooltipContent>
-        </Tooltip>
-      </td>
-      <td className="px-4 py-3">
-        <div className="flex justify-center">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <UserDisplay
-                  displayNames={email ? displayNames : undefined}
-                  email={email ?? pr.author}
-                  hideName
-                  linkToProfile={!!email}
-                  title=""
-                />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>
-              {email ? (displayNames.get(email) ?? pr.author) : pr.author}
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </td>
-      <td className="text-secondary px-4 py-3 text-center">
-        {pr.changed_files}
-      </td>
-      <td className="px-4 py-3 text-center">
-        <DiffBar additions={pr.additions} deletions={pr.deletions} />
-      </td>
-      <td className="text-tertiary px-4 py-3 text-right text-xs tabular-nums">
-        {relTime(pr.updated_at)}
-      </td>
-    </tr>
-  )
+  return {
+    enriched,
+    hasError: prsError || projectsError,
+    isLoading: prsFetching || projectsFetching,
+    projectTypeOptions,
+    refreshAll,
+    teamOptions,
+  }
 }

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -407,15 +407,20 @@ function PrRow({
         </span>
       </td>
       <td className="max-w-0 px-4 py-3">
-        <a
-          className="text-primary hover:text-action inline-flex max-w-full items-center gap-1.5 transition-colors"
-          href={pr.url}
-          rel="noreferrer"
-          target="_blank"
-        >
-          <span className="truncate">{pr.title}</span>
-          <ExternalLink className="text-tertiary size-3 shrink-0" />
-        </a>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <a
+              className="text-primary hover:text-action inline-flex max-w-full items-center gap-1.5 transition-colors"
+              href={pr.url}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <span className="truncate">{pr.title}</span>
+              <ExternalLink className="text-tertiary size-3 shrink-0" />
+            </a>
+          </TooltipTrigger>
+          <TooltipContent>{pr.title}</TooltipContent>
+        </Tooltip>
       </td>
       <td className="px-4 py-3">
         <div className="flex justify-center">

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -366,12 +366,14 @@ function PrRow({
 
   return (
     <tr className="border-tertiary hover:bg-secondary/30 border-b transition-colors last:border-b-0">
-      <td className="text-secondary px-4 py-3 text-xs">{pr.team_name}</td>
+      <td className="text-secondary px-4 py-3 font-mono text-xs">
+        {pr.team_slug}
+      </td>
       <td className="px-4 py-3">
         <div className="flex flex-wrap gap-1">
           {pr.project_types.map((pt) => (
             <Badge key={pt.slug} variant="neutral">
-              {pt.name}
+              {pt.slug}
             </Badge>
           ))}
         </div>

--- a/src/hooks/useLoginToEmail.ts
+++ b/src/hooks/useLoginToEmail.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react'
+
+import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
+
+/**
+ * Build a map from GitHub login to user email by matching email local-parts.
+ * Returns both the display-name map (from useUserDisplayNames) and the login→email lookup.
+ */
+export function useLoginToEmail() {
+  const { displayNames, users } = useUserDisplayNames()
+
+  const loginToEmail = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const u of users) {
+      if (!u.email) continue
+      const local = u.email.split('@')[0]
+      if (local) m.set(local, u.email)
+    }
+    return m
+  }, [users])
+
+  return { displayNames, loginToEmail }
+}

--- a/src/hooks/useProjectsSlimMap.ts
+++ b/src/hooks/useProjectsSlimMap.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { getProjectsSlim, type ProjectListItem } from '@/api/endpoints'
+
+/**
+ * Fetch the slim projects list for an organization and expose it as a
+ * Map keyed by project id alongside the query state.
+ */
+export function useProjectsSlimMap(orgSlug: string) {
+  const { data, isError, isFetching, refetch } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => getProjectsSlim(orgSlug, signal),
+    queryKey: ['projects-slim', orgSlug],
+    staleTime: 120_000,
+  })
+
+  const projectsById = useMemo(() => {
+    const m = new Map<string, ProjectListItem>()
+    for (const p of data ?? []) m.set(p.id, p)
+    return m
+  }, [data])
+
+  return { isError, isFetching, projectsById, refetch }
+}

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -34,7 +34,7 @@ const REPORTS: Report[] = [
   {
     description: 'Open pull requests across the org',
     id: 'open-pull-requests',
-    label: 'Open PRs',
+    label: 'Open Pull Requests',
     subtitle: 'Open pull requests, filterable by team and project type',
   },
   {

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -81,7 +81,7 @@ export function ReportsPage() {
         className="pt-16"
         style={{ paddingBottom: 'var(--assistant-height, 64px)' }}
       >
-        <div className="mx-auto flex max-w-[1400px] gap-6 px-6 py-7">
+        <div className="mx-auto flex max-w-screen-2xl gap-6 px-6 py-7">
           {/* Left sidebar — report list */}
           <aside className="w-56 shrink-0">
             <div className="border-tertiary bg-primary rounded-lg border">

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import {
   BarChart3,
   GitCommitHorizontal,
+  GitPullRequest,
   Network,
   TrendingUp,
 } from 'lucide-react'
@@ -10,6 +11,7 @@ import {
 import { CommandBar } from '@/components/CommandBar'
 import { Navigation } from '@/components/Navigation'
 import { MonthlyImprovementReport } from '@/components/reports/MonthlyImprovementReport'
+import { OpenPullRequestsReport } from '@/components/reports/OpenPullRequestsReport'
 import { ProjectsGraphReport } from '@/components/reports/ProjectsGraphReport'
 import { ScoreHistoryReport } from '@/components/reports/ScoreHistoryReport'
 import { TeamKPIReport } from '@/components/reports/TeamKPIReport'
@@ -28,6 +30,12 @@ const REPORTS: Report[] = [
     id: 'monthly-improvement',
     label: 'Monthly Improvement',
     subtitle: 'Score improvement by team for a selected month',
+  },
+  {
+    description: 'Open pull requests across the org',
+    id: 'open-pull-requests',
+    label: 'Open PRs',
+    subtitle: 'Open pull requests, filterable by team and project type',
   },
   {
     description: 'Service dependency graph',
@@ -102,6 +110,8 @@ export function ReportsPage() {
                         <GitCommitHorizontal className="mt-0.5 size-3.5 shrink-0" />
                       ) : r.id === 'projects-graph' ? (
                         <Network className="mt-0.5 size-3.5 shrink-0" />
+                      ) : r.id === 'open-pull-requests' ? (
+                        <GitPullRequest className="mt-0.5 size-3.5 shrink-0" />
                       ) : (
                         <TrendingUp className="mt-0.5 size-3.5 shrink-0" />
                       )}
@@ -128,6 +138,7 @@ export function ReportsPage() {
             </div>
             {activeId === 'team-kpi' && <TeamKPIReport />}
             {activeId === 'monthly-improvement' && <MonthlyImprovementReport />}
+            {activeId === 'open-pull-requests' && <OpenPullRequestsReport />}
             {activeId === 'score-history' && <ScoreHistoryReport />}
             {activeId === 'projects-graph' && <ProjectsGraphReport />}
           </div>


### PR DESCRIPTION
## Summary
- Adds a new **Open PRs** entry to the Reports sidebar
- Lists open pull requests across the org with Team, Project Type, and Project columns alongside the existing PR metadata (state, author, files, diff, updated)
- Filterable by team and project type via selects, with a search box for title/author/project/number
- Enriches `getOrgPullRequests` by joining against the slim projects list (also drops archived projects and drafts so the list only shows actionable PRs)

## Test plan
- [ ] Navigate to Reports → Open PRs
- [ ] Verify rows show Team, Project Type, Project, #, Title, Author, Files, Diff, Updated
- [ ] Filter by Team and confirm only matching rows remain
- [ ] Filter by Project Type and confirm only matching rows remain
- [ ] Clicking the project name navigates to the project detail page
- [ ] Clicking the PR title opens the PR URL in a new tab
- [ ] Refresh button refetches both PRs and projects