### PR TITLE
Adopt SegmentedControl in three container-style toggles

### DIFF
--- a/src/components/admin/blueprints/BlueprintSchemaEditor.tsx
+++ b/src/components/admin/blueprints/BlueprintSchemaEditor.tsx
@@ -3,6 +3,10 @@ import { useState } from 'react'
 import { AlertCircle, Code, List, Plus } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
 import type { SchemaProperty } from '@/types'
 
 import { type SchemaEditorMode } from './blueprint-schema-utils'
@@ -65,30 +69,20 @@ export function BlueprintSchemaEditor({
     <div className="border-border bg-card rounded-lg border p-6">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-primary text-sm font-medium">JSON Schema</h3>
-        <div className="border-input flex items-center rounded-lg border">
-          <button
-            className={`flex items-center gap-1.5 rounded-l-lg px-3 py-1.5 text-sm transition-colors ${
-              editorMode === 'visual'
-                ? 'bg-info text-info'
-                : 'text-secondary hover:text-primary'
-            }`}
-            onClick={() => handleEditorModeSwitch('visual')}
-          >
+        <SegmentedControl
+          ariaLabel="Editor mode"
+          onValueChange={(v) => handleEditorModeSwitch(v as 'code' | 'visual')}
+          value={editorMode}
+        >
+          <SegmentedControlItem className="px-3 py-1.5 text-sm" value="visual">
             <List className="size-3.5" />
             Visual
-          </button>
-          <button
-            className={`flex items-center gap-1.5 rounded-r-lg px-3 py-1.5 text-sm transition-colors ${
-              editorMode === 'code'
-                ? 'bg-info text-info'
-                : 'text-secondary hover:text-primary'
-            }`}
-            onClick={() => handleEditorModeSwitch('code')}
-          >
+          </SegmentedControlItem>
+          <SegmentedControlItem className="px-3 py-1.5 text-sm" value="code">
             <Code className="size-3.5" />
             Code
-          </button>
-        </div>
+          </SegmentedControlItem>
+        </SegmentedControl>
       </div>
 
       {/* Schema Error */}

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -6,6 +6,10 @@ import { API_BASE_URL } from '@/api/client'
 import { FormHeader } from '@/components/admin/form-header'
 import { Input } from '@/components/ui/input'
 import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -13,7 +17,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { useAuth } from '@/hooks/useAuth'
-import { slugify } from '@/lib/utils'
+import { cn, slugify } from '@/lib/utils'
 import type {
   ServiceApplication,
   ServiceApplicationCreate,
@@ -322,22 +326,30 @@ export function OAuth2ApplicationForm({
         {isEdit && canManageAuthProviders && initialUsage === 'integration' && (
           <div>
             <label className={labelClass}>Usage</label>
-            <div className="border-input inline-flex rounded-md border">
-              <button
-                className={`px-3 py-1.5 text-sm ${usage === 'integration' ? 'bg-amber-bg text-amber-text' : 'text-secondary'}`}
-                onClick={() => setUsage('integration')}
-                type="button"
+            <SegmentedControl
+              ariaLabel="Usage"
+              onValueChange={(v) => setUsage(v as 'both' | 'integration')}
+              value={usage}
+            >
+              <SegmentedControlItem
+                className={cn(
+                  'px-3 py-1.5 text-sm',
+                  usage === 'integration' && 'bg-amber-bg text-amber-text',
+                )}
+                value="integration"
               >
                 Integration
-              </button>
-              <button
-                className={`px-3 py-1.5 text-sm ${usage === 'both' ? 'bg-amber-bg text-amber-text' : 'text-secondary'}`}
-                onClick={() => setUsage('both')}
-                type="button"
+              </SegmentedControlItem>
+              <SegmentedControlItem
+                className={cn(
+                  'px-3 py-1.5 text-sm',
+                  usage === 'both' && 'bg-amber-bg text-amber-text',
+                )}
+                value="both"
               >
                 Both
-              </button>
-            </div>
+              </SegmentedControlItem>
+            </SegmentedControl>
             <p className="text-tertiary mt-1 text-xs">
               Promote to "Both" to also expose this application as a login
               provider. Demoting "Both" → "Login" must be done from the Auth

--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -211,27 +211,17 @@ export function OperationsLogToolbar({
     <div className="mb-4 flex flex-wrap items-center gap-2">
       {hideTimeRange ? null : (
         <>
-          <div
-            aria-label="Time range"
-            className="border-tertiary bg-secondary inline-flex items-center rounded-md border p-0.5"
-            role="group"
+          <SegmentedControl
+            ariaLabel="Time range"
+            onValueChange={(v) => onRange(v as TimeRange)}
+            value={range}
           >
             {RANGES.map((r) => (
-              <button
-                className={cn(
-                  'rounded px-2.5 py-1 text-xs font-medium transition-colors',
-                  range === r.key
-                    ? 'bg-primary text-primary shadow-sm'
-                    : 'text-secondary hover:text-primary',
-                )}
-                key={r.key}
-                onClick={() => onRange(r.key)}
-                type="button"
-              >
+              <SegmentedControlItem key={r.key} value={r.key}>
                 {r.label}
-              </button>
+              </SegmentedControlItem>
             ))}
-          </div>
+          </SegmentedControl>
 
           <span aria-hidden className="bg-tertiary mx-1 h-6 w-px" />
         </>


### PR DESCRIPTION
## Summary

Phase D2 of the shadcn canonical adoption sweep. Three remaining hand-rolled segmented controls — the ones whose visual already matches `<SegmentedControl>`'s bordered-container + active-pill pattern — now use the canonical primitive.

## Stacked on #347

This PR sits on top of `feature/shadcn-add-primitives` (#347), which introduces the `<SegmentedControl>` primitive. Merging #347 first; then this PR rebases onto `main`.

## Sites converted

- `OperationsLogToolbar` — time-range toggle (24h / 7d / 30d / 90d / All).
- `OAuth2ApplicationForm` — "Integration / Both" usage switch. Keeps the amber active state via per-item className.
- `BlueprintSchemaEditor` — "Visual / Code" mode switch.

## Deferred

- `ScoringPolicyForm` category + mapping-type buttons — individually-bordered chip pattern; doesn't fit a single bordered container.
- `RecentDeploymentsWidget`, `MyPullRequestsWidget` filter pills — round chip styling; not segmented.
- `LogsTab` range / level / env toggles — custom coloring per chip; defer to Tabs/Popover PR.

## Test plan

- [ ] `npm run build` passes on top of #347.
- [ ] Operations Log time-range switching still works (and now uses radiogroup semantics).
- [ ] OAuth2 application edit dialog: usage toggle preserves amber active state.
- [ ] Blueprint schema editor: Visual/Code mode switch.