### PR TITLE
Add useTeams / useEnvironments / useProjectTypes shared hooks

### DIFF
--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -1,13 +1,8 @@
 import { useState } from 'react'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-import {
-  createProject,
-  listEnvironments,
-  listProjectTypes,
-  listTeams,
-} from '@/api/endpoints'
+import { createProject } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Combobox } from '@/components/ui/combobox'
@@ -22,7 +17,11 @@ import { Input } from '@/components/ui/input'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
-import { queryKeys } from '@/lib/queryKeys'
+import {
+  useEnvironments,
+  useProjectTypes,
+  useTeams,
+} from '@/hooks/useOrgResources'
 import { slugify } from '@/lib/utils'
 import type { ProjectCreate } from '@/types'
 
@@ -49,22 +48,12 @@ export function NewProjectDialog({
   const [description, setDescription] = useState('')
   const [selectedEnvSlugs, setSelectedEnvSlugs] = useState<string[]>([])
 
-  const { data: teams = [] } = useQuery({
-    enabled: !!orgSlug && isOpen,
-    queryFn: ({ signal }) => listTeams(orgSlug, signal),
-    queryKey: ['teams', orgSlug],
+  const { data: teams = [] } = useTeams(orgSlug, { enabled: isOpen })
+  const { data: projectTypes = [] } = useProjectTypes(orgSlug, {
+    enabled: isOpen,
   })
-
-  const { data: projectTypes = [] } = useQuery({
-    enabled: !!orgSlug && isOpen,
-    queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
-    queryKey: queryKeys.projectTypes(orgSlug),
-  })
-
-  const { data: environments = [] } = useQuery({
-    enabled: !!orgSlug && isOpen,
-    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
-    queryKey: ['environments', orgSlug],
+  const { data: environments = [] } = useEnvironments(orgSlug, {
+    enabled: isOpen,
   })
 
   const createMutation = useMutation({

--- a/src/components/OperationsLog.tsx
+++ b/src/components/OperationsLog.tsx
@@ -4,11 +4,12 @@ import { useQuery } from '@tanstack/react-query'
 import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import { Activity, LoaderCircle, SearchX, X } from 'lucide-react'
 
-import { getProjects, listEnvironments } from '@/api/endpoints'
+import { getProjects } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { LoadingState } from '@/components/ui/loading-state'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useInfiniteOperationsLog } from '@/hooks/useInfiniteOperationsLog'
+import { useEnvironments } from '@/hooks/useOrgResources'
 import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
 import { cn } from '@/lib/utils'
 import type {
@@ -185,11 +186,7 @@ export function OperationsLog({
     data: environments = [],
     isError: environmentsError,
     refetch: refetchEnvironments,
-  } = useQuery({
-    enabled: !!orgSlug,
-    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
-    queryKey: ['environments', orgSlug],
-  })
+  } = useEnvironments(orgSlug)
   const {
     displayNames: performerDisplayNames,
     isError: usersError,

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -26,9 +26,7 @@ import {
   listLinkDefinitions,
   listProjectDocuments,
   listProjectPlugins,
-  listProjectTypes,
   listScoringPolicies,
-  listTeams,
   type ScoreTrend,
 } from '@/api/endpoints'
 import {
@@ -69,10 +67,10 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useProjectTypes, useTeams } from '@/hooks/useOrgResources'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { getIcon, useIconRegistryVersion } from '@/lib/icons'
 import { formatFieldKey } from '@/lib/project-field-formatting'
-import { queryKeys } from '@/lib/queryKeys'
 import { sanitizeHttpUrl, sortEnvironments } from '@/lib/utils'
 import type { Project, ScoringPolicy } from '@/types'
 
@@ -339,16 +337,8 @@ export function ProjectDetail({
     queryKey: ['projectSchema', orgSlug, project.id],
   })
 
-  const { data: teams = [] } = useQuery({
-    enabled: !!orgSlug,
-    queryFn: ({ signal }) => listTeams(orgSlug, signal),
-    queryKey: ['teams', orgSlug],
-  })
-  const { data: projectTypes = [] } = useQuery({
-    enabled: !!orgSlug,
-    queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
-    queryKey: queryKeys.projectTypes(orgSlug),
-  })
+  const { data: teams = [] } = useTeams(orgSlug)
+  const { data: projectTypes = [] } = useProjectTypes(orgSlug)
   const { data: projectDocuments = [] } = useQuery({
     enabled: !!orgSlug && !!project.id,
     queryFn: ({ signal }) =>

--- a/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
+++ b/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
@@ -6,17 +6,14 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import type { InfiniteData } from '@tanstack/react-query'
 import { CheckCircle, ChevronRight, Clock, Rocket } from 'lucide-react'
 
-import {
-  getProjects,
-  listEnvironments,
-  listOperationsLog,
-} from '@/api/endpoints'
+import { getProjects, listOperationsLog } from '@/api/endpoints'
 import type { OperationsLogPage } from '@/api/endpoints'
 import { Badge, type BadgeProps } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
+import { useEnvironments } from '@/hooks/useOrgResources'
 import { formatRelativeDate } from '@/lib/formatDate'
 import type { OperationsLogRecord, Project } from '@/types'
 
@@ -36,12 +33,7 @@ export function RecentDeploymentsWidget() {
     setEnvFilter((prev) => (prev === slug ? undefined : slug))
   }
 
-  const { data: environments } = useQuery({
-    enabled: Boolean(orgSlug),
-    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
-    queryKey: ['environments', orgSlug],
-    staleTime: 5 * 60_000,
-  })
+  const { data: environments } = useEnvironments(orgSlug)
 
   const { data: projects } = useQuery({
     enabled: Boolean(orgSlug),

--- a/src/hooks/useOrgResources.ts
+++ b/src/hooks/useOrgResources.ts
@@ -1,0 +1,60 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+
+import { listEnvironments, listProjectTypes, listTeams } from '@/api/endpoints'
+import { queryKeys } from '@/lib/queryKeys'
+import type { Environment, ProjectType, Team } from '@/types'
+
+// Org-scoped reference data changes slowly (admin edits). Pick one
+// staleTime so 8+ consumers don't refetch independently when one of
+// them visits its page. 10 minutes mirrors the existing
+// ProjectActivityLog environments query that was already using this
+// window.
+const ORG_RESOURCE_STALE_TIME = 10 * 60 * 1000
+
+interface ResourceHookOptions {
+  /** Extra gate ANDed with `!!orgSlug`. Use for dialog-open or tab gating. */
+  enabled?: boolean
+}
+
+/** Canonical hook for the org-scoped Environments list. See useTeams. */
+export function useEnvironments(
+  orgSlug: string,
+  { enabled = true }: ResourceHookOptions = {},
+): UseQueryResult<Environment[], Error> {
+  return useQuery({
+    enabled: !!orgSlug && enabled,
+    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
+    queryKey: queryKeys.environments(orgSlug),
+    staleTime: ORG_RESOURCE_STALE_TIME,
+  })
+}
+
+/** Canonical hook for the org-scoped Project Types list. See useTeams. */
+export function useProjectTypes(
+  orgSlug: string,
+  { enabled = true }: ResourceHookOptions = {},
+): UseQueryResult<ProjectType[], Error> {
+  return useQuery({
+    enabled: !!orgSlug && enabled,
+    queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
+    queryKey: queryKeys.projectTypes(orgSlug),
+    staleTime: ORG_RESOURCE_STALE_TIME,
+  })
+}
+
+/**
+ * Canonical hook for the org-scoped Teams list. Wraps useQuery with the
+ * shared key, fetcher, and staleTime so every site reads from the same
+ * cache.
+ */
+export function useTeams(
+  orgSlug: string,
+  { enabled = true }: ResourceHookOptions = {},
+): UseQueryResult<Team[], Error> {
+  return useQuery({
+    enabled: !!orgSlug && enabled,
+    queryFn: ({ signal }) => listTeams(orgSlug, signal),
+    queryKey: queryKeys.teams(orgSlug),
+    staleTime: ORG_RESOURCE_STALE_TIME,
+  })
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -15,6 +15,7 @@ export const queryKeys = {
     anchorSlug: string,
     relType: string,
   ) => ['anchor-edges', kind, orgSlug, anchorSlug, relType] as const,
+  environments: (orgSlug: string) => ['environments', orgSlug] as const,
   identityPlugins: (orgSlug: string) => ['identity-plugins', orgSlug] as const,
   pluginEdgesByOrg: (pluginSlug: string, relType: string, orgSlug: string) =>
     ['plugin-edges-by-org', pluginSlug, relType, orgSlug] as const,
@@ -29,6 +30,7 @@ export const queryKeys = {
   // different consumers. Mutations on the admin list must invalidate both so
   // the LoginPage picker stays in sync.
   publicAuthProviders: () => ['authProviders'] as const,
+  teams: (orgSlug: string) => ['teams', orgSlug] as const,
 } as const
 
 /**


### PR DESCRIPTION
## Summary

`listTeams` was called from 8 sites with hand-rolled `useQuery` args — all keyed under `['teams', orgSlug]` but with inconsistent `staleTime` (default 0 everywhere except `ProjectActivityLog` which used 10 min). Same pattern for `listEnvironments` (9 sites) and `listProjectTypes` (7 sites). When two consumers share a cache key but configure different `staleTime`, visiting the shorter-window page forces all consumers to refetch.

## Changes

- `src/hooks/useOrgResources.ts` (new): canonical `useTeams`, `useEnvironments`, `useProjectTypes` hooks. Single source of truth for key + fetcher + staleTime (10 min — matches `ProjectActivityLog`'s already-used value). Optional `{ enabled }` override for dialog-open or tab gating.
- `src/lib/queryKeys.ts`: add `teams(orgSlug)` and `environments(orgSlug)` helpers (`projectTypes` already existed).
- Migrate 4 representative consumers to validate the API:
  - `NewProjectDialog.tsx` (uses all three hooks; preserves `enabled: isOpen`)
  - `ProjectDetail.tsx` (teams + projectTypes)
  - `OperationsLog.tsx` (environments)
  - `dashboard/widgets/RecentDeploymentsWidget.tsx` (environments)

The remaining 15+ inline `useQuery` sites are intentionally left for a follow-up sweep so this PR stays scoped and reviewable. Until they migrate, they share the canonical cache key (so reads still hit the same cache) but keep their hand-rolled `staleTime`/`enabled` config.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: open Create Project (loads all three resources), open Operations Log (environments), open Dashboard (RecentDeploymentsWidget environments) — verify lists populate.