### PR TITLE
Gate overview-only queries on ProjectDetail by activeTab

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -342,7 +342,7 @@ export function ProjectDetail({
   // Overview-only: feeds ProjectAttributesSection inside <TabsContent
   // value="overview">. The other tabs render their own components.
   const { data: projectSchema } = useQuery({
-    enabled: !!orgSlug && activeTab === 'overview',
+    enabled: !!orgSlug && !!project.id && activeTab === 'overview',
     queryFn: ({ signal }) => getProjectSchema(orgSlug, project.id, signal),
     queryKey: ['projectSchema', orgSlug, project.id],
   })

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -246,15 +246,22 @@ export function ProjectDetail({
     queryKey: ['linkDefinitions', orgSlug],
   })
 
+  // Overview-tab-only queries: skip when the user lands on a deeper tab
+  // (e.g. /projects/:id/logs via deep link) — the overview cards that
+  // consume these aren't mounted in that case.
   const { data: scoreTrend } = useQuery({
-    enabled: !!orgSlug && !!project.id,
+    enabled: !!orgSlug && !!project.id && activeTab === 'overview',
     queryFn: ({ signal }) => getScoreTrend(orgSlug, project.id, 30, signal),
     queryKey: ['scoreTrend', orgSlug, project.id],
     staleTime: 5 * 60 * 1000,
   })
 
   const { data: projectWithBreakdown } = useQuery({
-    enabled: !!orgSlug && !!project.id && project.score != null,
+    enabled:
+      !!orgSlug &&
+      !!project.id &&
+      project.score != null &&
+      activeTab === 'overview',
     queryFn: ({ signal }) => getProjectBreakdown(orgSlug, project.id, signal),
     queryKey: ['projectBreakdown', orgSlug, project.id],
     staleTime: 5 * 60 * 1000,
@@ -332,8 +339,10 @@ export function ProjectDetail({
     [queryClient],
   )
 
+  // Overview-only: feeds ProjectAttributesSection inside <TabsContent
+  // value="overview">. The other tabs render their own components.
   const { data: projectSchema } = useQuery({
-    enabled: !!orgSlug,
+    enabled: !!orgSlug && activeTab === 'overview',
     queryFn: ({ signal }) => getProjectSchema(orgSlug, project.id, signal),
     queryKey: ['projectSchema', orgSlug, project.id],
   })


### PR DESCRIPTION
## Summary

`ProjectDetail.tsx` ran 11+ `useQuery` calls eagerly on every mount. The refactor plan (Phase 2.2) claimed gating could cut cold-load RTTs from ~11 to ~4, but on close audit most of those queries feed always-visible header chrome and can't safely be gated:

- `currentReleases` → deployment chips above the tabs
- `linkDefs` → external links above the tabs
- `openPrCount`, `projectDocuments` → tab-label counts ("Pull Requests (3)", "Documents (5)")
- `myIdentities`, `identityPlugins`, `scoringPolicies` → already gated by other predicates

The genuinely overview-only queries are three:
- `scoreTrend` → `ScoreTrendPill`
- `projectWithBreakdown` → score chip + breakdown popover
- `projectSchema` → `ProjectAttributesSection`

All three feed components inside `<TabsContent value="overview">`.

## Change

Add `enabled: ... && activeTab === 'overview'` to each. Cold-loading a deep link like `/projects/:id/logs` now skips three round-trips that aren't needed for that tab. Visiting overview (the default) is unchanged.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: deep-link to `/projects/<id>/logs` and verify the logs tab renders normally; click to Overview and verify the score-trend, score-breakdown, and project-attributes sections still populate.