### PR TITLE
Route RecentActivity through shared formatRelativeDate

### DIFF
--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import md5 from 'md5'
 
 import { usePluginOpsLogTemplates } from '@/hooks/usePluginOpsLogTemplates'
+import { formatRelativeDate } from '@/lib/formatDate'
 import type { ActivityFeedEntry, OperationsLogEntry } from '@/types'
 
 import { renderActivityTemplate } from './activityFeed/renderActivityTemplate'
@@ -102,12 +103,11 @@ export function RecentActivity({
               />
 
               <p className="text-tertiary mt-1 text-xs">
-                {getRelativeTime(
+                {formatRelativeDate(
                   activity.occurred_at ||
                     (activity.type === 'ProjectFeedEntry'
                       ? activity.when
-                      : undefined) ||
-                    '',
+                      : undefined),
                 )}
               </p>
             </div>
@@ -189,43 +189,6 @@ function ActivityLine({
 function getGravatarUrl(email: string, size: number = 40): string {
   const hash = md5(email.trim().toLowerCase())
   return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=identicon`
-}
-
-function getRelativeTime(timestamp: string): string {
-  try {
-    const now = new Date()
-    const past = new Date(timestamp)
-
-    // Check if date is valid
-    if (isNaN(past.getTime())) {
-      console.warn('Invalid timestamp:', timestamp)
-      return `Invalid date: ${timestamp}`
-    }
-
-    const diffMs = now.getTime() - past.getTime()
-
-    // Handle future dates or invalid differences
-    if (diffMs < 0) {
-      return 'just now'
-    }
-
-    const diffMins = Math.floor(diffMs / 60000)
-    const diffHours = Math.floor(diffMs / 3600000)
-    const diffDays = Math.floor(diffMs / 86400000)
-
-    if (diffMins < 1) {
-      return 'just now'
-    } else if (diffMins < 60) {
-      return `${diffMins} ${diffMins === 1 ? 'minute' : 'minutes'} ago`
-    } else if (diffHours < 24) {
-      return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'} ago`
-    } else {
-      return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ago`
-    }
-  } catch (error) {
-    console.error('Error parsing timestamp:', timestamp, error)
-    return 'unknown time'
-  }
 }
 
 function OpsLogActivityLine({


### PR DESCRIPTION
## Summary

Deletes the 35-line local `getRelativeTime()` helper in `RecentActivity.tsx` and routes through `formatRelativeDate()` from `@/lib/formatDate`.

## Why

The local helper had three bug-prone fallbacks:
1. `console.warn`/`console.error` calls that the prod build strips via `vite.config.ts` `esbuild.drop:['console']`.
2. An `"Invalid date: <iso>"` string shown to the user.
3. An `"unknown time"` fallback.

`formatRelativeDate` returns `'—'` for missing/invalid input and `'just now'` for current values.

## UX trade-off

Output format changes from long ("5 minutes ago", "3 hours ago", "7 days ago") to compact ("5m ago", "3h ago", "7d ago") — the format already used everywhere else in the dashboard. Dense feed reads fine in compact form.

## Not changed

- `src/components/documents/documentsHelpers.ts` `relativeShort()` — it has a deliberate "fall back to date at 8 weeks" UX (`"Jan 14"` instead of `"3mo ago"` for old documents) that `formatRelativeDate` doesn't provide. Leave it as a documents-specific variant for now.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: dashboard activity feed shows compact relative times for entries from "just now" through ">1y ago".