### PR TITLE
Convert DocumentTemplateForm project-type picker to DropdownMenu

### DIFF
--- a/src/components/admin/document-templates/DocumentTemplateForm.tsx
+++ b/src/components/admin/document-templates/DocumentTemplateForm.tsx
@@ -1,12 +1,18 @@
 import { useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
-import { AlertCircle, Save, X } from 'lucide-react'
+import { AlertCircle, ChevronDown, Plus, Save, X } from 'lucide-react'
 
 import { listProjectTypes } from '@/api/endpoints'
 import { TagCombobox } from '@/components/documents/TagCombobox'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
@@ -340,23 +346,44 @@ export function DocumentTemplateForm({
                   })}
                 </div>
               )}
-              <select
-                className="border-input bg-background text-foreground w-full rounded-lg border px-3 py-2 text-sm"
-                disabled={isLoading || !orgSlug}
-                onChange={(e) => {
-                  if (e.target.value) toggleProjectType(e.target.value)
-                }}
-                value=""
-              >
-                <option value="">Add project type...</option>
-                {projectTypes
-                  .filter((pt) => !projectTypeSlugs.includes(pt.slug))
-                  .map((pt) => (
-                    <option key={pt.slug} value={pt.slug}>
-                      {pt.name}
-                    </option>
-                  ))}
-              </select>
+              {/* Tag-adder pattern: pick one, append to the list, reset.
+                  Modeled as a DropdownMenu rather than a value-bound Select
+                  since there is no "current value" — picking is an action. */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    className="w-full justify-between"
+                    disabled={
+                      isLoading ||
+                      !orgSlug ||
+                      projectTypes.filter(
+                        (pt) => !projectTypeSlugs.includes(pt.slug),
+                      ).length === 0
+                    }
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    <span className="flex items-center gap-2">
+                      <Plus className="size-4" />
+                      Add project type...
+                    </span>
+                    <ChevronDown className="size-4 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-(--radix-dropdown-menu-trigger-width)">
+                  {projectTypes
+                    .filter((pt) => !projectTypeSlugs.includes(pt.slug))
+                    .map((pt) => (
+                      <DropdownMenuItem
+                        key={pt.slug}
+                        onSelect={() => toggleProjectType(pt.slug)}
+                      >
+                        {pt.name}
+                      </DropdownMenuItem>
+                    ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
 
             <div>


### PR DESCRIPTION
## Summary
The last remaining native `<select>` in the admin tree was a **tag-adder**: pick one project type, append it to the list, reset to `value=""`. That isn't a value-bound dropdown — Radix Select would reject `""` as a SelectItem value and the "selected" concept is meaningless here.

Modeled it as a `<DropdownMenu>` instead:
- Trigger is a `<Button variant="outline">` showing `Plus` + "Add project type...".
- Each `<DropdownMenuItem>` fires `toggleProjectType(ptSlug)` on select.
- Trigger disables when no remaining types are addable, matching the prior empty-options behavior.

With this in, **the native `<select>` sweep is fully complete across `src/`**.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify on the Document Template admin: opens the menu, picking an item adds it to the chips above and removes it from the dropdown; disables when all types are added