### PR TITLE
Operations log and project header quality-of-life tweaks

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -8,6 +8,7 @@ import {
   ArrowRight,
   Check,
   ChevronDown,
+  Copy,
   Filter,
   Info,
   Settings2 as SettingsIcon,
@@ -45,6 +46,7 @@ import { ProjectEnvironmentsCard } from '@/components/ProjectEnvironmentsCard'
 import { ProjectRelationshipsTab } from '@/components/ProjectRelationshipsTab'
 import { ProjectSettingsTab } from '@/components/ProjectSettingsTab'
 import { ScoreHistoryTab } from '@/components/ScoreHistoryTab'
+import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
@@ -61,12 +63,14 @@ import { LabelChip } from '@/components/ui/label-chip'
 import { ScoreBadge } from '@/components/ui/score-badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
+  IconTooltip,
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useClipboard } from '@/hooks/useClipboard'
 import { useProjectTypes, useTeams } from '@/hooks/useOrgResources'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { formatDateTime } from '@/lib/formatDate'
@@ -110,6 +114,7 @@ export function ProjectDetail({
   const orgSlug = selectedOrganization?.slug || ''
   const { patch, pendingPath } = useProjectPatch(orgSlug, project.id)
   const navigate = useNavigate()
+  const { copied: copiedProjectId, copy: copyProjectId } = useClipboard()
 
   const activeTab: TabType =
     initialTab && VALID_TAB_SET.has(initialTab)
@@ -669,6 +674,20 @@ export function ProjectDetail({
                 renderValue={renderNameValue}
                 value={project.name}
               />
+              <IconTooltip label="Copy project ID">
+                <Button
+                  aria-label="Copy project ID"
+                  onClick={() => void copyProjectId(project.id)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  {copiedProjectId ? (
+                    <Check className="size-4 text-green-500" />
+                  ) : (
+                    <Copy className="text-secondary size-4" />
+                  )}
+                </Button>
+              </IconTooltip>
               {project.archived && (
                 <span className="rounded border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium tracking-wide text-amber-800 uppercase dark:bg-amber-950 dark:text-amber-200">
                   Archived

--- a/src/components/operations-log/OperationsLogEntryDetails.tsx
+++ b/src/components/operations-log/OperationsLogEntryDetails.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import { Link } from 'react-router-dom'
+
 import { useQuery } from '@tanstack/react-query'
 import { Copy, ExternalLink } from 'lucide-react'
 import Markdown from 'react-markdown'
@@ -159,7 +161,13 @@ export function OperationsLogEntryDetails({ entry }: Props) {
         </p>
       )}
 
-      <div className="flex justify-end pt-2">
+      <div className="flex justify-end gap-2 pt-2">
+        <Button asChild size="sm" variant="outline">
+          <Link to={`/projects/${record.project_id}`}>
+            <ExternalLink className="mr-1.5 size-3.5" />
+            Go to Project
+          </Link>
+        </Button>
         <Button
           onClick={() => setDuplicateOpen(true)}
           size="sm"

--- a/src/components/operations-log/__tests__/OperationsLogEntryDetails.test.tsx
+++ b/src/components/operations-log/__tests__/OperationsLogEntryDetails.test.tsx
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { render, screen } from '@/test/utils'
+import type { OperationsLogRecord } from '@/types'
+
+import { OperationsLogEntryDetails } from '../OperationsLogEntryDetails'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/components/NewOpsLogDialog', () => ({
+  NewOpsLogDialog: () => null,
+}))
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', () => ({
+  getOperationsLogEntry: vi.fn(async () => makeRecord()),
+  listPluginOpsLogTemplates: vi.fn(async () => []),
+}))
+
+function makeRecord(
+  overrides: Partial<OperationsLogRecord> = {},
+): OperationsLogRecord {
+  return {
+    description: 'released v1.2.3 to testing',
+    entry_type: 'Deployed',
+    environment_slug: 'testing',
+    id: 'opslog-1',
+    occurred_at: '2026-05-12T02:24:59.841Z',
+    project_id: 'proj-abc',
+    project_slug: 'ai-content',
+    recorded_at: '2026-05-12T02:24:59.841Z',
+    recorded_by: 'alexs@aweber.com',
+    version: 'v1.2.3',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('OperationsLogEntryDetails', () => {
+  it('renders a Go to Project link pointing at the record project', () => {
+    render(<OperationsLogEntryDetails entry={makeRecord()} />)
+    const link = screen.getByRole('link', { name: /go to project/i })
+    expect(link).toHaveAttribute('href', '/projects/proj-abc')
+  })
+
+  it('renders the Duplicate button alongside the project link', () => {
+    render(<OperationsLogEntryDetails entry={makeRecord()} />)
+    expect(
+      screen.getByRole('button', { name: /duplicate/i }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/operations-log/opsRowLayout.ts
+++ b/src/components/operations-log/opsRowLayout.ts
@@ -4,6 +4,6 @@
 // room alongside the description row.
 //   rail | icon | project | version | desc | env/train | avatar | time | chevron
 export const OPS_ROW_GRID =
-  '4px 26px minmax(140px,180px) auto minmax(0,1fr) minmax(560px,4fr) 46px 44px 20px'
+  '4px 26px minmax(180px,320px) auto minmax(0,1fr) minmax(560px,4fr) 46px 44px 20px'
 
 export const OPS_ROW_PAD = 'py-4 pr-3.5 pl-0'


### PR DESCRIPTION
## Summary

Three small, independently-shippable UI papercuts on the Operations
Log and Project Detail screens, bundled here because they ship as a
single feature ([`plans/ui-qol-improvements.md`](https://github.com/AWeber-Imbi/imbi-development/blob/main/plans/ui-qol-improvements.md)).

<img width="1423" height="573" alt="image" src="https://github.com/user-attachments/assets/b48d144e-ab3c-4faa-b5fb-fc7c1243c01d" />

## Changes

- **Widen ops-log project column.** The shared `OPS_ROW_GRID`
  project column moves from `minmax(140px,180px)` →
  `minmax(180px,320px)` so common names like `imbi-plugin-github`
  stop truncating on the first line. Very long names still truncate
  gracefully with the existing `title=` tooltip.
- **Go to Project button.** Adds an outline button next to
  **Duplicate** in the expanded operations-log entry details that
  navigates to the record's project via a real React Router
  `<Link>`. The row stays a single `<button>` toggle (no
  refactor), and the new button supports ⌘-click / middle-click /
  right-click → open-in-new-tab as expected for an anchor.
- **Copy-ID button.** Adds a ghost-style icon button next to the
  project name in the Project Detail header that copies
  `project.id` to the clipboard via the existing `useClipboard`
  hook. Wraps with `IconTooltip` (label "Copy project ID") and
  flashes a green `Check` for ~2 s on success.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npx tsc --noEmit` — only the pre-existing unrelated
  `@sentry/react` error
- [x] `npx vitest run src/components/operations-log` — 23 / 23
  pass (new `OperationsLogEntryDetails.test.tsx` covers the link
  href + Duplicate co-existence)
- [ ] Manual: open `/operations-log`, confirm long project names
  render in full at ≥1200 px viewport; expand an entry → `Go to
  Project` lands on `/projects/<id>` and ⌘-click opens a new tab;
  visit any project, click the copy icon, paste and confirm the
  pasted value matches the UUID in the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)