### PR TITLE
Migrate raw red/green/yellow utilities to design tokens

### DIFF
--- a/src/components/EditRelationshipsDialog.tsx
+++ b/src/components/EditRelationshipsDialog.tsx
@@ -226,15 +226,11 @@ export function EditRelationshipsDialog({
             {changeCount > 0 ? (
               <>
                 {added.length > 0 && (
-                  <span className="text-green-600 dark:text-green-400">
-                    +{added.length} added
-                  </span>
+                  <span className="text-success">+{added.length} added</span>
                 )}
                 {added.length > 0 && removed.length > 0 && ', '}
                 {removed.length > 0 && (
-                  <span className="text-red-600 dark:text-red-400">
-                    -{removed.length} removed
-                  </span>
+                  <span className="text-danger">-{removed.length} removed</span>
                 )}
               </>
             ) : (
@@ -261,7 +257,7 @@ export function EditRelationshipsDialog({
         </DialogFooter>
 
         {mutation.isError && (
-          <p className="text-center text-sm text-red-600 dark:text-red-400">
+          <p className="text-danger text-center text-sm">
             Failed to save. Please try again.
           </p>
         )}

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -280,11 +280,10 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
         <CardContent>
           {!showDeleteConfirm ? (
             <Button
-              className="border-danger bg-red-700 text-white hover:bg-red-800"
               disabled={!project.id}
               onClick={() => setShowDeleteConfirm(true)}
               size="sm"
-              variant="outline"
+              variant="destructive"
             >
               Delete Project
             </Button>
@@ -310,16 +309,13 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
               />
               <div className="flex gap-2">
                 <Button
-                  className={
-                    'border-danger bg-red-700 text-white hover:bg-red-800'
-                  }
                   disabled={
                     deleteConfirmSlug !== project.slug ||
                     deleteMutation.isPending
                   }
                   onClick={() => deleteMutation.mutate()}
                   size="sm"
-                  variant="outline"
+                  variant="destructive"
                 >
                   {deleteMutation.isPending ? 'Deleting...' : 'Confirm Delete'}
                 </Button>

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -729,11 +729,11 @@ export function UserForm({
                           <div
                             className={cn(
                               'h-full transition-all',
-                              passwordStrength.color === 'red' && 'bg-red-500',
+                              passwordStrength.color === 'red' && 'bg-danger',
                               passwordStrength.color === 'yellow' &&
-                                'bg-yellow-500',
+                                'bg-warning',
                               passwordStrength.color === 'green' &&
-                                'bg-green-500',
+                                'bg-success',
                             )}
                             style={{
                               width: `${(passwordStrength.score / 6) * 100}%`,
@@ -743,11 +743,11 @@ export function UserForm({
                         <span
                           className={cn(
                             'text-xs',
-                            passwordStrength.color === 'red' && 'text-red-500',
+                            passwordStrength.color === 'red' && 'text-danger',
                             passwordStrength.color === 'yellow' &&
-                              'text-yellow-500',
+                              'text-warning',
                             passwordStrength.color === 'green' &&
-                              'text-green-500',
+                              'text-success',
                           )}
                         >
                           {passwordStrength.label}

--- a/src/components/settings/SettingsSecurity.tsx
+++ b/src/components/settings/SettingsSecurity.tsx
@@ -42,11 +42,7 @@ export function SettingsSecurity() {
                     Google OAuth ({user?.email})
                   </p>
                 </div>
-                <Badge
-                  className="border-green-200 bg-green-50 text-green-700"
-                  style={{ borderWidth: '0.5px' }}
-                  variant="outline"
-                >
+                <Badge style={{ borderWidth: '0.5px' }} variant="success">
                   Active
                 </Badge>
               </div>


### PR DESCRIPTION
## Summary

Replace four sites of raw Tailwind color utilities with design-system semantic tokens / `<Badge>` variants / `<Button>` variants. Net effect: identical-looking UI that respects dark mode and any future palette shift through the token layer instead of N hardcoded utilities.

## Changes

- `settings/SettingsSecurity.tsx` — `border-green-200 bg-green-50 text-green-700` "Active" badge → `<Badge variant="success">`.
- `EditRelationshipsDialog.tsx` — three `text-{red,green}-{600,400}` spans (added/removed counter + error message) → `text-success` / `text-danger`. The remaining `text-slate-*` / `bg-amber-*` utilities in this file are layout-specific and out of scope.
- `admin/users/UserForm.tsx` — password strength bar's `bg-red-500` / `bg-yellow-500` / `bg-green-500` segments and matching `text-*-500` labels → `bg-danger` / `bg-warning` / `bg-success` (and `text-*` equivalents).
- `ProjectSettingsTab.tsx` — two `border-danger bg-red-700 text-white hover:bg-red-800` destructive buttons → `<Button variant="destructive">`.

## Phase 4.4 deferred

The hex `bg-[#...]` literals in `ProjectActivityLog.tsx:49-51`, `ScoreHistoryTab.tsx:48-76`, and `SearchResultsPanel.tsx:35-54` are visually calibrated dot/chart fills. Migrating cleanly requires defining new semantic CSS variables (`--color-activity-info`, `--color-entity-project`, etc.) in `index.css` — that's a design decision worth its own PR with palette review, not a mechanical swap.

## Test plan

- [x] `npm test` — 270 / 270 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: open `/settings/security` (Active badge), edit a user with weak/medium/strong password (UserForm strength bar), open the relationships editor with pending changes (added/removed counter), trigger the project delete flow (destructive buttons). Verify identical-looking UI in both light and dark mode.