### PR TITLE
Dedupe LogsTab fieldFilters URL-initial state

### DIFF
--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -259,9 +259,9 @@ export function LogsTab({
     return p ? new Date(p) : undefined
   })
   const [query, setQuery] = useState(() => searchParams.get('q') ?? '')
-  const [fieldFilters, setFieldFilters] = useState<string[]>(() =>
-    searchParams.getAll('filter'),
-  )
+  const [fieldFilters, setFieldFilters] = useState<string[]>(() => [
+    ...new Set(searchParams.getAll('filter')),
+  ])
   const [datePickerOpen, setDatePickerOpen] = useState(false)
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
   const [selectedBucket, setSelectedBucket] = useState<null | number>(null)


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #307 (stable list keys). CodeRabbit flagged that the field-filter chips use the filter string as a React key and remove by value, so the list must stay free of duplicates. `handleAddFilter()` (line ~442) already enforces this, but the initial state read from `searchParams.getAll('filter')` did not — a hand-edited URL with two identical `?filter=` params would produce duplicate React keys and a remove-by-value would erase both rows at once.

Wrap the initial state in `[...new Set(...)]` so the URL-derived input follows the same uniqueness rule as the add path.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: navigate to a project's Logs tab with `?filter=foo&filter=foo` — verify only one chip appears.