### PR TITLE
Migrate ServiceAccountManagement filter + AuthProvidersManagement OAuth type selects to <Select>

### DIFF
--- a/src/components/admin/AuthProvidersManagement.tsx
+++ b/src/components/admin/AuthProvidersManagement.tsx
@@ -38,6 +38,13 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
 import { LoadingState } from '@/components/ui/loading-state'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { useAuth } from '@/hooks/useAuth'
 import { extractApiErrorDetail } from '@/lib/apiError'
@@ -497,16 +504,20 @@ function AuthProviderCreateDialog({
               <label className="text-secondary mb-1.5 block text-sm">
                 OAuth Type <RequiredAsterisk />
               </label>
-              <select
-                className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+              <Select
                 disabled={isSaving}
-                onChange={(e) => setAppType(e.target.value as OAuthAppType)}
+                onValueChange={(v) => setAppType(v as OAuthAppType)}
                 value={appType}
               >
-                <option value="google">Google</option>
-                <option value="github">GitHub</option>
-                <option value="oidc">OpenID Connect</option>
-              </select>
+                <SelectTrigger aria-label="OAuth type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="google">Google</SelectItem>
+                  <SelectItem value="github">GitHub</SelectItem>
+                  <SelectItem value="oidc">OpenID Connect</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div>
@@ -824,16 +835,20 @@ function AuthProviderEditDialog({
               <label className="text-secondary mb-1.5 block text-sm">
                 OAuth Type <RequiredAsterisk />
               </label>
-              <select
-                className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+              <Select
                 disabled={isSaving}
-                onChange={(e) => setAppType(e.target.value as OAuthAppType)}
+                onValueChange={(v) => setAppType(v as OAuthAppType)}
                 value={appType}
               >
-                <option value="google">Google</option>
-                <option value="github">GitHub</option>
-                <option value="oidc">OpenID Connect</option>
-              </select>
+                <SelectTrigger aria-label="OAuth type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="google">Google</SelectItem>
+                  <SelectItem value="github">GitHub</SelectItem>
+                  <SelectItem value="oidc">OpenID Connect</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div>

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -11,6 +11,13 @@ import {
   updateServiceAccount,
 } from '@/api/endpoints'
 import { AdminTable } from '@/components/ui/admin-table'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useAdminCrud } from '@/hooks/useAdminCrud'
 import { useAdminNav } from '@/hooks/useAdminNav'
 import { formatDateTime } from '@/lib/formatDate'
@@ -136,15 +143,22 @@ export function ServiceAccountManagement() {
       error={error}
       errorTitle="Failed to load service accounts"
       headerExtras={
-        <select
-          className="border-input bg-background text-foreground rounded-lg border px-3 py-2 text-sm"
-          onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+        <Select
+          onValueChange={(v) => setStatusFilter(v as StatusFilter)}
           value={statusFilter}
         >
-          <option value="all">All Status</option>
-          <option value="active">Active</option>
-          <option value="inactive">Inactive</option>
-        </select>
+          <SelectTrigger
+            aria-label="Filter service accounts by status"
+            className="w-36"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Status</SelectItem>
+            <SelectItem value="active">Active</SelectItem>
+            <SelectItem value="inactive">Inactive</SelectItem>
+          </SelectContent>
+        </Select>
       }
       isLoading={isLoading}
       loadingLabel="Loading service accounts..."


### PR DESCRIPTION
## Summary
- `ServiceAccountManagement`: list-page status filter dropdown, same pattern as the `UserManagement` filter from #326.
- `AuthProvidersManagement`: two `OAuth Type` selects inside the create- and edit-provider dialogs. Both have static valid values (`google`, `github`, `oidc`); no sentinel translation needed.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify the Service Account list status filter and the OAuth Type selects in both auth-provider dialogs