### PR TITLE
Adopt LoadingState in RecentActivity, ErrorBanner in OrganizationForm

### DIFF
--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 
 import { Gravatar } from '@/components/ui/gravatar'
+import { LoadingState } from '@/components/ui/loading-state'
 import { usePluginOpsLogTemplates } from '@/hooks/usePluginOpsLogTemplates'
 import { formatRelativeDate } from '@/lib/formatDate'
 import type { ActivityFeedEntry, OperationsLogEntry } from '@/types'
@@ -59,7 +60,10 @@ export function RecentActivity({
         {!hideHeading && (
           <h2 className="text-primary mb-6 text-xl">Recent Activity</h2>
         )}
-        <div className="text-muted-foreground py-8 text-center">Loading...</div>
+        <LoadingState
+          className="text-muted-foreground py-8 text-center"
+          label="Loading..."
+        />
       </Card>
     )
   }

--- a/src/components/admin/organizations/OrganizationForm.tsx
+++ b/src/components/admin/organizations/OrganizationForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 
 import { AlertCircle, Save, X } from 'lucide-react'
 
+import { ErrorBanner } from '@/components/ui/error-banner'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import type { Organization, OrganizationCreate } from '@/types'
 
@@ -107,23 +108,16 @@ export function OrganizationForm({
         </div>
       </div>
 
-      {/* API Error */}
       {error && (
-        <div className="border-danger bg-danger rounded-lg border p-4">
-          <div className="flex items-start gap-3">
-            <AlertCircle className="text-danger size-5 shrink-0" />
-            <div>
-              <div className="text-danger font-medium">
-                Failed to save organization
-              </div>
-              <div className="text-danger mt-1 text-sm">
-                {error?.response?.data?.detail ||
-                  error?.message ||
-                  'An error occurred'}
-              </div>
-            </div>
-          </div>
-        </div>
+        <ErrorBanner
+          error={error}
+          message={
+            error?.response?.data?.detail ||
+            error?.message ||
+            'An error occurred'
+          }
+          title="Failed to save organization"
+        />
       )}
 
       {/* Form */}


### PR DESCRIPTION
## Summary

Two narrow migrations of Phase 3.3 / 3.4 sites that are clean fits for the existing primitives.

### `RecentActivity.tsx` loading branch
Hand-rolled `<div className="text-muted-foreground py-8 text-center">Loading...</div>` → `<LoadingState className="text-muted-foreground py-8 text-center" label="Loading..." />`.

LoadingState's hardcoded inner text class (`text-secondary text-sm`) replaces the caller's `text-muted-foreground`. The two tokens resolve to similar greys but not identical, so this is a small visual harmonization — accepted as the point of having a primitive.

### `admin/organizations/OrganizationForm.tsx` API-error banner
17-line hand-rolled banner → `<ErrorBanner title="Failed to save organization" message={...} error={error} />`. This was the canonical ErrorBanner use case (saturated `bg-danger` + `AlertCircle` icon + title + detail).

## Deliberately left

The refactor plan grouped a lot of sites together but on close inspection most aren't clean primitive fits:

- `SettingsApiKeys.tsx:89` `Loading...` — inline `<p>`, not a block.
- Reports (`TeamKPIReport`, `MonthlyImprovementReport`, `ScoreHistoryReport`) use 3- to 4-state widgets (loading / empty / error / data) where every branch shares the same outer container shape — forcing only the loading branch through `<LoadingState>` breaks the symmetry.
- `LocalLoginForm` uses a paler error treatment, not the full-saturation pattern `<ErrorBanner>` produces. Migrating would change visual style.
- `OperationsLog` error/warning banners use `bg-*/10` (subtler tint) with embedded Retry buttons — a separate UX rule that `<ErrorBanner>` doesn't model.
- `ProjectsGraphReport.tsx:36` `Loading projects…` — different sizing, fine as-is.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: dashboard activity feed loading state shows; org admin save-error banner renders with title + detail.