### PR TITLE
Migrate MonthlyImprovementReport month select to <Select>

### DIFF
--- a/src/components/reports/MonthlyImprovementReport.tsx
+++ b/src/components/reports/MonthlyImprovementReport.tsx
@@ -1,13 +1,19 @@
 import { useMemo, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
-import { ChevronDown } from 'lucide-react'
 
 import {
   getMonthlyImprovement,
   listTeams,
   MonthlyImprovementRow,
 } from '@/api/endpoints'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { Team } from '@/types'
 
@@ -140,23 +146,24 @@ export function MonthlyImprovementReport() {
       {/* Month selector */}
       <div className="flex items-center gap-3">
         <span className="text-secondary text-sm">Month</span>
-        <div className="relative">
-          <select
-            className="border-tertiary bg-primary text-primary hover:border-secondary h-8 appearance-none rounded border py-0 pr-8 pl-3 text-sm transition-colors focus:ring-0 focus:outline-none"
-            onChange={(e) => {
-              const opt = monthOptions[Number(e.target.value)]
-              if (opt) setSelected(opt)
-            }}
-            value={monthOptions.indexOf(selected)}
-          >
+        <Select
+          onValueChange={(v) => {
+            const opt = monthOptions[Number(v)]
+            if (opt) setSelected(opt)
+          }}
+          value={String(monthOptions.indexOf(selected))}
+        >
+          <SelectTrigger aria-label="Month" className="h-8 w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
             {monthOptions.map((opt, i) => (
-              <option key={`${opt.year}-${opt.month}`} value={i}>
+              <SelectItem key={`${opt.year}-${opt.month}`} value={String(i)}>
                 {opt.label}
-              </option>
+              </SelectItem>
             ))}
-          </select>
-          <ChevronDown className="text-tertiary pointer-events-none absolute top-1/2 right-2 size-3.5 -translate-y-1/2" />
-        </div>
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Table */}


### PR DESCRIPTION
## Summary
Last value-bound native `<select>` outside the admin tree. The month picker is a closed enum indexed into `monthOptions`, so the conversion is straightforward — values stringified at the boundary since Radix only accepts string values.

Drops the manual `ChevronDown` and the `appearance-none` gymnastics the original needed; Radix's `SelectTrigger` renders its own caret.

## Remaining native `<select>` sites in the codebase
- `DocumentTemplateForm` — the project-type picker is a "tag adder" (resets `value=""` after each selection). Radix `Select` doesn't fit cleanly; this one is better as a Combobox / DropdownMenu in a follow-up.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify the Month selector on Reports → Monthly Improvement