### PR TITLE
Convert link-styled buttons to shadcn <Button variant="link">

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -320,13 +320,14 @@ export function Admin() {
                   <currentSectionData.icon className="text-amber-text size-5" />
                 )}
                 {isSubPage ? (
-                  <button
-                    className="text-primary hover:text-amber-text text-xl font-semibold"
+                  <Button
+                    className="hover:text-amber-text h-auto p-0 text-xl font-semibold no-underline hover:no-underline"
                     onClick={() => navigate(`/admin/${currentSection}`)}
                     type="button"
+                    variant="link"
                   >
                     {currentSectionData?.label}
-                  </button>
+                  </Button>
                 ) : (
                   <h1 className="text-primary text-xl font-semibold">
                     {currentSectionData?.label}

--- a/src/components/dashboard/widgets/OutdatedComponentsWidget.tsx
+++ b/src/components/dashboard/widgets/OutdatedComponentsWidget.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, ExternalLink, Package, TrendingUp } from 'lucide-react'
 
 import { Badge, type BadgeProps } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 
 interface OutdatedComponentsWidgetProps {
@@ -105,13 +106,14 @@ export function OutdatedComponentsWidget({
                       </Badge>
                     </div>
 
-                    <button
-                      className="text-info mb-2 text-sm hover:underline"
+                    <Button
+                      className="text-info mb-2 h-auto p-0 text-sm"
                       onClick={() => onProjectSelect?.(item.projectId)}
                       type="button"
+                      variant="link"
                     >
                       {item.project}
-                    </button>
+                    </Button>
 
                     <div className="text-secondary flex items-center gap-3 text-xs">
                       <span className="font-mono">
@@ -128,14 +130,16 @@ export function OutdatedComponentsWidget({
                   </div>
                 </div>
 
-                <button
+                <Button
                   aria-label={`View update details for ${item.component}`}
-                  className="text-secondary hover:bg-secondary hover:text-primary shrink-0 rounded p-2 transition-colors"
+                  className="size-8 shrink-0"
                   onClick={() => onProjectSelect?.(item.projectId)}
+                  size="icon"
                   type="button"
+                  variant="ghost"
                 >
-                  <TrendingUp className="size-4" />
-                </button>
+                  <TrendingUp />
+                </Button>
               </div>
             </div>
           )
@@ -143,14 +147,15 @@ export function OutdatedComponentsWidget({
       </div>
 
       <div className="border-tertiary mt-4 border-t pt-4">
-        <button
-          className="text-info hover:text-info/80 flex items-center gap-1 text-sm"
+        <Button
+          className="text-info hover:text-info/80 h-auto gap-1 p-0 text-sm hover:no-underline"
           onClick={() => onProjectSelect?.('outdated-components')}
           type="button"
+          variant="link"
         >
           View all outdated components
           <ExternalLink className="size-3" />
-        </button>
+        </Button>
       </div>
     </Card>
   )

--- a/src/components/dashboard/widgets/TeamActivityWidget.tsx
+++ b/src/components/dashboard/widgets/TeamActivityWidget.tsx
@@ -7,6 +7,7 @@ import {
   XCircle,
 } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 
 interface TeamActivityWidgetProps {
@@ -133,13 +134,14 @@ export function TeamActivityWidget({ onViewChange }: TeamActivityWidgetProps) {
                   {team.projects} projects
                 </div>
                 <div className="text-secondary text-sm">•</div>
-                <button
-                  className="text-info hover:text-info/80 text-sm"
+                <Button
+                  className="text-info hover:text-info/80 h-auto p-0 text-sm hover:no-underline"
                   onClick={(e) => handleDeploymentClick(e, team.name)}
                   type="button"
+                  variant="link"
                 >
                   {team.deployments} deployments
-                </button>
+                </Button>
               </div>
             </div>
           )

--- a/src/components/dashboard/widgets/UnconnectedIntegrationWidget.tsx
+++ b/src/components/dashboard/widgets/UnconnectedIntegrationWidget.tsx
@@ -99,13 +99,14 @@ export function UnconnectedIntegrationWidget({
             )}
             Connect {plugin.name}
           </Button>
-          <button
-            className="text-secondary hover:text-primary inline-flex items-center gap-1 text-xs font-medium"
+          <Button
+            className="text-secondary hover:text-primary h-auto gap-1 p-0 text-xs font-medium hover:no-underline"
             onClick={onManage}
             type="button"
+            variant="link"
           >
             Manage in settings →
-          </button>
+          </Button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Phase B5 of the shadcn canonical adoption sweep. Four hand-styled "looks like a link" raw `<button>` sites now use the canonical primitive with `className="h-auto p-0"` plus original sizing / color classes preserved. `hover:no-underline` is added where the original didn't underline-on-hover so we don't introduce a new visual.

## Sites converted

- `Admin` section title back-link (when on a sub-page) — keeps `text-xl font-semibold` and the amber hover.
- `OutdatedComponentsWidget` — project name link and the "View all outdated components" footer link. The per-row TrendingUp icon button is also converted to `<Button variant="ghost" size="icon">`.
- `TeamActivityWidget` — "N deployments" inline link.
- `UnconnectedIntegrationWidget` — "Manage in settings →" footer link.

## Deferred

- Widget filter pills (RecentDeploymentsWidget, MyPullRequestsWidget) are segmented controls — handled by the SegmentedControl conversion PR.
- `ProjectPullRequestsTab` retry link is in flight on the tooltip-icon-buttons PR; will pick up in a follow-up.

## Test plan

- [ ] `npm run build` passes.
- [ ] Navigate to `/admin/teams/new` then click back-title — sub-page navigation works.
- [ ] On Dashboard, click "View all outdated components" + project links.
- [ ] On Dashboard, click "Manage in settings →" link.