### PR TITLE
Add RequiredAsterisk primitive; migrate 57 inline form-label sites

### DIFF
--- a/src/components/NewOpsLogDialog.tsx
+++ b/src/components/NewOpsLogDialog.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import {
@@ -166,7 +167,7 @@ export function NewOpsLogDialog({
             {/* Project */}
             <div className="space-y-2">
               <label className="text-sm font-medium" htmlFor="new-ops-project">
-                Project <span className="text-red-500">*</span>
+                Project <RequiredAsterisk />
               </label>
               <Combobox
                 onChange={(val) => {
@@ -188,7 +189,7 @@ export function NewOpsLogDialog({
                 className="text-sm font-medium"
                 htmlFor="new-ops-environment"
               >
-                Environment <span className="text-red-500">*</span>
+                Environment <RequiredAsterisk />
               </label>
               <Combobox
                 disabled={
@@ -223,7 +224,7 @@ export function NewOpsLogDialog({
                 className="text-sm font-medium"
                 htmlFor="new-ops-entry-type"
               >
-                Entry Type <span className="text-red-500">*</span>
+                Entry Type <RequiredAsterisk />
               </label>
               <Combobox
                 onChange={(val) => setEntryType(val as OperationsLogEntryType)}
@@ -242,7 +243,7 @@ export function NewOpsLogDialog({
                 className="text-sm font-medium"
                 htmlFor="new-ops-description"
               >
-                Description <span className="text-red-500">*</span>
+                Description <RequiredAsterisk />
               </label>
               <Textarea
                 className="min-h-24 resize-none"

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { queryKeys } from '@/lib/queryKeys'
@@ -135,7 +136,7 @@ export function NewProjectDialog({
             {/* Team */}
             <div className="space-y-2">
               <label className="text-sm font-medium" htmlFor="new-project-team">
-                Team <span className="text-red-500">*</span>
+                Team <RequiredAsterisk />
               </label>
               <Combobox
                 onChange={setTeamSlug}
@@ -154,7 +155,7 @@ export function NewProjectDialog({
             {/* Project Type */}
             <div className="space-y-2">
               <label className="text-sm font-medium" htmlFor="new-project-type">
-                Project Type <span className="text-red-500">*</span>
+                Project Type <RequiredAsterisk />
               </label>
               <Combobox
                 onChange={setProjectTypeSlug}
@@ -173,7 +174,7 @@ export function NewProjectDialog({
             {/* Name */}
             <div className="space-y-2">
               <label className="text-sm font-medium" htmlFor="new-project-name">
-                Name <span className="text-red-500">*</span>
+                Name <RequiredAsterisk />
               </label>
               <Input
                 id="new-project-name"
@@ -189,7 +190,7 @@ export function NewProjectDialog({
             {/* Slug */}
             <div className="space-y-2">
               <label className="text-sm font-medium" htmlFor="new-project-slug">
-                Slug <span className="text-red-500">*</span>
+                Slug <RequiredAsterisk />
               </label>
               <Input
                 id="new-project-slug"

--- a/src/components/admin/AuthProvidersManagement.tsx
+++ b/src/components/admin/AuthProvidersManagement.tsx
@@ -36,6 +36,7 @@ import {
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
 import { LoadingState } from '@/components/ui/loading-state'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Switch } from '@/components/ui/switch'
 import { useAuth } from '@/hooks/useAuth'
 import { extractApiErrorDetail } from '@/lib/apiError'
@@ -500,7 +501,7 @@ function AuthProviderCreateDialog({
           <div className="space-y-4 p-6">
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                OAuth Type <span className="text-red-500">*</span>
+                OAuth Type <RequiredAsterisk />
               </label>
               <select
                 className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
@@ -541,7 +542,7 @@ function AuthProviderCreateDialog({
 
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Client ID <span className="text-red-500">*</span>
+                Client ID <RequiredAsterisk />
               </label>
               <Input
                 disabled={isSaving}
@@ -557,7 +558,7 @@ function AuthProviderCreateDialog({
 
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Client Secret <span className="text-red-500">*</span>
+                Client Secret <RequiredAsterisk />
               </label>
               <Input
                 autoComplete="new-password"
@@ -576,7 +577,7 @@ function AuthProviderCreateDialog({
             {showIssuerUrl && (
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Issuer URL <span className="text-red-500">*</span>
+                  Issuer URL <RequiredAsterisk />
                 </label>
                 <Input
                   disabled={isSaving}
@@ -813,7 +814,7 @@ function AuthProviderEditDialog({
           <div className="space-y-4 p-6">
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Display Name <span className="text-red-500">*</span>
+                Display Name <RequiredAsterisk />
               </label>
               <Input
                 disabled={isSaving}
@@ -827,7 +828,7 @@ function AuthProviderEditDialog({
 
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                OAuth Type <span className="text-red-500">*</span>
+                OAuth Type <RequiredAsterisk />
               </label>
               <select
                 className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
@@ -843,7 +844,7 @@ function AuthProviderEditDialog({
 
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Client ID <span className="text-red-500">*</span>
+                Client ID <RequiredAsterisk />
               </label>
               <Input
                 disabled={isSaving}
@@ -920,7 +921,7 @@ function AuthProviderEditDialog({
             {showIssuerUrl && (
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Issuer URL <span className="text-red-500">*</span>
+                  Issuer URL <RequiredAsterisk />
                 </label>
                 <Input
                   disabled={isSaving}

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { queryKeys } from '@/lib/queryKeys'
 import { parseFilterFromBlueprint } from '@/lib/utils'
@@ -539,7 +540,7 @@ export function BlueprintForm({
           {/* Name */}
           <div>
             <label className="text-secondary mb-1.5 block text-sm">
-              Name <span className="text-red-500">*</span>
+              Name <RequiredAsterisk />
             </label>
             <Input
               className=""
@@ -592,7 +593,7 @@ export function BlueprintForm({
           {/* Kind */}
           <div>
             <label className="text-secondary mb-1.5 block text-sm">
-              Kind <span className="text-red-500">*</span>
+              Kind <RequiredAsterisk />
             </label>
             <select
               className={`border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
@@ -616,7 +617,7 @@ export function BlueprintForm({
           {kind === 'node' ? (
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Type <span className="text-red-500">*</span>
+                Type <RequiredAsterisk />
               </label>
               <select
                 className={`border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
@@ -644,7 +645,7 @@ export function BlueprintForm({
             <div className="col-span-2 grid grid-cols-[1fr_auto_1fr_auto_1fr] items-end gap-2">
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Source <span className="text-red-500">*</span>
+                  Source <RequiredAsterisk />
                 </label>
                 <select
                   className={`border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}
@@ -673,7 +674,7 @@ export function BlueprintForm({
               <div className="text-tertiary pb-2">→</div>
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Relationship Type <span className="text-red-500">*</span>
+                  Relationship Type <RequiredAsterisk />
                 </label>
                 {source &&
                 target &&
@@ -721,7 +722,7 @@ export function BlueprintForm({
               <div className="text-tertiary pb-2">→</div>
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Target <span className="text-red-500">*</span>
+                  Target <RequiredAsterisk />
                 </label>
                 <select
                   className={`border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm ${isEditing ? 'cursor-not-allowed opacity-60' : ''}`}

--- a/src/components/admin/document-templates/DocumentTemplateForm.tsx
+++ b/src/components/admin/document-templates/DocumentTemplateForm.tsx
@@ -11,6 +11,7 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { queryKeys } from '@/lib/queryKeys'
@@ -163,7 +164,7 @@ export function DocumentTemplateForm({
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="document-tpl-name"
                 >
-                  Name <span className="text-red-500">*</span>
+                  Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={errors.name ? 'border-red-500' : ''}
@@ -187,7 +188,7 @@ export function DocumentTemplateForm({
                     className="text-secondary mb-1.5 block text-sm"
                     htmlFor="document-tpl-slug"
                   >
-                    Slug <span className="text-red-500">*</span>
+                    Slug <RequiredAsterisk />
                   </label>
                   <Input
                     className={errors.slug ? 'border-red-500' : ''}

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -15,6 +15,7 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Switch } from '@/components/ui/switch'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
@@ -170,7 +171,7 @@ export function EnvironmentForm({
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="environment-org"
               >
-                Organization <span className="text-red-500">*</span>
+                Organization <RequiredAsterisk />
               </label>
               <select
                 className={`border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm ${isEditing || isLoading || organizations.length <= 1 ? 'cursor-not-allowed opacity-60' : ''} ${
@@ -204,7 +205,7 @@ export function EnvironmentForm({
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="environment-name"
                 >
-                  Environment Name <span className="text-red-500">*</span>
+                  Environment Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
@@ -228,7 +229,7 @@ export function EnvironmentForm({
                     className="text-secondary mb-1.5 block text-sm"
                     htmlFor="environment-slug"
                   >
-                    Slug <span className="text-red-500">*</span>
+                    Slug <RequiredAsterisk />
                   </label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}

--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -8,6 +8,7 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
@@ -128,7 +129,7 @@ export function LinkDefinitionForm({
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="link-def-org"
               >
-                Organization <span className="text-red-500">*</span>
+                Organization <RequiredAsterisk />
               </label>
               <select
                 className={`border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm ${isEditing || isLoading || organizations.length <= 1 ? 'cursor-not-allowed opacity-60' : ''} ${
@@ -162,7 +163,7 @@ export function LinkDefinitionForm({
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="link-def-name"
                 >
-                  Name <span className="text-red-500">*</span>
+                  Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
@@ -186,7 +187,7 @@ export function LinkDefinitionForm({
                     className="text-secondary mb-1.5 block text-sm"
                     htmlFor="link-def-slug"
                   >
-                    Slug <span className="text-red-500">*</span>
+                    Slug <RequiredAsterisk />
                   </label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}

--- a/src/components/admin/organizations/OrganizationForm.tsx
+++ b/src/components/admin/organizations/OrganizationForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 
 import { AlertCircle, Save, X } from 'lucide-react'
 
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import type { Organization, OrganizationCreate } from '@/types'
 
 import { Button } from '../../ui/button'
@@ -134,7 +135,7 @@ export function OrganizationForm({
             >
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Organization Name <span className="text-red-500">*</span>
+                  Organization Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
@@ -154,7 +155,7 @@ export function OrganizationForm({
               {!isEditing && (
                 <div>
                   <label className="text-secondary mb-1.5 block text-sm">
-                    Slug <span className="text-red-500">*</span>
+                    Slug <RequiredAsterisk />
                   </label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -13,6 +13,7 @@ import {
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Switch } from '@/components/ui/switch'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
@@ -176,7 +177,7 @@ export function ProjectTypeForm({
           <CardContent className="space-y-4 pt-6">
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Organization <span className="text-red-500">*</span>
+                Organization <RequiredAsterisk />
               </label>
               <select
                 className={`border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm ${isEditing || isLoading || organizations.length <= 1 ? 'cursor-not-allowed opacity-60' : ''} ${
@@ -206,7 +207,7 @@ export function ProjectTypeForm({
             >
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Project Type Name <span className="text-red-500">*</span>
+                  Project Type Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
@@ -226,7 +227,7 @@ export function ProjectTypeForm({
               {!isEditing && (
                 <div>
                   <label className="text-secondary mb-1.5 block text-sm">
-                    Slug <span className="text-red-500">*</span>
+                    Slug <RequiredAsterisk />
                   </label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}

--- a/src/components/admin/roles/RoleForm.tsx
+++ b/src/components/admin/roles/RoleForm.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { FormField } from '@/components/ui/form-field'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
 import type { Permission, RoleCreate } from '@/types'
 
@@ -327,7 +328,7 @@ export function RoleForm({
             {!isEditing && (
               <div className="col-span-2">
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Slug <span className="text-red-500">*</span>
+                  Slug <RequiredAsterisk />
                 </label>
                 <Input
                   className={`font-mono ${

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
   SelectContent,
@@ -278,7 +279,7 @@ export function ScoringPolicyForm({
         <Card>
           <CardHeader>
             <CardTitle>
-              Policy Type <span className="text-danger">*</span>
+              Policy Type <RequiredAsterisk />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
@@ -325,7 +326,7 @@ export function ScoringPolicyForm({
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-name"
                 >
-                  Name <span className="text-danger">*</span>
+                  Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={errors.name ? 'border-danger' : ''}
@@ -342,7 +343,7 @@ export function ScoringPolicyForm({
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-slug"
                 >
-                  Slug <span className="text-danger">*</span>
+                  Slug <RequiredAsterisk />
                 </label>
                 <Input
                   className={errors.slug ? 'border-danger' : ''}
@@ -388,7 +389,7 @@ export function ScoringPolicyForm({
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-link-slug"
                 >
-                  Required Link Type <span className="text-danger">*</span>
+                  Required Link Type <RequiredAsterisk />
                 </label>
                 <Select
                   disabled={isLoading}
@@ -427,7 +428,7 @@ export function ScoringPolicyForm({
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-attribute"
                 >
-                  Attribute Name <span className="text-danger">*</span>
+                  Attribute Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={errors.attribute_name ? 'border-danger' : ''}
@@ -456,7 +457,7 @@ export function ScoringPolicyForm({
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-weight"
                 >
-                  Weight (0–100) <span className="text-danger">*</span>
+                  Weight (0–100) <RequiredAsterisk />
                 </label>
                 <Input
                   className={errors.weight ? 'border-danger' : ''}

--- a/src/components/admin/service-accounts/ClientCredentialsSection.tsx
+++ b/src/components/admin/service-accounts/ClientCredentialsSection.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Tooltip,
   TooltipContent,
@@ -303,7 +304,7 @@ export function ClientCredentialsSection({
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="credential-name"
               >
-                Name <span className="text-red-500">*</span>
+                Name <RequiredAsterisk />
               </label>
               <Input
                 autoFocus

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -8,6 +8,7 @@ import { FormHeader } from '@/components/admin/form-header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useDirtyState } from '@/hooks/useDirtyState'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
@@ -293,7 +294,7 @@ export function ServiceAccountForm({
             {/* Display Name */}
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Display Name <span className="text-red-500">*</span>
+                Display Name <RequiredAsterisk />
               </label>
               <Input
                 disabled={isLoading}
@@ -320,7 +321,7 @@ export function ServiceAccountForm({
             {/* Slug */}
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Slug <span className="text-red-500">*</span>
+                Slug <RequiredAsterisk />
               </label>
               <Input
                 disabled={isLoading}
@@ -386,7 +387,7 @@ export function ServiceAccountForm({
           <div className="grid grid-cols-2 gap-4">
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Organization <span className="text-red-500">*</span>
+                Organization <RequiredAsterisk />
               </label>
               <select
                 className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
@@ -416,7 +417,7 @@ export function ServiceAccountForm({
 
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Role <span className="text-red-500">*</span>
+                Role <RequiredAsterisk />
               </label>
               {rolesLoading ? (
                 <p className="text-secondary text-sm">Loading roles...</p>
@@ -660,7 +661,7 @@ function IdentityCardEdit({
         <div className="grid grid-cols-2 gap-3">
           <div>
             <label className="text-secondary mb-1.5 block text-sm">
-              Display name <span className="text-red-500">*</span>
+              Display name <RequiredAsterisk />
             </label>
             <Input
               disabled={isLoading}

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, Save, X } from 'lucide-react'
 import { getTeamSchema } from '@/api/endpoints'
 import { Card, CardContent } from '@/components/ui/card'
 import { IconPicker } from '@/components/ui/icon-picker'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { TEAM_BASE_FIELDS_SET } from '@/lib/constants'
@@ -162,7 +163,7 @@ export function TeamForm({
           <CardContent className="space-y-4 pt-6">
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Organization <span className="text-red-500">*</span>
+                Organization <RequiredAsterisk />
               </label>
               <select
                 className={`border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm ${isEditing || organizations.length <= 1 ? 'cursor-not-allowed opacity-60' : ''} ${
@@ -192,7 +193,7 @@ export function TeamForm({
             >
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Team Name <span className="text-red-500">*</span>
+                  Team Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
@@ -212,7 +213,7 @@ export function TeamForm({
               {!isEditing && (
                 <div>
                   <label className="text-secondary mb-1.5 block text-sm">
-                    Slug <span className="text-red-500">*</span>
+                    Slug <RequiredAsterisk />
                   </label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -9,6 +9,7 @@ import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
 import { KeyValueEditor } from '@/components/ui/key-value-editor'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
   SelectContent,
@@ -235,7 +236,7 @@ export function ThirdPartyServiceForm({
             >
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Service Name <span className="text-danger">*</span>
+                  Service Name <RequiredAsterisk />
                 </label>
                 <Input
                   className={` ${errors.name ? 'border-danger' : ''}`}
@@ -259,7 +260,7 @@ export function ThirdPartyServiceForm({
               {!isEditing && (
                 <div>
                   <label className="text-secondary mb-1.5 block text-sm">
-                    Slug <span className="text-danger">*</span>
+                    Slug <RequiredAsterisk />
                   </label>
                   <Input
                     className={` ${errors.slug ? 'border-danger' : ''}`}
@@ -285,7 +286,7 @@ export function ThirdPartyServiceForm({
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
                 <label className="text-secondary mb-1.5 block text-sm">
-                  Vendor <span className="text-danger">*</span>
+                  Vendor <RequiredAsterisk />
                 </label>
                 <Input
                   className={` ${errors.vendor ? 'border-danger' : ''}`}

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -12,6 +12,7 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
@@ -260,7 +261,7 @@ export function WebhookForm({
           <CardContent className="space-y-4 pt-6">
             <div>
               <label className="text-secondary mb-1.5 block text-sm">
-                Name <span className="text-red-500">*</span>
+                Name <RequiredAsterisk />
               </label>
               <Input
                 className={` ${errors.name ? 'border-red-500' : ''}`}
@@ -651,8 +652,7 @@ export function WebhookForm({
                         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                           <div>
                             <label className="text-secondary mb-1 block text-xs">
-                              Filter Expression (CEL){' '}
-                              <span className="text-red-500">*</span>
+                              Filter Expression (CEL) <RequiredAsterisk />
                             </label>
                             <Input
                               className={`font-mono text-sm ${
@@ -684,7 +684,7 @@ export function WebhookForm({
                           </div>
                           <div>
                             <label className="text-secondary mb-1 block text-xs">
-                              Handler <span className="text-red-500">*</span>
+                              Handler <RequiredAsterisk />
                             </label>
                             <Input
                               className={`font-mono text-sm ${

--- a/src/components/ui/required-asterisk.tsx
+++ b/src/components/ui/required-asterisk.tsx
@@ -1,0 +1,14 @@
+/**
+ * Required-field indicator. Use after a field's label text:
+ * `<label>Name <RequiredAsterisk /></label>`.
+ *
+ * Renders an `aria-hidden` asterisk in the danger color. Pair with
+ * `aria-required` on the field itself for accessible required state.
+ */
+export function RequiredAsterisk() {
+  return (
+    <span aria-hidden="true" className="text-danger">
+      *
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary

Adds `src/components/ui/required-asterisk.tsx` — a tiny primitive rendering `<span aria-hidden="true" className="text-danger">*</span>`. Centralizing it (a) routes through the design-system `text-danger` token instead of the raw `text-red-500` utility, and (b) makes the "required field" indicator consistent across forms.

## Migrated

Mass-replaces 57 occurrences across 16 form components:

- Two raw-utility variants normalized to the primitive:
  - `<span className="text-red-500">*</span>` (most sites)
  - `<span className="text-danger">*</span>` (ThirdPartyServiceForm)
- Affected files: NewProjectDialog, NewOpsLogDialog, AuthProvidersManagement, OrganizationForm, BlueprintForm, EnvironmentForm, ThirdPartyServiceForm, ScoringPolicyForm, RoleForm, ClientCredentialsSection, LinkDefinitionForm, ServiceAccountForm, TeamForm, DocumentTemplateForm, ProjectTypeForm, WebhookForm.

## A11y note

The asterisk gets `aria-hidden="true"` (it's decorative). For accessible required-state, fields should still set `aria-required` themselves — not addressed in this PR; existing markup wasn't doing that either.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: walk through each affected form (Create Project, Create Ops Log, Auth Providers admin, etc.) and verify the asterisk shows beside required labels and is in the same danger color across the app.