### PR TITLE
Use Zustand selectors instead of destructuring whole stores

### DIFF
--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -12,6 +12,7 @@ import {
   Sparkles,
   X,
 } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
 
 import {
   createConversation,
@@ -57,6 +58,10 @@ export function CommandBar() {
   const dragRef = useRef<null | { startHeight: number; startY: number }>(null)
   const [unreadAssistant, setUnreadAssistant] = useState(false)
 
+  // useShallow keeps the consumer subscribed only to the listed fields
+  // and re-runs render only when one of them changes — without it any
+  // store update would re-render this component (and the assistant store
+  // ticks on every SSE chunk).
   const {
     activeToolUse,
     addMessage,
@@ -74,7 +79,26 @@ export function CommandBar() {
     setMessages,
     startStreaming,
     streamingContent,
-  } = useAssistantStore()
+  } = useAssistantStore(
+    useShallow((s) => ({
+      activeToolUse: s.activeToolUse,
+      addMessage: s.addMessage,
+      addPendingToolUse: s.addPendingToolUse,
+      appendStreamingContent: s.appendStreamingContent,
+      clearConversation: s.clearConversation,
+      currentConversationId: s.currentConversationId,
+      finishStreaming: s.finishStreaming,
+      isExpanded: s.isExpanded,
+      isStreaming: s.isStreaming,
+      messages: s.messages,
+      setActiveToolUse: s.setActiveToolUse,
+      setCurrentConversation: s.setCurrentConversation,
+      setExpanded: s.setExpanded,
+      setMessages: s.setMessages,
+      startStreaming: s.startStreaming,
+      streamingContent: s.streamingContent,
+    })),
+  )
 
   // Debounced query for search (only active in search mode)
   const debouncedQuery = useDebounced(mode === 'search' ? input : '', 200)

--- a/src/contexts/OrganizationContext.tsx
+++ b/src/contexts/OrganizationContext.tsx
@@ -31,7 +31,8 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
     localStorage.getItem(ORG_STORAGE_KEY),
   )
 
-  const { accessToken, isTokenExpired } = useAuthStore()
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const isTokenExpired = useAuthStore((s) => s.isTokenExpired)
 
   const { data: organizations = [], isLoading } = useQuery({
     enabled: !!accessToken && !isTokenExpired(),

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -20,14 +20,15 @@ export function useAuth(): UseAuthReturn {
   const navigate = useNavigate()
   const location = useLocation()
   const queryClient = useQueryClient()
-  const {
-    accessToken,
-    clearTokens,
-    getUsername,
-    isTokenExpired,
-    refreshToken,
-    setTokens,
-  } = useAuthStore()
+  // Subscribe per-field instead of destructuring the whole store: a token
+  // tick would otherwise re-render every consumer of useAuth, which sits at
+  // the app root and would cascade through the whole tree.
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const refreshToken = useAuthStore((s) => s.refreshToken)
+  const clearTokens = useAuthStore((s) => s.clearTokens)
+  const setTokens = useAuthStore((s) => s.setTokens)
+  const getUsername = useAuthStore((s) => s.getUsername)
+  const isTokenExpired = useAuthStore((s) => s.isTokenExpired)
 
   const {
     data: user,

--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -10,7 +10,8 @@ import { useAuthStore } from '@/stores/authStore'
 export function OAuthCallbackPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { accessToken, setTokens } = useAuthStore()
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const setTokens = useAuthStore((s) => s.setTokens)
   const { error, user } = useAuth()
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Destructuring `useAuthStore()` / `useAssistantStore()` subscribes the consumer to every field in the store, so any update — token tick, SSE chunk, anything — re-renders the component. Two of the four sites sit near the root of the tree (`useAuth`, `OrganizationProvider`); without selectors, every store update was cascading through most of the app.

## Changes

- `src/hooks/useAuth.ts`: subscribe per-field (`accessToken`, `refreshToken`, `clearTokens`, `setTokens`, `getUsername`, `isTokenExpired`).
- `src/contexts/OrganizationContext.tsx`: per-field for `accessToken`, `isTokenExpired`.
- `src/pages/OAuthCallbackPage.tsx`: per-field for `accessToken`, `setTokens`.
- `src/components/CommandBar.tsx`: 16 fields read together — switch to `useShallow(...)` so the consumer re-renders only when one of the listed fields actually changes. The assistant store ticks on every SSE chunk while a message streams, so this is the most impactful of the four sites.

`OrganizationProvider`'s value-object re-render storm (caused by the memoized `value` rebuilding when `organizations` reference changes on refetch) is a separate issue tracked as Phase 2.5.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: log in / log out (auth flow exercise), open the CommandBar assistant and stream a long response, switch organizations — verify no functional regressions. (Behavior should be identical; perf only.)