### PR TITLE
Improve Graph Query workbench results and errors

### DIFF
--- a/src/components/admin/graph-query/DetailDrawer.tsx
+++ b/src/components/admin/graph-query/DetailDrawer.tsx
@@ -1,0 +1,81 @@
+import { ChevronRight } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import type { GraphQueryInspection } from '@/types'
+
+interface DetailDrawerProps {
+  inspected: GraphQueryInspection
+  onClose: () => void
+}
+
+export function DetailDrawer({ inspected, onClose }: DetailDrawerProps) {
+  return (
+    <aside
+      className="border-tertiary flex h-full w-72 shrink-0 flex-col border-l"
+      style={{ borderLeftWidth: '0.5px' }}
+    >
+      <div
+        className="border-tertiary flex items-center gap-2 border-b px-3 py-2"
+        style={{ borderBottomWidth: '0.5px' }}
+      >
+        <Button
+          aria-label="Close details"
+          className="text-secondary hover:text-primary size-6 shrink-0"
+          onClick={onClose}
+          size="icon"
+          title="Close details"
+          variant="ghost"
+        >
+          <ChevronRight className="size-4" />
+        </Button>
+        <span className="text-primary truncate font-mono text-xs">
+          {inspected.heading}
+        </span>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3">
+        {inspected.id !== undefined && <Row label="id" value={inspected.id} />}
+        {inspected.entries.length === 0 ? (
+          <p className="text-tertiary text-xs italic">No properties.</p>
+        ) : (
+          inspected.entries.map(([key, value]) => (
+            <Row key={key} label={key} value={value} />
+          ))
+        )}
+      </div>
+    </aside>
+  )
+}
+
+function Row({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div
+      className="border-tertiary flex flex-col gap-0.5 border-b py-1.5 last:border-b-0"
+      style={{ borderBottomWidth: '0.5px' }}
+    >
+      <span className="text-tertiary font-mono text-[11px] tracking-wide">
+        {label}
+      </span>
+      <Value value={value} />
+    </div>
+  )
+}
+
+function Value({ value }: { value: unknown }) {
+  if (value === null || value === undefined) {
+    return <span className="text-tertiary text-xs italic">null</span>
+  }
+  if (typeof value === 'string') {
+    return <span className="text-primary text-xs wrap-break-word">{value}</span>
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return (
+      <span className="text-primary font-mono text-xs">{String(value)}</span>
+    )
+  }
+  return (
+    <pre className="text-primary overflow-x-auto font-mono text-[11px] leading-relaxed">
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  )
+}

--- a/src/components/admin/graph-query/GraphQueryWorkbench.tsx
+++ b/src/components/admin/graph-query/GraphQueryWorkbench.tsx
@@ -126,41 +126,43 @@ export function GraphQueryWorkbench() {
       )}
 
       {/* Workbench */}
-      <div className="flex min-w-0 flex-1 flex-col">
-        {/* Sticky editor */}
-        <div
-          className="border-tertiary bg-primary sticky top-0 z-20 border-b p-3"
-          style={{ borderBottomWidth: '0.5px' }}
-        >
-          <div className="flex items-start gap-2">
-            <div className="flex-1">
-              <CypherEditor
-                autoFocus
-                maxHeight="160px"
-                minHeight="32px"
-                onChange={setEditorValue}
-                onSubmit={handleRun}
-                value={editorValue}
-              />
-            </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <span className="text-tertiary font-mono text-[11px]">⌘⏎</span>
-              <Button
-                className="border-amber-border bg-amber-bg text-amber-text h-8 gap-1.5 border font-medium"
-                disabled={!editorValue.trim() || isRunning}
-                onClick={handleRun}
-                size="sm"
-                style={{ borderWidth: '0.5px' }}
-              >
-                <Play className="size-3.5" />
-                {isRunning ? 'Running…' : 'Run'}
-              </Button>
+      <div className="bg-tertiary flex min-w-0 flex-1 flex-col">
+        {/* Editor card — aligned with the result cards below */}
+        <div className="px-3 pt-3">
+          <div
+            className="border-tertiary bg-primary rounded-md border p-3"
+            style={{ borderWidth: '0.5px' }}
+          >
+            <div className="flex items-start gap-2">
+              <div className="flex-1">
+                <CypherEditor
+                  autoFocus
+                  maxHeight="160px"
+                  minHeight="32px"
+                  onChange={setEditorValue}
+                  onSubmit={handleRun}
+                  value={editorValue}
+                />
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className="text-tertiary font-mono text-[11px]">⌘⏎</span>
+                <Button
+                  className="border-amber-border bg-amber-bg text-amber-text h-8 gap-1.5 border font-medium"
+                  disabled={!editorValue.trim() || isRunning}
+                  onClick={handleRun}
+                  size="sm"
+                  style={{ borderWidth: '0.5px' }}
+                >
+                  <Play className="size-3.5" />
+                  {isRunning ? 'Running…' : 'Run'}
+                </Button>
+              </div>
             </div>
           </div>
         </div>
 
         {/* Result cards */}
-        <div className="bg-tertiary flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto">
           {cards.length === 0 ? (
             <div className="flex h-full items-center justify-center p-8">
               <div className="max-w-md text-center">

--- a/src/components/admin/graph-query/ResultCard.tsx
+++ b/src/components/admin/graph-query/ResultCard.tsx
@@ -1,16 +1,20 @@
-import { lazy, Suspense, useMemo } from 'react'
+import { lazy, Suspense, useMemo, useState } from 'react'
 
-import { ChevronDown, ChevronRight, X } from 'lucide-react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { useGraphQuery } from '@/contexts/GraphQueryContext'
+import { inspectRow } from '@/lib/graphInspection'
 import type {
   GraphQueryCard,
   GraphQueryCardTab,
   GraphQueryCell,
   GraphQueryCellEdge,
   GraphQueryCellNode,
+  GraphQueryInspection,
 } from '@/types'
+
+import { DetailDrawer } from './DetailDrawer'
 
 const ResultGraph = lazy(() =>
   import('./ResultGraph').then((m) => ({ default: m.ResultGraph })),
@@ -27,7 +31,8 @@ const TABS: { id: GraphQueryCardTab; label: string }[] = [
 ]
 
 export function ResultCard({ card }: ResultCardProps) {
-  const { dismissCard, setCardTab, toggleCardCollapsed } = useGraphQuery()
+  const { setCardTab, toggleCardCollapsed } = useGraphQuery()
+  const [inspected, setInspected] = useState<GraphQueryInspection | null>(null)
 
   const recordCount = card.result?.rows.length ?? 0
   const isError = card.status === 'error'
@@ -63,15 +68,6 @@ export function ResultCard({ card }: ResultCardProps) {
         >
           {card.query}
         </code>
-        <Button
-          aria-label="Dismiss result"
-          className="text-secondary hover:text-primary size-6 shrink-0"
-          onClick={() => dismissCard(card.id)}
-          size="icon"
-          variant="ghost"
-        >
-          <X className="size-4" />
-        </Button>
       </div>
 
       {!card.collapsed && (
@@ -102,25 +98,38 @@ export function ResultCard({ card }: ResultCardProps) {
           </div>
 
           {/* Body */}
-          <div className="h-120 overflow-hidden">
-            {isError ? (
-              <ErrorBody card={card} />
-            ) : (
-              <>
-                {card.tab === 'table' && <TableTab result={card.result!} />}
-                {card.tab === 'graph' && (
-                  <Suspense
-                    fallback={
-                      <div className="text-tertiary flex h-full items-center justify-center text-xs">
-                        Loading graph…
-                      </div>
-                    }
-                  >
-                    <ResultGraph result={card.result!} />
-                  </Suspense>
-                )}
-                {card.tab === 'raw' && <RawTab result={card.result!} />}
-              </>
+          <div className="flex h-120 overflow-hidden">
+            <div className="min-w-0 flex-1">
+              {isError ? (
+                <ErrorBody card={card} />
+              ) : (
+                <>
+                  {card.tab === 'table' && (
+                    <TableTab onInspect={setInspected} result={card.result!} />
+                  )}
+                  {card.tab === 'graph' && (
+                    <Suspense
+                      fallback={
+                        <div className="text-tertiary flex h-full items-center justify-center text-xs">
+                          Loading graph…
+                        </div>
+                      }
+                    >
+                      <ResultGraph
+                        onInspect={setInspected}
+                        result={card.result!}
+                      />
+                    </Suspense>
+                  )}
+                  {card.tab === 'raw' && <RawTab result={card.result!} />}
+                </>
+              )}
+            </div>
+            {inspected && (
+              <DetailDrawer
+                inspected={inspected}
+                onClose={() => setInspected(null)}
+              />
             )}
           </div>
 
@@ -252,8 +261,10 @@ function RawTab({ result }: { result: NonNullable<GraphQueryCard['result']> }) {
 }
 
 function TableTab({
+  onInspect,
   result,
 }: {
+  onInspect: (item: GraphQueryInspection) => void
   result: NonNullable<GraphQueryCard['result']>
 }) {
   if (result.rows.length === 0) {
@@ -282,8 +293,9 @@ function TableTab({
         <tbody>
           {result.rows.map((row, rowIdx) => (
             <tr
-              className="border-tertiary border-b last:border-b-0"
+              className="border-tertiary hover:bg-secondary cursor-pointer border-b last:border-b-0"
               key={rowIdx}
+              onClick={() => onInspect(inspectRow(result.columns, row))}
               style={{ borderBottomWidth: '0.5px' }}
             >
               {result.columns.map((col) => (

--- a/src/components/admin/graph-query/ResultGraph.tsx
+++ b/src/components/admin/graph-query/ResultGraph.tsx
@@ -1,16 +1,24 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { darkTheme, GraphCanvas, lightTheme } from 'reagraph'
-import type { GraphEdge, GraphNode } from 'reagraph'
+import type { GraphEdge, GraphNode, InternalGraphEdge } from 'reagraph'
+import type { InternalGraphNode } from 'reagraph'
 
 import { useTheme } from '@/contexts/ThemeContext'
-import type { GraphQueryResult } from '@/types'
+import { inspectEdge, inspectNode } from '@/lib/graphInspection'
+import type {
+  GraphQueryEdge,
+  GraphQueryInspection,
+  GraphQueryNode,
+  GraphQueryResult,
+} from '@/types'
 
 interface ResultGraphProps {
+  onInspect: (item: GraphQueryInspection) => void
   result: GraphQueryResult
 }
 
-export function ResultGraph({ result }: ResultGraphProps) {
+export function ResultGraph({ onInspect, result }: ResultGraphProps) {
   const { isDarkMode } = useTheme()
 
   const nodes = useMemo<GraphNode[]>(
@@ -24,12 +32,12 @@ export function ResultGraph({ result }: ResultGraphProps) {
           n.id
         return {
           data: n,
-          fill: nodeColor(n.labels),
+          fill: nodeColor(n.labels, isDarkMode),
           id: n.id,
           label: String(labelText),
         }
       }),
-    [result.nodes],
+    [result.nodes, isDarkMode],
   )
 
   const edges = useMemo<GraphEdge[]>(
@@ -42,6 +50,18 @@ export function ResultGraph({ result }: ResultGraphProps) {
         target: e.end,
       })),
     [result.edges],
+  )
+
+  const handleNodeClick = useCallback(
+    (node: InternalGraphNode) =>
+      onInspect(inspectNode(node.data as GraphQueryNode)),
+    [onInspect],
+  )
+
+  const handleEdgeClick = useCallback(
+    (edge: InternalGraphEdge) =>
+      onInspect(inspectEdge(edge.data as GraphQueryEdge)),
+    [onInspect],
   )
 
   if (nodes.length === 0) {
@@ -62,6 +82,8 @@ export function ResultGraph({ result }: ResultGraphProps) {
         labelType="nodes"
         layoutType="forceDirected2d"
         nodes={nodes}
+        onEdgeClick={handleEdgeClick}
+        onNodeClick={handleNodeClick}
         theme={isDarkMode ? darkTheme : lightTheme}
       />
     </div>
@@ -76,8 +98,14 @@ function hashHue(value: string): number {
   return h % 360
 }
 
-function nodeColor(labels: string[]): string {
+// Keep a distinct hue per label, but tune lightness/saturation to the active
+// theme so every hue stays legible: deeper on the light (#fff) background,
+// brighter on the dark (#1E2026) background. Empty-label nodes fall back to
+// the same slate the projects graph uses. NOTE: reagraph passes fills to
+// three.js, whose color parser only understands comma-separated hsl() — the
+// space-separated CSS form silently renders white, so keep the commas.
+function nodeColor(labels: string[], isDarkMode: boolean): string {
   if (labels.length === 0) return '#64748b'
   const hue = hashHue(labels[0])
-  return `hsl(${hue} 55% 55%)`
+  return isDarkMode ? `hsl(${hue}, 60%, 64%)` : `hsl(${hue}, 58%, 42%)`
 }

--- a/src/contexts/GraphQueryContext.tsx
+++ b/src/contexts/GraphQueryContext.tsx
@@ -11,13 +11,11 @@ import {
   useState,
 } from 'react'
 
-import { ApiError } from '@/api/client'
 import { executeGraphQuery } from '@/api/endpoints'
+import { extractGraphQueryError } from '@/lib/graphQueryError'
 import type {
   GraphQueryCard,
   GraphQueryCardTab,
-  GraphQueryError,
-  GraphQueryErrorEnvelope,
   GraphQueryHistoryEntry,
   GraphQueryResult,
 } from '@/types'
@@ -179,7 +177,7 @@ export function GraphQueryProvider({ children }: { children: ReactNode }) {
         card: {
           collapsed: false,
           elapsedMs: Date.now() - startedAt,
-          error: extractErrorFromApi(err),
+          error: extractGraphQueryError(err),
           id: cardId,
           query: trimmed,
           startedAt,
@@ -240,20 +238,6 @@ export function useGraphQuery() {
     throw new Error('useGraphQuery must be used within a GraphQueryProvider')
   }
   return ctx
-}
-
-function extractErrorFromApi(err: unknown): GraphQueryError {
-  if (err instanceof ApiError) {
-    const data = err.data as GraphQueryErrorEnvelope | undefined
-    if (data && typeof data === 'object' && 'error' in data && data.error) {
-      return data.error
-    }
-    return { message: err.message || `HTTP ${err.status}` }
-  }
-  if (err instanceof Error) {
-    return { message: err.message }
-  }
-  return { message: 'Unknown error' }
 }
 
 function generateCardId(): string {

--- a/src/lib/__tests__/graphQueryError.test.ts
+++ b/src/lib/__tests__/graphQueryError.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { ApiError } from '@/api/client'
+import { extractGraphQueryError } from '@/lib/graphQueryError'
+
+describe('extractGraphQueryError', () => {
+  it('unwraps the structured error from FastAPI detail envelopes', () => {
+    const err = new ApiError(400, '', {
+      detail: {
+        error: {
+          code: '42601',
+          column: 14,
+          message: 'syntax error at or near "RETUR"',
+        },
+      },
+    })
+    expect(extractGraphQueryError(err)).toEqual({
+      code: '42601',
+      column: 14,
+      message: 'syntax error at or near "RETUR"',
+    })
+  })
+
+  it('falls back to a plain string detail (e.g. 403)', () => {
+    const err = new ApiError(403, '', { detail: 'Admin privileges required' })
+    expect(extractGraphQueryError(err)).toEqual({
+      message: 'Admin privileges required',
+    })
+  })
+
+  it('still accepts an unwrapped error envelope', () => {
+    const err = new ApiError(400, '', { error: { message: 'boom' } })
+    expect(extractGraphQueryError(err)).toEqual({ message: 'boom' })
+  })
+
+  it('falls back to the HTTP status when no detail is present', () => {
+    const err = new ApiError(400, '')
+    expect(extractGraphQueryError(err).message).toBe('HTTP 400: ')
+  })
+
+  it('handles non-ApiError values', () => {
+    expect(extractGraphQueryError(new Error('network down'))).toEqual({
+      message: 'network down',
+    })
+    expect(extractGraphQueryError('weird')).toEqual({
+      message: 'Unknown error',
+    })
+  })
+})

--- a/src/lib/graphInspection.ts
+++ b/src/lib/graphInspection.ts
@@ -1,0 +1,71 @@
+import type {
+  GraphQueryCell,
+  GraphQueryCellEdge,
+  GraphQueryCellNode,
+  GraphQueryEdge,
+  GraphQueryInspection,
+  GraphQueryNode,
+} from '@/types'
+
+/** Build a drawer inspection for a graph edge. */
+export function inspectEdge(
+  edge: GraphQueryCellEdge | GraphQueryEdge,
+): GraphQueryInspection {
+  return {
+    entries: Object.entries(edge.properties),
+    heading: `[:${edge.type}]`,
+    id: edge.id,
+    kind: 'edge',
+  }
+}
+
+/** Build a drawer inspection for a graph node. */
+export function inspectNode(
+  node: GraphQueryCellNode | GraphQueryNode,
+): GraphQueryInspection {
+  return {
+    entries: Object.entries(node.properties),
+    heading: node.labels.length ? `:${node.labels.join(':')}` : 'Node',
+    id: node.id,
+    kind: 'node',
+  }
+}
+
+/**
+ * Build a drawer inspection for a table row. A single-column row whose value
+ * is a node or edge inspects that element directly (the common
+ * ``RETURN p`` case); anything else lists the row's columns.
+ */
+export function inspectRow(
+  columns: string[],
+  row: Record<string, GraphQueryCell>,
+): GraphQueryInspection {
+  if (columns.length === 1) {
+    const only = row[columns[0]]
+    if (isNodeCell(only)) return inspectNode(only)
+    if (isEdgeCell(only)) return inspectEdge(only)
+  }
+  return {
+    entries: columns.map((col) => [col, row[col]]),
+    heading: 'Row',
+    kind: 'row',
+  }
+}
+
+function isEdgeCell(cell: GraphQueryCell): cell is GraphQueryCellEdge {
+  return (
+    typeof cell === 'object' &&
+    cell !== null &&
+    !Array.isArray(cell) &&
+    (cell as { _kind?: string })._kind === 'edge'
+  )
+}
+
+function isNodeCell(cell: GraphQueryCell): cell is GraphQueryCellNode {
+  return (
+    typeof cell === 'object' &&
+    cell !== null &&
+    !Array.isArray(cell) &&
+    (cell as { _kind?: string })._kind === 'node'
+  )
+}

--- a/src/lib/graphQueryError.ts
+++ b/src/lib/graphQueryError.ts
@@ -1,0 +1,47 @@
+import { ApiError } from '@/api/client'
+import type { GraphQueryError, GraphQueryErrorEnvelope } from '@/types'
+
+/**
+ * Translate an error thrown by the graph-query endpoint into the structured
+ * {@link GraphQueryError} the workbench renders (message + optional SQLSTATE
+ * code, line/column, and hint).
+ *
+ * The backend returns the actual PostgreSQL / Apache AGE error wrapped in
+ * FastAPI's ``{ detail: { error: { ... } } }`` envelope. Earlier we only
+ * looked for ``error`` at the top level, so every failure collapsed to a bare
+ * ``HTTP 400``. Here we unwrap the ``detail`` layer first, then fall back to a
+ * plain string detail (e.g. the 403 "Admin privileges required") and finally
+ * the HTTP status line.
+ */
+export function extractGraphQueryError(err: unknown): GraphQueryError {
+  if (err instanceof ApiError) {
+    const detail = (err.data as undefined | { detail?: unknown })?.detail
+    const envelope =
+      unwrapErrorEnvelope(detail) ?? unwrapErrorEnvelope(err.data)
+    if (envelope) {
+      return envelope
+    }
+    if (typeof detail === 'string' && detail) {
+      return { message: detail }
+    }
+    return { message: err.message || `HTTP ${err.status}` }
+  }
+  if (err instanceof Error) {
+    return { message: err.message }
+  }
+  return { message: 'Unknown error' }
+}
+
+function unwrapErrorEnvelope(value: unknown): GraphQueryError | undefined {
+  if (value && typeof value === 'object' && 'error' in value) {
+    const { error } = value as GraphQueryErrorEnvelope
+    if (
+      error &&
+      typeof error === 'object' &&
+      typeof error.message === 'string'
+    ) {
+      return error
+    }
+  }
+  return undefined
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -651,6 +651,17 @@ export interface GraphQueryHistoryEntry {
   query: string
 }
 
+/**
+ * A node, edge, or table row selected in a result card and shown in the
+ * detail drawer as a flat list of key/value pairs.
+ */
+export interface GraphQueryInspection {
+  entries: Array<[string, unknown]>
+  heading: string
+  id?: string
+  kind: 'edge' | 'node' | 'row'
+}
+
 export interface GraphQueryNode {
   id: string
   labels: string[]


### PR DESCRIPTION
## Summary

Several refinements to the admin Graph Query workbench, surfaced while testing real Cypher queries.

## Problem

- A failed query showed a bare **`HTTP 400:`** in the RAW tab — the actual Postgres/AGE error was buried in FastAPI's `detail` envelope.
- There was no way to inspect a result object's fields; you could see nodes/rows but not their key/value pairs.
- Graph node dots didn't respect light/dark mode and rendered **white on a white background** (reagraph passes `fill` to three.js `Color`, which renders space-separated `hsl()` as white).
- The editor/Run bar and the sidebar didn't align with the result cards, and the result card had a redundant X dismiss button.

## Solution

- **Real errors:** `extractGraphQueryError` (new, with `graphQueryError.test.ts`) unwraps the `detail` envelope and the structured error within, falling back to `HTTP <status>` only when nothing better exists.
- **Detail drawer:** clicking a node, edge, or table row slides out a per-card `DetailDrawer` (inside the result card) showing the object's key/value pairs. `graphInspection` builds the inspection payload.
- **Theme-aware colors:** `nodeColor(labels, isDarkMode)` returns comma-separated `hsl()` so three.js parses it correctly, matching the projects graph report.
- **Layout:** editor/Run bar wrapped in a card aligned with the result cards; sidebar moved inside the result card; removed the dismiss X.

## Testing

- `npm run lint` — 0 errors
- `npm run format:check` — clean
- `npx tsc --noEmit` — clean
- `npx vitest run src/lib/__tests__/graphQueryError.test.ts` — 5 passing

## Related

Pairs with imbi-common #130 (raw-Cypher literal-brace fix). The matching imbi-api change (`raw=True` on the graph query call) is held until imbi-common 2.5.7 is released and the pin bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)