### PR TITLE
Add Alert primitive; migrate info/warning banners

### DIFF
--- a/src/components/admin/AuthProvidersManagement.tsx
+++ b/src/components/admin/AuthProvidersManagement.tsx
@@ -22,6 +22,7 @@ import {
   updateAuthProvider,
   updateLocalAuthConfig,
 } from '@/api/endpoints'
+import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
@@ -214,17 +215,10 @@ export function AuthProvidersManagement() {
   return (
     <div className="space-y-4">
       {!canWrite && (
-        <div
-          className={
-            'border-info bg-info flex items-start gap-3 rounded-lg border p-4'
-          }
-        >
-          <Power className="text-info mt-0.5 size-5 shrink-0" />
-          <p className="text-info text-sm">
-            You don't have permission to modify auth providers. Contact an
-            administrator to add or change providers.
-          </p>
-        </div>
+        <Alert icon={Power} variant="info">
+          You don't have permission to modify auth providers. Contact an
+          administrator to add or change providers.
+        </Alert>
       )}
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -16,6 +16,7 @@ import {
   getApplicationSecrets,
   updateApplicationSecrets,
 } from '@/api/endpoints'
+import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -183,10 +184,7 @@ export function ApplicationSecretsPanel({
       )}
 
       {revealed && is403 && (
-        <div className="border-warning bg-warning text-warning flex items-center gap-3 rounded-lg border p-4">
-          <AlertCircle className="size-5 shrink-0" />
-          <div className="text-sm">Admin access required to view secrets.</div>
-        </div>
+        <Alert variant="warning">Admin access required to view secrets.</Alert>
       )}
 
       {revealed && error && !is403 && (

--- a/src/components/settings/SettingsApiKeys.tsx
+++ b/src/components/settings/SettingsApiKeys.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { createApiKey, deleteApiKey, listApiKeys } from '@/api/endpoints'
+import { Alert } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -168,25 +169,11 @@ export function SettingsApiKeys() {
         )}
       </Card>
 
-      {/* Security info banner */}
-      <Card
-        className="border-info bg-info p-6"
-        style={{ borderWidth: '0.5px' }}
-      >
-        <div className="flex gap-3">
-          <span className="mt-0.5 shrink-0 text-blue-600">ⓘ</span>
-          <div>
-            <h3 className="text-info mb-1 text-[14px] font-medium">
-              Keep your API keys secure
-            </h3>
-            <p className="text-info text-[12px]">
-              API keys grant access to your Imbi resources. Never share them or
-              commit them to version control. Rotate keys regularly and revoke
-              any that may have been compromised.
-            </p>
-          </div>
-        </div>
-      </Card>
+      <Alert title="Keep your API keys secure" variant="info">
+        API keys grant access to your Imbi resources. Never share them or commit
+        them to version control. Rotate keys regularly and revoke any that may
+        have been compromised.
+      </Alert>
 
       {/* Create key dialog */}
       <Dialog

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,82 @@
+/* eslint-disable react-refresh/only-export-components */
+import type { HTMLAttributes, ReactNode } from 'react'
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle,
+  Info,
+  type LucideIcon,
+} from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const alertVariants = cva(
+  'flex items-start gap-3 rounded-lg border p-4 text-sm',
+  {
+    defaultVariants: {
+      variant: 'info',
+    },
+    variants: {
+      variant: {
+        danger: 'border-danger bg-danger text-danger',
+        info: 'border-info bg-info text-info',
+        success: 'border-success bg-success text-success',
+        warning: 'border-warning bg-warning text-warning',
+      },
+    },
+  },
+)
+
+const ICON_FOR_VARIANT: Record<
+  NonNullable<VariantProps<typeof alertVariants>['variant']>,
+  LucideIcon
+> = {
+  danger: AlertCircle,
+  info: Info,
+  success: CheckCircle,
+  warning: AlertTriangle,
+}
+
+export interface AlertProps
+  extends
+    Omit<HTMLAttributes<HTMLDivElement>, 'title'>,
+    VariantProps<typeof alertVariants> {
+  /** Override the default icon for the variant. Pass `null` to suppress it. */
+  icon?: LucideIcon | null
+  /** Optional bold lead-in displayed above the body. */
+  title?: ReactNode
+}
+
+/**
+ * Inline alert / banner with semantic variants. Use for informational,
+ * warning, success, or danger messages embedded in a page. For dedicated
+ * error displays prefer `<ErrorBanner>`, which formats API errors.
+ */
+export function Alert({
+  children,
+  className,
+  icon,
+  title,
+  variant,
+  ...props
+}: AlertProps) {
+  const Icon =
+    icon === null ? null : (icon ?? ICON_FOR_VARIANT[variant ?? 'info'])
+  return (
+    <div
+      className={cn(alertVariants({ variant }), className)}
+      role="alert"
+      {...props}
+    >
+      {Icon && <Icon className="mt-0.5 size-5 shrink-0" />}
+      <div className="flex-1">
+        {title && <div className="mb-1 font-medium">{title}</div>}
+        <div>{children}</div>
+      </div>
+    </div>
+  )
+}
+
+export { alertVariants }


### PR DESCRIPTION
## Summary

Adds `src/components/ui/alert.tsx` with semantic variants `info` / `warning` / `success` / `danger`. Icon defaults to the variant (Info / AlertTriangle / CheckCircle / AlertCircle); can be overridden via `icon={...}` or suppressed with `icon={null}`. Optional `title` renders as a bold lead-in.

## Migrated

- `admin/AuthProvidersManagement.tsx` — "no write permission" info banner with a `Power` icon.
- `settings/SettingsApiKeys.tsx` — "Keep your API keys secure" banner (was a hand-rolled `<Card>` with `ⓘ` glyph).
- `admin/third-party-services/ApplicationSecretsPanel.tsx` — "Admin access required" warning banner.

## Deliberately left

- `OperationsLog.tsx` error/warning banners use `bg-*/10` (subtler tint for in-page status). Different visual rule.
- Pure-danger banners that are showing errors (`OrganizationForm`, `blueprint detail/form`, several third-party-services panels). Most should migrate to `<ErrorBanner>` (the API-error-aware wrapper); separate pass.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors
- [ ] Manual smoke: visit the auth-providers admin page as a non-admin (info banner), the settings/api-keys page (info banner), and trigger the secrets-403 path (warning banner). Verify they render with the correct semantic color + icon.