### PR TITLE
Convert plain text inputs to shadcn <Input>

### DIFF
--- a/src/components/admin/service-accounts/ApiKeysSection.tsx
+++ b/src/components/admin/service-accounts/ApiKeysSection.tsx
@@ -15,6 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import {
   Tooltip,
   TooltipContent,
@@ -246,9 +247,9 @@ export function ApiKeysSection({
               <label className="text-secondary mb-1.5 block text-sm">
                 Key name
               </label>
-              <input
+              <Input
                 autoFocus
-                className="border-input bg-background text-foreground placeholder:text-muted-foreground focus:ring-action w-full rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+                className="rounded-lg"
                 onChange={(e) => setNewKeyName(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/api/endpoints'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { LoadingState } from '@/components/ui/loading-state'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { cn, sortEnvironments } from '@/lib/utils'
@@ -415,9 +416,9 @@ function BranchPicker({
   return (
     <div className="grid grid-cols-2 gap-3">
       <div className="flex flex-col gap-2">
-        <input
+        <Input
           aria-label="Filter branches"
-          className="border-secondary placeholder:text-tertiary focus:border-action rounded-md border bg-transparent px-2 py-1 text-sm focus:outline-none"
+          className="h-8"
           onChange={(e) => onQueryChange(e.target.value)}
           placeholder="Filter branches…"
           type="text"


### PR DESCRIPTION
## Summary

Phase B6 of the shadcn canonical adoption sweep. Two raw `<input type="text">` sites now use the canonical `<Input>` primitive; the reimplemented border / bg / focus-ring utility classes drop because `<Input>` already supplies them.

## Sites converted

- `DeployTab` — branch filter input. Keeps `h-8` via className for the tighter toolbar height.
- `ApiKeysSection` — new-key-name input in the create dialog. Keeps `rounded-lg` for parity with the surrounding form.

## KEEPs (matches audit)

- Chip-input patterns: `AuthProvidersManagement`, `TagCombobox`, `ServicePluginConfiguration` — borderless inputs inside a chip container.
- `CommandBar` and `DocumentsPinboardNew` title — borderless full-bleed editors.
- `LogsTab` toolbar/datetime-local inputs — borderless inputs inside a custom toolbar frame.
- `AvatarUpload` hidden file input.
- `ProjectPullRequestsTab` filter input — already touched in #351; will follow up.

## Test plan

- [ ] `npm run build` passes.
- [ ] Visit a project's Deploy tab, type into the branch filter.
- [ ] Open API key creation dialog on a service account, type a name, press Enter.