### PR TITLE
FormField primitive uses shadcn <Label>

### DIFF
--- a/src/components/ui/form-field.tsx
+++ b/src/components/ui/form-field.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+import { Label } from '@/components/ui/label'
+
 // Label + input + error chrome shared by admin *Form.tsx components.
 // Layout (grid-span etc.) stays with the caller; this only wraps the
 // label, the input slot, optional description, and the error message.
@@ -24,10 +26,10 @@ export function FormField({
 }: FormFieldProps) {
   return (
     <div>
-      <label className="text-secondary mb-1.5 block text-sm" htmlFor={htmlFor}>
+      <Label className="text-secondary mb-1.5 block text-sm" htmlFor={htmlFor}>
         {label}
         {required && <span className="text-red-500"> *</span>}
-      </label>
+      </Label>
       {children}
       {description && (
         <p className="text-secondary mt-1 text-sm">{description}</p>


### PR DESCRIPTION
## Summary

Phase B1 of the shadcn canonical adoption sweep. Single-file change inside the `FormField` primitive: the internal `<label>` becomes `<Label>` (Radix). Every admin form already routing labels through `FormField` (ProjectTypeForm, TeamForm, UserForm, EnvironmentForm, RoleForm) picks up the canonical primitive automatically — no caller changes.

Styling props are preserved verbatim so there is no visual change; this only swaps the underlying element so peer-disabled handling and forwarded refs come along.

## Test plan

- [ ] `npm run build` passes.
- [ ] Visit `/admin/teams/new`, `/admin/users/new`, `/admin/environments/new`, `/admin/roles/new`, `/admin/project-types/new` — confirm form labels render identically and clicking a label still focuses its input.