### PR TITLE
Centralize auth-provider query keys

### DIFF
--- a/src/components/admin/AuthProvidersManagement.tsx
+++ b/src/components/admin/AuthProvidersManagement.tsx
@@ -39,6 +39,7 @@ import { LoadingState } from '@/components/ui/loading-state'
 import { Switch } from '@/components/ui/switch'
 import { useAuth } from '@/hooks/useAuth'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { queryKeys } from '@/lib/queryKeys'
 import type {
   LocalAuthConfig,
   LoginProviderCreate,
@@ -109,12 +110,12 @@ export function AuthProvidersManagement() {
 
   const { data, error, isLoading } = useQuery({
     queryFn: ({ signal }) => listAuthProviders(signal),
-    queryKey: ['admin', 'auth-providers'],
+    queryKey: queryKeys.adminAuthProviders(),
   })
 
   const localAuthQuery = useQuery({
     queryFn: ({ signal }) => getLocalAuthConfig(signal),
-    queryKey: ['admin', 'local-auth'],
+    queryKey: queryKeys.adminLocalAuth(),
   })
 
   const localAuthMutation = useMutation({
@@ -123,16 +124,15 @@ export function AuthProvidersManagement() {
       toast.error(
         `Failed to update local authentication: ${extractApiErrorDetail(err)}`,
       )
-      queryClient.invalidateQueries({ queryKey: ['admin', 'local-auth'] })
+      queryClient.invalidateQueries({ queryKey: queryKeys.adminLocalAuth() })
     },
     onMutate: async (enabled: boolean) => {
-      await queryClient.cancelQueries({ queryKey: ['admin', 'local-auth'] })
-      const previous = queryClient.getQueryData<LocalAuthConfig>([
-        'admin',
-        'local-auth',
-      ])
+      await queryClient.cancelQueries({ queryKey: queryKeys.adminLocalAuth() })
+      const previous = queryClient.getQueryData<LocalAuthConfig>(
+        queryKeys.adminLocalAuth(),
+      )
       if (previous) {
-        queryClient.setQueryData<LocalAuthConfig>(['admin', 'local-auth'], {
+        queryClient.setQueryData<LocalAuthConfig>(queryKeys.adminLocalAuth(), {
           ...previous,
           enabled,
         })
@@ -140,8 +140,10 @@ export function AuthProvidersManagement() {
       return { previous }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'local-auth'] })
-      queryClient.invalidateQueries({ queryKey: ['authProviders'] })
+      queryClient.invalidateQueries({ queryKey: queryKeys.adminLocalAuth() })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.publicAuthProviders(),
+      })
       toast.success('Local authentication updated')
     },
   })
@@ -149,8 +151,8 @@ export function AuthProvidersManagement() {
   const providers = useMemo(() => sortProviders(data ?? []), [data])
 
   const invalidateAll = () => {
-    queryClient.invalidateQueries({ queryKey: ['admin', 'auth-providers'] })
-    queryClient.invalidateQueries({ queryKey: ['authProviders'] })
+    queryClient.invalidateQueries({ queryKey: queryKeys.adminAuthProviders() })
+    queryClient.invalidateQueries({ queryKey: queryKeys.publicAuthProviders() })
   }
 
   const createMutation = useMutation({

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -5,6 +5,8 @@
  * breaks the other.  Use these builders instead of literals.
  */
 export const queryKeys = {
+  adminAuthProviders: () => ['admin', 'auth-providers'] as const,
+  adminLocalAuth: () => ['admin', 'local-auth'] as const,
   adminPlugin: (slug: string) => ['admin-plugin', slug] as const,
   adminPlugins: () => ['admin-plugins'] as const,
   anchorEdges: (
@@ -21,6 +23,12 @@ export const queryKeys = {
   pluginEntitySchema: (slug: string, label: string) =>
     ['plugin-entity-schema', slug, label] as const,
   projectTypes: (orgSlug: string) => ['projectTypes', orgSlug] as const,
+  // Login form's view of providers (/auth/providers, public payload with
+  // default_redirect). Distinct from adminAuthProviders, which lists admin
+  // metadata from /admin/auth-providers — different endpoint, different shape,
+  // different consumers. Mutations on the admin list must invalidate both so
+  // the LoginPage picker stays in sync.
+  publicAuthProviders: () => ['authProviders'] as const,
 } as const
 
 /**

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -14,6 +14,7 @@ import { useTheme } from '@/contexts/ThemeContext'
 import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { queryKeys } from '@/lib/queryKeys'
 
 const REMEMBERED_EMAIL_KEY = 'imbi_remembered_email'
 
@@ -33,7 +34,7 @@ export function LoginPage() {
 
   const { data: providersData, isLoading: providersLoading } = useQuery({
     queryFn: ({ signal }) => getAuthProviders(signal),
-    queryKey: ['authProviders'],
+    queryKey: queryKeys.publicAuthProviders(),
     retry: false,
     staleTime: 10 * 60 * 1000,
   })


### PR DESCRIPTION
## Summary

Centralizes the three auth-provider-related React Query keys (`['admin','auth-providers']`, `['authProviders']`, `['admin','local-auth']`) into `queryKeys.*` helpers in `src/lib/queryKeys.ts`. Replaces the inline string literals at all three sites.

## Why

The login page and the admin auth-providers page hit different endpoints (`/auth/providers` vs `/admin/auth-providers`) that return different shapes for different consumers, so two cache keys is correct — they're not duplicates. But the rule that mutations on the admin list must invalidate **both** so the LoginPage picker stays in sync was kept only as tribal knowledge in an `invalidateAll()` helper, with the literals scattered across three files plus a one-off invalidation in the `localAuthMutation`. A future contributor could easily drop half.

> **Note:** the refactor-plan doc framed this as a bug ("every change requires a hard reload"). On closer reading the existing code does call `invalidateAll()` from every mutation, so there is no behavior bug. This PR is a refactor; the plan will be amended in #304.

## Changes

- `src/lib/queryKeys.ts`: add `adminAuthProviders`, `publicAuthProviders`, `adminLocalAuth` with a comment explaining why both auth-provider keys must be invalidated together.
- `src/pages/LoginPage.tsx`: use `queryKeys.publicAuthProviders()`.
- `src/components/admin/AuthProvidersManagement.tsx`: use the three helpers in the `useQuery` keys, mutation invalidations, and `setQueryData` calls.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors
- [ ] Manual smoke: toggle local-auth in admin → LoginPage picker updates; create/update/delete a provider → both the admin list and the LoginPage refresh.