### PR TITLE
Strip leading whitespace from text inputs

### DIFF
--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -84,10 +84,10 @@ export function NewProjectDialog({
   const handleSave = () => {
     if (!orgSlug || !canProceed || createMutation.isPending) return
     const projectData: ProjectCreate = {
-      description: description || null,
+      description: description.trim() || null,
       environment_slugs:
         selectedEnvSlugs.length > 0 ? selectedEnvSlugs : undefined,
-      name,
+      name: name.trim(),
       project_type_slugs: [projectTypeSlug],
       slug,
       team_slug: teamSlug,

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '@/test/utils'
+
+import { Input } from '../input'
+
+function ControlledInput({ type }: { type?: string }) {
+  const [value, setValue] = useState('')
+  return (
+    <Input
+      onChange={(e) => setValue(e.target.value)}
+      type={type}
+      value={value}
+    />
+  )
+}
+
+describe('Input', () => {
+  it('strips leading whitespace as the user types', async () => {
+    render(<ControlledInput />)
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, '   Acme')
+    expect(input).toHaveValue('Acme')
+  })
+
+  it('preserves interior and trailing whitespace', async () => {
+    render(<ControlledInput />)
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'Acme Corp ')
+    expect(input).toHaveValue('Acme Corp ')
+  })
+
+  it('strips leading whitespace from pasted text', async () => {
+    render(<ControlledInput />)
+    const input = screen.getByRole('textbox')
+    input.focus()
+    await userEvent.paste('   pasted')
+    expect(input).toHaveValue('pasted')
+  })
+
+  it('leaves password values untouched', async () => {
+    render(<ControlledInput type="password" />)
+    // Password inputs expose no textbox role; query by the rendered element.
+    const input = document.querySelector('input[type="password"]')!
+    ;(input as HTMLInputElement).focus()
+    await userEvent.type(input as HTMLInputElement, ' secret')
+    expect(input).toHaveValue(' secret')
+  })
+})

--- a/src/components/ui/__tests__/textarea.test.tsx
+++ b/src/components/ui/__tests__/textarea.test.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '@/test/utils'
+
+import { Textarea } from '../textarea'
+
+function ControlledTextarea() {
+  const [value, setValue] = useState('')
+  return <Textarea onChange={(e) => setValue(e.target.value)} value={value} />
+}
+
+describe('Textarea', () => {
+  it('strips leading whitespace as the user types', async () => {
+    render(<ControlledTextarea />)
+    const textarea = screen.getByRole('textbox')
+    await userEvent.type(textarea, '   A description')
+    expect(textarea).toHaveValue('A description')
+  })
+
+  it('preserves interior and trailing whitespace', async () => {
+    render(<ControlledTextarea />)
+    const textarea = screen.getByRole('textbox')
+    await userEvent.type(textarea, 'line one line two ')
+    expect(textarea).toHaveValue('line one line two ')
+  })
+})

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -5,13 +5,24 @@ import { cn } from '@/lib/utils'
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, onChange, type, ...props }, ref) => {
+    // Strip leading whitespace as the user types or pastes. A leading space is
+    // never meaningful in our text inputs, but it can be a valid password
+    // character, so passwords are left untouched.
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (type !== 'password') {
+        const stripped = e.target.value.replace(/^\s+/, '')
+        if (stripped !== e.target.value) e.target.value = stripped
+      }
+      onChange?.(e)
+    }
     return (
       <input
         className={cn(
           'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
+        onChange={handleChange}
         ref={ref}
         type={type}
         {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -5,13 +5,21 @@ import { cn } from '@/lib/utils'
 export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, onChange, ...props }, ref) => {
+    // Strip leading whitespace as the user types or pastes; a leading space is
+    // never meaningful in our text inputs.
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const stripped = e.target.value.replace(/^\s+/, '')
+      if (stripped !== e.target.value) e.target.value = stripped
+      onChange?.(e)
+    }
     return (
       <textarea
         className={cn(
           'flex min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
+        onChange={handleChange}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
## Summary

Prevents leading whitespace in text inputs at the source.

## Problem

A v1-migrated project (#292) carried a leading space in its name. A leading space is never meaningful in our text inputs, but today trimming is scattered and inconsistent — admin forms trim at submit, `NewProjectDialog` (the form from the report) trimmed nothing, and `ProjectsView` even carries a sort workaround for the legacy bad data.

## Solution

- **`Input` / `Textarea`** now strip leading whitespace on every change, covering both typing and paste, so every current and future consumer is protected without per-form changes. `type="password"` is excluded since a leading space can be a valid secret.
- **`NewProjectDialog`** now trims `name` and `description` on submit (it previously trimmed nothing), catching trailing whitespace too.
- Added tests for the `Input`/`Textarea` stripping behavior (leading stripped on type and paste, interior/trailing preserved, password untouched).

## Scope / notes

- This guards against **new** bad data only. Existing records (the migrated project) and the `ProjectsView` sort workaround are unaffected — cleaning existing data needs a backend/migrator change.
- Leading-only stripping during typing is deliberate; stripping trailing/interior live would block typing spaces between words. Trailing cleanup belongs in submit-time `.trim()`.

## Verification

- `npm run build` (tsc + vite) — clean
- `npm run lint` / `npm run format:check` — clean
- New `Input`/`Textarea` tests — 6/6 pass

Closes #292