### PR TITLE
Convert raw <textarea> in admin forms to shadcn <Textarea>

### DIFF
--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { queryKeys } from '@/lib/queryKeys'
 import { parseFilterFromBlueprint } from '@/lib/utils'
@@ -803,8 +804,8 @@ export function BlueprintForm({
             <label className="text-secondary mb-1.5 block text-sm">
               Description
             </label>
-            <textarea
-              className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-md border px-3 py-2 text-sm"
+            <Textarea
+              className="resize-none"
               disabled={isLoading}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Brief description of what this blueprint defines"

--- a/src/components/admin/blueprints/BlueprintSchemaEditor.tsx
+++ b/src/components/admin/blueprints/BlueprintSchemaEditor.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { AlertCircle, Code, List, Plus } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
 import type { SchemaProperty } from '@/types'
 
 import { type SchemaEditorMode } from './blueprint-schema-utils'
@@ -143,8 +144,8 @@ export function BlueprintSchemaEditor({
 
       {/* Code Mode */}
       {editorMode === 'code' && (
-        <textarea
-          className="border-input bg-secondary text-primary w-full resize-y rounded-md border px-4 py-3 font-mono text-sm"
+        <Textarea
+          className="bg-secondary text-primary resize-y px-4 py-3 font-mono"
           onBlur={() => syncCodeToVisual(rawSchema)}
           onChange={(e) => {
             setRawSchema(e.target.value)

--- a/src/components/admin/blueprints/ImportBlueprintDialog.tsx
+++ b/src/components/admin/blueprints/ImportBlueprintDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
 import { type DetectedFormat, detectFormat } from '@/lib/import-format'
 import type { BlueprintCreate, BlueprintFilter } from '@/types'
 
@@ -221,8 +222,8 @@ export function ImportBlueprintDialog({
           )}
 
           {/* Input area */}
-          <textarea
-            className={`border-input bg-secondary text-primary placeholder:text-muted-foreground w-full resize-y rounded-md border px-4 py-3 font-mono text-sm leading-relaxed ${error ? 'border-danger' : ''}`}
+          <Textarea
+            className={`bg-secondary text-primary resize-y px-4 py-3 font-mono leading-relaxed ${error ? 'border-danger' : ''}`}
             onChange={(e) => handleInputChange(e.target.value)}
             placeholder={`{
   "name": "AWS Metadata",

--- a/src/components/admin/document-templates/DocumentTemplateForm.tsx
+++ b/src/components/admin/document-templates/DocumentTemplateForm.tsx
@@ -18,6 +18,7 @@ import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { queryKeys } from '@/lib/queryKeys'
@@ -221,8 +222,8 @@ export function DocumentTemplateForm({
               >
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 id="document-tpl-description"
                 onChange={(e) => setDescription(e.target.value)}
@@ -287,8 +288,8 @@ export function DocumentTemplateForm({
               >
                 Content
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-y rounded-lg border px-3 py-2 font-mono text-sm"
+              <Textarea
+                className="resize-y rounded-lg font-mono"
                 disabled={isLoading}
                 id="document-tpl-content"
                 onChange={(e) => setContent(e.target.value)}

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
@@ -287,8 +288,8 @@ export function EnvironmentForm({
               >
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 id="environment-description"
                 onChange={(e) => setDescription(e.target.value)}

--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
@@ -224,8 +225,8 @@ export function LinkDefinitionForm({
               >
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 id="link-def-description"
                 onChange={(e) => setDescription(e.target.value)}

--- a/src/components/admin/organizations/OrganizationForm.tsx
+++ b/src/components/admin/organizations/OrganizationForm.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, Save, X } from 'lucide-react'
 
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import { Textarea } from '@/components/ui/textarea'
 import type { Organization, OrganizationCreate } from '@/types'
 
 import { Button } from '../../ui/button'
@@ -172,8 +173,8 @@ export function OrganizationForm({
               <label className="text-secondary mb-1.5 block text-sm">
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Brief description of the organization's purpose"

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { PROJECT_TYPE_BASE_FIELDS_SET } from '@/lib/constants'
@@ -264,8 +265,8 @@ export function ProjectTypeForm({
               <label className="text-secondary mb-1.5 block text-sm">
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Brief description of this project type"

--- a/src/components/admin/roles/RoleForm.tsx
+++ b/src/components/admin/roles/RoleForm.tsx
@@ -17,6 +17,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { FormField } from '@/components/ui/form-field'
 import { Input } from '@/components/ui/input'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import { Textarea } from '@/components/ui/textarea'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
 import type { Permission, RoleCreate } from '@/types'
 
@@ -363,8 +364,8 @@ export function RoleForm({
               <label className="text-secondary mb-1.5 block text-sm">
                 Description
               </label>
-              <textarea
-                className={`border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-md border px-3 py-2 text-sm ${isSystemRole ? 'cursor-not-allowed opacity-60' : ''}`}
+              <Textarea
+                className={`resize-none ${isSystemRole ? 'cursor-not-allowed opacity-60' : ''}`}
                 disabled={isLoading || isSystemRole}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Brief description of this role's purpose and scope"

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
 import { type DetectedFormat, detectFormat } from '@/lib/import-format'
 import type {
   AgeScoringPolicyCreate,
@@ -285,8 +286,8 @@ export function ImportScoringPolicyDialog({
             </div>
           )}
 
-          <textarea
-            className={`border-input bg-secondary text-primary placeholder:text-muted-foreground w-full resize-y rounded-md border px-4 py-3 font-mono text-sm leading-relaxed ${error ? 'border-danger' : ''}`}
+          <Textarea
+            className={`bg-secondary text-primary resize-y px-4 py-3 font-mono leading-relaxed ${error ? 'border-danger' : ''}`}
             onChange={(e) => handleInputChange(e.target.value)}
             placeholder={`{
   "name": "Test Coverage",

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { queryKeys } from '@/lib/queryKeys'
 import { slugify } from '@/lib/utils'
@@ -364,8 +365,8 @@ export function ScoringPolicyForm({
               >
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2 text-sm"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 id="sp-description"
                 onChange={(e) => setDescription(e.target.value)}

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useDirtyState } from '@/hooks/useDirtyState'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
@@ -361,8 +362,7 @@ export function ServiceAccountForm({
                 {description.length}/500
               </span>
             </label>
-            <textarea
-              className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full rounded-md border px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            <Textarea
               disabled={isLoading}
               maxLength={500}
               onChange={(e) => setDescription(e.target.value)}
@@ -716,8 +716,7 @@ function IdentityCardEdit({
               {description.length}/500
             </span>
           </label>
-          <textarea
-            className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full rounded-md border px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+          <Textarea
             disabled={isLoading}
             maxLength={500}
             onChange={(e) => onDescriptionChange(e.target.value)}

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -14,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { TEAM_BASE_FIELDS_SET } from '@/lib/constants'
@@ -250,8 +251,8 @@ export function TeamForm({
               <label className="text-secondary mb-1.5 block text-sm">
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Brief description of the team's purpose"

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -19,6 +19,7 @@ import {
 import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import {
   Tooltip,
   TooltipContent,
@@ -270,8 +271,8 @@ export function ApplicationSecretsPanel({
                 {FIELD_LABELS[field]}
               </label>
               {field === 'private_key' ? (
-                <textarea
-                  className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 font-mono text-sm"
+                <Textarea
+                  className="font-mono"
                   onChange={(e) =>
                     setEditValues({ ...editValues, [field]: e.target.value })
                   }

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { useAuth } from '@/hooks/useAuth'
 import { slugify } from '@/lib/utils'
 import type {
@@ -412,8 +413,8 @@ export function OAuth2ApplicationForm({
             {extraSecretFields.includes('private_key') && (
               <div>
                 <label className={labelClass}>Private Key (PEM)</label>
-                <textarea
-                  className="border-input bg-background text-foreground w-full rounded-md border px-3 py-2 font-mono text-sm"
+                <Textarea
+                  className="font-mono"
                   onChange={(e) => setPrivateKey(e.target.value)}
                   placeholder={'-----BEGIN RSA PRIVATE KEY-----\n...'}
                   rows={4}

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
@@ -380,8 +381,8 @@ export function ThirdPartyServiceForm({
               <label className="text-secondary mb-1.5 block text-sm">
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Brief description of this service and how it is used"

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { slugify } from '@/lib/utils'
@@ -373,8 +374,8 @@ export function WebhookForm({
               <label className="text-secondary mb-1.5 block text-sm">
                 Description
               </label>
-              <textarea
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border px-3 py-2"
+              <Textarea
+                className="resize-none rounded-lg"
                 disabled={isLoading}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Brief description of this webhook"
@@ -735,8 +736,8 @@ export function WebhookForm({
                           <label className="text-secondary mb-1 block text-xs">
                             Handler Config (JSON)
                           </label>
-                          <textarea
-                            className={`border-input bg-background text-foreground placeholder:text-muted-foreground w-full resize-y rounded-lg border px-3 py-2 font-mono text-sm ${
+                          <Textarea
+                            className={`resize-y rounded-lg font-mono ${
                               errors[`rule_${index}_config`]
                                 ? 'border-red-500'
                                 : ''


### PR DESCRIPTION
## Summary

Phase B3 of the shadcn canonical adoption sweep. Seventeen raw `<textarea>` sites across 16 admin form / dialog files now use the canonical `<Textarea>` primitive. The reimplemented utility classes (`border-input` / `bg-background` / `placeholder:text-muted-foreground` / `w-full`) drop because `<Textarea>` already supplies them. Only non-default behavior is preserved via `className`:
- `resize-none` / `resize-y` where the original chose one.
- `rounded-lg` where the form uses lg corners (Textarea defaults to `rounded-md`).
- `font-mono` for the JSON/code fields.

## Sites converted

`BlueprintForm`, `BlueprintSchemaEditor`, `ImportBlueprintDialog`, `DocumentTemplateForm` (×2), `EnvironmentForm`, `LinkDefinitionForm`, `OrganizationForm`, `ProjectTypeForm`, `RoleForm`, `ImportScoringPolicyDialog`, `ScoringPolicyForm`, `ServiceAccountForm` (×2), `TeamForm`, `ApplicationSecretsPanel`, `OAuth2ApplicationForm`, `ThirdPartyServiceForm`, `WebhookForm` (×2).

## KEEPs (matches audit)

- `DocumentsPinboardNew` — borderless full-bleed markdown editor.
- `ConfigurationTab` — inline editor with multi-state focus + masking + loading-pulse animations.

## Test plan

- [ ] `npm run build` passes.
- [ ] Spot-check each form: `/admin/teams/new`, `/admin/blueprints/new`, `/admin/document-templates/new` — confirm description-style fields render and accept input.
- [ ] Spot-check JSON-textarea fields: webhook handler config, blueprint import, scoring policy import — confirm font remains monospace and resize handle still appears.