### PR TITLE
Adopt UserDisplay in admin tables; add displayName prop

### DIFF
--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -21,7 +21,7 @@ import { buildDiffPatch, buildReplacePatch } from '@/lib/json-patch'
 import type { AdminUser, AdminUserCreate, PatchOperation } from '@/types'
 
 import { Badge } from '../ui/badge'
-import { Gravatar } from '../ui/gravatar'
+import { UserDisplay } from '../ui/user-display'
 import { AdminSection } from './AdminSection'
 import { UserDetail } from './users/UserDetail'
 import { UserForm } from './users/UserForm'
@@ -265,17 +265,13 @@ export function UserManagement() {
             headerAlign: 'left',
             key: 'user',
             render: (user) => (
-              <div className="flex items-center gap-3">
-                <Gravatar
-                  alt={user.display_name}
-                  className="size-8 rounded-full"
-                  email={user.email}
-                  size={32}
-                />
-                <div className="text-primary text-sm font-medium">
-                  {user.display_name}
-                </div>
-              </div>
+              <UserDisplay
+                className="gap-3"
+                displayName={user.display_name}
+                email={user.email}
+                size={32}
+                textClassName="text-primary text-sm font-medium"
+              />
             ),
           },
           {

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -269,6 +269,7 @@ export function UserManagement() {
                 className="gap-3"
                 displayName={user.display_name}
                 email={user.email}
+                linkToProfile={false}
                 size={32}
                 textClassName="text-primary text-sm font-medium"
               />

--- a/src/components/admin/teams/TeamDetail.tsx
+++ b/src/components/admin/teams/TeamDetail.tsx
@@ -24,7 +24,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { DynamicDetailFields } from '@/components/ui/dynamic-fields'
 import { EntityIcon } from '@/components/ui/entity-icon'
-import { Gravatar } from '@/components/ui/gravatar'
 import { Input } from '@/components/ui/input'
 import {
   Table,
@@ -40,6 +39,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { UserDisplay } from '@/components/ui/user-display'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { TEAM_BASE_FIELDS_SET } from '@/lib/constants'
 import { extractDynamicFields } from '@/lib/utils'
@@ -269,17 +269,13 @@ export function TeamDetail({ onBack, onEdit, team }: TeamDetailProps) {
                 {members.map((member) => (
                   <TableRow className="hover:bg-secondary" key={member.email}>
                     <TableCell className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <Gravatar
-                          alt={member.display_name}
-                          className="size-8 rounded-full"
-                          email={member.email}
-                          size={32}
-                        />
-                        <div className="text-primary">
-                          {member.display_name}
-                        </div>
-                      </div>
+                      <UserDisplay
+                        className="gap-3"
+                        displayName={member.display_name}
+                        email={member.email}
+                        size={32}
+                        textClassName="text-primary"
+                      />
                     </TableCell>
                     <TableCell className="text-secondary px-6 py-4 text-sm">
                       {member.email}

--- a/src/components/ui/user-display.tsx
+++ b/src/components/ui/user-display.tsx
@@ -6,6 +6,9 @@ import { Gravatar } from './gravatar'
 
 interface Props {
   className?: string
+  /** Override the resolved name (e.g. when the caller already has user.display_name in hand). */
+  displayName?: string
+  /** Email → display_name lookup, for row lists. Ignored if `displayName` is set. */
   displayNames?: Map<string, string>
   email: string
   hideName?: boolean
@@ -21,10 +24,15 @@ interface Props {
 
 /**
  * Compact user identity: Gravatar + display name (or local-part fallback).
- * Pass `displayNames` to resolve email → display_name.
+ * Resolution order for the rendered name:
+ *   1. Explicit `displayName` prop
+ *   2. `displayNames.get(email)` if a map is provided
+ *   3. Local-part of the email (the bit before `@`)
+ *   4. The email itself
  */
 export function UserDisplay({
   className,
+  displayName,
   displayNames,
   email,
   hideName = false,
@@ -33,7 +41,8 @@ export function UserDisplay({
   textClassName,
   title,
 }: Props) {
-  const name = displayNames?.get(email) ?? email.split('@')[0] ?? email
+  const name =
+    displayName ?? displayNames?.get(email) ?? email.split('@')[0] ?? email
   const body = (
     <>
       <Gravatar className="shrink-0 rounded-full" email={email} size={size} />


### PR DESCRIPTION
## Summary

`UserDisplay` previously expected callers to pass a `displayNames` Map<email, name> for name resolution. Callers that already have `user.display_name` in hand (admin tables that render rows of fully-loaded user objects) had no clean way to use the primitive.

Add a `displayName` prop that overrides the lookup. Resolution order is now: `displayName` → `displayNames.get(email)` → email local-part → email.

## Migrated

- `admin/UserManagement.tsx` — users table row (size 32, name only).
- `admin/teams/TeamDetail.tsx` — members table row (size 32, name only; email is a separate column).

## Deliberately left

The audit grouped these together but each has a different layout:

- `admin/users/UserDetail.tsx` header — large Gravatar with name stacked on top of email. `UserDisplay` is single-line.
- `admin/roles/RoleDetail.tsx` — list rows with name + email stacked. Same reason.
- `Navigation.tsx` — Gravatar only, no inline name (name lives in a separate dropdown item).
- `UserProfile/ProfileHeader.tsx` — full profile header with bio, etc.
- `ProjectActivityLog.tsx` `getDisplayName()` — returns a *string* for plain-text contexts, not a UserDisplay use. The 3-line fallback could be lifted to a shared util but it's not worth a separate file right now.

A follow-up could add a `UserDisplay` variant for the stacked-name+email layout, but that's a design call worth its own PR.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: visit `/admin/users` (table rows) and `/admin/teams/<team>` (member list) — verify the Gravatar + name still renders identically and clicking through navigates to the user profile page.