### PR TITLE
Migrate ServiceAccountForm org + role selects to <Select>

### DIFF
--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -9,6 +9,13 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useDirtyState } from '@/hooks/useDirtyState'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
@@ -386,27 +393,31 @@ export function ServiceAccountForm({
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <label
+                className="text-secondary mb-1.5 block text-sm"
+                htmlFor="service-account-org"
+              >
                 Organization <RequiredAsterisk />
               </label>
-              <select
-                className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+              <Select
                 disabled={isLoading || organizations.length === 1}
-                onChange={(e) => {
-                  setOrganizationSlug(e.target.value)
+                onValueChange={(v) => {
+                  setOrganizationSlug(v)
                   handleFieldChange('organization_slug')
                 }}
                 value={organizationSlug}
               >
-                {organizations.length !== 1 && (
-                  <option value="">Select an organization...</option>
-                )}
-                {organizations.map((org) => (
-                  <option key={org.slug} value={org.slug}>
-                    {org.name}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger id="service-account-org">
+                  <SelectValue placeholder="Select an organization..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {organizations.map((org) => (
+                    <SelectItem key={org.slug} value={org.slug}>
+                      {org.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {touched.organization_slug &&
                 validationErrors.organization_slug && (
                   <p className="mt-1 text-sm text-red-600">
@@ -416,7 +427,10 @@ export function ServiceAccountForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <label
+                className="text-secondary mb-1.5 block text-sm"
+                htmlFor="service-account-role"
+              >
                 Role <RequiredAsterisk />
               </label>
               {rolesLoading ? (
@@ -426,22 +440,25 @@ export function ServiceAccountForm({
                   Failed to load roles. Please refresh and try again.
                 </p>
               ) : (
-                <select
-                  className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                <Select
                   disabled={isLoading}
-                  onChange={(e) => {
-                    setRoleSlug(e.target.value)
+                  onValueChange={(v) => {
+                    setRoleSlug(v)
                     handleFieldChange('role_slug')
                   }}
                   value={roleSlug}
                 >
-                  <option value="">Select a role...</option>
-                  {availableRoles.map((role) => (
-                    <option key={role.slug} value={role.slug}>
-                      {role.name}
-                    </option>
-                  ))}
-                </select>
+                  <SelectTrigger id="service-account-role">
+                    <SelectValue placeholder="Select a role..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableRoles.map((role) => (
+                      <SelectItem key={role.slug} value={role.slug}>
+                        {role.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               )}
               {touched.role_slug && validationErrors.role_slug && (
                 <p className="mt-1 text-sm text-red-600">


### PR DESCRIPTION
## Summary
- Same conversion landed in #328 and #330: replace the native `<select>` for Organization and Role in `ServiceAccountForm` with the shadcn `<Select>` primitive.
- Disabled state driven by Radix props; empty-state placeholders moved to `<SelectValue>`.
- Labels gain `htmlFor` / `id` association for a11y.

Deliberately left for follow-up:
- `WebhookForm` — Third-Party Service select has a "None" option mapped to empty string. Radix disallows `""` values, so it needs a sentinel and translation layer (similar to ScoringPolicyManagement's `'all'`). Worth doing in its own PR.
- `DocumentTemplateForm` — the project-type picker resets `value=""` after each selection (it's a "tag adder", not a value-bound select). Radix Select doesn't fit; this is a Combobox / Dropdown menu pattern.
- `UserForm`, `BlueprintForm`, `RoleForm`, `ThirdPartyServiceForm`, `OAuth2ApplicationForm` — still pending.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify both selects open, select, show placeholder when empty, and disable correctly