### PR TITLE
Convert raw <label> to shadcn <Label> in remaining non-form sites

### DIFF
--- a/src/components/EditEnvironmentsCard.tsx
+++ b/src/components/EditEnvironmentsCard.tsx
@@ -7,6 +7,7 @@ import { Card } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { EnvironmentBadge } from '@/components/ui/environment-badge'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { SavedIndicator } from '@/components/ui/saved-indicator'
 import {
   Select,
@@ -142,12 +143,12 @@ export function EditEnvironmentsCard({
               ) : (
                 dynamicFields.map((field) => (
                   <div className="flex items-center gap-3" key={field}>
-                    <label
+                    <Label
                       className="text-tertiary w-20 shrink-0 text-xs font-medium"
                       htmlFor={`env-${env.slug}-${field}`}
                     >
                       {toLabel(field)}
-                    </label>
+                    </Label>
                     <div className="relative flex-1">
                       <Input
                         className="pr-8 text-sm"

--- a/src/components/EditRelationshipsDialog.tsx
+++ b/src/components/EditRelationshipsDialog.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import type { ProjectRelationship } from '@/types'
 
@@ -195,7 +196,7 @@ export function EditRelationshipsDialog({
                   .join(', ')
 
                 return (
-                  <label
+                  <Label
                     className={`flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 transition-colors hover:bg-slate-50 hover:dark:bg-slate-700 ${
                       isChanged ? 'bg-amber-50 dark:bg-amber-900/30' : ''
                     }`}
@@ -213,7 +214,7 @@ export function EditRelationshipsDialog({
                         {typeLabel}
                       </span>
                     )}
-                  </label>
+                  </Label>
                 )
               })
             )}

--- a/src/components/NewOpsLogDialog.tsx
+++ b/src/components/NewOpsLogDialog.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -166,9 +167,9 @@ export function NewOpsLogDialog({
           <div className="space-y-6">
             {/* Project */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-ops-project">
+              <Label className="text-sm font-medium" htmlFor="new-ops-project">
                 Project <RequiredAsterisk />
-              </label>
+              </Label>
               <Combobox
                 onChange={(val) => {
                   setProjectId(val)
@@ -185,12 +186,12 @@ export function NewOpsLogDialog({
 
             {/* Environment */}
             <div className="space-y-2">
-              <label
+              <Label
                 className="text-sm font-medium"
                 htmlFor="new-ops-environment"
               >
                 Environment <RequiredAsterisk />
-              </label>
+              </Label>
               <Combobox
                 disabled={
                   !projectId ||
@@ -220,12 +221,12 @@ export function NewOpsLogDialog({
 
             {/* Entry Type */}
             <div className="space-y-2">
-              <label
+              <Label
                 className="text-sm font-medium"
                 htmlFor="new-ops-entry-type"
               >
                 Entry Type <RequiredAsterisk />
-              </label>
+              </Label>
               <Combobox
                 onChange={(val) => setEntryType(val as OperationsLogEntryType)}
                 options={OPERATIONS_LOG_ENTRY_TYPES.map((t) => ({
@@ -239,12 +240,12 @@ export function NewOpsLogDialog({
 
             {/* Description */}
             <div className="space-y-2">
-              <label
+              <Label
                 className="text-sm font-medium"
                 htmlFor="new-ops-description"
               >
                 Description <RequiredAsterisk />
-              </label>
+              </Label>
               <Textarea
                 className="min-h-24 resize-none"
                 id="new-ops-description"
@@ -256,9 +257,9 @@ export function NewOpsLogDialog({
 
             {/* Version */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-ops-version">
+              <Label className="text-sm font-medium" htmlFor="new-ops-version">
                 Version
-              </label>
+              </Label>
               <Input
                 id="new-ops-version"
                 onChange={(e) => setVersion(e.target.value)}
@@ -269,9 +270,9 @@ export function NewOpsLogDialog({
 
             {/* Link */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-ops-link">
+              <Label className="text-sm font-medium" htmlFor="new-ops-link">
                 Link
-              </label>
+              </Label>
               <Input
                 id="new-ops-link"
                 onChange={(e) => setLink(e.target.value)}
@@ -283,9 +284,9 @@ export function NewOpsLogDialog({
 
             {/* Ticket */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-ops-ticket">
+              <Label className="text-sm font-medium" htmlFor="new-ops-ticket">
                 Ticket
-              </label>
+              </Label>
               <Input
                 id="new-ops-ticket"
                 onChange={(e) => setTicketSlug(e.target.value)}
@@ -296,9 +297,9 @@ export function NewOpsLogDialog({
 
             {/* Notes */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-ops-notes">
+              <Label className="text-sm font-medium" htmlFor="new-ops-notes">
                 Notes
-              </label>
+              </Label>
               <Textarea
                 className="min-h-24 resize-none"
                 id="new-ops-notes"

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import { Textarea } from '@/components/ui/textarea'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -124,9 +125,9 @@ export function NewProjectDialog({
           <div className="space-y-6">
             {/* Team */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-project-team">
+              <Label className="text-sm font-medium" htmlFor="new-project-team">
                 Team <RequiredAsterisk />
-              </label>
+              </Label>
               <Combobox
                 onChange={setTeamSlug}
                 options={teams.map((t) => ({
@@ -143,9 +144,9 @@ export function NewProjectDialog({
 
             {/* Project Type */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-project-type">
+              <Label className="text-sm font-medium" htmlFor="new-project-type">
                 Project Type <RequiredAsterisk />
-              </label>
+              </Label>
               <Combobox
                 onChange={setProjectTypeSlug}
                 options={projectTypes.map((pt) => ({
@@ -162,9 +163,9 @@ export function NewProjectDialog({
 
             {/* Name */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-project-name">
+              <Label className="text-sm font-medium" htmlFor="new-project-name">
                 Name <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 id="new-project-name"
                 onChange={(e) => handleNameChange(e.target.value)}
@@ -178,9 +179,9 @@ export function NewProjectDialog({
 
             {/* Slug */}
             <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="new-project-slug">
+              <Label className="text-sm font-medium" htmlFor="new-project-slug">
                 Slug <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 id="new-project-slug"
                 onChange={(e) => setSlug(e.target.value)}
@@ -194,12 +195,12 @@ export function NewProjectDialog({
 
             {/* Description */}
             <div className="space-y-2">
-              <label
+              <Label
                 className="text-sm font-medium"
                 htmlFor="new-project-description"
               >
                 Description
-              </label>
+              </Label>
               <Textarea
                 className="min-h-30 resize-none"
                 id="new-project-description"
@@ -212,7 +213,7 @@ export function NewProjectDialog({
             {/* Environments */}
             {environments.length > 0 && (
               <div className="space-y-2">
-                <label className="text-sm font-medium">Environments</label>
+                <Label className="text-sm font-medium">Environments</Label>
                 <div className="flex flex-wrap gap-2">
                   {environments.map((env) => (
                     <button

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -41,6 +41,7 @@ import { Checkbox } from './ui/checkbox'
 import { EnvironmentBadge } from './ui/environment-badge'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from './ui/hover-card'
 import { Input } from './ui/input'
+import { Label } from './ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { ScoreBadge } from './ui/score-badge'
 
@@ -990,7 +991,7 @@ function FilterPopover({
         </p>
         <div className="space-y-0.5">
           {options.map((opt) => (
-            <label
+            <Label
               className="hover:bg-secondary flex cursor-pointer items-center gap-2 rounded px-1 py-1.5"
               key={opt.slug}
             >
@@ -999,7 +1000,7 @@ function FilterPopover({
                 onCheckedChange={() => onToggle(opt.slug)}
               />
               <span className="text-primary text-sm">{opt.label}</span>
-            </label>
+            </Label>
           ))}
         </div>
       </PopoverContent>

--- a/src/components/admin/PluginEntityManagement.tsx
+++ b/src/components/admin/PluginEntityManagement.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/dialog'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { LoadingState } from '@/components/ui/loading-state'
 import {
   Table,
@@ -341,7 +342,7 @@ export function PluginEntityManagement({
 
           <div className="space-y-3 p-6">
             {properties.map(({ key, prop, required }) => (
-              <label className="block text-sm" key={key}>
+              <Label className="block text-sm" key={key}>
                 <span className="text-secondary">
                   {prop.title || toTitleCase(key)}
                   {required && <span className="text-red-500"> *</span>}
@@ -357,7 +358,7 @@ export function PluginEntityManagement({
                     {prop.description}
                   </p>
                 )}
-              </label>
+              </Label>
             ))}
           </div>
 

--- a/src/components/admin/PluginPackageDetail.tsx
+++ b/src/components/admin/PluginPackageDetail.tsx
@@ -22,6 +22,7 @@ import {
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { LoadingState } from '@/components/ui/loading-state'
 import { Textarea } from '@/components/ui/textarea'
 import { extractApiErrorDetail } from '@/lib/apiError'
@@ -339,7 +340,7 @@ export function PluginPackageDetail({
                     </div>
                   </div>
                   <div className="grid gap-3 md:grid-cols-2">
-                    <label className="block text-sm">
+                    <Label className="block text-sm">
                       <span className="text-secondary">Display name</span>
                       <Input
                         onChange={(e) =>
@@ -357,8 +358,8 @@ export function PluginPackageDetail({
                       <p className="text-tertiary mt-1 text-xs">
                         Page header / detail title.
                       </p>
-                    </label>
-                    <label className="block text-sm">
+                    </Label>
+                    <Label className="block text-sm">
                       <span className="text-secondary">Sidebar label</span>
                       <Input
                         onChange={(e) =>
@@ -376,9 +377,9 @@ export function PluginPackageDetail({
                       <p className="text-tertiary mt-1 text-xs">
                         Defaults to display name when empty.
                       </p>
-                    </label>
+                    </Label>
                   </div>
-                  <label className="block text-sm">
+                  <Label className="block text-sm">
                     <span className="text-secondary">Description</span>
                     <Textarea
                       onChange={(e) =>
@@ -394,7 +395,7 @@ export function PluginPackageDetail({
                       rows={2}
                       value={draft.description}
                     />
-                  </label>
+                  </Label>
                   <div className="flex items-center gap-2">
                     <Button
                       disabled={!dirty || patchMutation.isPending}

--- a/src/components/admin/blueprints/BlueprintUiMapEditor.tsx
+++ b/src/components/admin/blueprints/BlueprintUiMapEditor.tsx
@@ -1,6 +1,7 @@
 import { Plus, X } from 'lucide-react'
 
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -35,7 +36,7 @@ export function BlueprintUiMapEditor({
   return (
     <div key={mapType}>
       <div className="mb-1 flex items-center justify-between">
-        <label className="text-secondary text-xs">{mapLabel}</label>
+        <Label className="text-secondary text-xs">{mapLabel}</Label>
         <button
           className={
             'text-info hover:text-info/80 flex items-center gap-1 text-xs'

--- a/src/components/admin/service-accounts/ApiKeysSection.tsx
+++ b/src/components/admin/service-accounts/ApiKeysSection.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Tooltip,
   TooltipContent,
@@ -244,9 +245,9 @@ export function ApiKeysSection({
           </DialogHeader>
           <div className="space-y-3 p-6">
             <div>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 Key name
-              </label>
+              </Label>
               <Input
                 autoFocus
                 className="rounded-lg"

--- a/src/components/admin/service-accounts/ClientCredentialsSection.tsx
+++ b/src/components/admin/service-accounts/ClientCredentialsSection.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { RequiredAsterisk } from '@/components/ui/required-asterisk'
 import {
   Tooltip,
@@ -304,12 +305,12 @@ export function ClientCredentialsSection({
           </DialogHeader>
           <div className="space-y-3 p-6">
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="credential-name"
               >
                 Name <RequiredAsterisk />
-              </label>
+              </Label>
               <Input
                 autoFocus
                 id="credential-name"
@@ -319,12 +320,12 @@ export function ClientCredentialsSection({
               />
             </div>
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="credential-description"
               >
                 Description
-              </label>
+              </Label>
               <Input
                 id="credential-description"
                 onChange={(e) => setCredentialDescription(e.target.value)}
@@ -333,13 +334,13 @@ export function ClientCredentialsSection({
               />
             </div>
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="credential-scopes"
               >
                 Scopes{' '}
                 <span className="text-tertiary text-xs">(comma-separated)</span>
-              </label>
+              </Label>
               <Input
                 id="credential-scopes"
                 onChange={(e) => setCredentialScopes(e.target.value)}
@@ -348,7 +349,7 @@ export function ClientCredentialsSection({
               />
             </div>
             <div>
-              <label
+              <Label
                 className="text-secondary mb-1.5 block text-sm"
                 htmlFor="credential-expires-days"
               >
@@ -356,7 +357,7 @@ export function ClientCredentialsSection({
                 <span className="text-tertiary text-xs">
                   (leave empty for no expiration)
                 </span>
-              </label>
+              </Label>
               <Input
                 id="credential-expires-days"
                 min="1"

--- a/src/components/admin/service-accounts/OrgMembershipsCard.tsx
+++ b/src/components/admin/service-accounts/OrgMembershipsCard.tsx
@@ -5,6 +5,7 @@ import { Building2, Plus, Trash2 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -91,9 +92,9 @@ export function OrgMembershipsCard({
           <div className="border-input bg-secondary mb-4 rounded-lg border p-4">
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Organization
-                </label>
+                </Label>
                 <Select onValueChange={setNewOrgSlug} value={newOrgSlug}>
                   <SelectTrigger aria-label="Organization">
                     <SelectValue placeholder="Select..." />
@@ -108,9 +109,9 @@ export function OrgMembershipsCard({
                 </Select>
               </div>
               <div>
-                <label className="text-secondary mb-1.5 block text-sm">
+                <Label className="text-secondary mb-1.5 block text-sm">
                   Role
-                </label>
+                </Label>
                 {rolesLoading ? (
                   <p className="text-secondary text-sm">Loading roles...</p>
                 ) : rolesError ? (

--- a/src/components/admin/users/UserDetail.tsx
+++ b/src/components/admin/users/UserDetail.tsx
@@ -26,6 +26,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Gravatar } from '@/components/ui/gravatar'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -276,9 +277,9 @@ export function UserDetail({ onBack, onEdit, user }: UserDetailProps) {
             <div className="border-input bg-secondary mb-4 rounded-lg border p-4">
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="text-secondary mb-1.5 block text-sm">
+                  <Label className="text-secondary mb-1.5 block text-sm">
                     Organization
-                  </label>
+                  </Label>
                   <Select onValueChange={setNewOrgSlug} value={newOrgSlug}>
                     <SelectTrigger aria-label="Organization">
                       <SelectValue placeholder="Select..." />
@@ -293,9 +294,9 @@ export function UserDetail({ onBack, onEdit, user }: UserDetailProps) {
                   </Select>
                 </div>
                 <div>
-                  <label className="text-secondary mb-1.5 block text-sm">
+                  <Label className="text-secondary mb-1.5 block text-sm">
                     Role
-                  </label>
+                  </Label>
                   <Select onValueChange={setNewRoleSlug} value={newRoleSlug}>
                     <SelectTrigger aria-label="Role">
                       <SelectValue placeholder="Select..." />

--- a/src/components/auth/LocalLoginForm.tsx
+++ b/src/components/auth/LocalLoginForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 
 interface LocalLoginFormProps {
   error?: string
@@ -92,9 +93,9 @@ export function LocalLoginForm({
       )}
 
       <div>
-        <label className="mb-1.5 block text-sm text-gray-700" htmlFor="email">
+        <Label className="mb-1.5 block text-sm text-gray-700" htmlFor="email">
           Email Address
-        </label>
+        </Label>
         <Input
           autoComplete="email"
           autoFocus
@@ -117,12 +118,12 @@ export function LocalLoginForm({
       </div>
 
       <div>
-        <label
+        <Label
           className="mb-1.5 block text-sm text-gray-700"
           htmlFor="password"
         >
           Password
-        </label>
+        </Label>
         <Input
           autoComplete="current-password"
           disabled={isLoading}

--- a/src/components/deploy/PromoteTab.tsx
+++ b/src/components/deploy/PromoteTab.tsx
@@ -14,6 +14,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { LoadingState } from '@/components/ui/loading-state'
 import { Textarea } from '@/components/ui/textarea'
 import { extractApiErrorDetail } from '@/lib/apiError'
@@ -329,11 +330,11 @@ export function PromoteTab({
           Step 2 — Tag & release notes
         </p>
         <div className="grid grid-cols-[160px_160px_1fr] gap-3">
-          <label className="text-tertiary flex flex-col gap-1 text-xs">
+          <Label className="text-tertiary flex flex-col gap-1 text-xs">
             Current
             <Input className="font-mono" disabled value={lastTag ?? ''} />
-          </label>
-          <label className="text-tertiary flex flex-col gap-1 text-xs">
+          </Label>
+          <Label className="text-tertiary flex flex-col gap-1 text-xs">
             New tag
             <Input
               aria-invalid={!tagValid && tag.length > 0}
@@ -345,7 +346,7 @@ export function PromoteTab({
               placeholder="vX.Y.Z"
               value={tag}
             />
-          </label>
+          </Label>
           <div className="flex flex-col gap-1 text-xs">
             <span className="text-tertiary">AI suggestion</span>
             <div className="border-accent bg-accent/10 text-accent flex min-h-10 items-start gap-2 rounded-md border p-2">

--- a/src/components/search/SearchResultsPanel.tsx
+++ b/src/components/search/SearchResultsPanel.tsx
@@ -10,6 +10,7 @@ import {
   type SearchResult,
 } from '@/api/search'
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible'
+import { Label } from '@/components/ui/label'
 import { Slider } from '@/components/ui/slider'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
@@ -324,9 +325,9 @@ export function SearchResultsPanel({
           </div>
           <div className="grid grid-cols-2 gap-6">
             <div>
-              <label className="text-muted-foreground mb-1.5 block text-xs">
+              <Label className="text-muted-foreground mb-1.5 block text-xs">
                 Similarity threshold
-              </label>
+              </Label>
               <Slider
                 max={1.0}
                 min={0.1}
@@ -339,9 +340,9 @@ export function SearchResultsPanel({
               </span>
             </div>
             <div>
-              <label className="text-muted-foreground mb-1.5 block text-xs">
+              <Label className="text-muted-foreground mb-1.5 block text-xs">
                 Max results
-              </label>
+              </Label>
               <Slider
                 max={100}
                 min={5}

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -2,6 +2,7 @@ import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
 
 import { Check } from 'lucide-react'
 
+import { Label } from '@/components/ui/label'
 import { useTheme } from '@/contexts/ThemeContext'
 import { deriveChipColors, hexToRgb } from '@/lib/chip-colors'
 
@@ -119,7 +120,7 @@ export function ColorPicker({
 
   return (
     <div className="space-y-3">
-      <label
+      <Label
         className="text-secondary mb-1.5 block text-sm"
         htmlFor="color-picker-swatches"
       >
@@ -127,7 +128,7 @@ export function ColorPicker({
         <span className="text-tertiary ml-1 text-xs">
           · used on chips wherever this {objectType} appears
         </span>
-      </label>
+      </Label>
 
       <div className="bg-tertiary max-w-md rounded-md p-3.5">
         {/* Swatch radio group */}
@@ -191,7 +192,7 @@ export function ColorPicker({
 
         {/* Hex input group */}
         <div className="border-tertiary bg-primary focus-within:border-secondary flex items-center gap-1 rounded-md border p-1 transition-colors">
-          <label
+          <Label
             aria-label="Open OS color picker"
             className="border-tertiary relative size-7 shrink-0 cursor-pointer rounded-md border"
             style={{ backgroundColor: pipBackground }}
@@ -203,7 +204,7 @@ export function ColorPicker({
               type="color"
               value={isValidHex ? hexInput : '#000000'}
             />
-          </label>
+          </Label>
           <input
             aria-label="Hex color"
             className="text-primary placeholder:text-tertiary flex-1 border-0 bg-transparent px-2 font-mono text-[13px] outline-none"

--- a/src/components/ui/dynamic-fields.tsx
+++ b/src/components/ui/dynamic-fields.tsx
@@ -6,6 +6,7 @@ import { AlertCircle } from 'lucide-react'
 import type { DynamicFieldSchema, DynamicSchema } from '@/api/endpoints'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -89,10 +90,10 @@ export function DynamicFormFields({
         if (field.enum) {
           return (
             <div key={key}>
-              <label className="text-secondary mb-1.5 block text-sm">
+              <Label className="text-secondary mb-1.5 block text-sm">
                 {label}
                 {isRequired && <span className="text-red-500"> *</span>}
-              </label>
+              </Label>
               <Select
                 disabled={isLoading}
                 onValueChange={(v) =>
@@ -140,12 +141,12 @@ export function DynamicFormFields({
                 id={`dynamic-${key}`}
                 onCheckedChange={(checked) => onChange(key, checked === true)}
               />
-              <label
+              <Label
                 className="text-secondary text-sm"
                 htmlFor={`dynamic-${key}`}
               >
                 {label}
-              </label>
+              </Label>
               {field.description && (
                 <span className="text-tertiary text-xs">
                   — {field.description}
@@ -157,10 +158,10 @@ export function DynamicFormFields({
 
         return (
           <div key={key}>
-            <label className="text-secondary mb-1.5 block text-sm">
+            <Label className="text-secondary mb-1.5 block text-sm">
               {label}
               {isRequired && <span className="text-red-500"> *</span>}
-            </label>
+            </Label>
             <Input
               className={` ${fieldError ? 'border-red-500' : ''}`}
               disabled={isLoading}

--- a/src/components/ui/required-asterisk.tsx
+++ b/src/components/ui/required-asterisk.tsx
@@ -1,6 +1,6 @@
 /**
  * Required-field indicator. Use after a field's label text:
- * `<label>Name <RequiredAsterisk /></label>`.
+ * `<Label>Name <RequiredAsterisk /></Label>`.
  *
  * Renders an `aria-hidden` asterisk in the danger color. Pair with
  * `aria-required` on the field itself for accessible required state.


### PR DESCRIPTION
## Summary

Phase C-4 (final slice) of the shadcn canonical adoption sweep — 49 raw `<label>` sites across non-form components (dialogs, dashboards, `ui/` primitives that render schema-driven labels) now use the canonical `<Label>` primitive.

- `ProjectsView`, `NewProjectDialog`, `NewOpsLogDialog`
- `PluginPackageDetail`, `PluginEntityManagement`, `UserDetail`
- `EditRelationshipsDialog`, `EditEnvironmentsCard`
- `SearchResultsPanel`, `PromoteTab`, `LocalLoginForm`
- `OrgMembershipsCard`, `ClientCredentialsSection`, `ApiKeysSection`
- `color-picker`, `dynamic-fields`, `BlueprintUiMapEditor`
- `required-asterisk` — JSDoc comment example only.

After this PR, no raw `<label>` JSX remains in `src/` outside test files and the `FormField` primitive (already updated in #348).

## Test plan

- [ ] `npm run build` passes.
- [ ] Spot-check `/login` (local), Dashboard widgets, Project list, the New Project / New Ops Log dialogs — labels render consistently.