### PR TITLE
Migrate admin form org selects to <Select>

### DIFF
--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -16,6 +16,13 @@ import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
@@ -173,22 +180,25 @@ export function EnvironmentForm({
               >
                 Organization <RequiredAsterisk />
               </label>
-              <select
-                className={`border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm ${isEditing || isLoading || organizations.length <= 1 ? 'cursor-not-allowed opacity-60' : ''} ${
-                  errors.organization ? 'border-red-500' : ''
-                }`}
+              <Select
                 disabled={isEditing || isLoading || organizations.length <= 1}
-                id="environment-org"
-                onChange={(e) => setOrgSlug(e.target.value)}
+                onValueChange={setOrgSlug}
                 value={orgSlug}
               >
-                <option value="">Select organization...</option>
-                {organizations.map((org) => (
-                  <option key={org.slug} value={org.slug}>
-                    {org.name}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger
+                  className={errors.organization ? 'border-red-500' : ''}
+                  id="environment-org"
+                >
+                  <SelectValue placeholder="Select organization..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {organizations.map((org) => (
+                    <SelectItem key={org.slug} value={org.slug}>
+                      {org.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {errors.organization && (
                 <div className="text-danger mt-1 flex items-center gap-1 text-xs">
                   <AlertCircle className="size-3" />

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -7,6 +7,13 @@ import { getTeamSchema } from '@/api/endpoints'
 import { Card, CardContent } from '@/components/ui/card'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { TEAM_BASE_FIELDS_SET } from '@/lib/constants'
@@ -165,21 +172,24 @@ export function TeamForm({
               <label className="text-secondary mb-1.5 block text-sm">
                 Organization <RequiredAsterisk />
               </label>
-              <select
-                className={`border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm ${isEditing || organizations.length <= 1 ? 'cursor-not-allowed opacity-60' : ''} ${
-                  errors.organization ? 'border-red-500' : ''
-                }`}
+              <Select
                 disabled={isEditing || isLoading || organizations.length <= 1}
-                onChange={(e) => setOrgSlug(e.target.value)}
+                onValueChange={setOrgSlug}
                 value={orgSlug}
               >
-                <option value="">Select organization...</option>
-                {organizations.map((org) => (
-                  <option key={org.slug} value={org.slug}>
-                    {org.name}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger
+                  className={errors.organization ? 'border-red-500' : ''}
+                >
+                  <SelectValue placeholder="Select organization..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {organizations.map((org) => (
+                    <SelectItem key={org.slug} value={org.slug}>
+                      {org.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {errors.organization && (
                 <div className="text-danger mt-1 flex items-center gap-1 text-xs">
                   <AlertCircle className="size-3" />

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -169,7 +169,10 @@ export function TeamForm({
         <Card>
           <CardContent className="space-y-4 pt-6">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <label
+                className="text-secondary mb-1.5 block text-sm"
+                htmlFor="team-org"
+              >
                 Organization <RequiredAsterisk />
               </label>
               <Select
@@ -179,6 +182,7 @@ export function TeamForm({
               >
                 <SelectTrigger
                   className={errors.organization ? 'border-red-500' : ''}
+                  id="team-org"
                 >
                   <SelectValue placeholder="Select organization..." />
                 </SelectTrigger>


### PR DESCRIPTION
## Summary
- Replaces the native `<select>` ``Organization`` dropdown in `EnvironmentForm` and `TeamForm` with the shadcn `<Select>` primitive.
- Disabled state (editing or only one org) is now driven by Radix props instead of opacity class twiddling.
- Error styling uses the trigger's `className` border override; placeholder hangs off `<SelectValue>` rather than a sentinel `<option value="">`.

This is the smallest next bite of Phase 4.2 (native select → Select sweep): the two list-filter selects in `UserManagement` already shipped in #326 — these were the only two admin-form sites that read straightforward enough to migrate without restructuring.

Deliberately left for follow-up: `BlueprintForm`, `LinkDefinitionForm`, `ScoringPolicyForm`, `ServiceAccountForm`, `ProjectTypeForm`, `UserForm`, `WebhookForm`, `DocumentTemplateForm`, `ThirdPartyServiceForm`, `OAuth2ApplicationForm`, and a few admin-section selects in `AuthProvidersManagement` / `BlueprintManagement` / `ServiceAccountManagement` — most of those have schema-driven or multi-section selects that need more care.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 270/270 passing
- [x] `npm run lint` — 1860 pre-existing warnings, 0 errors
- [ ] Visually verify the Organization select in EnvironmentForm and TeamForm: opens, selects, shows placeholder when empty, disables when editing