### PR TITLE
Use stable keys for removable list items

### DIFF
--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -79,10 +79,10 @@ export function RecentActivity({
 
   const activityList = (
     <div className="max-h-[calc(100vh-380px)] space-y-4 overflow-y-auto pr-2">
-      {activities.map((activity, index) => (
+      {activities.map((activity) => (
         <div
           className="border-tertiary border-b pb-4 last:border-0 last:pb-0"
-          key={index}
+          key={activityKey(activity)}
         >
           <div className="flex gap-3">
             <img
@@ -139,6 +139,13 @@ export function RecentActivity({
       {activityList}
     </Card>
   )
+}
+
+function activityKey(activity: ActivityFeedEntry): string {
+  if (activity.type === 'OperationsLogEntry') {
+    return `ops-${activity.id}`
+  }
+  return `feed-${activity.project_id}-${activity.what}-${activity.when ?? activity.occurred_at ?? ''}`
 }
 
 function ActivityLine({

--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -904,16 +904,16 @@ export function LogsTab({
       {/* Active field filters */}
       {fieldFilters.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
-          {fieldFilters.map((f, i) => (
+          {fieldFilters.map((f) => (
             <span
               className="bg-tertiary text-secondary flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[11px]"
-              key={i}
+              key={f}
             >
               {f}
               <button
                 className="text-tertiary hover:text-primary"
                 onClick={() =>
-                  setFieldFilters((prev) => prev.filter((_, j) => j !== i))
+                  setFieldFilters((prev) => prev.filter((cur) => cur !== f))
                 }
               >
                 <X size={10} />


### PR DESCRIPTION
## Summary

Replaces index-based React keys with stable keys on two lists whose items can be removed independently. Removing an item from an index-keyed list causes React to reuse the same component instance for the next item that slides into that slot — any per-row state (focus, hover) attaches to the wrong row.

## Changes

### `src/components/project/LogsTab.tsx` (field-filter chips)
- Field filter strings are deduplicated on insert (`handleAddFilter`, line 442), so the filter string itself is a safe React key.
- Changed `key={i}` → `key={f}` and the remove callback from "filter by index" → "filter by value".

### `src/components/RecentActivity.tsx` (activity feed)
- Feed mixes `OperationsLogEntry` (has stable `id`) and `ProjectFeedEntry` (no id; `project_id` + `what` + `when` is unique). Added a tiny `activityKey()` helper.
- Switched the feed `.map()` to `key={activityKey(activity)}`.

## What I deliberately did **not** change

- `src/components/ScoreHistoryTab.tsx:415,777,804` — event log uses index-keyed hover state (`hoveredIdx`) and an `eventCorrelations: Map<number, ...>` keyed by index by design. Reworking that is a deeper refactor; events aren't user-removable, so the same-index reuse bug doesn't actually trigger today.
- `src/components/project/LogsTab.tsx:1233,1294` — these are histogram bucket cells and axis labels, both purely positional and not user-removable.

The refactor plan in #304 will be amended to narrow the original audit claim.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: in a project's Logs tab, add 3 field filters, remove the middle one — verify the remaining two stay in place; in the activity feed, scroll-load more entries and verify no flicker / state-bleed on the boundary.