### PR TITLE
Reimplement ConfirmDialog on top of AlertDialog

### DIFF
--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,12 +1,14 @@
-import { Button } from './button'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from './dialog'
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './alert-dialog'
+import { buttonVariants } from './button'
 
 interface ConfirmDialogProps {
   confirmLabel?: string
@@ -26,26 +28,29 @@ export function ConfirmDialog({
   title,
 }: ConfirmDialogProps) {
   return (
-    <Dialog
-      onOpenChange={(open) => {
-        if (!open) onCancel()
+    <AlertDialog
+      onOpenChange={(next) => {
+        if (!next) onCancel()
       }}
       open={open}
     >
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-          {description && <DialogDescription>{description}</DialogDescription>}
-        </DialogHeader>
-        <DialogFooter>
-          <Button onClick={onCancel} variant="outline">
-            Cancel
-          </Button>
-          <Button onClick={onConfirm} variant="destructive">
+      <AlertDialogContent className="sm:max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({ variant: 'destructive' })}
+            onClick={onConfirm}
+          >
             {confirmLabel}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }


### PR DESCRIPTION
## Summary
`ConfirmDialog` wraps `<Dialog>`, which is the generic modal primitive.
`AlertDialog` (Radix) is purpose-built for destructive confirms — it traps
focus on Cancel, announces as `role=alertdialog`, and blocks outside-click
dismissal so users can't accidentally lose the confirmation step.

Rewriting `confirm-dialog.tsx` against the AlertDialog primitive lifts the
upgrade to all 17 consumers without touching them.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx oxlint` clean
- [x] `npm run build` succeeds
- [ ] Manual: trigger a delete in admin (e.g., AuthProviders, PluginEntity, Team, User) and verify Cancel/Delete still wire up correctly and focus lands on Cancel by default