### PR TITLE
Surface failed archive/unarchive lifecycle results to the user

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -10,6 +10,7 @@ import type {
   AdminUserCreate,
   ApiKey,
   ApiKeyCreated,
+  ArchiveProjectResponse,
   AuthProvider,
   Blueprint,
   BlueprintCreate,
@@ -321,12 +322,12 @@ export const deleteProject = (orgSlug: string, projectId: string) =>
   )
 
 export const archiveProject = (orgSlug: string, projectId: string) =>
-  apiClient.post<Project>(
+  apiClient.post<ArchiveProjectResponse>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/archive`,
   )
 
 export const unarchiveProject = (orgSlug: string, projectId: string) =>
-  apiClient.post<Project>(
+  apiClient.post<ArchiveProjectResponse>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/unarchive`,
   )
 

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -77,10 +77,37 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
       mutationErrorHandler(
         action === 'unarchive' ? 'unarchive project' : 'archive project',
       )(error),
-    onSuccess: (_data, action) => {
-      toast.success(
-        action === 'unarchive' ? 'Project restored' : 'Project archived',
+    onSuccess: (data, action) => {
+      const base =
+        action === 'unarchive' ? 'Project restored' : 'Project archived'
+      // The Imbi state change always succeeds here; per-plugin lifecycle
+      // handlers (e.g. archiving the GitHub repo) can still fail without
+      // rolling it back. Surface those failures so they are not silent.
+      const failed = (data.lifecycle_results ?? []).filter(
+        (result) => result.status === 'failed',
       )
+      if (failed.length > 0) {
+        toast.error(
+          `${base}, but ${failed.length} integration${
+            failed.length > 1 ? 's' : ''
+          } failed`,
+          {
+            description: (
+              <ul className="mt-1 space-y-0.5">
+                {failed.map((result) => (
+                  <li key={result.plugin_id}>
+                    <span className="font-medium">{result.plugin_slug}</span>:{' '}
+                    {result.message ?? 'unknown error'}
+                  </li>
+                ))}
+              </ul>
+            ),
+            duration: 10000,
+          },
+        )
+      } else {
+        toast.success(base)
+      }
       setShowArchiveConfirm(false)
       invalidateProject()
       queryClient.invalidateQueries({ queryKey: ['projects', orgSlug] })

--- a/src/components/__tests__/ProjectSettingsTab.test.tsx
+++ b/src/components/__tests__/ProjectSettingsTab.test.tsx
@@ -1,0 +1,145 @@
+import { MemoryRouter } from 'react-router-dom'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import type { ArchiveProjectResponse, Project } from '@/types'
+
+import { ProjectSettingsTab } from '../ProjectSettingsTab'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return {
+    ...actual,
+    archiveProject: vi.fn(),
+    listEnvironments: vi.fn(),
+    listLinkDefinitions: vi.fn(),
+    listProjectPlugins: vi.fn(),
+    unarchiveProject: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+// Isolate the archive card: the surrounding editor cards do their own
+// data fetching and are irrelevant to the lifecycle-result behaviour.
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/components/EditLinksCard', () => ({ EditLinksCard: () => null }))
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/components/EditEnvironmentsCard', () => ({
+  EditEnvironmentsCard: () => null,
+}))
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/components/EditIdentifiersCard', () => ({
+  EditIdentifiersCard: () => null,
+}))
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/components/project/ProjectPluginsSection', () => ({
+  ProjectPluginsSection: () => null,
+}))
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/contexts/OrganizationContext', () => ({
+  useOrganization: () => ({ selectedOrganization: { slug: 'acme' } }),
+}))
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { is_admin: false, permissions: [] } }),
+}))
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/hooks/useProjectPatch', () => ({
+  useProjectPatch: () => ({ patch: vi.fn(), scheduleScoreRefresh: vi.fn() }),
+}))
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/hooks/useDeploymentResync', () => ({
+  useProjectDeploymentResync: () => ({ isPending: false, mutate: vi.fn() }),
+}))
+
+const ARCHIVED_PROJECT = {
+  archived: true,
+  id: 'p1',
+  name: 'Demo',
+  slug: 'demo',
+  team: { name: 'Team', organization: { name: 'Acme', slug: 'acme' } },
+} as Project
+
+function renderTab() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <ProjectSettingsTab project={ARCHIVED_PROJECT} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('ProjectSettingsTab archive lifecycle results', () => {
+  let toast: {
+    error: ReturnType<typeof vi.fn>
+    success: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.mocked(endpoints.listEnvironments).mockResolvedValue([])
+    vi.mocked(endpoints.listLinkDefinitions).mockResolvedValue([])
+    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([])
+    toast = (await import('sonner')).toast as unknown as typeof toast
+  })
+
+  it('surfaces a failed lifecycle result as an error toast', async () => {
+    vi.mocked(endpoints.unarchiveProject).mockResolvedValue({
+      ...ARCHIVED_PROJECT,
+      lifecycle_results: [
+        {
+          artifacts: {},
+          message: "404 Not Found for '/repos/archives/demo'",
+          plugin_id: 'pi-1',
+          plugin_slug: 'github-lifecycle-ec',
+          status: 'failed',
+        },
+      ],
+    } as ArchiveProjectResponse)
+
+    const { getByRole } = renderTab()
+    fireEvent.click(getByRole('button', { name: 'Restore project' }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledTimes(1)
+    })
+    expect(toast.error.mock.calls[0][0]).toContain('1 integration failed')
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('shows a plain success toast when no lifecycle plugin fails', async () => {
+    vi.mocked(endpoints.unarchiveProject).mockResolvedValue({
+      ...ARCHIVED_PROJECT,
+      lifecycle_results: [
+        {
+          artifacts: {},
+          message: 'Unarchived archives/demo',
+          plugin_id: 'pi-1',
+          plugin_slug: 'github-lifecycle-ec',
+          status: 'ok',
+        },
+      ],
+    } as ArchiveProjectResponse)
+
+    const { getByRole } = renderTab()
+    fireEvent.click(getByRole('button', { name: 'Restore project' }))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Project restored')
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,12 @@ export interface AgeScoringPolicyCreate extends ScoringPolicyCreateBase {
   category: 'age'
 }
 
+// Response from POST .../archive and .../unarchive: the updated project
+// plus the per-plugin lifecycle results.
+export interface ArchiveProjectResponse extends Project {
+  lifecycle_results?: LifecycleInvocation[]
+}
+
 export interface AttributeScoringPolicy extends ScoringPolicyBase {
   attribute_name: string
   category: 'attribute'
@@ -58,6 +64,18 @@ export interface EnvironmentCreate {
   name: string
   slug: string
   sort_order?: null | number
+}
+
+// Per-plugin outcome returned by the archive / unarchive endpoints, one
+// entry per lifecycle plugin assigned to the project. `failed` is the
+// case worth surfacing — e.g. a GitHub repo transfer that left the repo
+// un-archived. Mirrors the API's `LifecycleInvocation`.
+export interface LifecycleInvocation {
+  artifacts: Record<string, string>
+  message: null | string
+  plugin_id: string
+  plugin_slug: string
+  status: 'failed' | 'ok' | 'skipped'
 }
 
 export type LinkDefinition = Schemas['LinkDefinitionResponse']


### PR DESCRIPTION
## Summary

`POST /api/.../archive` and `/unarchive` return an `ArchiveProjectResponse` — the updated project **plus** a `lifecycle_results` array, one entry per assigned lifecycle plugin (`{ plugin_slug, status, message, artifacts }`). The UI typed both endpoints as returning a bare `Project` and ignored that array, so a plugin failure was **silent**: the operator saw the green "Project archived" toast even when the GitHub side actually failed.

This is the UI half of the GitHub-lifecycle archive incident (see imbi-plugin-github#19). The backend already commits the Imbi archive before dispatching plugins and never rolls back on plugin failure, so surfacing per-plugin outcomes is the only way the operator learns an integration didn't complete.

## Problem

Concrete case from the lifecycle event log: two GHEC repos were archived in Imbi and transferred to the `archives` org but failed to archive in GitHub (`404` during the async-transfer window). The `failed` lifecycle result was returned to the UI but discarded.

## Solution

- Add `LifecycleInvocation` and `ArchiveProjectResponse` types; type `archiveProject` / `unarchiveProject` as `ArchiveProjectResponse`.
- In `ProjectSettingsTab`'s archive mutation `onSuccess`, filter `lifecycle_results` for `status === 'failed'`. If any failed, show a 10s **error** toast titled `"<Project archived|restored>, but N integration(s) failed"` with a per-plugin breakdown (`plugin_slug: message`) instead of the plain success toast. Clean runs keep the existing success toast.

## Tests

New `ProjectSettingsTab.test.tsx` (the component had no test before) covering both paths via the unarchive button:
- a `failed` result → `toast.error` with `"1 integration failed"`, no success toast;
- an all-`ok` result → `toast.success('Project restored')`, no error toast.

`tsc`, `oxlint`, `oxfmt`, and `vitest` all pass locally; the fallow commit gate reports no new issues.