### PR TITLE
Clip score-breakdown recommendations to the blueprint's enum

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -28,6 +28,7 @@ import {
   listProjectDocuments,
   listProjectPlugins,
   listScoringPolicies,
+  type ProjectSchemaResponse,
   type ScoreTrend,
 } from '@/api/endpoints'
 import {
@@ -1005,6 +1006,7 @@ export function ProjectDetail({
                         <ScoreBreakdownDetail
                           contributions={scoreBreakdown.attribute_contributions}
                           policies={scoringPolicies}
+                          projectSchema={projectSchema}
                         />
                       )}
                     </CardFooter>
@@ -1173,11 +1175,18 @@ export function ProjectDetail({
 function buildRecommendation(
   c: AttributeContribution,
   policy: ScoringPolicy,
+  allowedValues?: Set<string>,
 ): null | string {
   if (policy.category !== 'attribute') return null
   const current = c.mapped_score
   if (policy.value_score_map) {
-    const better = entriesAbove(policy.value_score_map, current)
+    let better = entriesAbove(policy.value_score_map, current)
+    // Clip to values the blueprint actually allows for this attribute, so we
+    // don't suggest frameworks (or whatever) that aren't pickable anymore.
+    // Skip the clip when the blueprint defines no enum for this attribute.
+    if (allowedValues && allowedValues.size > 0) {
+      better = better.filter(([name]) => allowedValues.has(name))
+    }
     if (better.length === 0) return null
     const topScore = better[0][1]
     const top = better
@@ -1228,9 +1237,11 @@ function PlaceholderTab({ name }: { name: string }) {
 function ScoreBreakdownDetail({
   contributions,
   policies,
+  projectSchema,
 }: {
   contributions: AttributeContribution[]
   policies: ScoringPolicy[]
+  projectSchema?: ProjectSchemaResponse
 }) {
   const totalWeight = contributions.reduce((s, c) => s + c.weight, 0)
   const policyBySlug = useMemo(() => {
@@ -1238,6 +1249,24 @@ function ScoreBreakdownDetail({
     for (const p of policies) map.set(p.slug, p)
     return map
   }, [policies])
+
+  // attribute_name -> the set of values the blueprint declares as valid for
+  // that attribute. Used to clip score recommendations down to choices the
+  // user can actually pick — a policy may score a wider universe than the
+  // current blueprint enum (e.g. legacy frameworks that have been pruned).
+  // fallow-ignore-next-line complexity
+  const allowedValuesByAttribute = useMemo(() => {
+    const map = new Map<string, Set<string>>()
+    if (!projectSchema) return map
+    for (const section of projectSchema.sections) {
+      for (const [key, def] of Object.entries(section.properties)) {
+        if (def.enum && def.enum.length > 0) {
+          map.set(key, new Set(def.enum))
+        }
+      }
+    }
+    return map
+  }, [projectSchema])
 
   const enriched = contributions.map((c) => {
     const maxPts = totalWeight > 0 ? (c.weight / totalWeight) * 100 : 0
@@ -1282,7 +1311,11 @@ function ScoreBreakdownDetail({
                 policy?.name ||
                 formatFieldKey(c.policy_slug)
               const recommendation = policy
-                ? buildRecommendation(c, policy)
+                ? buildRecommendation(
+                    c,
+                    policy,
+                    allowedValuesByAttribute.get(c.attribute_name),
+                  )
                 : null
               return (
                 <div


### PR DESCRIPTION
## Problem
The "Update to ..." suggestion under **Health & compliance → Score breakdown → To improve** was built solely from the scoring policy's `value_score_map`. When the policy scored a wider universe than the attribute's current blueprint enum (e.g. a `Framework` policy with `value_score_map` entries for `python-unittest`, `cypress`, `react`, `rejected`, `http-service-lib`, ... while the current Framework blueprint enum is only `{Tornado, http-service-lib}`), the suggestion listed values the user couldn't actually pick.

## Fix
- `ScoreBreakdownDetail` now accepts the project schema and builds an `attribute_name → enum` map from `schema.sections[].properties[key].enum`.
- `buildRecommendation` accepts that set and clips `entriesAbove` to it before formatting the string.
- When the blueprint defines no enum for the attribute (free-form), the clip is skipped — prior behavior preserved.

After this:
- `Framework` with blueprint enum `{Tornado, http-service-lib}` and current value `Tornado` → recommendation is just `Update to http-service-lib`.
- Free-form attributes (no enum on the schema) keep their previous recommendations unchanged.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Open the screenshot's project: confirm the Framework breakdown row reads `Update to http-service-lib` instead of listing all the scored values.