### PR TITLE
Add Skeleton primitive; migrate hand-rolled animate-pulse blocks

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useRecentDeployments } from '@/hooks/useRecentDeployments'
 import { queryKeys } from '@/lib/queryKeys'
@@ -351,9 +352,9 @@ export function Dashboard({
         </CardHeader>
         <CardContent className="mt-auto">
           {isOpenPrsLoading ? (
-            <span
+            <Skeleton
               aria-label="Loading Total Open PRs"
-              className="bg-tertiary/40 inline-block h-9 w-32 animate-pulse rounded"
+              className="bg-tertiary/40 inline-block h-9 w-32"
               role="status"
             />
           ) : isOpenPrsError ? (

--- a/src/components/dashboard/widgets/MyPullRequestCountsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestCountsWidget.tsx
@@ -5,6 +5,7 @@ import { GitMerge } from 'lucide-react'
 
 import { getOrgPullRequests } from '@/api/endpoints'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useGithubLogin } from '@/hooks/useGithubLogin'
 
@@ -64,9 +65,9 @@ export function MyPullRequestCountsWidget() {
       </CardHeader>
       <CardContent className="mt-auto">
         {isLoading ? (
-          <span
+          <Skeleton
             aria-label="Loading My Open PRs"
-            className="bg-tertiary/40 inline-block h-8 w-20 animate-pulse rounded"
+            className="bg-tertiary/40 inline-block h-8 w-20"
             role="status"
           />
         ) : isError ? (

--- a/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
@@ -11,6 +11,7 @@ import {
 
 import { getOrgPullRequests, type ProjectListItem } from '@/api/endpoints'
 import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useGithubLogin } from '@/hooks/useGithubLogin'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
@@ -146,9 +147,9 @@ export function MyPullRequestsWidget() {
         {isLoading ? (
           <div className="space-y-2">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div
+              <Skeleton
                 aria-hidden="true"
-                className="bg-tertiary/30 h-20 animate-pulse rounded-lg"
+                className="h-20 rounded-lg"
                 key={i}
               />
             ))}
@@ -178,10 +179,7 @@ export function MyPullRequestsWidget() {
             ))}
             <div ref={sentinelRef}>
               {isFetchingNextPage && (
-                <div
-                  aria-hidden="true"
-                  className="bg-tertiary/30 h-16 animate-pulse rounded-lg"
-                />
+                <Skeleton aria-hidden="true" className="h-16 rounded-lg" />
               )}
             </div>
           </div>

--- a/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
+++ b/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
@@ -14,6 +14,7 @@ import {
 import type { OperationsLogPage } from '@/api/endpoints'
 import { Badge, type BadgeProps } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import { formatRelativeDate } from '@/lib/formatDate'
@@ -128,9 +129,9 @@ export function RecentDeploymentsWidget() {
         {isLoading ? (
           <div className="space-y-2">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div
+              <Skeleton
                 aria-hidden="true"
-                className="bg-tertiary/30 h-16 animate-pulse rounded-lg"
+                className="h-16 rounded-lg"
                 key={i}
               />
             ))}
@@ -154,10 +155,7 @@ export function RecentDeploymentsWidget() {
             ))}
             <div ref={sentinelRef}>
               {isFetchingNextPage && (
-                <div
-                  aria-hidden="true"
-                  className="bg-tertiary/30 h-16 animate-pulse rounded-lg"
-                />
+                <Skeleton aria-hidden="true" className="h-16 rounded-lg" />
               )}
             </div>
           </div>

--- a/src/components/dashboard/widgets/StatWidget.tsx
+++ b/src/components/dashboard/widgets/StatWidget.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 
 interface StatWidgetProps {
   icon: string
@@ -41,9 +42,9 @@ export function StatWidget({
       </CardHeader>
       <CardContent className="mt-auto">
         {isLoading ? (
-          <span
+          <Skeleton
             aria-label={`Loading ${title}`}
-            className="bg-tertiary/40 inline-block h-8 w-20 animate-pulse rounded"
+            className="bg-tertiary/40 inline-block h-8 w-20"
             role="status"
           />
         ) : isError ? (

--- a/src/components/operations-log/OperationsLogSummary.tsx
+++ b/src/components/operations-log/OperationsLogSummary.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import type { OperationsLogMetrics } from '@/api/endpoints'
+import { Skeleton } from '@/components/ui/skeleton'
 import { sortEnvironments } from '@/lib/utils'
 import type { Environment, OperationsLogRecord } from '@/types'
 
@@ -16,15 +17,6 @@ interface SummaryProps {
   // universe, the tiles display those numbers rather than stats derived
   // only from `entries` (which is just the loaded pages).
   serverMetrics?: OperationsLogMetrics
-}
-
-function SkeletonBlock({ className }: { className: string }) {
-  return (
-    <span
-      aria-hidden
-      className={`bg-tertiary/40 inline-block animate-pulse rounded ${className}`}
-    />
-  )
 }
 
 const RANGE_WINDOW_MS: Record<Exclude<TimeRange, 'all'>, number> = {
@@ -134,7 +126,10 @@ export function OperationsLogSummary({
           Events
         </span>
         {loading ? (
-          <SkeletonBlock className="mt-0.5 h-5 w-16" />
+          <Skeleton
+            aria-hidden
+            className="bg-tertiary/40 mt-0.5 inline-block h-5 w-16"
+          />
         ) : (
           <span className="text-primary flex items-baseline gap-1.5 font-medium tabular-nums">
             <span className="text-xl leading-none">
@@ -170,8 +165,14 @@ export function OperationsLogSummary({
         </span>
         {loading ? (
           <>
-            <SkeletonBlock className="mt-0.5 h-5 w-12" />
-            <SkeletonBlock className="mt-1 h-3 w-24" />
+            <Skeleton
+              aria-hidden
+              className="bg-tertiary/40 mt-0.5 inline-block h-5 w-12"
+            />
+            <Skeleton
+              aria-hidden
+              className="bg-tertiary/40 mt-1 inline-block h-3 w-24"
+            />
           </>
         ) : (
           <>
@@ -192,8 +193,14 @@ export function OperationsLogSummary({
         </span>
         {loading ? (
           <>
-            <SkeletonBlock className="mt-0.5 h-5 w-10" />
-            <SkeletonBlock className="mt-1 h-3 w-32" />
+            <Skeleton
+              aria-hidden
+              className="bg-tertiary/40 mt-0.5 inline-block h-5 w-10"
+            />
+            <Skeleton
+              aria-hidden
+              className="bg-tertiary/40 mt-1 inline-block h-3 w-32"
+            />
           </>
         ) : (
           <>
@@ -213,8 +220,14 @@ export function OperationsLogSummary({
         </span>
         {loading ? (
           <>
-            <SkeletonBlock className="mt-0.5 h-5 w-10" />
-            <SkeletonBlock className="mt-1 h-3 w-28" />
+            <Skeleton
+              aria-hidden
+              className="bg-tertiary/40 mt-0.5 inline-block h-5 w-10"
+            />
+            <Skeleton
+              aria-hidden
+              className="bg-tertiary/40 mt-1 inline-block h-3 w-28"
+            />
           </>
         ) : (
           <>

--- a/src/components/project/ProjectPullRequestsTab.tsx
+++ b/src/components/project/ProjectPullRequestsTab.tsx
@@ -13,6 +13,7 @@ import { getProjectPullRequests } from '@/api/endpoints'
 import { DiffBar } from '@/components/pull-requests/DiffBar'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { UserDisplay } from '@/components/ui/user-display'
 import { useLoginToEmail } from '@/hooks/useLoginToEmail'
 import { relTime } from '@/lib/formatDate'
@@ -237,7 +238,7 @@ export function ProjectPullRequestsTab({ orgSlug, projectId }: Props) {
               Array.from({ length: 5 }).map((_, i) => (
                 <tr className="border-border border-b" key={i}>
                   <td className="px-4 py-3" colSpan={7}>
-                    <div className="bg-tertiary/30 h-4 animate-pulse rounded" />
+                    <Skeleton className="h-4" />
                   </td>
                 </tr>
               ))

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -15,6 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Tooltip,
   TooltipContent,
@@ -568,7 +569,7 @@ function SkeletonRows() {
       {Array.from({ length: 6 }).map((_, i) => (
         <tr className="border-tertiary border-b" key={i}>
           <td className="px-4 py-3" colSpan={9}>
-            <div className="bg-tertiary/30 h-4 animate-pulse rounded" />
+            <Skeleton className="h-4" />
           </td>
         </tr>
       ))}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,20 @@
+import type { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * Loading placeholder block. Apply size/shape via className (h-*, w-*,
+ * rounded-*). The default surface tone (`bg-tertiary/30`) matches the
+ * other skeleton patterns already in the codebase.
+ */
+export function Skeleton({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded bg-tertiary/30', className)}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

Adds `src/components/ui/skeleton.tsx` with the canonical shadcn pattern (`bg-tertiary/30 animate-pulse rounded` + caller `className` via `cn()`). Migrates 11 hand-rolled `animate-pulse` skeleton blocks to `<Skeleton>`.

## Migrated

- `Dashboard.tsx` — Total Open PRs widget loading state
- `dashboard/widgets/StatWidget.tsx`, `MyPullRequestCountsWidget.tsx`, `MyPullRequestsWidget.tsx`, `RecentDeploymentsWidget.tsx` (5 sites total)
- `operations-log/OperationsLogSummary.tsx` — drops the local `SkeletonBlock` helper (was 7 call-sites of bespoke `<span>` pulsers)
- `project/ProjectPullRequestsTab.tsx` — table-row loading placeholder
- `reports/OpenPullRequestsReport.tsx` — `SkeletonRows` helper

## Deliberately left

- `ProjectDetail.tsx` `versionSlot` (line 715) uses an inline `<span>` with `bg-current/25 blur-[2px]`. It's text-inside-chip (the `versionSlot` is composed into a `<LabelChip>` span), and a `<div>` there would be invalid HTML. Skeleton is a `<div>`.
- `CommandBar.tsx` (`<span className="animate-pulse">...</span>`) and `SearchResultsPanel.tsx` use `animate-pulse` on inline status text, not on skeleton blocks.
- `ConfigurationTab.tsx` applies `animate-pulse` to `<Input>` fields during save, not as a placeholder.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Manual smoke: load the dashboard with a cold cache and confirm the four widgets (Total Open PRs, StatWidget tiles, MyPullRequestsWidget, RecentDeploymentsWidget) all show the same pulsing skeletons as before.