### PR TITLE
Convert raw <label> to shadcn <Label> in 3p / identity / webhook forms

### DIFF
--- a/src/components/admin/AuthProvidersManagement.tsx
+++ b/src/components/admin/AuthProvidersManagement.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/ui/dialog'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { LoadingState } from '@/components/ui/loading-state'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
@@ -502,9 +503,9 @@ function AuthProviderCreateDialog({
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 p-6">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 OAuth Type <RequiredAsterisk />
-              </label>
+              </Label>
               <Select
                 disabled={isSaving}
                 onValueChange={(v) => setAppType(v as OAuthAppType)}
@@ -522,9 +523,9 @@ function AuthProviderCreateDialog({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Redirect URL
-              </label>
+              </Label>
               <div className="flex items-center gap-2">
                 <Input
                   className="flex-1 font-mono text-xs"
@@ -547,9 +548,9 @@ function AuthProviderCreateDialog({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Client ID <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 disabled={isSaving}
                 onChange={(e) => setClientId(e.target.value)}
@@ -563,9 +564,9 @@ function AuthProviderCreateDialog({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Client Secret <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 autoComplete="new-password"
                 disabled={isSaving}
@@ -582,9 +583,9 @@ function AuthProviderCreateDialog({
 
             {showIssuerUrl && (
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Issuer URL <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   disabled={isSaving}
                   onChange={(e) => setIssuerUrl(e.target.value)}
@@ -600,9 +601,9 @@ function AuthProviderCreateDialog({
             )}
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Scopes
-              </label>
+              </Label>
               <Input
                 disabled={isSaving}
                 onChange={(e) => setScopes(e.target.value)}
@@ -613,9 +614,9 @@ function AuthProviderCreateDialog({
 
             {showAllowedDomains && (
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Allowed Email Domains
-                </label>
+                </Label>
                 <div
                   className={
                     'border-input bg-background flex flex-wrap items-center gap-2 rounded-lg border p-2'
@@ -673,7 +674,7 @@ function AuthProviderCreateDialog({
               </div>
             )}
 
-            <label className="text-secondary flex w-full items-center gap-2 text-sm">
+            <Label className="text-secondary flex w-full items-center gap-2 text-sm">
               <Checkbox
                 checked={enableIntegration}
                 disabled={isSaving}
@@ -682,7 +683,7 @@ function AuthProviderCreateDialog({
                 }
               />
               Enable Integration
-            </label>
+            </Label>
           </div>
 
           <DialogFooter>
@@ -821,9 +822,9 @@ function AuthProviderEditDialog({
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 p-6">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Display Name <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 disabled={isSaving}
                 onChange={(e) => setName(e.target.value)}
@@ -835,9 +836,9 @@ function AuthProviderEditDialog({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 OAuth Type <RequiredAsterisk />
-              </label>
+              </Label>
               <Select
                 disabled={isSaving}
                 onValueChange={(v) => setAppType(v as OAuthAppType)}
@@ -855,9 +856,9 @@ function AuthProviderEditDialog({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Client ID <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 disabled={isSaving}
                 onChange={(e) => setClientId(e.target.value)}
@@ -871,9 +872,9 @@ function AuthProviderEditDialog({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Client Secret
-              </label>
+              </Label>
               {provider.has_secret && !replaceSecret ? (
                 <div
                   className={
@@ -932,9 +933,9 @@ function AuthProviderEditDialog({
 
             {showIssuerUrl && (
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Issuer URL <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   disabled={isSaving}
                   onChange={(e) => setIssuerUrl(e.target.value)}
@@ -950,9 +951,9 @@ function AuthProviderEditDialog({
             )}
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Scopes
-              </label>
+              </Label>
               <Input
                 disabled={isSaving}
                 onChange={(e) => setScopes(e.target.value)}
@@ -963,9 +964,9 @@ function AuthProviderEditDialog({
 
             {showAllowedDomains && (
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Allowed Email Domains
-                </label>
+                </Label>
                 <div
                   className={
                     'border-input bg-background flex flex-wrap items-center gap-2 rounded-lg border p-2'
@@ -1023,7 +1024,7 @@ function AuthProviderEditDialog({
               </div>
             )}
 
-            <label className="text-secondary flex w-full items-center gap-2 text-sm">
+            <Label className="text-secondary flex w-full items-center gap-2 text-sm">
               <Checkbox
                 checked={enableIntegration}
                 disabled={isSaving}
@@ -1032,7 +1033,7 @@ function AuthProviderEditDialog({
                 }
               />
               Enable Integration
-            </label>
+            </Label>
           </div>
 
           <DialogFooter>

--- a/src/components/admin/service-accounts/ServiceAccountForm.tsx
+++ b/src/components/admin/service-accounts/ServiceAccountForm.tsx
@@ -8,6 +8,7 @@ import { FormHeader } from '@/components/admin/form-header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -301,9 +302,9 @@ export function ServiceAccountForm({
           <div className="grid grid-cols-2 gap-4">
             {/* Display Name */}
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Display Name <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 disabled={isLoading}
                 onBlur={() => {
@@ -328,9 +329,9 @@ export function ServiceAccountForm({
 
             {/* Slug */}
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Slug <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 disabled={isLoading}
                 onBlur={() => {
@@ -356,12 +357,12 @@ export function ServiceAccountForm({
 
           {/* Description */}
           <div>
-            <label className="text-secondary mb-1.5 flex items-center justify-between text-sm">
+            <Label className="text-secondary mb-1.5 flex items-center justify-between text-sm">
               <span>Description</span>
               <span className="text-tertiary text-xs">
                 {description.length}/500
               </span>
-            </label>
+            </Label>
             <Textarea
               disabled={isLoading}
               maxLength={500}
@@ -393,12 +394,12 @@ export function ServiceAccountForm({
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="service-account-org"
               >
                 Organization <RequiredAsterisk />
-              </label>
+              </Label>
               <Select
                 disabled={isLoading || organizations.length === 1}
                 onValueChange={(v) => {
@@ -427,12 +428,12 @@ export function ServiceAccountForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="service-account-role"
               >
                 Role <RequiredAsterisk />
-              </label>
+              </Label>
               {rolesLoading ? (
                 <p className="text-secondary text-sm">Loading roles...</p>
               ) : rolesError ? (
@@ -677,9 +678,9 @@ function IdentityCardEdit({
         {/* Display name + slug in one row */}
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="text-secondary mb-1.5 block text-sm">
+            <Label className="text-secondary mb-1.5 block text-sm">
               Display name <RequiredAsterisk />
-            </label>
+            </Label>
             <Input
               disabled={isLoading}
               onBlur={onBlurDisplayName}
@@ -694,12 +695,12 @@ function IdentityCardEdit({
             )}
           </div>
           <div>
-            <label className="text-secondary mb-1.5 flex items-center justify-between text-sm">
+            <Label className="text-secondary mb-1.5 flex items-center justify-between text-sm">
               <span>Slug</span>
               <span className="text-tertiary text-xs">
                 URL identifier · read-only
               </span>
-            </label>
+            </Label>
             <Input
               className="text-tertiary font-mono"
               disabled
@@ -710,12 +711,12 @@ function IdentityCardEdit({
 
         {/* Description */}
         <div>
-          <label className="text-secondary mb-1.5 flex items-center justify-between text-sm">
+          <Label className="text-secondary mb-1.5 flex items-center justify-between text-sm">
             <span>Description</span>
             <span className="text-tertiary text-xs">
               {description.length}/500
             </span>
-          </label>
+          </Label>
           <Textarea
             disabled={isLoading}
             maxLength={500}
@@ -728,7 +729,7 @@ function IdentityCardEdit({
 
         {/* Avatar */}
         <div>
-          <label className="text-secondary mb-1.5 block text-sm">Avatar</label>
+          <Label className="text-secondary mb-1.5 block text-sm">Avatar</Label>
           <div className="flex items-center gap-3">
             <AvatarUpload
               avatarUrl={account.avatar_url}

--- a/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
+++ b/src/components/admin/third-party-services/ApplicationSecretsPanel.tsx
@@ -19,6 +19,7 @@ import {
 import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import {
   Tooltip,
@@ -267,9 +268,9 @@ export function ApplicationSecretsPanel({
 
           {visibleFields.map((field) => (
             <div key={field}>
-              <label className="text-secondary mb-1 block text-sm font-medium">
+              <Label className="text-secondary mb-1 block text-sm font-medium">
                 {FIELD_LABELS[field]}
-              </label>
+              </Label>
               {field === 'private_key' ? (
                 <Textarea
                   className="font-mono"

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -5,6 +5,7 @@ import { AlertCircle } from 'lucide-react'
 import { API_BASE_URL } from '@/api/client'
 import { FormHeader } from '@/components/admin/form-header'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   SegmentedControl,
   SegmentedControlItem,
@@ -233,7 +234,7 @@ export function OAuth2ApplicationForm({
       <div className="border-border bg-card space-y-4 rounded-lg border p-6">
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className={labelClass}>Name *</label>
+            <Label className={labelClass}>Name *</Label>
             <Input
               className={inputClass}
               onChange={(e) => handleNameChange(e.target.value)}
@@ -242,7 +243,7 @@ export function OAuth2ApplicationForm({
             />
           </div>
           <div>
-            <label className={labelClass}>Slug *</label>
+            <Label className={labelClass}>Slug *</Label>
             <Input
               className={inputClass}
               disabled={isEdit}
@@ -254,7 +255,7 @@ export function OAuth2ApplicationForm({
         </div>
 
         <div>
-          <label className={labelClass}>Description</label>
+          <Label className={labelClass}>Description</Label>
           <Input
             className={inputClass}
             onChange={(e) => setDescription(e.target.value)}
@@ -265,7 +266,7 @@ export function OAuth2ApplicationForm({
 
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div>
-            <label className={labelClass}>Application URL</label>
+            <Label className={labelClass}>Application URL</Label>
             <Input
               className={inputClass}
               onChange={(e) => setApplicationUrl(e.target.value)}
@@ -274,7 +275,7 @@ export function OAuth2ApplicationForm({
             />
           </div>
           <div>
-            <label className={labelClass}>Callback URL</label>
+            <Label className={labelClass}>Callback URL</Label>
             <Input
               className={inputClass}
               onChange={(e) => handleCallbackUrlChange(e.target.value)}
@@ -286,7 +287,7 @@ export function OAuth2ApplicationForm({
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className={labelClass}>Application Type *</label>
+            <Label className={labelClass}>Application Type *</Label>
             <Select
               disabled={isEdit}
               onValueChange={setAppType}
@@ -305,7 +306,7 @@ export function OAuth2ApplicationForm({
             </Select>
           </div>
           <div>
-            <label className={labelClass}>Status</label>
+            <Label className={labelClass}>Status</Label>
             <Select
               onValueChange={(v) =>
                 setStatus(v as 'active' | 'inactive' | 'revoked')
@@ -326,7 +327,7 @@ export function OAuth2ApplicationForm({
 
         {isEdit && canManageAuthProviders && initialUsage === 'integration' && (
           <div>
-            <label className={labelClass}>Usage</label>
+            <Label className={labelClass}>Usage</Label>
             <SegmentedControl
               ariaLabel="Usage"
               onValueChange={(v) => setUsage(v as 'both' | 'integration')}
@@ -361,7 +362,7 @@ export function OAuth2ApplicationForm({
 
         {isEdit && initialUsage === 'both' && (
           <div>
-            <label className={labelClass}>Usage</label>
+            <Label className={labelClass}>Usage</Label>
             <p className="text-secondary text-sm">
               Integration + Login. Demote from the Auth Providers screen to drop
               the login face.
@@ -370,7 +371,7 @@ export function OAuth2ApplicationForm({
         )}
 
         <div>
-          <label className={labelClass}>Client ID *</label>
+          <Label className={labelClass}>Client ID *</Label>
           <Input
             className={inputClass}
             onChange={(e) => setClientId(e.target.value)}
@@ -380,7 +381,7 @@ export function OAuth2ApplicationForm({
         </div>
 
         <div>
-          <label className={labelClass}>Scopes</label>
+          <Label className={labelClass}>Scopes</Label>
           <Input
             className={inputClass}
             onChange={(e) => setScopes(e.target.value)}
@@ -399,7 +400,7 @@ export function OAuth2ApplicationForm({
             </div>
 
             <div>
-              <label className={labelClass}>Client Secret *</label>
+              <Label className={labelClass}>Client Secret *</Label>
               <Input
                 className={inputClass}
                 onChange={(e) => setClientSecret(e.target.value)}
@@ -411,7 +412,7 @@ export function OAuth2ApplicationForm({
 
             {extraSecretFields.includes('webhook_secret') && (
               <div>
-                <label className={labelClass}>Webhook Secret</label>
+                <Label className={labelClass}>Webhook Secret</Label>
                 <Input
                   className={inputClass}
                   onChange={(e) => setWebhookSecret(e.target.value)}
@@ -424,7 +425,7 @@ export function OAuth2ApplicationForm({
 
             {extraSecretFields.includes('private_key') && (
               <div>
-                <label className={labelClass}>Private Key (PEM)</label>
+                <Label className={labelClass}>Private Key (PEM)</Label>
                 <Textarea
                   className="font-mono"
                   onChange={(e) => setPrivateKey(e.target.value)}
@@ -437,7 +438,7 @@ export function OAuth2ApplicationForm({
 
             {extraSecretFields.includes('signing_secret') && (
               <div>
-                <label className={labelClass}>Signing Secret</label>
+                <Label className={labelClass}>Signing Secret</Label>
                 <Input
                   className={inputClass}
                   onChange={(e) => setSigningSecret(e.target.value)}

--- a/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
+++ b/src/components/admin/third-party-services/ThirdPartyServiceForm.tsx
@@ -9,6 +9,7 @@ import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
 import { KeyValueEditor } from '@/components/ui/key-value-editor'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -212,9 +213,9 @@ export function ThirdPartyServiceForm({
 
           <div className="space-y-4">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Managing Team
-              </label>
+              </Label>
               {/* Radix disallows '' as a SelectItem value, so 'none' is the
                   empty sentinel and gets translated at the boundary. */}
               <Select
@@ -240,9 +241,9 @@ export function ThirdPartyServiceForm({
               className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
             >
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Service Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.name ? 'border-danger' : ''}`}
                   disabled={isLoading}
@@ -264,9 +265,9 @@ export function ThirdPartyServiceForm({
 
               {!isEditing && (
                 <div>
-                  <label className="text-secondary mb-1.5 block text-sm">
+                  <Label className="text-secondary mb-1.5 block text-sm">
                     Slug <RequiredAsterisk />
-                  </label>
+                  </Label>
                   <Input
                     className={` ${errors.slug ? 'border-danger' : ''}`}
                     disabled={isLoading}
@@ -290,9 +291,9 @@ export function ThirdPartyServiceForm({
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Vendor <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.vendor ? 'border-danger' : ''}`}
                   disabled={isLoading}
@@ -313,9 +314,9 @@ export function ThirdPartyServiceForm({
               </div>
 
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Category
-                </label>
+                </Label>
                 <Input
                   className=""
                   disabled={isLoading}
@@ -328,9 +329,9 @@ export function ThirdPartyServiceForm({
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Service URL
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.service_url ? 'border-danger' : ''}`}
                   disabled={isLoading}
@@ -351,9 +352,9 @@ export function ThirdPartyServiceForm({
               </div>
 
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Status
-                </label>
+                </Label>
                 <Select
                   disabled={isLoading}
                   onValueChange={(v) =>
@@ -378,9 +379,9 @@ export function ThirdPartyServiceForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -392,9 +393,9 @@ export function ThirdPartyServiceForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Icon
-              </label>
+              </Label>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <p className="text-tertiary mb-1.5 text-xs">Pick an icon</p>
@@ -436,9 +437,9 @@ export function ThirdPartyServiceForm({
 
           <div className="space-y-4">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 API Endpoint
-              </label>
+              </Label>
               <Input
                 className={errors.api_endpoint ? 'border-danger' : ''}
                 disabled={isLoading}
@@ -456,9 +457,9 @@ export function ThirdPartyServiceForm({
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Authorization Endpoint
-                </label>
+                </Label>
                 <Input
                   className={
                     errors.authorization_endpoint ? 'border-danger' : ''
@@ -477,9 +478,9 @@ export function ThirdPartyServiceForm({
               </div>
 
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Token Endpoint
-                </label>
+                </Label>
                 <Input
                   className={errors.token_endpoint ? 'border-danger' : ''}
                   disabled={isLoading}
@@ -498,9 +499,9 @@ export function ThirdPartyServiceForm({
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Revoke Endpoint
-                </label>
+                </Label>
                 <Input
                   className={errors.revoke_endpoint ? 'border-danger' : ''}
                   disabled={isLoading}
@@ -517,9 +518,9 @@ export function ThirdPartyServiceForm({
               </div>
 
               <div className="flex flex-col justify-center">
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Use PKCE
-                </label>
+                </Label>
                 <Select
                   disabled={isLoading}
                   onValueChange={(v) =>

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -12,6 +12,7 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -267,9 +268,9 @@ export function WebhookForm({
         <Card>
           <CardContent className="space-y-4 pt-6">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Name <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 className={` ${errors.name ? 'border-red-500' : ''}`}
                 disabled={isLoading}
@@ -296,12 +297,12 @@ export function WebhookForm({
             {/* Slug — only shown and editable when editing an existing webhook */}
             {isEditing && (
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Slug{' '}
                   <span className="text-tertiary text-xs">
                     (auto-regenerated when service changes; editable)
                   </span>
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.slug ? 'border-red-500' : ''}`}
                   disabled={isLoading}
@@ -326,10 +327,10 @@ export function WebhookForm({
             {isEditing && webhook && (
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
-                  <label className="text-secondary mb-1.5 block text-sm">
+                  <Label className="text-secondary mb-1.5 block text-sm">
                     ID{' '}
                     <span className="text-tertiary text-xs">(read-only)</span>
-                  </label>
+                  </Label>
                   <div className="border-input bg-muted rounded-lg border px-3 py-2">
                     <code className="text-muted-foreground text-sm">
                       {webhook.id}
@@ -337,10 +338,10 @@ export function WebhookForm({
                   </div>
                 </div>
                 <div>
-                  <label className="text-secondary mb-1.5 block text-sm">
+                  <Label className="text-secondary mb-1.5 block text-sm">
                     Notification Path{' '}
                     <span className="text-tertiary text-xs">(read-only)</span>
-                  </label>
+                  </Label>
                   <div className="border-input bg-muted rounded-lg border px-3 py-2">
                     <code className="text-muted-foreground text-sm">
                       {webhook.notification_path}
@@ -351,14 +352,14 @@ export function WebhookForm({
             )}
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Secret{' '}
                 {isEditing && (
                   <span className="text-tertiary text-xs">
                     (leave blank to keep current)
                   </span>
                 )}
-              </label>
+              </Label>
               <Input
                 className=""
                 disabled={isLoading}
@@ -372,9 +373,9 @@ export function WebhookForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -386,9 +387,9 @@ export function WebhookForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Icon
-              </label>
+              </Label>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <p className="text-tertiary mb-1.5 text-xs">Pick an icon</p>
@@ -434,12 +435,12 @@ export function WebhookForm({
 
             <div className="space-y-4">
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="webhook-tps"
                 >
                   Third-Party Service
-                </label>
+                </Label>
                 {/* Radix disallows '' as a SelectItem value, so 'none' is
                     the empty sentinel and gets translated at the boundary. */}
                 <Select
@@ -466,9 +467,9 @@ export function WebhookForm({
               {tpsSlug && (
                 <>
                   <div>
-                    <label className="text-secondary mb-1.5 block text-sm">
+                    <Label className="text-secondary mb-1.5 block text-sm">
                       Identifier Selector (JSON Path)
-                    </label>
+                    </Label>
                     <Input
                       className={`font-mono text-sm ${
                         errors.identifier_selector ? 'border-red-500' : ''
@@ -495,9 +496,9 @@ export function WebhookForm({
                   </div>
 
                   <div>
-                    <label className="text-secondary mb-1.5 block text-sm">
+                    <Label className="text-secondary mb-1.5 block text-sm">
                       User Subject Selector (JSON Pointer)
-                    </label>
+                    </Label>
                     <Input
                       className={`font-mono text-sm ${
                         errors.user_subject_selector ? 'border-red-500' : ''
@@ -525,10 +526,10 @@ export function WebhookForm({
                   </div>
 
                   <div>
-                    <label className="text-secondary mb-1.5 block text-sm">
+                    <Label className="text-secondary mb-1.5 block text-sm">
                       Identity Plugin Slug{' '}
                       <span className="text-tertiary text-xs">(optional)</span>
-                    </label>
+                    </Label>
                     <Input
                       className={`font-mono text-sm ${
                         errors.identity_plugin_slug ? 'border-red-500' : ''
@@ -556,10 +557,10 @@ export function WebhookForm({
                   </div>
 
                   <div>
-                    <label className="text-secondary mb-1.5 block text-sm">
+                    <Label className="text-secondary mb-1.5 block text-sm">
                       Event Type Selector{' '}
                       <span className="text-tertiary text-xs">(optional)</span>
-                    </label>
+                    </Label>
                     <Input
                       className={`font-mono text-sm ${
                         errors.event_type_selector ? 'border-red-500' : ''
@@ -665,9 +666,9 @@ export function WebhookForm({
                       <div className="flex-1 space-y-3">
                         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                           <div>
-                            <label className="text-secondary mb-1 block text-xs">
+                            <Label className="text-secondary mb-1 block text-xs">
                               Filter Expression (CEL) <RequiredAsterisk />
-                            </label>
+                            </Label>
                             <Input
                               className={`font-mono text-sm ${
                                 errors[`rule_${index}_filter`]
@@ -697,9 +698,9 @@ export function WebhookForm({
                             )}
                           </div>
                           <div>
-                            <label className="text-secondary mb-1 block text-xs">
+                            <Label className="text-secondary mb-1 block text-xs">
                               Handler <RequiredAsterisk />
-                            </label>
+                            </Label>
                             <Input
                               className={`font-mono text-sm ${
                                 errors[`rule_${index}_handler`]
@@ -730,9 +731,9 @@ export function WebhookForm({
                           </div>
                         </div>
                         <div>
-                          <label className="text-secondary mb-1 block text-xs">
+                          <Label className="text-secondary mb-1 block text-xs">
                             Handler Config (JSON)
-                          </label>
+                          </Label>
                           <Textarea
                             className={`resize-y rounded-lg font-mono ${
                               errors[`rule_${index}_config`]


### PR DESCRIPTION
## Summary

Phase C-2 of the shadcn canonical adoption sweep — second slice of the label conversion. 69 raw `<label>` sites across six files now use the canonical `<Label>` primitive.

- `AuthProvidersManagement.tsx` (16)
- `WebhookForm.tsx` (15)
- `OAuth2ApplicationForm.tsx` (15)
- `ThirdPartyServiceForm.tsx` (14)
- `ServiceAccountForm.tsx` (9)
- `ApplicationSecretsPanel.tsx` — secret-edit row label

Layout classes are preserved verbatim; the small `font-medium` contribution from `<Label>` unifies with the rest of the shadcn-driven forms.

## Test plan

- [ ] `npm run build` passes.
- [ ] Spot-check each form page (`/admin/auth-providers`, `/admin/webhooks/new`, `/admin/third-party-services/new`, etc.) — labels render as before and clicking a label focuses its input where `htmlFor` is set.