### PR TITLE
Migrate ThirdPartyServiceForm + OAuth2ApplicationForm selects to <Select>

### DIFF
--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -5,6 +5,13 @@ import { AlertCircle } from 'lucide-react'
 import { API_BASE_URL } from '@/api/client'
 import { FormHeader } from '@/components/admin/form-header'
 import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useAuth } from '@/hooks/useAuth'
 import { slugify } from '@/lib/utils'
 import type {
@@ -275,32 +282,40 @@ export function OAuth2ApplicationForm({
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className={labelClass}>Application Type *</label>
-            <select
-              className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+            <Select
               disabled={isEdit}
-              onChange={(e) => setAppType(e.target.value)}
+              onValueChange={setAppType}
               value={appType}
             >
-              {APP_TYPES.map((t) => (
-                <option key={t.value} value={t.value}>
-                  {t.label}
-                </option>
-              ))}
-            </select>
+              <SelectTrigger aria-label="Application Type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {APP_TYPES.map((t) => (
+                  <SelectItem key={t.value} value={t.value}>
+                    {t.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div>
             <label className={labelClass}>Status</label>
-            <select
-              className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
-              onChange={(e) =>
-                setStatus(e.target.value as 'active' | 'inactive' | 'revoked')
+            <Select
+              onValueChange={(v) =>
+                setStatus(v as 'active' | 'inactive' | 'revoked')
               }
               value={status}
             >
-              <option value="active">Active</option>
-              <option value="inactive">Inactive</option>
-              <option value="revoked">Revoked</option>
-            </select>
+              <SelectTrigger aria-label="Status">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="inactive">Inactive</SelectItem>
+                <SelectItem value="revoked">Revoked</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </div>
 

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -159,8 +159,6 @@ export function ThirdPartyServiceForm({
     }
   }
 
-  const selectClass = `w-full px-3 py-2 rounded-lg border text-sm border-input bg-background text-foreground`
-
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -216,19 +214,25 @@ export function ThirdPartyServiceForm({
               <label className="text-secondary mb-1.5 block text-sm">
                 Managing Team
               </label>
-              <select
-                className={selectClass}
+              {/* Radix disallows '' as a SelectItem value, so 'none' is the
+                  empty sentinel and gets translated at the boundary. */}
+              <Select
                 disabled={isLoading || !orgSlug}
-                onChange={(e) => setTeamSlug(e.target.value)}
-                value={teamSlug}
+                onValueChange={(v) => setTeamSlug(v === 'none' ? '' : v)}
+                value={teamSlug || 'none'}
               >
-                <option value="">No team assigned</option>
-                {orgTeams.map((team) => (
-                  <option key={team.slug} value={team.slug}>
-                    {team.name}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger aria-label="Managing Team">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No team assigned</SelectItem>
+                  {orgTeams.map((team) => (
+                    <SelectItem key={team.slug} value={team.slug}>
+                      {team.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div
@@ -349,26 +353,26 @@ export function ThirdPartyServiceForm({
                 <label className="text-secondary mb-1.5 block text-sm">
                   Status
                 </label>
-                <select
-                  className={selectClass}
+                <Select
                   disabled={isLoading}
-                  onChange={(e) =>
+                  onValueChange={(v) =>
                     setStatus(
-                      e.target.value as
-                        | 'active'
-                        | 'deprecated'
-                        | 'evaluating'
-                        | 'inactive',
+                      v as 'active' | 'deprecated' | 'evaluating' | 'inactive',
                     )
                   }
                   value={status}
                 >
-                  {STATUS_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
+                  <SelectTrigger aria-label="Status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STATUS_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- **ThirdPartyServiceForm**: Managing Team picker and Status select. Team uses the `"none"` sentinel (same pattern as `WebhookForm` in #335) since Radix disallows `""` SelectItem values; translation happens at the `onValueChange` boundary. Drops the now-unused `selectClass` local.
- **OAuth2ApplicationForm**: Application Type and Status — both bound to closed enums with no empty sentinel.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify the Team / Status pickers in TPS form and the Application Type / Status pickers in OAuth2 form