### PR TITLE
Fix project-types cache key split between admin and consumers

### DIFF
--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -21,6 +21,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { queryKeys } from '@/lib/queryKeys'
 import { slugify } from '@/lib/utils'
 import type { ProjectCreate } from '@/types'
 
@@ -56,7 +57,7 @@ export function NewProjectDialog({
   const { data: projectTypes = [] } = useQuery({
     enabled: !!orgSlug && isOpen,
     queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
-    queryKey: ['projectTypes', orgSlug],
+    queryKey: queryKeys.projectTypes(orgSlug),
   })
 
   const { data: environments = [] } = useQuery({

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -72,6 +72,7 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { getIcon, useIconRegistryVersion } from '@/lib/icons'
 import { formatFieldKey } from '@/lib/project-field-formatting'
+import { queryKeys } from '@/lib/queryKeys'
 import { sanitizeHttpUrl, sortEnvironments } from '@/lib/utils'
 import type { Project, ScoringPolicy } from '@/types'
 
@@ -346,7 +347,7 @@ export function ProjectDetail({
   const { data: projectTypes = [] } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
-    queryKey: ['projectTypes', orgSlug],
+    queryKey: queryKeys.projectTypes(orgSlug),
   })
   const { data: projectDocuments = [] } = useQuery({
     enabled: !!orgSlug && !!project.id,

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -16,6 +16,7 @@ import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { buildDiffPatch } from '@/lib/json-patch'
+import { queryKeys } from '@/lib/queryKeys'
 import type { PatchOperation, ProjectType, ProjectTypeCreate } from '@/types'
 
 import { AdminSection } from './AdminSection'
@@ -51,7 +52,7 @@ export function ProjectTypeManagement() {
     deleteFn: ({ orgSlug, slug }) => deleteProjectType(orgSlug, slug),
     listFn: orgSlug ? (signal) => listProjectTypes(orgSlug, signal) : null,
     onMutationSuccess: goToList,
-    queryKey: ['projectTypes', orgSlug],
+    queryKey: queryKeys.projectTypes(orgSlug ?? ''),
     updateFn: ({ operations, orgSlug, slug }) =>
       updateProjectType(orgSlug, slug, operations),
   })

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -13,6 +13,7 @@ import { CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { queryKeys } from '@/lib/queryKeys'
 import { parseFilterFromBlueprint } from '@/lib/utils'
 import type { BlueprintCreate, BlueprintFilter, SchemaProperty } from '@/types'
 
@@ -72,7 +73,7 @@ export function BlueprintForm({
   } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listProjectTypes(orgSlug!, signal),
-    queryKey: ['projectTypes', orgSlug],
+    queryKey: queryKeys.projectTypes(orgSlug ?? ''),
   })
 
   const {

--- a/src/components/admin/document-templates/DocumentTemplateForm.tsx
+++ b/src/components/admin/document-templates/DocumentTemplateForm.tsx
@@ -13,6 +13,7 @@ import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
+import { queryKeys } from '@/lib/queryKeys'
 import { slugify } from '@/lib/utils'
 import type {
   DocumentTemplate,
@@ -62,7 +63,7 @@ export function DocumentTemplateForm({
   const { data: projectTypes = [] } = useQuery<ProjectType[]>({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
-    queryKey: ['projectTypes', orgSlug],
+    queryKey: queryKeys.projectTypes(orgSlug),
   })
 
   const validate = () => {

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { queryKeys } from '@/lib/queryKeys'
 import { slugify } from '@/lib/utils'
 import type {
   ScoringPolicy,
@@ -146,7 +147,7 @@ export function ScoringPolicyForm({
   } = useQuery({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listProjectTypes(orgSlug!, signal),
-    queryKey: ['projectTypes', orgSlug],
+    queryKey: queryKeys.projectTypes(orgSlug ?? ''),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -761,7 +761,7 @@ function ProjectTypesCard({
 
   const { data: projectTypes } = useQuery({
     queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
-    queryKey: ['project-types', orgSlug],
+    queryKey: queryKeys.projectTypes(orgSlug),
     staleTime: 60 * 1000,
   })
 

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -20,6 +20,7 @@ export const queryKeys = {
     ['plugin-entities', slug, label] as const,
   pluginEntitySchema: (slug: string, label: string) =>
     ['plugin-entity-schema', slug, label] as const,
+  projectTypes: (orgSlug: string) => ['projectTypes', orgSlug] as const,
 } as const
 
 /**
@@ -45,7 +46,9 @@ export function getQueryKeysForResource(
     case 'organizations':
       return [['organizations']]
     case 'project_types':
-      return orgSlug ? [['projectTypes', orgSlug]] : [['projectTypes']]
+      return orgSlug
+        ? [Array.from(queryKeys.projectTypes(orgSlug))]
+        : [['projectTypes']]
     case 'projects':
       return [['projects']]
     case 'roles':


### PR DESCRIPTION
## Summary

Adds `queryKeys.projectTypes(orgSlug)` to `src/lib/queryKeys.ts` and replaces 8 inline call sites — one of which (`ServicePluginConfiguration.tsx`) was using kebab-case `['project-types', orgSlug]` while every other site uses camelCase `['projectTypes', orgSlug]`.

## Why

`useAdminCrud` in `ProjectTypeManagement.tsx` invalidates `['projectTypes', orgSlug]` after every CRUD action. `ServicePluginConfiguration.tsx:764` was reading `listProjectTypes(orgSlug)` from `['project-types', orgSlug]` — a parallel cache that the admin mutations never touched. Net effect: after a project-type edit, the service-plugin configuration page kept stale data until a hard refresh.

## Changes

- `src/lib/queryKeys.ts`: add `projectTypes(orgSlug: string)` helper; `getQueryKeysForResource('project_types', orgSlug)` now composes from it.
- 7 sites switch from `['projectTypes', orgSlug]` to `queryKeys.projectTypes(orgSlug)`:
  - `ProjectDetail.tsx`, `NewProjectDialog.tsx`, `ProjectTypeManagement.tsx`, `BlueprintForm.tsx`, `ScoringPolicyForm.tsx`, `DocumentTemplateForm.tsx`
- 1 site (`ServicePluginConfiguration.tsx`) switches from `['project-types', orgSlug]` — this is the bug fix.

Three of the callers (`ProjectTypeManagement`, `BlueprintForm`, `ScoringPolicyForm`) had `orgSlug: string | undefined` that the inline literal silently accepted. Coalesce with `?? ''` so the strict helper signature is satisfied; the query is already gated by `enabled: !!orgSlug` so the empty-string key never fires.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: edit a project type in `/admin/project-types`, then open a Service Plugin Configuration → its project-type picker should reflect the change without a hard refresh.