### PR TITLE
Stabilize OrganizationContext value across loading renders

### DIFF
--- a/src/contexts/OrganizationContext.tsx
+++ b/src/contexts/OrganizationContext.tsx
@@ -23,7 +23,7 @@ const EMPTY_ORGS: readonly Organization[] = Object.freeze([])
 
 interface OrganizationContextValue {
   isLoading: boolean
-  organizations: Organization[]
+  organizations: readonly Organization[]
   selectedOrganization: null | Organization
   setSelectedOrganization: (org: Organization) => void
 }
@@ -48,7 +48,7 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
   // already keeps `data` stable across no-op refetches, but the inline
   // `?? []` default would produce a fresh array on every render while
   // the query is loading, blowing up every useOrganization() consumer.
-  const organizations = (data ?? EMPTY_ORGS) as Organization[]
+  const organizations: readonly Organization[] = data ?? EMPTY_ORGS
 
   // Auto-select when orgs load and nothing valid is selected
   useEffect(() => {

--- a/src/contexts/OrganizationContext.tsx
+++ b/src/contexts/OrganizationContext.tsx
@@ -17,6 +17,10 @@ import type { Organization } from '@/types'
 
 const ORG_STORAGE_KEY = 'imbi-selected-org'
 
+// Stable sentinel so consumers don't see a new reference on every render
+// while the query is loading (when `data` is undefined).
+const EMPTY_ORGS: readonly Organization[] = Object.freeze([])
+
 interface OrganizationContextValue {
   isLoading: boolean
   organizations: Organization[]
@@ -31,14 +35,20 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
     localStorage.getItem(ORG_STORAGE_KEY),
   )
 
-  const { accessToken, isTokenExpired } = useAuthStore()
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const isTokenExpired = useAuthStore((s) => s.isTokenExpired)
 
-  const { data: organizations = [], isLoading } = useQuery({
+  const { data, isLoading } = useQuery({
     enabled: !!accessToken && !isTokenExpired(),
     queryFn: ({ signal }) => listOrganizations(signal),
     queryKey: ['organizations'],
     retry: 1,
   })
+  // Hold the empty-state reference stable. TanStack's structural sharing
+  // already keeps `data` stable across no-op refetches, but the inline
+  // `?? []` default would produce a fresh array on every render while
+  // the query is loading, blowing up every useOrganization() consumer.
+  const organizations = (data ?? EMPTY_ORGS) as Organization[]
 
   // Auto-select when orgs load and nothing valid is selected
   useEffect(() => {


### PR DESCRIPTION
## Summary

`OrganizationProvider`'s memoized context value was rebuilt whenever the `organizations` reference changed — and the inline `data ?? []` default produced a **fresh empty array on every render while the query was loading**. Every `useOrganization()` consumer (most of the app) re-rendered each tick during that window.

## Change

- Hoist a module-level `EMPTY_ORGS: readonly Organization[]` sentinel.
- Replace inline destructure default `data: organizations = []` with explicit `const organizations = (data ?? EMPTY_ORGS) as Organization[]` so the loading-state reference is held stable.
- TanStack Query's structural sharing already covers the post-load case (identical refetches preserve `data` reference); this just plugs the loading-state hole.

Also folds in the auth-store selectors so this file no longer destructures `useAuthStore()` (matches the Zustand-selectors pass in #315).

## Note re: depending on #315

This PR overlaps with #315 on the `useAuthStore` selector lines. Whichever lands first, the other will fast-forward / cleanly rebase — no semantic conflict.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: cold-load any page that uses `useOrganization()` and verify behavior is unchanged. (Behavior is identical; perf only.)