### PR TITLE
Add useClipboard hook; migrate setCopied/setTimeout sites

### DIFF
--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/components/ui/tooltip'
 import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { useAdminNav } from '@/hooks/useAdminNav'
+import { useClipboard } from '@/hooks/useClipboard'
 import { buildDiffPatch } from '@/lib/json-patch'
 import { parseFilterFromBlueprint } from '@/lib/utils'
 import type { Blueprint, BlueprintCreate, PatchOperation } from '@/types'
@@ -57,7 +58,7 @@ export function BlueprintManagement() {
   const [typeFilter, setTypeFilter] = useState<string>('')
   const [enabledFilter, setEnabledFilter] = useState<string>('')
   const [importDialogOpen, setImportDialogOpen] = useState(false)
-  const [copiedKey, setCopiedKey] = useState<null | string>(null)
+  const { copied: copiedKey, copy } = useClipboard()
   const [copyError, setCopyError] = useState<null | string>(null)
 
   // Parse compound key from URL slug (format: "type:slug")
@@ -163,17 +164,10 @@ export function BlueprintManagement() {
       json_schema: schemaObj,
     }
     const rowKey = `${blueprintPathType(bp)}/${bp.slug}`
-    navigator.clipboard
-      .writeText(JSON.stringify(exportObj, null, 2))
-      .then(() => {
-        setCopyError(null)
-        setCopiedKey(rowKey)
-        setTimeout(() => setCopiedKey(null), 2000)
-      })
-      .catch(() => {
-        setCopyError(`Failed to copy "${bp.name}" to clipboard`)
-        setCopiedKey(null)
-      })
+    void copy(JSON.stringify(exportObj, null, 2), rowKey).then((ok) => {
+      if (ok) setCopyError(null)
+      else setCopyError(`Failed to copy "${bp.name}" to clipboard`)
+    })
   }
 
   const handleEditClick = (key: BlueprintKey) => {

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/tooltip'
 import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { useAdminNav } from '@/hooks/useAdminNav'
+import { useClipboard } from '@/hooks/useClipboard'
 import { buildDiffPatch } from '@/lib/json-patch'
 import type {
   AttributeScoringPolicy,
@@ -59,7 +60,7 @@ export function ScoringPolicyManagement() {
   const [enabledFilter, setEnabledFilter] = useState('')
   const [rescoreResult, setRescoreResult] = useState<null | number>(null)
   const [importDialogOpen, setImportDialogOpen] = useState(false)
-  const [copiedSlug, setCopiedSlug] = useState<null | string>(null)
+  const { copied: copiedSlug, copy } = useClipboard()
 
   const rescoreMutation = useMutation({
     mutationFn: rescoreAll,
@@ -115,16 +116,7 @@ export function ScoringPolicyManagement() {
 
   const handleCopy = (policy: ScoringPolicy) => {
     const exportObj = policyToExportPayload(policy)
-    if (!navigator.clipboard?.writeText) return
-    navigator.clipboard
-      .writeText(JSON.stringify(exportObj, null, 2))
-      .then(() => {
-        setCopiedSlug(policy.slug)
-        setTimeout(() => setCopiedSlug(null), 2000)
-      })
-      .catch(() => {
-        setCopiedSlug(null)
-      })
+    void copy(JSON.stringify(exportObj, null, 2), policy.slug)
   }
 
   const handleImport = (data: ScoringPolicyCreate) => {

--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -26,6 +26,7 @@ import { Button } from '@/components/ui/button'
 import { CardTitle } from '@/components/ui/card'
 import { LabelChip } from '@/components/ui/label-chip'
 import { LoadingState } from '@/components/ui/loading-state'
+import { useClipboard } from '@/hooks/useClipboard'
 import { parseFilterFromBlueprint } from '@/lib/utils'
 import type { SchemaProperty } from '@/types'
 
@@ -54,7 +55,7 @@ export function BlueprintDetail({
   onEdit,
 }: BlueprintDetailProps) {
   const [rawSchemaOpen, setRawSchemaOpen] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const { copied, copy } = useClipboard()
 
   const {
     data: blueprint,
@@ -124,12 +125,7 @@ export function BlueprintDetail({
       json_schema: schemaObj,
     }
 
-    navigator.clipboard
-      .writeText(JSON.stringify(exportObj, null, 2))
-      .then(() => {
-        setCopied(true)
-        setTimeout(() => setCopied(false), 2000)
-      })
+    void copy(JSON.stringify(exportObj, null, 2))
   }
 
   return (

--- a/src/components/admin/service-accounts/RevealSecret.tsx
+++ b/src/components/admin/service-accounts/RevealSecret.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react'
-
 import { Check, Copy } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import { useClipboard } from '@/hooks/useClipboard'
 
 interface RevealSecretProps {
   label: string
@@ -30,13 +29,11 @@ export function RevealSecretRow({
   onCopy,
   value,
 }: RevealSecretRowProps) {
-  const [copied, setCopied] = useState(false)
+  const { copied, copy } = useClipboard()
 
   const handleCopy = () => {
-    navigator.clipboard?.writeText(value)
+    void copy(value)
     onCopy?.()
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
   }
 
   return (

--- a/src/components/admin/service-accounts/RevealSecret.tsx
+++ b/src/components/admin/service-accounts/RevealSecret.tsx
@@ -32,8 +32,9 @@ export function RevealSecretRow({
   const { copied, copy } = useClipboard()
 
   const handleCopy = () => {
-    void copy(value)
-    onCopy?.()
+    void copy(value).then((ok) => {
+      if (ok) onCopy?.()
+    })
   }
 
   return (

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -24,6 +24,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { useClipboard } from '@/hooks/useClipboard'
 import { buildDiffPatch } from '@/lib/json-patch'
 import type { PatchOperation } from '@/types'
 
@@ -56,7 +57,7 @@ export function ApplicationSecretsPanel({
   const queryClient = useQueryClient()
   const [revealed, setRevealed] = useState(false)
   const [editing, setEditing] = useState(false)
-  const [copiedField, setCopiedField] = useState<null | string>(null)
+  const { copied: copiedField, copy } = useClipboard()
   const [editValues, setEditValues] = useState<Record<string, string>>({})
 
   const visibleFields = TYPE_SECRET_FIELDS[appType] || ['client_secret']
@@ -97,10 +98,8 @@ export function ApplicationSecretsPanel({
     setEditValues({})
   }
 
-  const handleCopy = async (field: string, value: string) => {
-    await navigator.clipboard.writeText(value)
-    setCopiedField(field)
-    setTimeout(() => setCopiedField(null), 2000)
+  const handleCopy = (field: string, value: string) => {
+    void copy(value, field)
   }
 
   const handleStartEdit = () => {

--- a/src/components/settings/SettingsApiKeys.tsx
+++ b/src/components/settings/SettingsApiKeys.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { useClipboard } from '@/hooks/useClipboard'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { formatDate } from '@/lib/formatDate'
 import type { ApiKey, ApiKeyCreated } from '@/types'
@@ -25,7 +26,7 @@ export function SettingsApiKeys() {
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [newKeyName, setNewKeyName] = useState('')
   const [createdKey, setCreatedKey] = useState<ApiKeyCreated | null>(null)
-  const [copiedKeyId, setCopiedKeyId] = useState<null | string>(null)
+  const { copied: copiedKeyId, copy } = useClipboard()
   const [revokingKeyId, setRevokingKeyId] = useState<null | string>(null)
   const [createError, setCreateError] = useState<null | string>(null)
 
@@ -62,10 +63,8 @@ export function SettingsApiKeys() {
     },
   })
 
-  const handleCopyKey = async (text: string, keyId: string) => {
-    await navigator.clipboard.writeText(text)
-    setCopiedKeyId(keyId)
-    setTimeout(() => setCopiedKeyId(null), 2000)
+  const handleCopyKey = (text: string, keyId: string) => {
+    void copy(text, keyId)
   }
 
   const activeKeys = apiKeys.filter((k: ApiKey) => !k.revoked)

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface UseClipboardOptions {
+  /** Milliseconds to keep the "copied" state set before reverting. */
+  timeoutMs?: number
+}
+
+interface UseClipboardResult {
+  /**
+   * The most recently copied key, or `null` if nothing has been copied
+   * (or the reset timeout has elapsed). When `copy(text)` is called
+   * without an explicit `key`, the copied text itself is used.
+   */
+  copied: null | string
+  /**
+   * Writes `text` to the clipboard. Sets `copied` to `key` (or `text` if
+   * no key is given) for `timeoutMs` ms. Returns `true` on success.
+   */
+  copy: (text: string, key?: string) => Promise<boolean>
+}
+
+/**
+ * Shared clipboard-copy behavior: write text and flash a "just copied"
+ * indicator that auto-clears after a delay. Use the optional `key`
+ * argument when several copy buttons share the same hook instance and
+ * each needs to highlight independently (e.g. `copied === thisField`).
+ */
+export function useClipboard({
+  timeoutMs = 2000,
+}: UseClipboardOptions = {}): UseClipboardResult {
+  const [copied, setCopied] = useState<null | string>(null)
+  const timerRef = useRef<null | ReturnType<typeof setTimeout>>(null)
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    [],
+  )
+
+  const copy = useCallback(
+    async (text: string, key?: string) => {
+      try {
+        await navigator.clipboard.writeText(text)
+        setCopied(key ?? text)
+        if (timerRef.current) clearTimeout(timerRef.current)
+        timerRef.current = setTimeout(() => setCopied(null), timeoutMs)
+        return true
+      } catch {
+        return false
+      }
+    },
+    [timeoutMs],
+  )
+
+  return { copied, copy }
+}


### PR DESCRIPTION
## Summary

Adds `src/hooks/useClipboard.ts` returning `{ copied, copy(text, key?) }`. The optional `key` argument lets sites with multiple copy buttons highlight only the active one (`copied === thisField`); when omitted, the copied text itself becomes the key. The hook clears its timer on unmount and on a new copy — neither of which the inline patterns were doing.

## Migrated (6 sites)

- `settings/SettingsApiKeys.tsx` (was `setCopiedKeyId`)
- `admin/ScoringPolicyManagement.tsx` (`setCopiedSlug`)
- `admin/blueprints/BlueprintDetail.tsx` (`setCopied`)
- `admin/third-party-services/ApplicationSecretsPanel.tsx` (`setCopiedField`)
- `admin/BlueprintManagement.tsx` (`setCopiedKey`) — also preserves the explicit error toast on clipboard failure via `copy()`'s boolean return.
- `admin/service-accounts/RevealSecret.tsx` (`setCopied`)

## Deliberately left

- `admin/AuthProvidersManagement.tsx` and `admin/users/UserForm.tsx` use different patterns (toast-on-copy / interleaved-with-form-state). The hook isn't a natural fit without reshaping behavior.
- `project/LogsTab.tsx` and `admin/service-accounts/ApiKeysSection.tsx` call `writeText` without any copied-state indicator — fire and forget, nothing to migrate.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: visit `/settings/api-keys`, `/admin/blueprints`, `/admin/scoring-policies` and verify the copy buttons still flash a checkmark for ~2s and the icon reverts.