### PR TITLE
Convert raw <button> to shadcn <Button> on admin detail pages

### DIFF
--- a/src/components/admin/blueprints/BlueprintDetail.tsx
+++ b/src/components/admin/blueprints/BlueprintDetail.tsx
@@ -471,9 +471,11 @@ export function BlueprintDetail({
 
       {/* Raw JSON Schema (collapsible) */}
       <div className="border-border bg-card rounded-lg border">
-        <button
-          className={`hover:bg-secondary flex w-full items-center gap-2 px-6 py-4 text-left ${rawSchemaOpen ? 'border-tertiary border-b' : ''}`}
+        <Button
+          aria-expanded={rawSchemaOpen}
+          className={`hover:bg-secondary h-auto w-full justify-start gap-2 rounded-none px-6 py-4 ${rawSchemaOpen ? 'border-tertiary border-b' : ''}`}
           onClick={() => setRawSchemaOpen(!rawSchemaOpen)}
+          variant="ghost"
         >
           {rawSchemaOpen ? (
             <ChevronDown className="text-tertiary size-4" />
@@ -484,7 +486,7 @@ export function BlueprintDetail({
           <span className="text-tertiary text-xs">
             {raw.split('\n').length} lines
           </span>
-        </button>
+        </Button>
         {rawSchemaOpen && (
           <pre className="text-primary overflow-x-auto px-6 py-4 font-mono text-sm leading-relaxed">
             {raw}

--- a/src/components/admin/roles/RoleDetail.tsx
+++ b/src/components/admin/roles/RoleDetail.tsx
@@ -316,12 +316,14 @@ export function RoleDetail({ onBack, onEdit, slug }: RoleDetailProps) {
                 <h3 className="text-primary text-sm font-medium">
                   Assign Permission
                 </h3>
-                <button
-                  className="text-info hover:text-info/80 text-sm"
+                <Button
+                  className="text-info hover:text-info/80"
                   onClick={() => setShowAddPermission(!showAddPermission)}
+                  size="sm"
+                  variant="link"
                 >
                   {showAddPermission ? 'Cancel' : 'Add Permission'}
-                </button>
+                </Button>
               </div>
 
               {showAddPermission && (
@@ -417,15 +419,18 @@ export function RoleDetail({ onBack, onEdit, slug }: RoleDetailProps) {
                               <TooltipProvider delayDuration={200}>
                                 <Tooltip>
                                   <TooltipTrigger asChild>
-                                    <button
-                                      className="text-danger hover:bg-danger rounded p-1.5"
+                                    <Button
+                                      aria-label={`Remove ${perm.name} permission`}
+                                      className="text-danger hover:bg-danger size-7"
                                       disabled={revokeMutation.isPending}
                                       onClick={() =>
                                         handleRevokePermission(perm.name)
                                       }
+                                      size="icon"
+                                      variant="ghost"
                                     >
                                       <Trash2 className="size-4" />
-                                    </button>
+                                    </Button>
                                   </TooltipTrigger>
                                   <TooltipContent>
                                     <p>Remove permission</p>

--- a/src/components/admin/service-accounts/ApiKeysSection.tsx
+++ b/src/components/admin/service-accounts/ApiKeysSection.tsx
@@ -156,15 +156,17 @@ export function ApiKeysSection({
                       <TooltipProvider delayDuration={200}>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <button
+                            <Button
                               aria-label={`Rotate API key ${key.name}`}
-                              className="text-info hover:bg-secondary rounded p-1.5"
+                              className="text-info hover:bg-secondary size-7"
                               disabled={rotateApiKeyMutation.isPending}
                               onClick={() => onConfirmRotate(key.key_id)}
+                              size="icon"
                               type="button"
+                              variant="ghost"
                             >
                               <RotateCw className="size-4" />
-                            </button>
+                            </Button>
                           </TooltipTrigger>
                           <TooltipContent>
                             <p>Rotate API key</p>
@@ -174,15 +176,17 @@ export function ApiKeysSection({
                       <TooltipProvider delayDuration={200}>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <button
+                            <Button
                               aria-label={`Revoke API key ${key.name}`}
-                              className="text-danger hover:bg-secondary rounded p-1.5"
+                              className="text-danger hover:bg-secondary size-7"
                               disabled={revokeApiKeyMutation.isPending}
                               onClick={() => onConfirmRevoke(key.key_id)}
+                              size="icon"
                               type="button"
+                              variant="ghost"
                             >
                               <Trash2 className="size-4" />
-                            </button>
+                            </Button>
                           </TooltipTrigger>
                           <TooltipContent>
                             <p>Revoke API key</p>

--- a/src/components/admin/service-accounts/ClientCredentialsSection.tsx
+++ b/src/components/admin/service-accounts/ClientCredentialsSection.tsx
@@ -213,15 +213,17 @@ export function ClientCredentialsSection({
                       <TooltipProvider delayDuration={200}>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <button
+                            <Button
                               aria-label={`Rotate credential ${cred.name}`}
-                              className="text-info hover:bg-secondary rounded p-1.5"
+                              className="text-info hover:bg-secondary size-7"
                               disabled={rotateCredentialMutation.isPending}
                               onClick={() => onConfirmRotate(cred.client_id)}
+                              size="icon"
                               type="button"
+                              variant="ghost"
                             >
                               <RotateCw className="size-4" />
-                            </button>
+                            </Button>
                           </TooltipTrigger>
                           <TooltipContent>
                             <p>Rotate credential</p>
@@ -231,15 +233,17 @@ export function ClientCredentialsSection({
                       <TooltipProvider delayDuration={200}>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <button
+                            <Button
                               aria-label={`Revoke credential ${cred.name}`}
-                              className="text-danger hover:bg-secondary rounded p-1.5"
+                              className="text-danger hover:bg-secondary size-7"
                               disabled={revokeCredentialMutation.isPending}
                               onClick={() => onConfirmRevoke(cred.client_id)}
+                              size="icon"
                               type="button"
+                              variant="ghost"
                             >
                               <Trash2 className="size-4" />
-                            </button>
+                            </Button>
                           </TooltipTrigger>
                           <TooltipContent>
                             <p>Revoke credential</p>

--- a/src/components/admin/service-accounts/OrgMembershipsCard.tsx
+++ b/src/components/admin/service-accounts/OrgMembershipsCard.tsx
@@ -225,9 +225,9 @@ export function OrgMembershipsCard({
                   <TooltipProvider delayDuration={200}>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
+                        <Button
                           aria-label={`Remove from ${membership.organization_name}`}
-                          className="text-danger hover:bg-secondary rounded p-1.5"
+                          className="text-danger hover:bg-secondary size-7"
                           disabled={removeOrgMutation.isPending}
                           onClick={() =>
                             onConfirmRemove(
@@ -235,10 +235,12 @@ export function OrgMembershipsCard({
                               membership.organization_name,
                             )
                           }
+                          size="icon"
                           type="button"
+                          variant="ghost"
                         >
                           <Trash2 className="size-4" />
-                        </button>
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>
                         <p>Remove from organization</p>

--- a/src/components/admin/teams/TeamDetail.tsx
+++ b/src/components/admin/teams/TeamDetail.tsx
@@ -289,15 +289,17 @@ export function TeamDetail({ onBack, onEdit, team }: TeamDetailProps) {
                       <TooltipProvider delayDuration={200}>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <button
+                            <Button
                               aria-label={`Remove ${member.display_name} from team`}
-                              className="text-danger hover:bg-danger rounded p-1.5"
+                              className="text-danger hover:bg-danger size-7"
                               disabled={removeMemberMutation.isPending}
                               onClick={() => handleRemoveMember(member.email)}
+                              size="icon"
                               type="button"
+                              variant="ghost"
                             >
                               <X className="size-4" />
-                            </button>
+                            </Button>
                           </TooltipTrigger>
                           <TooltipContent>
                             <p>Remove from team</p>

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -385,8 +385,9 @@ export function UserDetail({ onBack, onEdit, user }: UserDetailProps) {
                     <TooltipProvider delayDuration={200}>
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <button
-                            className="text-danger hover:bg-secondary rounded p-1.5"
+                          <Button
+                            aria-label="Remove from organization"
+                            className="text-danger hover:bg-secondary size-7"
                             disabled={removeOrgMutation.isPending}
                             onClick={() =>
                               setConfirm({
@@ -395,9 +396,11 @@ export function UserDetail({ onBack, onEdit, user }: UserDetailProps) {
                                 orgSlug: membership.organization_slug,
                               })
                             }
+                            size="icon"
+                            variant="ghost"
                           >
                             <Trash2 className="size-4" />
-                          </button>
+                          </Button>
                         </TooltipTrigger>
                         <TooltipContent>
                           <p>Remove from organization</p>


### PR DESCRIPTION
## Summary
Phase 4.3, pass 1. Replace raw `<button>` with the canonical shadcn `<Button>` primitive in cases where the button has a matching shape — icon-only ghost actions inside TooltipTriggers, inline text "Add/Cancel" links, and a collapsible panel toggle.

Files touched:
- `UserDetail`: per-membership "Remove from organization" TooltipTrigger button → `Button variant="ghost" size="icon"`.
- `TeamDetail`: per-member "Remove from team" same treatment.
- `OrgMembershipsCard`: parallel "Remove" icon button.
- `RoleDetail`: "Add Permission" / "Cancel" inline toggle → `Button variant="link" size="sm"`; per-permission "Remove permission" icon button → `Button variant="ghost" size="icon"`.
- `BlueprintDetail`: "Raw JSON Schema" collapse trigger → a full-width ghost `Button` with the original padding preserved.

Deliberately left raw:
- `RoleDetail`'s tab nav (custom underline-tab pattern; needs a wholesale `<Tabs>` conversion, not in scope here).
- Chip-action `<X>` buttons (so small that wrapping them in `<Button>` adds more code than it saves).
- `UserManagement`'s inline `Active/Inactive` status pill (custom two-tone chip pattern).
- Other surfaces — separate follow-up passes.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 272/272 passing
- [ ] Visually verify each touched button still renders with the same tooltip and hover state