### PR TITLE
Migrate admin filter selects from native <select> to <Select>

### DIFF
--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -20,6 +20,13 @@ import {
 import { AdminTable } from '@/components/ui/admin-table'
 import { Button } from '@/components/ui/button'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -57,7 +64,8 @@ export function ScoringPolicyManagement() {
     viewMode,
   } = useAdminNav()
   const [searchQuery, setSearchQuery] = useState('')
-  const [enabledFilter, setEnabledFilter] = useState('')
+  // 'all' acts as the unfiltered sentinel; Radix Select disallows '' values.
+  const [enabledFilter, setEnabledFilter] = useState('all')
   const [rescoreResult, setRescoreResult] = useState<null | number>(null)
   const [importDialogOpen, setImportDialogOpen] = useState(false)
   const { copied: copiedSlug, copy } = useClipboard()
@@ -192,15 +200,16 @@ export function ScoringPolicyManagement() {
           </>
         }
         headerExtras={
-          <select
-            className="border-input bg-background text-foreground rounded-lg border px-3 py-2 text-sm"
-            onChange={(e) => setEnabledFilter(e.target.value)}
-            value={enabledFilter}
-          >
-            <option value="">All</option>
-            <option value="enabled">Enabled</option>
-            <option value="disabled">Disabled</option>
-          </select>
+          <Select onValueChange={setEnabledFilter} value={enabledFilter}>
+            <SelectTrigger className="w-35">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="enabled">Enabled</SelectItem>
+              <SelectItem value="disabled">Disabled</SelectItem>
+            </SelectContent>
+          </Select>
         }
         isLoading={isLoading}
         loadingLabel="Loading scoring policies..."
@@ -318,7 +327,7 @@ export function ScoringPolicyManagement() {
             },
           ]}
           emptyMessage={
-            searchQuery || enabledFilter
+            searchQuery || enabledFilter !== 'all'
               ? 'No policies match your filters.'
               : 'No scoring policies defined yet.'
           }

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -14,6 +14,13 @@ import {
 import { AdminTable } from '@/components/ui/admin-table'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import { extractApiErrorDetail } from '@/lib/apiError'
@@ -218,26 +225,32 @@ export function UserManagement() {
       errorTitle="Failed to load users"
       headerExtras={
         <>
-          <select
-            aria-label="Filter users by type"
-            className="border-input bg-background text-foreground rounded-lg border px-3 py-2 text-sm"
-            onChange={(e) => setUserFilter(e.target.value as UserFilter)}
+          <Select
+            onValueChange={(v) => setUserFilter(v as UserFilter)}
             value={userFilter}
           >
-            <option value="all">All Types</option>
-            <option value="users">Regular Users</option>
-            <option value="admins">Administrators</option>
-          </select>
-          <select
-            aria-label="Filter users by status"
-            className="border-input bg-background text-foreground rounded-lg border px-3 py-2 text-sm"
-            onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+            <SelectTrigger aria-label="Filter users by type" className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              <SelectItem value="users">Regular Users</SelectItem>
+              <SelectItem value="admins">Administrators</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select
+            onValueChange={(v) => setStatusFilter(v as StatusFilter)}
             value={statusFilter}
           >
-            <option value="all">All Status</option>
-            <option value="active">Active</option>
-            <option value="inactive">Inactive</option>
-          </select>
+            <SelectTrigger aria-label="Filter users by status" className="w-35">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Status</SelectItem>
+              <SelectItem value="active">Active</SelectItem>
+              <SelectItem value="inactive">Inactive</SelectItem>
+            </SelectContent>
+          </Select>
         </>
       }
       isLoading={isLoading}


### PR DESCRIPTION
## Summary

Native `<select>` elements skip the design-system styling, can't show controlled placeholder text, and disagree with the shadcn `<Select>` used elsewhere in the app. Migrate the two highest-visibility admin filter clusters.

## Changes

- `admin/UserManagement.tsx` — type filter + status filter at the top of the users list. State was already typed with `'all'` as the unfiltered sentinel.
- `admin/ScoringPolicyManagement.tsx` — enabled-filter at the top of the scoring-policy list. Initial state was `''`, which Radix Select disallows; moved to `'all'` and updated the one consumer (empty-state-message ternary) to check against `'all'` instead of falsy.

## Why this is a small batch

The refactor plan listed 22 files / ~41 native `<select>` sites for this sweep. On close audit each form has site-specific wiring (className transferred to `SelectTrigger`, `onChange→onValueChange` semantic shift, `<optgroup>` → `SelectGroup`, disabled propagation differences). A blanket codemod is too risky for an unattended pass. These two PRs demonstrate the migration pattern; the remaining form selects (EnvironmentForm, TeamForm, ProjectTypeForm, UserForm, WebhookForm, etc.) are better landed one-form-at-a-time in follow-ups.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: visit `/admin/users` and `/admin/scoring-policies`, exercise both filters (All / Enabled / Disabled, All Types / Users / Admins, All Status / Active / Inactive). Verify filtering behavior matches the previous native-select behavior.