### PR TITLE
Migrate RoleDetail + UserDetail native selects to <Select>

### DIFF
--- a/src/components/admin/roles/RoleDetail.tsx
+++ b/src/components/admin/roles/RoleDetail.tsx
@@ -31,6 +31,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   Table,
   TableBody,
   TableCell,
@@ -319,18 +326,24 @@ export function RoleDetail({ onBack, onEdit, slug }: RoleDetailProps) {
 
               {showAddPermission && (
                 <div className="flex items-center gap-2">
-                  <select
-                    className="border-input bg-background text-foreground flex-1 rounded-lg border px-3 py-2 text-sm"
-                    onChange={(e) => setSelectedPermission(e.target.value)}
+                  <Select
+                    onValueChange={setSelectedPermission}
                     value={selectedPermission}
                   >
-                    <option value="">Select a permission...</option>
-                    {availablePermissions.map((perm) => (
-                      <option key={perm.name} value={perm.name}>
-                        {perm.name} - {perm.description || perm.action}
-                      </option>
-                    ))}
-                  </select>
+                    <SelectTrigger
+                      aria-label="Select a permission"
+                      className="flex-1"
+                    >
+                      <SelectValue placeholder="Select a permission..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availablePermissions.map((perm) => (
+                        <SelectItem key={perm.name} value={perm.name}>
+                          {perm.name} - {perm.description || perm.action}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <Button
                     className="bg-action text-action-foreground hover:bg-action-hover"
                     disabled={!selectedPermission || grantMutation.isPending}

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -27,6 +27,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Gravatar } from '@/components/ui/gravatar'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -272,35 +279,35 @@ export function UserDetail({ onBack, onEdit, user }: UserDetailProps) {
                   <label className="text-secondary mb-1.5 block text-sm">
                     Organization
                   </label>
-                  <select
-                    className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
-                    onChange={(e) => setNewOrgSlug(e.target.value)}
-                    value={newOrgSlug}
-                  >
-                    <option value="">Select...</option>
-                    {availableOrgs.map((org) => (
-                      <option key={org.slug} value={org.slug}>
-                        {org.name}
-                      </option>
-                    ))}
-                  </select>
+                  <Select onValueChange={setNewOrgSlug} value={newOrgSlug}>
+                    <SelectTrigger aria-label="Organization">
+                      <SelectValue placeholder="Select..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableOrgs.map((org) => (
+                        <SelectItem key={org.slug} value={org.slug}>
+                          {org.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
                 <div>
                   <label className="text-secondary mb-1.5 block text-sm">
                     Role
                   </label>
-                  <select
-                    className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
-                    onChange={(e) => setNewRoleSlug(e.target.value)}
-                    value={newRoleSlug}
-                  >
-                    <option value="">Select...</option>
-                    {availableRoles.map((role) => (
-                      <option key={role.slug} value={role.slug}>
-                        {role.name}
-                      </option>
-                    ))}
-                  </select>
+                  <Select onValueChange={setNewRoleSlug} value={newRoleSlug}>
+                    <SelectTrigger aria-label="Role">
+                      <SelectValue placeholder="Select..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableRoles.map((role) => (
+                        <SelectItem key={role.slug} value={role.slug}>
+                          {role.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
               <div className="mt-3 flex items-center gap-2">
@@ -351,23 +358,30 @@ export function UserDetail({ onBack, onEdit, user }: UserDetailProps) {
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <select
-                      className="border-input bg-background text-foreground rounded border px-2 py-1 text-xs"
+                    <Select
                       disabled={updateRoleMutation.isPending}
-                      onChange={(e) =>
+                      onValueChange={(roleSlug) =>
                         updateRoleMutation.mutate({
                           orgSlug: membership.organization_slug,
-                          roleSlug: e.target.value,
+                          roleSlug,
                         })
                       }
                       value={membership.role}
                     >
-                      {availableRoles.map((role) => (
-                        <option key={role.slug} value={role.slug}>
-                          {role.name}
-                        </option>
-                      ))}
-                    </select>
+                      <SelectTrigger
+                        aria-label={`Role for ${membership.organization_slug}`}
+                        className="h-7 w-auto text-xs"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {availableRoles.map((role) => (
+                          <SelectItem key={role.slug} value={role.slug}>
+                            {role.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                     <TooltipProvider delayDuration={200}>
                       <Tooltip>
                         <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- `RoleDetail`: ``Add Permission`` dropdown.
- `UserDetail`: ``Add Membership`` org + role dropdowns, plus the inline role switcher on each existing org membership.

All four are value-bound selects with no sentinel translation. The inline role switcher keeps its compact sizing via `className="h-7 w-auto text-xs"` on the trigger.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify the Add Permission picker (RoleDetail) and the three select sites in UserDetail