### PR TITLE
Gate Sync Deployments on its permission, not admin

### DIFF
--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -46,6 +46,8 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   const isAdmin = user?.is_admin === true
   const canRescore =
     isAdmin || (user?.permissions ?? []).includes('scoring_policy:rescore')
+  const canResyncDeployments =
+    isAdmin || (user?.permissions ?? []).includes('project:deployment:write')
   const { patch, scheduleScoreRefresh } = useProjectPatch(orgSlug, project.id)
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -214,7 +216,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
 
       <ProjectPluginsSection orgSlug={orgSlug} projectId={project.id} />
 
-      {(canRescore || (isAdmin && deploymentPlugin)) && (
+      {(canRescore || (canResyncDeployments && deploymentPlugin)) && (
         <Card>
           <CardHeader>
             <CardTitle>Utility Functions</CardTitle>
@@ -230,7 +232,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
                 {rescoreMutation.isPending ? 'Enqueuing...' : 'Recompute Score'}
               </Button>
             )}
-            {isAdmin && deploymentPlugin && (
+            {canResyncDeployments && deploymentPlugin && (
               <Button
                 disabled={resyncMutation.isPending}
                 onClick={() => resyncMutation.mutate()}

--- a/src/components/__tests__/ProjectSettingsTab.test.tsx
+++ b/src/components/__tests__/ProjectSettingsTab.test.tsx
@@ -5,7 +5,11 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as endpoints from '@/api/endpoints'
-import type { ArchiveProjectResponse, Project } from '@/types'
+import type {
+  ArchiveProjectResponse,
+  PluginAssignmentResponse,
+  Project,
+} from '@/types'
 
 import { ProjectSettingsTab } from '../ProjectSettingsTab'
 
@@ -48,9 +52,14 @@ vi.mock('@/components/project/ProjectPluginsSection', () => ({
 vi.mock('@/contexts/OrganizationContext', () => ({
   useOrganization: () => ({ selectedOrganization: { slug: 'acme' } }),
 }))
+// Mutable so individual tests can vary admin status / permissions.
+let mockAuthUser: { is_admin: boolean; permissions: string[] } = {
+  is_admin: false,
+  permissions: [],
+}
 // fallow-ignore-next-line unresolved-import
 vi.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({ user: { is_admin: false, permissions: [] } }),
+  useAuth: () => ({ user: mockAuthUser }),
 }))
 // fallow-ignore-next-line unresolved-import
 vi.mock('@/hooks/useProjectPatch', () => ({
@@ -68,6 +77,17 @@ const ARCHIVED_PROJECT = {
   slug: 'demo',
   team: { name: 'Team', organization: { name: 'Acme', slug: 'acme' } },
 } as Project
+
+const DEPLOYMENT_PLUGIN = {
+  default: true,
+  label: 'Deploy',
+  options: {},
+  plugin_id: 'dep-1',
+  plugin_slug: 'github-deploy',
+  source: 'project',
+  supports_deployment_sync: true,
+  tab: 'deployment',
+} as PluginAssignmentResponse
 
 function renderTab() {
   const client = new QueryClient({
@@ -90,6 +110,7 @@ describe('ProjectSettingsTab archive lifecycle results', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    mockAuthUser = { is_admin: false, permissions: [] }
     vi.mocked(endpoints.listEnvironments).mockResolvedValue([])
     vi.mocked(endpoints.listLinkDefinitions).mockResolvedValue([])
     vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([])
@@ -141,5 +162,58 @@ describe('ProjectSettingsTab archive lifecycle results', () => {
       expect(toast.success).toHaveBeenCalledWith('Project restored')
     })
     expect(toast.error).not.toHaveBeenCalled()
+  })
+})
+
+describe('ProjectSettingsTab utility functions gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthUser = { is_admin: false, permissions: [] }
+    vi.mocked(endpoints.listEnvironments).mockResolvedValue([])
+    vi.mocked(endpoints.listLinkDefinitions).mockResolvedValue([])
+    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([])
+  })
+
+  it('hides the card when the user has neither permission', async () => {
+    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([
+      DEPLOYMENT_PLUGIN,
+    ])
+    const { queryByText } = renderTab()
+    await waitFor(() => expect(endpoints.listProjectPlugins).toHaveBeenCalled())
+    expect(queryByText('Utility Functions')).not.toBeInTheDocument()
+  })
+
+  it('shows the card with only Recompute Score for rescore permission', async () => {
+    mockAuthUser = { is_admin: false, permissions: ['scoring_policy:rescore'] }
+    const { queryByRole, queryByText } = renderTab()
+    await waitFor(() =>
+      expect(queryByText('Utility Functions')).toBeInTheDocument(),
+    )
+    expect(
+      queryByRole('button', { name: 'Recompute Score' }),
+    ).toBeInTheDocument()
+    expect(
+      queryByRole('button', { name: 'Sync Deployments' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows Sync Deployments for project:deployment:write without admin', async () => {
+    mockAuthUser = {
+      is_admin: false,
+      permissions: ['project:deployment:write'],
+    }
+    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([
+      DEPLOYMENT_PLUGIN,
+    ])
+    const { queryByRole, queryByText } = renderTab()
+    await waitFor(() =>
+      expect(queryByText('Utility Functions')).toBeInTheDocument(),
+    )
+    expect(
+      queryByRole('button', { name: 'Sync Deployments' }),
+    ).toBeInTheDocument()
+    expect(
+      queryByRole('button', { name: 'Recompute Score' }),
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Fixes the Utility Functions card on the project Settings tab so it appears for users who can use *either* button, as intended.

## Problem

The card renders when `(canRescore || (isAdmin && deploymentPlugin))`. The OR is structurally fine, but the second operand was wrong: the **Sync Deployments** button (and the card's second term) was gated on `is_admin`, while the backend authorizes the `/resync` endpoint with the **`project:deployment:write`** permission (`project_deployments.py:961`, checked via `require_permission`).

As a result, a non-admin who holds `project:deployment:write` is authorized by the API but never sees the Sync Deployments button — and, lacking `scoring_policy:rescore`, never sees the **card** either. The deployment side was effectively admin-only.

`Recompute Score` was already correct (`scoring_policy:rescore`, matching `scoring.py:521`).

## Solution

Add a permission-based check mirroring `canRescore`:

```ts
const canResyncDeployments =
  isAdmin || (user?.permissions ?? []).includes('project:deployment:write')
```

…and use it for both the card-level OR and the Sync Deployments button. `deploymentPlugin` (manifest opt-in via `supports_deployment_sync`) is still required — only the `isAdmin` term was swapped for the permission.

## Tests

Added gating tests to `ProjectSettingsTab.test.tsx`:
- card hidden when the user has neither permission (even with a deployment plugin present)
- card shown with only Recompute Score for `scoring_policy:rescore`
- Sync Deployments shown for `project:deployment:write` **without** admin

## Verification

- `npm run build` (tsc + vite) — clean
- `npm run lint` / `npm run format:check` — clean
- `ProjectSettingsTab` tests — 5/5 pass