### PR TITLE
Convert raw checkbox inputs to shadcn <Checkbox>

### DIFF
--- a/src/components/admin/AuthProvidersManagement.tsx
+++ b/src/components/admin/AuthProvidersManagement.tsx
@@ -25,6 +25,7 @@ import {
 import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import {
   Dialog,
@@ -671,12 +672,12 @@ function AuthProviderCreateDialog({
             )}
 
             <label className="text-secondary flex w-full items-center gap-2 text-sm">
-              <input
+              <Checkbox
                 checked={enableIntegration}
-                className="border-input size-4 rounded"
                 disabled={isSaving}
-                onChange={(e) => setEnableIntegration(e.target.checked)}
-                type="checkbox"
+                onCheckedChange={(checked) =>
+                  setEnableIntegration(checked === true)
+                }
               />
               Enable Integration
             </label>
@@ -1019,12 +1020,12 @@ function AuthProviderEditDialog({
             )}
 
             <label className="text-secondary flex w-full items-center gap-2 text-sm">
-              <input
+              <Checkbox
                 checked={enableIntegration}
-                className="border-input size-4 rounded"
                 disabled={isSaving}
-                onChange={(e) => setEnableIntegration(e.target.checked)}
-                type="checkbox"
+                onCheckedChange={(checked) =>
+                  setEnableIntegration(checked === true)
+                }
               />
               Enable Integration
             </label>

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -30,6 +30,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -960,13 +961,12 @@ function ProjectTypesCard({
                         </span>
                       </TableCell>
                       <TableCell className="align-middle">
-                        <input
+                        <Checkbox
                           checked={draft.default}
-                          onChange={(e) =>
-                            updateDraft(idx, { default: e.target.checked })
+                          onCheckedChange={(checked) =>
+                            updateDraft(idx, { default: checked === true })
                           }
                           onClick={(e) => e.stopPropagation()}
-                          type="checkbox"
                         />
                       </TableCell>
                       <TableCell className="align-middle">

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -24,6 +24,7 @@ import { getLocalAuthConfig, getRoles } from '@/api/endpoints'
 import { FormHeader } from '@/components/admin/form-header'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import {
   Dialog,
@@ -503,12 +504,11 @@ export function UserForm({
                     key={org.slug}
                   >
                     <div className="flex min-w-0 items-center gap-3">
-                      <input
+                      <Checkbox
                         checked={checked}
-                        className="border-tertiary size-4 rounded"
                         disabled={isLoading}
-                        onChange={(e) => {
-                          if (e.target.checked) {
+                        onCheckedChange={(value) => {
+                          if (value === true) {
                             const defaultRole = availableRoles[0]?.slug ?? ''
                             setMemberships([
                               ...memberships,
@@ -525,7 +525,6 @@ export function UserForm({
                             )
                           }
                         }}
-                        type="checkbox"
                       />
                       <span className="text-primary truncate text-sm font-medium">
                         {org.name}

--- a/src/components/project/ProjectPluginsSection.tsx
+++ b/src/components/project/ProjectPluginsSection.tsx
@@ -27,6 +27,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -382,11 +383,10 @@ export function ProjectPluginsSection({
               </div>
             )}
             <div className="flex items-center gap-2">
-              <input
+              <Checkbox
                 checked={isDefault}
                 id="proj-is-default"
-                onChange={(e) => setIsDefault(e.target.checked)}
-                type="checkbox"
+                onCheckedChange={(checked) => setIsDefault(checked === true)}
               />
               <Label htmlFor="proj-is-default">
                 Set as default for this tab

--- a/src/components/ui/dynamic-fields.tsx
+++ b/src/components/ui/dynamic-fields.tsx
@@ -4,6 +4,7 @@ import addFormats from 'ajv-formats'
 import { AlertCircle } from 'lucide-react'
 
 import type { DynamicFieldSchema, DynamicSchema } from '@/api/endpoints'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -133,13 +134,11 @@ export function DynamicFormFields({
         if (field.type === 'boolean') {
           return (
             <div className="flex items-center gap-2" key={key}>
-              <input
+              <Checkbox
                 checked={!!data[key]}
-                className="rounded border-gray-300"
                 disabled={isLoading}
                 id={`dynamic-${key}`}
-                onChange={(e) => onChange(key, e.target.checked)}
-                type="checkbox"
+                onCheckedChange={(checked) => onChange(key, checked === true)}
               />
               <label
                 className="text-secondary text-sm"


### PR DESCRIPTION
## Summary

Phase B2 of the shadcn canonical adoption sweep. Six remaining raw `<input type="checkbox">` sites now use the canonical `<Checkbox>` primitive. `dynamic-fields.tsx` — itself a `ui/` primitive that renders schema-driven UI — counts because the rendered checkbox is just another call site.

## Sites converted

- `AuthProvidersManagement` (create + edit dialogs) — "Enable Integration" toggle.
- `UserForm` — per-organization membership toggle in the org/role table.
- `ServicePluginConfiguration` — default-flag toggle inside the option rows table.
- `ProjectPluginsSection` — "Set as default for this tab" in the add-plugin dialog.
- `dynamic-fields` — boolean-typed schema field renderer.

## Test plan

- [ ] `npm run build` passes.
- [ ] Toggle Enable Integration in `/admin/auth-providers` create + edit dialogs — confirm state persists.
- [ ] Toggle organization membership in `/admin/users/<slug>` — confirm role select enables/disables.
- [ ] Toggle default-flag in plugin configuration table.
- [ ] Toggle "Set as default" in project add-plugin dialog.
- [ ] Boolean field in a dynamic-fields schema (e.g., add a webhook with a boolean option) toggles correctly.