### PR TITLE
Migrate ProjectTypeForm + LinkDefinitionForm org selects to <Select>

### DIFF
--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -9,6 +9,13 @@ import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
@@ -131,22 +138,25 @@ export function LinkDefinitionForm({
               >
                 Organization <RequiredAsterisk />
               </label>
-              <select
-                className={`border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm ${isEditing || isLoading || organizations.length <= 1 ? 'cursor-not-allowed opacity-60' : ''} ${
-                  errors.organization ? 'border-red-500' : ''
-                }`}
+              <Select
                 disabled={isEditing || isLoading || organizations.length <= 1}
-                id="link-def-org"
-                onChange={(e) => setOrgSlug(e.target.value)}
+                onValueChange={setOrgSlug}
                 value={orgSlug}
               >
-                <option value="">Select organization...</option>
-                {organizations.map((org) => (
-                  <option key={org.slug} value={org.slug}>
-                    {org.name}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger
+                  className={errors.organization ? 'border-red-500' : ''}
+                  id="link-def-org"
+                >
+                  <SelectValue placeholder="Select organization..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {organizations.map((org) => (
+                    <SelectItem key={org.slug} value={org.slug}>
+                      {org.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {errors.organization && (
                 <div className="text-danger mt-1 flex items-center gap-1 text-xs">
                   <AlertCircle className="size-3" />

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -14,6 +14,13 @@ import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
@@ -176,24 +183,31 @@ export function ProjectTypeForm({
         <Card>
           <CardContent className="space-y-4 pt-6">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <label
+                className="text-secondary mb-1.5 block text-sm"
+                htmlFor="project-type-org"
+              >
                 Organization <RequiredAsterisk />
               </label>
-              <select
-                className={`border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm ${isEditing || isLoading || organizations.length <= 1 ? 'cursor-not-allowed opacity-60' : ''} ${
-                  errors.organization ? 'border-red-500' : ''
-                }`}
+              <Select
                 disabled={isEditing || isLoading || organizations.length <= 1}
-                onChange={(e) => setOrgSlug(e.target.value)}
+                onValueChange={setOrgSlug}
                 value={orgSlug}
               >
-                <option value="">Select organization...</option>
-                {organizations.map((org) => (
-                  <option key={org.slug} value={org.slug}>
-                    {org.name}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger
+                  className={errors.organization ? 'border-red-500' : ''}
+                  id="project-type-org"
+                >
+                  <SelectValue placeholder="Select organization..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {organizations.map((org) => (
+                    <SelectItem key={org.slug} value={org.slug}>
+                      {org.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {errors.organization && (
                 <div className="text-danger mt-1 flex items-center gap-1 text-xs">
                   <AlertCircle className="size-3" />


### PR DESCRIPTION
## Summary
- Same conversion landed in #328: replace the native `<select>` Organization dropdown with the shadcn `<Select>` primitive in `ProjectTypeForm` and `LinkDefinitionForm`.
- Disabled state (editing or only one org) is driven by Radix props instead of opacity class twiddling.
- Error styling uses the trigger's `className` border override; placeholder hangs off `<SelectValue>`.
- `ProjectTypeForm`'s label gains `htmlFor` / `id` association to match the a11y fix applied to `TeamForm` during #328 review. `LinkDefinitionForm` already had the association.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify the Organization select in both forms: opens, selects, shows placeholder when empty, disables when editing