### PR TITLE
Convert raw <label> to shadcn <Label> in remaining admin forms

### DIFF
--- a/src/components/admin/document-templates/DocumentTemplateForm.tsx
+++ b/src/components/admin/document-templates/DocumentTemplateForm.tsx
@@ -17,6 +17,7 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -167,12 +168,12 @@ export function DocumentTemplateForm({
               className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
             >
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="document-tpl-name"
                 >
                   Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={errors.name ? 'border-red-500' : ''}
                   disabled={isLoading}
@@ -191,12 +192,12 @@ export function DocumentTemplateForm({
 
               {!isEditing && (
                 <div>
-                  <label
+                  <Label
                     className="text-secondary mb-1.5 block text-sm"
                     htmlFor="document-tpl-slug"
                   >
                     Slug <RequiredAsterisk />
-                  </label>
+                  </Label>
                   <Input
                     className={errors.slug ? 'border-red-500' : ''}
                     disabled={isLoading}
@@ -216,12 +217,12 @@ export function DocumentTemplateForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="document-tpl-description"
               >
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -234,9 +235,9 @@ export function DocumentTemplateForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Icon
-              </label>
+              </Label>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <p className="text-tertiary mb-1.5 text-xs">Pick an icon</p>
@@ -266,12 +267,12 @@ export function DocumentTemplateForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="document-tpl-title"
               >
                 Default Document Title
-              </label>
+              </Label>
               <Input
                 disabled={isLoading}
                 id="document-tpl-title"
@@ -282,12 +283,12 @@ export function DocumentTemplateForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="document-tpl-content"
               >
                 Content
-              </label>
+              </Label>
               <Textarea
                 className="resize-y rounded-lg font-mono"
                 disabled={isLoading}
@@ -300,9 +301,9 @@ export function DocumentTemplateForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Default Tags
-              </label>
+              </Label>
               <p className="text-tertiary mb-2 text-xs">
                 Tags applied to documents created from this template.
               </p>
@@ -317,9 +318,9 @@ export function DocumentTemplateForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Project Types
-              </label>
+              </Label>
               <p className="text-tertiary mb-2 text-xs">
                 Limit this template to specific project types. Leave empty to
                 offer it for every project type.
@@ -388,12 +389,12 @@ export function DocumentTemplateForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="document-tpl-sort-order"
               >
                 Sort Order
-              </label>
+              </Label>
               <Input
                 className={errors.sort_order ? 'border-red-500' : ''}
                 disabled={isLoading}

--- a/src/components/admin/environments/EnvironmentForm.tsx
+++ b/src/components/admin/environments/EnvironmentForm.tsx
@@ -15,6 +15,7 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -175,12 +176,12 @@ export function EnvironmentForm({
         <Card>
           <CardContent className="space-y-4 pt-6">
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="environment-org"
               >
                 Organization <RequiredAsterisk />
-              </label>
+              </Label>
               <Select
                 disabled={isEditing || isLoading || organizations.length <= 1}
                 onValueChange={setOrgSlug}
@@ -212,12 +213,12 @@ export function EnvironmentForm({
               className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
             >
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="environment-name"
                 >
                   Environment Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                   disabled={isLoading}
@@ -236,12 +237,12 @@ export function EnvironmentForm({
 
               {!isEditing && (
                 <div>
-                  <label
+                  <Label
                     className="text-secondary mb-1.5 block text-sm"
                     htmlFor="environment-slug"
                   >
                     Slug <RequiredAsterisk />
-                  </label>
+                  </Label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                     disabled={isLoading}
@@ -261,12 +262,12 @@ export function EnvironmentForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="environment-sort-order"
               >
                 Sort Order
-              </label>
+              </Label>
               <Input
                 className="w-32"
                 disabled={isLoading}
@@ -282,12 +283,12 @@ export function EnvironmentForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="environment-description"
               >
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -300,9 +301,9 @@ export function EnvironmentForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Icon
-              </label>
+              </Label>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <p className="text-tertiary mb-1.5 text-xs">Pick an icon</p>
@@ -382,12 +383,12 @@ function ReleaseTrainSwitches({
       <div className="border-input space-y-3 rounded-lg border p-3">
         <div className="flex items-start justify-between gap-3">
           <div>
-            <label
+            <Label
               className="text-foreground text-sm font-medium"
               htmlFor="environment-can-deploy"
             >
               Allow direct deploy
-            </label>
+            </Label>
             <p className="text-tertiary text-xs">
               Show the &quot;Deploy&quot; button on the release train so
               operators can roll an explicit commit or tag into this
@@ -403,12 +404,12 @@ function ReleaseTrainSwitches({
         </div>
         <div className="flex items-start justify-between gap-3">
           <div>
-            <label
+            <Label
               className="text-foreground text-sm font-medium"
               htmlFor="environment-can-promote"
             >
               Allow promote
-            </label>
+            </Label>
             <p className="text-tertiary text-xs">
               Show the &quot;Promote&quot; button on the release train. Promotes
               cut a tag / GitHub Release when the source build is at a SHA, or

--- a/src/components/admin/link-definitions/LinkDefinitionForm.tsx
+++ b/src/components/admin/link-definitions/LinkDefinitionForm.tsx
@@ -8,6 +8,7 @@ import { ErrorBanner } from '@/components/ui/error-banner'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -133,12 +134,12 @@ export function LinkDefinitionForm({
         <Card>
           <CardContent className="space-y-4 pt-6">
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="link-def-org"
               >
                 Organization <RequiredAsterisk />
-              </label>
+              </Label>
               <Select
                 disabled={isEditing || isLoading || organizations.length <= 1}
                 onValueChange={setOrgSlug}
@@ -170,12 +171,12 @@ export function LinkDefinitionForm({
               className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
             >
               <div>
-                <label
+                <Label
                   className="text-secondary mb-1.5 block text-sm"
                   htmlFor="link-def-name"
                 >
                   Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                   disabled={isLoading}
@@ -194,12 +195,12 @@ export function LinkDefinitionForm({
 
               {!isEditing && (
                 <div>
-                  <label
+                  <Label
                     className="text-secondary mb-1.5 block text-sm"
                     htmlFor="link-def-slug"
                   >
                     Slug <RequiredAsterisk />
-                  </label>
+                  </Label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                     disabled={isLoading}
@@ -219,12 +220,12 @@ export function LinkDefinitionForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="link-def-description"
               >
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -237,9 +238,9 @@ export function LinkDefinitionForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Icon
-              </label>
+              </Label>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <p className="text-tertiary mb-1.5 text-xs">Pick an icon</p>
@@ -269,12 +270,12 @@ export function LinkDefinitionForm({
             </div>
 
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="link-def-url-template"
               >
                 URL Template
-              </label>
+              </Label>
               <Input
                 className=""
                 disabled={isLoading}

--- a/src/components/admin/organizations/OrganizationForm.tsx
+++ b/src/components/admin/organizations/OrganizationForm.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { AlertCircle, Save, X } from 'lucide-react'
 
 import { ErrorBanner } from '@/components/ui/error-banner'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Textarea } from '@/components/ui/textarea'
 import type { Organization, OrganizationCreate } from '@/types'
@@ -129,9 +130,9 @@ export function OrganizationForm({
               className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
             >
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Organization Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                   disabled={isLoading}
@@ -149,9 +150,9 @@ export function OrganizationForm({
 
               {!isEditing && (
                 <div>
-                  <label className="text-secondary mb-1.5 block text-sm">
+                  <Label className="text-secondary mb-1.5 block text-sm">
                     Slug <RequiredAsterisk />
-                  </label>
+                  </Label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                     disabled={isLoading}
@@ -170,9 +171,9 @@ export function OrganizationForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -184,9 +185,9 @@ export function OrganizationForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Icon
-              </label>
+              </Label>
               <IconUpload onChange={setIcon} value={icon} />
             </div>
           </CardContent>

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -13,6 +13,7 @@ import {
 import { IconPicker } from '@/components/ui/icon-picker'
 import { IconUpload } from '@/components/ui/icon-upload'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -184,12 +185,12 @@ export function ProjectTypeForm({
         <Card>
           <CardContent className="space-y-4 pt-6">
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="project-type-org"
               >
                 Organization <RequiredAsterisk />
-              </label>
+              </Label>
               <Select
                 disabled={isEditing || isLoading || organizations.length <= 1}
                 onValueChange={setOrgSlug}
@@ -221,9 +222,9 @@ export function ProjectTypeForm({
               className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
             >
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Project Type Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                   disabled={isLoading}
@@ -241,9 +242,9 @@ export function ProjectTypeForm({
 
               {!isEditing && (
                 <div>
-                  <label className="text-secondary mb-1.5 block text-sm">
+                  <Label className="text-secondary mb-1.5 block text-sm">
                     Slug <RequiredAsterisk />
-                  </label>
+                  </Label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                     disabled={isLoading}
@@ -262,9 +263,9 @@ export function ProjectTypeForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -278,12 +279,12 @@ export function ProjectTypeForm({
             <div>
               <div className="border-input flex items-start justify-between gap-3 rounded-lg border p-3">
                 <div>
-                  <label
+                  <Label
                     className="text-foreground text-sm font-medium"
                     htmlFor="project-type-deployable"
                   >
                     Deployable
-                  </label>
+                  </Label>
                   <p className="text-tertiary text-xs">
                     Enable deployment tracking and release-train features for
                     projects of this type.
@@ -299,9 +300,9 @@ export function ProjectTypeForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Icon
-              </label>
+              </Label>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <p className="text-tertiary mb-1.5 text-xs">Pick an icon</p>

--- a/src/components/admin/roles/RoleForm.tsx
+++ b/src/components/admin/roles/RoleForm.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { FormField } from '@/components/ui/form-field'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Textarea } from '@/components/ui/textarea'
 import { useFormScaffold } from '@/hooks/useFormScaffold'
@@ -328,9 +329,9 @@ export function RoleForm({
             {/* Slug */}
             {!isEditing && (
               <div className="col-span-2">
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Slug <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={`font-mono ${
                     isSystemRole ? 'cursor-not-allowed opacity-60' : ''
@@ -361,9 +362,9 @@ export function RoleForm({
 
             {/* Description */}
             <div className="col-span-2">
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Description
-              </label>
+              </Label>
               <Textarea
                 className={`resize-none ${isSystemRole ? 'cursor-not-allowed opacity-60' : ''}`}
                 disabled={isLoading || isSystemRole}
@@ -376,9 +377,9 @@ export function RoleForm({
 
             {/* Priority */}
             <div className="col-span-2 sm:col-span-1">
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Priority
-              </label>
+              </Label>
               <Input
                 className={` ${
                   isSystemRole ? 'cursor-not-allowed opacity-60' : ''
@@ -478,12 +479,12 @@ export function RoleForm({
                           id={`group-${resource}`}
                           onCheckedChange={() => toggleAllInGroup(resource)}
                         />
-                        <label
+                        <Label
                           className="text-primary flex-1 cursor-pointer select-none"
                           htmlFor={`group-${resource}`}
                         >
                           {resourceLabel(resource)}
-                        </label>
+                        </Label>
                         <span
                           className={`rounded-full px-2 py-0.5 text-xs ${
                             selectedCount > 0
@@ -515,7 +516,7 @@ export function RoleForm({
                                   togglePermission(perm.name)
                                 }
                               />
-                              <label
+                              <Label
                                 className="flex-1 cursor-pointer select-none"
                                 htmlFor={perm.name}
                               >
@@ -527,7 +528,7 @@ export function RoleForm({
                                 <div className="text-secondary mt-0.5 text-xs">
                                   {perm.description || perm.name}
                                 </div>
-                              </label>
+                              </Label>
                             </div>
                           ))}
                       </div>

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, Save, X } from 'lucide-react'
 import { getTeamSchema } from '@/api/endpoints'
 import { Card, CardContent } from '@/components/ui/card'
 import { IconPicker } from '@/components/ui/icon-picker'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Select,
@@ -170,12 +171,12 @@ export function TeamForm({
         <Card>
           <CardContent className="space-y-4 pt-6">
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="team-org"
               >
                 Organization <RequiredAsterisk />
-              </label>
+              </Label>
               <Select
                 disabled={isEditing || isLoading || organizations.length <= 1}
                 onValueChange={setOrgSlug}
@@ -207,9 +208,9 @@ export function TeamForm({
               className={`grid grid-cols-1 gap-4 ${!isEditing ? 'md:grid-cols-2' : ''}`}
             >
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Team Name <RequiredAsterisk />
-                </label>
+                </Label>
                 <Input
                   className={` ${errors.name ? 'border-red-500' : ''}`}
                   disabled={isLoading}
@@ -227,9 +228,9 @@ export function TeamForm({
 
               {!isEditing && (
                 <div>
-                  <label className="text-secondary mb-1.5 block text-sm">
+                  <Label className="text-secondary mb-1.5 block text-sm">
                     Slug <RequiredAsterisk />
-                  </label>
+                  </Label>
                   <Input
                     className={` ${errors.slug ? 'border-red-500' : ''}`}
                     disabled={isLoading}
@@ -248,9 +249,9 @@ export function TeamForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="resize-none rounded-lg"
                 disabled={isLoading}
@@ -262,9 +263,9 @@ export function TeamForm({
             </div>
 
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Icon
-              </label>
+              </Label>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <p className="text-tertiary mb-1.5 text-xs">Pick an icon</p>

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -35,6 +35,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { FormField } from '@/components/ui/form-field'
+import { Label } from '@/components/ui/label'
 import {
   SegmentedControl,
   SegmentedControlItem,
@@ -490,7 +491,7 @@ export function UserForm({
                 )
                 const checked = idx !== -1
                 return (
-                  <label
+                  <Label
                     className={cn(
                       'grid cursor-pointer grid-cols-[1fr_180px] items-center gap-4 border-b border-tertiary px-4 py-2.5 last:border-b-0 hover:bg-secondary/50',
                       !checked && 'opacity-60',
@@ -549,7 +550,7 @@ export function UserForm({
                         </SelectContent>
                       </Select>
                     </div>
-                  </label>
+                  </Label>
                 )
               })}
             </div>
@@ -1119,12 +1120,12 @@ function ToggleRow({
   return (
     <div className="border-tertiary grid grid-cols-[1fr_auto] items-center gap-4 border-b py-3 first:pt-0 last:border-b-0 last:pb-0">
       <div>
-        <label
+        <Label
           className="text-primary block cursor-pointer text-sm font-medium"
           htmlFor={id}
         >
           {label}
-        </label>
+        </Label>
         <p className="text-secondary mt-0.5 text-sm">{description}</p>
       </div>
       <Switch


### PR DESCRIPTION
## Summary

Phase C-3 of the shadcn canonical adoption sweep — final slice of admin-form labels. 49 raw `<label>` sites across eight files now use the canonical `<Label>` primitive.

- `DocumentTemplateForm.tsx` (9)
- `EnvironmentForm.tsx` (8)
- `ProjectTypeForm.tsx` (6)
- `LinkDefinitionForm.tsx` (6)
- `TeamForm.tsx` (5)
- `RoleForm.tsx` (5)
- `OrganizationForm.tsx` (4)
- `UserForm.tsx` (2)

After this PR every admin `*/Form.tsx` routes labels through `<Label>`. The remaining raw `<label>` usages are in non-form components (`NewProjectDialog`, `NewOpsLogDialog`, `LocalLoginForm`, `SearchResultsPanel`, etc.) and will be handled in a follow-up.

## Test plan

- [ ] `npm run build` passes.
- [ ] Spot-check each form page — labels render as before; `htmlFor` wiring still focuses the matching input where present.