### PR TITLE
Wrap DropdownMenu/Popover triggers in shadcn Button

### DIFF
--- a/src/components/operations-log/OperationsLogToolbar.tsx
+++ b/src/components/operations-log/OperationsLogToolbar.tsx
@@ -17,6 +17,7 @@ import {
   Search,
 } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -93,22 +94,22 @@ function toggle<T>(arr: T[], value: T): T[] {
 }
 
 // Radix's DropdownMenuTrigger (used with `asChild`) composes its ref and
-// event handlers onto the direct child. Using forwardRef and spreading
-// the received props lets Radix wire open/close, focus, and a11y
-// attributes onto the real <button>.
+// event handlers onto the direct child. forwardRef + spread lets Radix
+// wire open/close, focus, and a11y onto the underlying <Button>.
 const TriggerButton = forwardRef<HTMLButtonElement, TriggerButtonProps>(
   function TriggerButton(
     { className, count, icon, label, value, ...props },
     ref,
   ) {
     return (
-      <button
+      <Button
         className={cn(
-          'inline-flex h-9 items-center gap-2 rounded-md border border-tertiary bg-primary px-3 text-sm text-secondary transition-colors hover:bg-secondary hover:text-primary',
+          'h-9 gap-2 border-tertiary bg-primary px-3 font-normal text-secondary hover:bg-secondary hover:text-primary',
           className,
         )}
         ref={ref}
         type="button"
+        variant="outline"
         {...props}
       >
         <span className="text-tertiary flex size-4 items-center justify-center">
@@ -121,7 +122,7 @@ const TriggerButton = forwardRef<HTMLButtonElement, TriggerButtonProps>(
           </span>
         ) : null}
         <ChevronDown className="text-tertiary size-3.5" />
-      </button>
+      </Button>
     )
   },
 )

--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -741,8 +741,9 @@ export function LogsTab({
         {/* Date picker */}
         <Popover onOpenChange={setDatePickerOpen} open={datePickerOpen}>
           <PopoverTrigger asChild>
-            <button
-              className={`bg-primary text-primary hover:border-primary flex items-center gap-1.5 rounded border px-2.5 py-1.5 font-mono text-xs transition-colors ${datePickerOpen ? 'ring-action/20 border-action ring-1' : ''}`}
+            <Button
+              className={`bg-primary text-primary hover:border-primary h-auto gap-1.5 rounded px-2.5 py-1.5 font-mono text-xs font-normal ${datePickerOpen ? 'ring-action/20 border-action ring-1' : ''}`}
+              variant="outline"
             >
               <Calendar className="text-tertiary" size={12} />
               {customStart && customEnd
@@ -751,7 +752,7 @@ export function LogsTab({
                     customEnd.toISOString(),
                   )
                 : fmtRangeLabel(datetimes.start, datetimes.end)}
-            </button>
+            </Button>
           </PopoverTrigger>
           <PopoverContent align="start" className="min-w-72 p-3">
             <div className="text-tertiary mb-2 text-[10px] font-semibold tracking-wide uppercase">


### PR DESCRIPTION
## Summary
- `OperationsLogToolbar`'s `TriggerButton` (used 5x as `DropdownMenuTrigger asChild`) now wraps `<Button variant=\"outline\">`
- `LogsTab`'s date-picker `<PopoverTrigger asChild>` now wraps `<Button variant=\"outline\">`

Radix slot-merging on `asChild` forwards open/close, focus, and a11y onto the inner `<Button>`. Existing class overrides preserve the toolbar look.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx oxlint` 0 errors on touched files
- [ ] Manual: open each dropdown / date popover and verify focus + open/close behavior