### PR TITLE
Convert raw <label> to shadcn <Label> in blueprints + scoring forms

### DIFF
--- a/src/components/admin/blueprints/BlueprintFilterEditor.tsx
+++ b/src/components/admin/blueprints/BlueprintFilterEditor.tsx
@@ -1,6 +1,7 @@
 import { Filter } from 'lucide-react'
 
 import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
 import type { Environment, ProjectType } from '@/types'
 
 interface BlueprintFilterEditorProps {
@@ -56,12 +57,12 @@ export function BlueprintFilterEditor({
               }
             }}
           />
-          <label
+          <Label
             className="text-secondary cursor-pointer text-sm select-none"
             htmlFor="filter-enabled"
           >
             Enable filter
-          </label>
+          </Label>
         </div>
       </div>
 
@@ -74,9 +75,9 @@ export function BlueprintFilterEditor({
 
           {/* Project Type filter */}
           <div>
-            <label className="text-secondary mb-2 block text-sm font-medium">
+            <Label className="text-secondary mb-2 block text-sm font-medium">
               Project Types
-            </label>
+            </Label>
             {ptLoading ? (
               <p className="text-tertiary text-xs italic">
                 Loading project types...
@@ -107,14 +108,14 @@ export function BlueprintFilterEditor({
                         setSelectedProjectTypes(next)
                       }}
                     />
-                    <label
+                    <Label
                       className={
                         'text-secondary cursor-pointer text-sm select-none'
                       }
                       htmlFor={`filter-pt-${pt.slug}`}
                     >
                       {pt.name}
-                    </label>
+                    </Label>
                   </div>
                 ))}
               </div>
@@ -123,9 +124,9 @@ export function BlueprintFilterEditor({
 
           {/* Environment filter */}
           <div>
-            <label className="text-secondary mb-2 block text-sm font-medium">
+            <Label className="text-secondary mb-2 block text-sm font-medium">
               Environments
-            </label>
+            </Label>
             {envLoading ? (
               <p className="text-tertiary text-xs italic">
                 Loading environments...
@@ -156,14 +157,14 @@ export function BlueprintFilterEditor({
                         setSelectedEnvironments(next)
                       }}
                     />
-                    <label
+                    <Label
                       className={
                         'text-secondary cursor-pointer text-sm select-none'
                       }
                       htmlFor={`filter-env-${env.slug}`}
                     >
                       {env.name}
-                    </label>
+                    </Label>
                   </div>
                 ))}
               </div>

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -547,9 +548,9 @@ export function BlueprintForm({
         <div className="grid grid-cols-2 gap-4">
           {/* Name */}
           <div>
-            <label className="text-secondary mb-1.5 block text-sm">
+            <Label className="text-secondary mb-1.5 block text-sm">
               Name <RequiredAsterisk />
-            </label>
+            </Label>
             <Input
               className=""
               disabled={isLoading}
@@ -575,9 +576,9 @@ export function BlueprintForm({
           {/* Slug */}
           {!isEditing && (
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Slug
-              </label>
+              </Label>
               <Input
                 className="font-mono"
                 disabled={isLoading}
@@ -600,9 +601,9 @@ export function BlueprintForm({
 
           {/* Kind */}
           <div>
-            <label className="text-secondary mb-1.5 block text-sm">
+            <Label className="text-secondary mb-1.5 block text-sm">
               Kind <RequiredAsterisk />
-            </label>
+            </Label>
             <Select
               disabled={isLoading || isEditing}
               onValueChange={(v) => setKind(v as 'node' | 'relationship')}
@@ -626,9 +627,9 @@ export function BlueprintForm({
           {/* Type (node) or Source/Target/Edge (relationship) */}
           {kind === 'node' ? (
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Type <RequiredAsterisk />
-              </label>
+              </Label>
               <Select
                 disabled={isLoading || isEditing}
                 onValueChange={(v) => {
@@ -657,9 +658,9 @@ export function BlueprintForm({
           ) : (
             <div className="col-span-2 grid grid-cols-[1fr_auto_1fr_auto_1fr] items-end gap-2">
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Source <RequiredAsterisk />
-                </label>
+                </Label>
                 <Select
                   disabled={isLoading || isEditing}
                   onValueChange={(v) => {
@@ -689,9 +690,9 @@ export function BlueprintForm({
               </div>
               <div className="text-tertiary pb-2">→</div>
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Relationship Type <RequiredAsterisk />
-                </label>
+                </Label>
                 {source &&
                 target &&
                 (getRelationshipTypes(source, target).length === 0 ||
@@ -742,9 +743,9 @@ export function BlueprintForm({
               </div>
               <div className="text-tertiary pb-2">→</div>
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Target <RequiredAsterisk />
-                </label>
+                </Label>
                 <Select
                   disabled={isLoading || isEditing}
                   onValueChange={(v) => {
@@ -777,9 +778,9 @@ export function BlueprintForm({
 
           {/* Priority */}
           <div>
-            <label className="text-secondary mb-1.5 block text-sm">
+            <Label className="text-secondary mb-1.5 block text-sm">
               Priority
-            </label>
+            </Label>
             <Input
               className=""
               disabled={isLoading}
@@ -801,9 +802,9 @@ export function BlueprintForm({
 
           {/* Description */}
           <div className="col-span-2">
-            <label className="text-secondary mb-1.5 block text-sm">
+            <Label className="text-secondary mb-1.5 block text-sm">
               Description
-            </label>
+            </Label>
             <Textarea
               className="resize-none"
               disabled={isLoading}
@@ -823,12 +824,12 @@ export function BlueprintForm({
                 id="blueprint-enabled"
                 onCheckedChange={(checked) => setEnabled(checked === true)}
               />
-              <label
+              <Label
                 className="text-secondary cursor-pointer text-sm select-none"
                 htmlFor="blueprint-enabled"
               >
                 Enabled
-              </label>
+              </Label>
             </div>
             <p className="text-tertiary mt-1 ml-6 text-xs">
               Disabled blueprints are not applied to entities

--- a/src/components/admin/blueprints/BlueprintSchemaPropertyRow.tsx
+++ b/src/components/admin/blueprints/BlueprintSchemaPropertyRow.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react'
 
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -149,12 +150,12 @@ export function BlueprintSchemaPropertyRow({
               })
             }
           />
-          <label
+          <Label
             className={'text-secondary cursor-pointer text-xs select-none'}
             htmlFor={`req-${prop.id}`}
           >
             Required
-          </label>
+          </Label>
         </div>
 
         <div className="flex items-center gap-1.5">
@@ -167,12 +168,12 @@ export function BlueprintSchemaPropertyRow({
               })
             }
           />
-          <label
+          <Label
             className={'text-secondary cursor-pointer text-xs select-none'}
             htmlFor={`editable-${prop.id}`}
           >
             Editable
-          </label>
+          </Label>
         </div>
 
         <TooltipProvider delayDuration={200}>
@@ -225,9 +226,9 @@ export function BlueprintSchemaPropertyRow({
         <div className="border-secondary space-y-3 border-t px-3 pt-2 pb-3">
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="text-secondary mb-1 block text-xs">
+              <Label className="text-secondary mb-1 block text-xs">
                 Description
-              </label>
+              </Label>
               <Input
                 className="text-sm"
                 onChange={(e) =>
@@ -240,9 +241,9 @@ export function BlueprintSchemaPropertyRow({
               />
             </div>
             <div>
-              <label className="text-secondary mb-1 block text-xs">
+              <Label className="text-secondary mb-1 block text-xs">
                 Default Value
-              </label>
+              </Label>
               <Input
                 className="text-sm"
                 onChange={(e) =>
@@ -259,9 +260,9 @@ export function BlueprintSchemaPropertyRow({
           {prop.type === 'string' && (
             <div className="grid grid-cols-3 gap-3">
               <div>
-                <label className="text-secondary mb-1 block text-xs">
+                <Label className="text-secondary mb-1 block text-xs">
                   Format
-                </label>
+                </Label>
                 {/* Radix disallows '' as a SelectItem value; the empty
                     STRING_FORMATS entry becomes "none" and gets translated
                     back to undefined on store. */}
@@ -286,9 +287,9 @@ export function BlueprintSchemaPropertyRow({
                 </Select>
               </div>
               <div>
-                <label className="text-secondary mb-1 block text-xs">
+                <Label className="text-secondary mb-1 block text-xs">
                   Min Length
-                </label>
+                </Label>
                 <Input
                   className="text-sm"
                   onChange={(e) =>
@@ -303,9 +304,9 @@ export function BlueprintSchemaPropertyRow({
                 />
               </div>
               <div>
-                <label className="text-secondary mb-1 block text-xs">
+                <Label className="text-secondary mb-1 block text-xs">
                   Max Length
-                </label>
+                </Label>
                 <Input
                   className="text-sm"
                   onChange={(e) =>
@@ -325,9 +326,9 @@ export function BlueprintSchemaPropertyRow({
           {prop.type === 'array' && (
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-secondary mb-1 block text-xs">
+                <Label className="text-secondary mb-1 block text-xs">
                   Items Type
-                </label>
+                </Label>
                 <Select
                   onValueChange={(v) =>
                     updateProperty(prop.id, {
@@ -349,9 +350,9 @@ export function BlueprintSchemaPropertyRow({
                 </Select>
               </div>
               <div>
-                <label className="text-secondary mb-1 block text-xs">
+                <Label className="text-secondary mb-1 block text-xs">
                   Items Enum (comma-separated)
-                </label>
+                </Label>
                 <Input
                   className="text-sm"
                   onBlur={() => {
@@ -393,9 +394,9 @@ export function BlueprintSchemaPropertyRow({
           {(prop.type === 'integer' || prop.type === 'number') && (
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-secondary mb-1 block text-xs">
+                <Label className="text-secondary mb-1 block text-xs">
                   Minimum
-                </label>
+                </Label>
                 <Input
                   className="text-sm"
                   onChange={(e) =>
@@ -410,9 +411,9 @@ export function BlueprintSchemaPropertyRow({
                 />
               </div>
               <div>
-                <label className="text-secondary mb-1 block text-xs">
+                <Label className="text-secondary mb-1 block text-xs">
                   Maximum
-                </label>
+                </Label>
                 <Input
                   className="text-sm"
                   onChange={(e) =>
@@ -430,9 +431,9 @@ export function BlueprintSchemaPropertyRow({
           )}
 
           <div>
-            <label className="text-secondary mb-1 block text-xs">
+            <Label className="text-secondary mb-1 block text-xs">
               Enum Values (comma-separated)
-            </label>
+            </Label>
             <Input
               className="text-sm"
               onBlur={() => {

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -323,12 +324,12 @@ export function ScoringPolicyForm({
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-name"
                 >
                   Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={errors.name ? 'border-danger' : ''}
                   disabled={isLoading}
@@ -340,12 +341,12 @@ export function ScoringPolicyForm({
                 {fieldError('name')}
               </div>
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-slug"
                 >
                   Slug <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={errors.slug ? 'border-danger' : ''}
                   disabled={isEditing || isLoading}
@@ -359,12 +360,12 @@ export function ScoringPolicyForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="sp-description"
               >
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -386,12 +387,12 @@ export function ScoringPolicyForm({
           <CardContent className="space-y-4">
             {category === 'link_presence' ? (
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-link-slug"
                 >
                   Required Link Type <RequiredAsterisk />
-                </label>
+                </Label>
                 <Select
                   disabled={isLoading}
                   onValueChange={setLinkSlug}
@@ -425,12 +426,12 @@ export function ScoringPolicyForm({
               </div>
             ) : (
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-attribute"
                 >
                   Attribute Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={errors.attribute_name ? 'border-danger' : ''}
                   disabled={isLoading}
@@ -454,12 +455,12 @@ export function ScoringPolicyForm({
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-weight"
                 >
                   Weight (0–100) <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={errors.weight ? 'border-danger' : ''}
                   disabled={isLoading}
@@ -474,12 +475,12 @@ export function ScoringPolicyForm({
               </div>
 
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="sp-priority"
                 >
                   Priority
-                </label>
+                </Label>
                 <Input
                   disabled={isLoading}
                   id="sp-priority"
@@ -493,7 +494,7 @@ export function ScoringPolicyForm({
               </div>
 
               <div className="flex flex-col justify-center gap-1.5">
-                <label className="text-secondary text-sm">Enabled</label>
+                <Label className="text-secondary text-sm">Enabled</Label>
                 <Switch
                   checked={enabled}
                   disabled={isLoading}
@@ -512,9 +513,9 @@ export function ScoringPolicyForm({
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Mapping type
-                </label>
+                </Label>
                 <div className="flex gap-3">
                   {(['value', 'range'] as const).map((t) => (
                     <button
@@ -598,12 +599,12 @@ export function ScoringPolicyForm({
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
-                  <label
+                  <Label
                     className="text-secondary mb-1.5 block text-sm"
                     htmlFor="sp-present-score"
                   >
                     Present score (0–100)
-                  </label>
+                  </Label>
                   <Input
                     className={errors.present_score ? 'border-danger' : ''}
                     disabled={isLoading}
@@ -622,12 +623,12 @@ export function ScoringPolicyForm({
                   {fieldError('present_score')}
                 </div>
                 <div>
-                  <label
+                  <Label
                     className="text-secondary mb-1.5 block text-sm"
                     htmlFor="sp-missing-score"
                   >
                     Missing score (0–100)
-                  </label>
+                  </Label>
                   <Input
                     className={errors.missing_score ? 'border-danger' : ''}
                     disabled={isLoading}
@@ -687,12 +688,12 @@ export function ScoringPolicyForm({
                         )
                       }
                     />
-                    <label
+                    <Label
                       className="text-secondary cursor-pointer text-sm select-none"
                       htmlFor={`target-pt-${pt.slug}`}
                     >
                       {pt.name}
-                    </label>
+                    </Label>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

Phase C-1 of the shadcn canonical adoption sweep — first slice of the label conversion. 39 raw `<label>` sites across four files now use the canonical `<Label>` primitive.

- `BlueprintForm.tsx` (10)
- `BlueprintSchemaPropertyRow.tsx` (12)
- `BlueprintFilterEditor.tsx` (5)
- `ScoringPolicyForm.tsx` (12)

Layout classes (`mb-1.5 block text-secondary`, etc.) are preserved verbatim. The new `font-medium` that `<Label>` contributes is a small visual unification with the rest of the shadcn-driven forms (matches the rendering in Input, Textarea, Switch, etc.). `htmlFor` wiring is preserved where present; the missing `htmlFor` pairs are a pre-existing a11y debt the audit flagged for a separate sweep.

## Test plan

- [ ] `npm run build` passes.
- [ ] Open `/admin/blueprints/new`, `/admin/scoring-policies/new` — confirm form labels render consistently and clicking a label focuses the input where `htmlFor` is set.