### PR TITLE
Tokenize ProjectActivityLog dot colors

### DIFF
--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -46,9 +46,9 @@ interface Props {
 }
 
 const DOT_CLASS = {
-  info: 'bg-[#3d86d1]',
-  neutral: 'bg-[#888780]',
-  warning: 'bg-[#ef9f27]',
+  info: 'bg-activity-info-dot',
+  neutral: 'bg-activity-neutral-dot',
+  warning: 'bg-activity-warning-dot',
 }
 
 interface KeyChange {

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,12 @@
   --color-status-failed-dot: #e24b4a;
   --color-status-failed-text: #791f1f;
 
+  /* Activity log row markers. Saturated dot colors that read on both
+     light and dark backgrounds without per-theme overrides. */
+  --color-activity-info-dot: #3d86d1;
+  --color-activity-neutral-dot: #888780;
+  --color-activity-warning-dot: #ef9f27;
+
   /* --- Per-utility design system colors (separate bg/text/border) --- */
   --background-color-primary: var(--ds-bg-primary);
   --background-color-secondary: var(--ds-bg-secondary);


### PR DESCRIPTION
## Summary
Phase 4.4 (first chunk): replace three arbitrary-value hex utilities (`bg-[#3d86d1]`, `bg-[#888780]`, `bg-[#ef9f27]`) in `ProjectActivityLog`'s `DOT_CLASS` with semantic `--color-activity-{info,neutral,warning}-dot` tokens and the corresponding Tailwind v4 utilities (`bg-activity-info-dot`, …).

Mirrors the existing `--color-status-*-dot` family already in `index.css`. The dot colors are saturated and read on either theme, so no dark-mode override is needed.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify project activity log dots match the previous render (light + dark)

## Remaining for Phase 4.4
- `SearchResultsPanel` — 17 entity-category brand hexes (Blueprint, Document, Organization, Project, …). Larger naming exercise — separate PR.