### PR TITLE
Migrate refresh token to an HttpOnly cookie (C2)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -46,17 +46,10 @@ async function refreshAccessToken(): Promise<string> {
 
   refreshPromise = (async () => {
     try {
-      const authStore = useAuthStore.getState()
-      const currentRefreshToken = authStore.refreshToken
-
-      if (!currentRefreshToken) {
-        throw new Error('No refresh token available')
-      }
-
+      // The refresh token rides along as an HttpOnly cookie (C2), sent
+      // automatically via credentials:'include'; no request body needed.
       const response = await fetch(`${API_BASE_URL}/auth/token/refresh`, {
-        body: JSON.stringify({ refresh_token: currentRefreshToken }),
         credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       })
 
@@ -64,9 +57,8 @@ async function refreshAccessToken(): Promise<string> {
         throw new ApiError(response.status, response.statusText)
       }
 
-      const { access_token, refresh_token } =
-        (await response.json()) as TokenResponse
-      authStore.setTokens(access_token, refresh_token)
+      const { access_token } = (await response.json()) as TokenResponse
+      useAuthStore.getState().setTokens(access_token)
 
       return access_token
     } catch (error) {

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -124,10 +124,9 @@ export const getAuthProviders = (signal?: AbortSignal) =>
 export const loginWithPassword = (credentials: LoginRequest) =>
   apiClient.post<TokenResponse>('/auth/login', credentials)
 
-export const refreshToken = (refreshToken: string) =>
-  apiClient.post<TokenResponse>('/auth/token/refresh', {
-    refresh_token: refreshToken,
-  })
+// The refresh token is sent as an HttpOnly cookie (C2), not in the body.
+export const refreshToken = () =>
+  apiClient.post<TokenResponse>('/auth/token/refresh')
 
 export const logoutAuth = () => apiClient.post<void>('/auth/logout', {})
 

--- a/src/components/BootstrapGate.tsx
+++ b/src/components/BootstrapGate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useLocation, useNavigate } from 'react-router-dom'
 
@@ -17,8 +17,17 @@ export function BootstrapGate({ children, fallback }: BootstrapGateProps) {
   const location = useLocation()
   const navigate = useNavigate()
   const [ready, setReady] = useState(false)
+  // React StrictMode double-invokes effects in development. Bootstrap must
+  // fire only once: it calls /auth/token/refresh, the API rotates the refresh
+  // token on first use and treats the second (concurrent) call as token reuse,
+  // revoking the whole token family and logging the user straight back out.
+  // The ref persists across StrictMode's re-invocation but is per-instance, so
+  // it does not leak between tests the way module state would.
+  const didBootstrap = useRef(false)
 
   useEffect(() => {
+    if (didBootstrap.current) return
+    didBootstrap.current = true
     const store = useAuthStore.getState()
     bootstrapAuth({
       accessToken: store.accessToken,
@@ -26,7 +35,6 @@ export function BootstrapGate({ children, fallback }: BootstrapGateProps) {
       isTokenExpired: store.isTokenExpired,
       onRedirect: () => navigate('/login', { replace: true }),
       pathname: location.pathname,
-      refreshToken: store.refreshToken,
       refreshTokenApi,
       search: location.search,
       setTokens: store.setTokens,

--- a/src/hooks/__tests__/authBootstrap.test.ts
+++ b/src/hooks/__tests__/authBootstrap.test.ts
@@ -21,7 +21,6 @@ function makeDeps(overrides: Partial<BootstrapDeps> = {}): {
       isTokenExpired: () => true,
       onRedirect,
       pathname: '/dashboard',
-      refreshToken: null,
       refreshTokenApi,
       search: '',
       setTokens,
@@ -54,24 +53,44 @@ describe('bootstrapAuth', () => {
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
   })
 
-  it('no tokens on a protected path: clears, saves redirect, calls onRedirect', async () => {
-    const { clearTokens, deps, onRedirect, refreshTokenApi } = makeDeps({
-      pathname: '/projects',
-      search: '?filter=x',
+  it('no access token, cookie refresh succeeds: setTokens, no redirect', async () => {
+    const { clearTokens, deps, onRedirect, refreshTokenApi, setTokens } =
+      makeDeps({ pathname: '/projects', search: '?filter=x' })
+    refreshTokenApi.mockResolvedValue({
+      access_token: 'new',
+      expires_in: 3600,
+      refresh_token: 'ignored',
+      token_type: 'bearer',
     })
 
     await bootstrapAuth(deps)
 
+    expect(refreshTokenApi).toHaveBeenCalledOnce()
+    expect(setTokens).toHaveBeenCalledWith('new')
+    expect(clearTokens).not.toHaveBeenCalled()
+    expect(onRedirect).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
+  })
+
+  it('no access token, cookie refresh fails on protected path: clears, saves, redirects', async () => {
+    const { clearTokens, deps, onRedirect, refreshTokenApi, setTokens } =
+      makeDeps({ pathname: '/projects', search: '?filter=x' })
+    refreshTokenApi.mockRejectedValue(new Error('boom'))
+
+    await bootstrapAuth(deps)
+
+    expect(refreshTokenApi).toHaveBeenCalledOnce()
+    expect(setTokens).not.toHaveBeenCalled()
     expect(clearTokens).toHaveBeenCalledOnce()
-    expect(refreshTokenApi).not.toHaveBeenCalled()
     expect(onRedirect).toHaveBeenCalledOnce()
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
       '/projects?filter=x',
     )
   })
 
-  it('no tokens on /login: clears but does NOT save redirect or call onRedirect', async () => {
+  it('refresh fails on /login: clears but does NOT save redirect or call onRedirect', async () => {
     const { clearTokens, deps, onRedirect } = makeDeps({ pathname: '/login' })
+    deps.refreshTokenApi = vi.fn().mockRejectedValue(new Error('boom'))
 
     await bootstrapAuth(deps)
 
@@ -80,90 +99,38 @@ describe('bootstrapAuth', () => {
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
   })
 
-  it('expired access + valid refresh, refresh succeeds: setTokens, no redirect', async () => {
-    const { clearTokens, deps, onRedirect, refreshTokenApi, setTokens } =
-      makeDeps({
-        accessToken: 'old',
-        refreshToken: 'rt',
-      })
+  it('expired access token still attempts a refresh', async () => {
+    const { deps, refreshTokenApi, setTokens } = makeDeps({
+      accessToken: 'old',
+    })
     refreshTokenApi.mockResolvedValue({
       access_token: 'new',
       expires_in: 3600,
-      refresh_token: 'rt-new',
+      refresh_token: 'ignored',
       token_type: 'bearer',
     })
 
     await bootstrapAuth(deps)
 
-    expect(refreshTokenApi).toHaveBeenCalledWith('rt')
-    expect(setTokens).toHaveBeenCalledWith('new', 'rt-new')
-    expect(clearTokens).not.toHaveBeenCalled()
-    expect(onRedirect).not.toHaveBeenCalled()
-    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
-  })
-
-  it('expired access + valid refresh, refresh fails on protected path: clears, saves, redirects', async () => {
-    const { clearTokens, deps, onRedirect, refreshTokenApi, setTokens } =
-      makeDeps({
-        accessToken: 'old',
-        pathname: '/projects',
-        refreshToken: 'rt',
-      })
-    refreshTokenApi.mockRejectedValue(new Error('boom'))
-
-    await bootstrapAuth(deps)
-
-    expect(refreshTokenApi).toHaveBeenCalledWith('rt')
-    expect(setTokens).not.toHaveBeenCalled()
-    expect(clearTokens).toHaveBeenCalledOnce()
-    expect(onRedirect).toHaveBeenCalledOnce()
-    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
-      '/projects',
-    )
-  })
-
-  it('expired access + valid refresh, refresh fails on /login: clears, no redirect, no save', async () => {
-    const { clearTokens, deps, onRedirect, refreshTokenApi } = makeDeps({
-      accessToken: 'old',
-      pathname: '/login',
-      refreshToken: 'rt',
-    })
-    refreshTokenApi.mockRejectedValue(new Error('boom'))
-
-    await bootstrapAuth(deps)
-
-    expect(clearTokens).toHaveBeenCalledOnce()
-    expect(onRedirect).not.toHaveBeenCalled()
-    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
-  })
-
-  it('expired access + no refresh token: clears, saves, redirects', async () => {
-    const { clearTokens, deps, onRedirect, refreshTokenApi } = makeDeps({
-      accessToken: 'old',
-      pathname: '/dashboard',
-      refreshToken: null,
-    })
-
-    await bootstrapAuth(deps)
-
-    expect(refreshTokenApi).not.toHaveBeenCalled()
-    expect(clearTokens).toHaveBeenCalledOnce()
-    expect(onRedirect).toHaveBeenCalledOnce()
-    expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
-      '/dashboard',
-    )
+    expect(refreshTokenApi).toHaveBeenCalledOnce()
+    expect(setTokens).toHaveBeenCalledWith('new')
   })
 
   it('resolves without throwing on any outcome', async () => {
     // The pre-refactor queryFn threw as control flow. bootstrapAuth must not.
-    const { deps: a, refreshTokenApi: apiA } = makeDeps({
-      accessToken: 'old',
-      refreshToken: 'rt',
-    })
+    const { deps: a, refreshTokenApi: apiA } = makeDeps({ accessToken: 'old' })
     apiA.mockRejectedValue(new Error('boom'))
     await expect(bootstrapAuth(a)).resolves.toBeUndefined()
 
-    const { deps: b } = makeDeps({ accessToken: 'old', refreshToken: null })
+    const { deps: b, refreshTokenApi: apiB } = makeDeps({
+      accessToken: 'old',
+    })
+    apiB.mockResolvedValue({
+      access_token: 'new',
+      expires_in: 3600,
+      refresh_token: 'ignored',
+      token_type: 'bearer',
+    })
     await expect(bootstrapAuth(b)).resolves.toBeUndefined()
   })
 })

--- a/src/hooks/__tests__/useAuth.test.tsx
+++ b/src/hooks/__tests__/useAuth.test.tsx
@@ -62,15 +62,10 @@ function LocationProbe() {
   return null
 }
 
-function setExpiredAccess({
-  refreshToken = 'rt',
-}: {
-  refreshToken?: null | string
-} = {}) {
+function setExpiredAccess() {
   const token = makeJwt({ exp: Math.floor(Date.now() / 1000) - 3600 })
   useAuthStore.setState({
     accessToken: token,
-    refreshToken,
     tokenExpiry: Date.now() - 1000,
   })
   return token
@@ -102,7 +97,6 @@ function setValidAccess() {
   const token = makeJwt({ exp })
   useAuthStore.setState({
     accessToken: token,
-    refreshToken: 'rt',
     tokenExpiry: exp * 1000,
   })
   return token
@@ -162,23 +156,22 @@ describe('useAuth', () => {
 
   // ── Bootstrap matrix ────────────────────────────────────────────────
 
-  it('no tokens on /login: no redirect, no API calls', async () => {
+  it('no tokens on /login: cookie refresh attempted, fails, no redirect', async () => {
+    vi.mocked(endpoints.refreshToken).mockRejectedValue(new Error('no cookie'))
     const { Wrapper } = setupEnv('/login')
     const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
 
-    // Let React Query drain its microtask queue.
-    await act(async () => {
-      await Promise.resolve()
-    })
+    // Let the bootstrap refresh attempt settle.
+    await waitFor(() => expect(endpoints.refreshToken).toHaveBeenCalled())
 
-    expect(endpoints.refreshToken).not.toHaveBeenCalled()
     expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
     expect(latestLocation.pathname).toBe('/login')
     expect(result.current.isAuthenticated).toBe(false)
   })
 
-  it('no tokens on a protected path: redirects to /login, saves path, no API calls', async () => {
+  it('no tokens on a protected path: cookie refresh fails, redirects to /login, saves path', async () => {
+    vi.mocked(endpoints.refreshToken).mockRejectedValue(new Error('no cookie'))
     const { Wrapper } = setupEnv('/projects')
     renderHook(() => useAuth(), { wrapper: Wrapper })
 
@@ -186,7 +179,7 @@ describe('useAuth', () => {
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
       '/projects',
     )
-    expect(endpoints.refreshToken).not.toHaveBeenCalled()
+    expect(endpoints.refreshToken).toHaveBeenCalledOnce()
     expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
   })
 
@@ -223,11 +216,9 @@ describe('useAuth', () => {
 
     await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
     expect(endpoints.refreshToken).toHaveBeenCalledTimes(1)
-    expect(endpoints.refreshToken).toHaveBeenCalledWith('rt')
     expect(endpoints.getUserByUsername).toHaveBeenCalled()
     expect(latestLocation.pathname).toBe('/dashboard')
     expect(useAuthStore.getState().accessToken).toBe(newToken)
-    expect(useAuthStore.getState().refreshToken).toBe('rt-new')
   })
 
   it('expired access + valid refresh fails: clears tokens, redirects with saved path (including search)', async () => {
@@ -245,14 +236,15 @@ describe('useAuth', () => {
     expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
   })
 
-  it('expired access + no refresh token: redirects, saves path, no refresh API call', async () => {
-    setExpiredAccess({ refreshToken: null })
+  it('expired access + no valid cookie: refresh attempted, redirects, saves path', async () => {
+    setExpiredAccess()
+    vi.mocked(endpoints.refreshToken).mockRejectedValue(new Error('no cookie'))
 
     const { Wrapper } = setupEnv('/projects')
     renderHook(() => useAuth(), { wrapper: Wrapper })
 
     await waitFor(() => expect(latestLocation.pathname).toBe('/login'))
-    expect(endpoints.refreshToken).not.toHaveBeenCalled()
+    expect(endpoints.refreshToken).toHaveBeenCalledOnce()
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
       '/projects',
     )
@@ -354,7 +346,6 @@ describe('useAuth', () => {
       password: 'pw',
     })
     expect(useAuthStore.getState().accessToken).toBe(token)
-    expect(useAuthStore.getState().refreshToken).toBe('rt-new')
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['organizations'],
     })
@@ -364,6 +355,8 @@ describe('useAuth', () => {
   it('login failure: error exposed via hook return, user stays null', async () => {
     const err = new Error('invalid credentials')
     vi.mocked(endpoints.loginWithPassword).mockRejectedValue(err)
+    // No valid session cookie on the login page: bootstrap refresh must fail.
+    vi.mocked(endpoints.refreshToken).mockRejectedValue(new Error('no cookie'))
 
     const { Wrapper } = setupEnv('/login')
     const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
@@ -438,9 +431,8 @@ describe('useAuth', () => {
       await result.current.refreshToken()
     })
 
-    expect(endpoints.refreshToken).toHaveBeenCalledWith('rt')
+    expect(endpoints.refreshToken).toHaveBeenCalledOnce()
     expect(useAuthStore.getState().accessToken).toBe(newToken)
-    expect(useAuthStore.getState().refreshToken).toBe('rt-new')
   })
 
   it('refreshToken mutation failure on a protected route: clears tokens, redirects with saved path', async () => {
@@ -467,18 +459,16 @@ describe('useAuth', () => {
   // ── Redirect-key invariant (HB-2) ───────────────────────────────────
 
   it('HB-2: does not write imbi_redirect_after_login when already on /login', async () => {
-    setExpiredAccess({ refreshToken: null })
+    setExpiredAccess()
+    vi.mocked(endpoints.refreshToken).mockRejectedValue(new Error('no cookie'))
 
     const { Wrapper } = setupEnv('/login')
     renderHook(() => useAuth(), { wrapper: Wrapper })
 
-    // Let the bootstrap queryFn run to completion.
-    await act(async () => {
-      await Promise.resolve()
-    })
+    // Let the bootstrap refresh attempt settle.
+    await waitFor(() => expect(endpoints.refreshToken).toHaveBeenCalled())
 
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
     expect(latestLocation.pathname).toBe('/login')
-    expect(endpoints.refreshToken).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/authBootstrap.ts
+++ b/src/hooks/authBootstrap.ts
@@ -6,27 +6,23 @@ export interface BootstrapDeps {
   isTokenExpired: () => boolean
   onRedirect: () => void
   pathname: string
-  refreshToken: null | string
-  refreshTokenApi: (rt: string) => Promise<TokenResponse>
+  refreshTokenApi: () => Promise<TokenResponse>
   search: string
-  setTokens: (access: string, refresh: string) => void
+  setTokens: (access: string) => void
 }
 
-// Direct port of the previous `['authInit']` queryFn, minus the throws (which
-// were only used as dead signalling). Resolves on every outcome; callers wait
-// for the returned promise, then render.
+// Resolves on every outcome; callers wait for the returned promise, then
+// render. The refresh token lives in an HttpOnly cookie (C2), so we always
+// attempt a refresh and let the API decide whether the session is still
+// valid. BootstrapGate guarantees this runs at most once (see its dedupe
+// guard), so the API's refresh-token rotation/reuse detection is never
+// tripped by a duplicate bootstrap.
 export async function bootstrapAuth(deps: BootstrapDeps): Promise<void> {
   if (deps.accessToken && !deps.isTokenExpired()) return
 
-  if (!deps.refreshToken) {
-    deps.clearTokens()
-    triggerRedirect(deps)
-    return
-  }
-
   try {
-    const response = await deps.refreshTokenApi(deps.refreshToken)
-    deps.setTokens(response.access_token, response.refresh_token)
+    const response = await deps.refreshTokenApi()
+    deps.setTokens(response.access_token)
   } catch (error) {
     console.error('[Auth] Token refresh failed during initialization:', error)
     deps.clearTokens()

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -24,7 +24,6 @@ export function useAuth(): UseAuthReturn {
   // tick would otherwise re-render every consumer of useAuth, which sits at
   // the app root and would cascade through the whole tree.
   const accessToken = useAuthStore((s) => s.accessToken)
-  const refreshToken = useAuthStore((s) => s.refreshToken)
   const clearTokens = useAuthStore((s) => s.clearTokens)
   const setTokens = useAuthStore((s) => s.setTokens)
   const getUsername = useAuthStore((s) => s.getUsername)
@@ -69,7 +68,7 @@ export function useAuth(): UseAuthReturn {
       console.error('[Auth] Login failed:', error)
     },
     onSuccess: async (data) => {
-      setTokens(data.access_token, data.refresh_token)
+      setTokens(data.access_token)
       queryClient.invalidateQueries({ queryKey: ['organizations'] })
 
       try {
@@ -106,12 +105,7 @@ export function useAuth(): UseAuthReturn {
   })
 
   const refreshTokenMutation = useMutation({
-    mutationFn: async () => {
-      if (!refreshToken) {
-        throw new Error('No refresh token available')
-      }
-      return refreshTokenApi(refreshToken)
-    },
+    mutationFn: () => refreshTokenApi(),
     onError: () => {
       clearTokens()
       if (location.pathname !== '/login') {
@@ -122,7 +116,7 @@ export function useAuth(): UseAuthReturn {
       }
     },
     onSuccess: async (data) => {
-      setTokens(data.access_token, data.refresh_token)
+      setTokens(data.access_token)
       await refetch()
     },
   })

--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -15,8 +15,9 @@ export function OAuthCallbackPage() {
   const { error, user } = useAuth()
 
   useEffect(() => {
-    // The API callback redirects with tokens in the URL fragment:
-    //   /auth/callback#access_token=...&refresh_token=...&token_type=bearer
+    // The API callback redirects with the access token in the URL fragment:
+    //   /auth/callback#access_token=...&token_type=bearer
+    // The refresh token is delivered out-of-band as an HttpOnly cookie (C2).
     // Errors come through as ?error=... on the search params instead.
     const search = new URLSearchParams(window.location.search)
     const errorParam = search.get('error')
@@ -32,16 +33,21 @@ export function OAuthCallbackPage() {
       ? window.location.hash.slice(1)
       : ''
     const params = new URLSearchParams(fragment)
-    const accessToken = params.get('access_token')
-    const refreshToken = params.get('refresh_token')
+    const accessTokenParam = params.get('access_token')
 
-    if (!accessToken || !refreshToken) {
-      console.error('[OAuth] Missing tokens in callback URL')
-      navigate('/login?error=no_token', { replace: true })
+    if (!accessTokenParam) {
+      // Under React StrictMode the effect runs twice in development; the
+      // first run consumes the fragment via replaceState below, so the
+      // second run sees an empty hash. That is benign as long as we already
+      // captured a token — only a genuinely tokenless callback is an error.
+      if (!useAuthStore.getState().accessToken) {
+        console.error('[OAuth] Missing access token in callback URL')
+        navigate('/login?error=no_token', { replace: true })
+      }
       return
     }
 
-    setTokens(accessToken, refreshToken)
+    setTokens(accessTokenParam)
     queryClient.invalidateQueries({ queryKey: ['organizations'] })
 
     window.history.replaceState({}, '', '/auth/callback')

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -8,9 +8,8 @@ interface AuthStore {
   getUsername: () => null | string
 
   isTokenExpired: () => boolean
-  refreshToken: null | string
   setAccessToken: (token: string) => void
-  setTokens: (accessToken: string, refreshToken: string) => void
+  setTokens: (accessToken: string) => void
   tokenExpiry: null | number
 }
 
@@ -25,7 +24,7 @@ export const useAuthStore = create<AuthStore>()(
     (set, get) => ({
       accessToken: null,
       clearTokens: () => {
-        set({ accessToken: null, refreshToken: null, tokenExpiry: null })
+        set({ accessToken: null, tokenExpiry: null })
       },
       getUsername: () => {
         const { accessToken } = get()
@@ -44,8 +43,6 @@ export const useAuthStore = create<AuthStore>()(
         return Date.now() > tokenExpiry - 5 * 60 * 1000
       },
 
-      refreshToken: null,
-
       setAccessToken: (token: string) => {
         try {
           const decoded = jwtDecode<JwtPayload>(token)
@@ -58,17 +55,16 @@ export const useAuthStore = create<AuthStore>()(
         }
       },
 
-      setTokens: (accessToken: string, refreshToken: string) => {
+      setTokens: (accessToken: string) => {
         try {
           const decoded = jwtDecode<JwtPayload>(accessToken)
           const tokenExpiry = decoded.exp * 1000
           set({
             accessToken,
-            refreshToken,
             tokenExpiry,
           })
         } catch {
-          set({ accessToken: null, refreshToken: null, tokenExpiry: null })
+          set({ accessToken: null, tokenExpiry: null })
         }
       },
 


### PR DESCRIPTION
## Summary

Companion to imbi-api PR #397. The API now delivers the refresh token as an
HttpOnly cookie instead of the OAuth callback URL fragment, and no longer
expects it in the refresh request body. This migrates the SPA to match.

- **authStore**: drop the `refreshToken` field; `setTokens` takes only the
  access token, so the refresh token is never written to `localStorage`.
- **client / endpoints**: `POST /auth/token/refresh` with no body
  (`credentials: 'include'` carries the cookie).
- **OAuthCallbackPage**: require only `access_token` from the fragment.
- **authBootstrap / BootstrapGate**: always attempt a cookie-based refresh
  when there's no valid access token; redirect to `/login` only on failure.
- **useAuth**: `setTokens(access)` on login/refresh success.

### StrictMode hardening
Bootstrap is guarded by a per-instance ref so React StrictMode's
double-invoked effect fires a **single** `/auth/token/refresh`. Two concurrent
refreshes trip the API's refresh-token rotation/reuse detection, which revokes
the entire token family and logs the user straight back out. The
OAuthCallbackPage effect is likewise guarded — its StrictMode second pass sees
the fragment already consumed by `replaceState`.

## Test plan
- [x] `vitest` — authStore, useAuth, authBootstrap suites pass (32 tests)
- [x] `tsc --noEmit` clean; `oxlint` clean
- [x] Live against the PSE environment: Google OAuth login → dashboard;
  cleared-`localStorage` reload re-authenticates via the cookie; single
  refresh call, no 500, no callback error.

> [!IMPORTANT]
> Lockstep with imbi-api #397 — the backend cookie contract and this frontend
> must deploy together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)