### PR TITLE
Surface release dependencies in a project Dependencies tab

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -77,6 +77,8 @@ import type {
   ProjectType,
   ProjectTypeCreate,
   PullRequestListResponse,
+  Release,
+  ReleaseDependenciesResponse,
   Role,
   RoleCreate,
   RoleDetail,
@@ -1472,6 +1474,31 @@ export const listCurrentReleases = async (
   )
   return Array.isArray(response) ? response : []
 }
+
+export const listProjectReleases = async (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<Release[]> => {
+  const response = await apiClient.get<Release[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/releases/`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const listReleaseDependencies = (
+  orgSlug: string,
+  projectId: string,
+  releaseId: string,
+  signal?: AbortSignal,
+): Promise<ReleaseDependenciesResponse> =>
+  apiClient.get<ReleaseDependenciesResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/releases/${encodeURIComponent(releaseId)}/dependencies`,
+    undefined,
+    signal,
+  )
 
 // Deployments
 const deploymentsBase = (orgSlug: string, projectId: string): string =>

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -31,6 +31,7 @@ import {
   type ProjectSchemaResponse,
   type ScoreTrend,
 } from '@/api/endpoints'
+import { DependenciesTab } from '@/components/dependencies/DependenciesTab'
 import {
   type DeploymentRunStarted,
   ReleaseModal,
@@ -51,7 +52,6 @@ import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
-  CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
@@ -1052,7 +1052,7 @@ export function ProjectDetail({
           />
         </TabsContent>
         <TabsContent value="dependencies">
-          <PlaceholderTab name="Dependencies" />
+          <DependenciesTab orgSlug={orgSlug} project={project} />
         </TabsContent>
         {hasLogsPlugin && (
           <TabsContent value="logs">
@@ -1219,19 +1219,6 @@ function fmtAttributeValue(value: unknown): string {
   return isFinite(n) && String(value).trim() !== ''
     ? String(Math.round(n))
     : String(value)
-}
-
-function PlaceholderTab({ name }: { name: string }) {
-  return (
-    <Card>
-      <CardContent className="py-12 text-center">
-        <CardTitle>{name}</CardTitle>
-        <CardDescription className="text-tertiary">
-          This tab will be implemented in a future update.
-        </CardDescription>
-      </CardContent>
-    </Card>
-  )
 }
 
 function ScoreBreakdownDetail({

--- a/src/components/dependencies/DependenciesTab.tsx
+++ b/src/components/dependencies/DependenciesTab.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { listProjectReleases, listReleaseDependencies } from '@/api/endpoints'
+import { AdminTable, type AdminTableColumn } from '@/components/ui/admin-table'
+import { Card, CardContent } from '@/components/ui/card'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+import type { Project, ReleaseDependencyComponent } from '@/types'
+
+interface DependenciesTabProps {
+  orgSlug: string
+  project: Pick<Project, 'id' | 'slug'>
+}
+
+const COLUMNS: AdminTableColumn<ReleaseDependencyComponent>[] = [
+  {
+    header: 'Component',
+    key: 'name',
+    render: (row) => (
+      <div>
+        <div className="font-medium">{row.name}</div>
+        <div className="text-muted-foreground text-xs">{row.purl_name}</div>
+      </div>
+    ),
+  },
+  {
+    header: 'Ecosystem',
+    key: 'ecosystem',
+    render: (row) => (
+      <span className="text-muted-foreground text-sm">{row.ecosystem}</span>
+    ),
+  },
+  {
+    header: 'Version',
+    key: 'version',
+    render: (row) => <code className="text-sm">{row.version}</code>,
+  },
+  {
+    header: 'License',
+    key: 'license',
+    render: (row) =>
+      row.license ? (
+        <span className="text-sm">{row.license}</span>
+      ) : (
+        <span className="text-muted-foreground text-xs">—</span>
+      ),
+  },
+  {
+    header: 'Usage',
+    key: 'usage',
+    render: (row) => {
+      const scopeClass =
+        row.scope === 'optional'
+          ? 'border-amber-300 bg-amber-50 text-amber-900'
+          : row.scope === 'excluded'
+            ? 'border-slate-300 bg-slate-50 text-slate-700'
+            : 'border-emerald-300 bg-emerald-50 text-emerald-900'
+      if (!row.scope && row.groups.length === 0) {
+        return <span className="text-muted-foreground text-xs">—</span>
+      }
+      return (
+        <div className="flex flex-wrap gap-1">
+          {row.scope && (
+            <span
+              aria-label={`scope: ${row.scope}`}
+              className={cn(
+                'inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium',
+                scopeClass,
+              )}
+            >
+              {row.scope}
+            </span>
+          )}
+          {row.groups.map((g) => (
+            <span
+              aria-label={`group: ${g}`}
+              className="inline-flex items-center rounded border border-blue-300 bg-blue-50 px-1.5 py-0.5 text-xs font-medium text-blue-900"
+              key={g}
+            >
+              {g}
+            </span>
+          ))}
+        </div>
+      )
+    },
+  },
+  {
+    header: 'Identifiers',
+    key: 'identifiers',
+    render: (row) =>
+      row.identifiers.length === 0 ? (
+        <span className="text-muted-foreground text-xs">—</span>
+      ) : (
+        <div className="space-y-1">
+          {row.identifiers.map((i) => (
+            <div className="text-xs" key={`${i.kind}:${i.value}`}>
+              <span className="text-muted-foreground">{i.kind}:</span>{' '}
+              <code>{i.value}</code>
+            </div>
+          ))}
+        </div>
+      ),
+  },
+]
+
+export function DependenciesTab({ orgSlug, project }: DependenciesTabProps) {
+  const releasesQuery = useQuery({
+    queryFn: ({ signal }) => listProjectReleases(orgSlug, project.id, signal),
+    queryKey: ['project-releases', orgSlug, project.id],
+  })
+
+  const releases = useMemo(() => releasesQuery.data ?? [], [releasesQuery.data])
+
+  const [selectedReleaseId, setSelectedReleaseId] = useState<null | string>(
+    null,
+  )
+
+  // Default the dropdown to the most-recently-created release once the
+  // list lands. Keep user-driven selections sticky across refetches.
+  useEffect(() => {
+    if (selectedReleaseId) return
+    if (releases.length === 0) return
+    const sorted = [...releases].sort((a, b) =>
+      a.created_at < b.created_at ? 1 : -1,
+    )
+    setSelectedReleaseId(sorted[0].id)
+  }, [releases, selectedReleaseId])
+
+  const dependenciesQuery = useQuery({
+    enabled: selectedReleaseId !== null,
+    queryFn: ({ signal }) =>
+      listReleaseDependencies(
+        orgSlug,
+        project.id,
+        selectedReleaseId as string,
+        signal,
+      ),
+    queryKey: ['release-dependencies', orgSlug, project.id, selectedReleaseId],
+  })
+
+  if (releasesQuery.isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          <LoadingState label="Loading releases…" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (releases.length === 0) {
+    return (
+      <Card>
+        <CardContent className="text-muted-foreground p-8 text-center">
+          No releases yet. Once a release is created and a CycloneDX SBoM is
+          ingested, its dependencies will appear here.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const components = dependenciesQuery.data?.components ?? []
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <label
+          className="text-secondary text-sm font-medium"
+          htmlFor="dependencies-release-select"
+        >
+          Release
+        </label>
+        <Select
+          onValueChange={setSelectedReleaseId}
+          value={selectedReleaseId ?? ''}
+        >
+          <SelectTrigger
+            aria-label="Release"
+            className="w-64"
+            id="dependencies-release-select"
+          >
+            <SelectValue placeholder="Select a release" />
+          </SelectTrigger>
+          <SelectContent>
+            {releases.map((release) => (
+              <SelectItem key={release.id} value={release.id}>
+                {release.tag ?? release.committish}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {dependenciesQuery.isLoading ? (
+        <Card>
+          <CardContent className="p-6">
+            <LoadingState label="Loading dependencies…" />
+          </CardContent>
+        </Card>
+      ) : (
+        <AdminTable
+          columns={COLUMNS}
+          emptyMessage="No SBoM has been ingested for this release yet."
+          getRowKey={(row) => `${row.purl_name}@${row.version}`}
+          rows={components}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/dependencies/DependenciesTab.tsx
+++ b/src/components/dependencies/DependenciesTab.tsx
@@ -157,6 +157,16 @@ export function DependenciesTab({ orgSlug, project }: DependenciesTabProps) {
     )
   }
 
+  if (releasesQuery.isError) {
+    return (
+      <Card>
+        <CardContent className="text-muted-foreground p-8 text-center">
+          Failed to load releases.
+        </CardContent>
+      </Card>
+    )
+  }
+
   if (releases.length === 0) {
     return (
       <Card>
@@ -204,6 +214,12 @@ export function DependenciesTab({ orgSlug, project }: DependenciesTabProps) {
         <Card>
           <CardContent className="p-6">
             <LoadingState label="Loading dependencies…" />
+          </CardContent>
+        </Card>
+      ) : dependenciesQuery.isError ? (
+        <Card>
+          <CardContent className="text-muted-foreground p-8 text-center">
+            Failed to load dependencies.
           </CardContent>
         </Card>
       ) : (

--- a/src/components/dependencies/__tests__/DependenciesTab.test.tsx
+++ b/src/components/dependencies/__tests__/DependenciesTab.test.tsx
@@ -1,0 +1,255 @@
+import React from 'react'
+
+import { MemoryRouter } from 'react-router-dom'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import type { Project, Release, ReleaseDependenciesResponse } from '@/types'
+
+import { DependenciesTab } from '../DependenciesTab'
+
+function wrapper(qc: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const PROJECT: Pick<Project, 'id' | 'slug'> = {
+  id: 'proj-1',
+  slug: 'my-project',
+}
+
+function makeDeps(
+  releaseId: string,
+  overrides: Partial<ReleaseDependenciesResponse> = {},
+): ReleaseDependenciesResponse {
+  return {
+    components: [
+      {
+        ecosystem: 'npm',
+        groups: [],
+        hashes: {},
+        identifiers: [{ kind: 'purl', value: 'pkg:npm/express' }],
+        license: 'MIT',
+        name: 'express',
+        purl_name: 'pkg:npm/express',
+        scope: null,
+        version: '4.18.2',
+      },
+    ],
+    release_id: releaseId,
+    ...overrides,
+  }
+}
+
+function makeRelease(overrides: Partial<Release> = {}): Release {
+  return {
+    committish: 'abc1234',
+    created_at: '2026-05-01T00:00:00Z',
+    created_by: 'alice@example.com',
+    id: 'rel-1',
+    links: [],
+    project_id: PROJECT.id,
+    tag: '1.0.0',
+    title: 'Initial release',
+    ...overrides,
+  }
+}
+
+let qc: QueryClient
+
+// Radix Select interrogates these PointerEvent methods on its trigger;
+// jsdom doesn't ship them, so userEvent.click would throw without
+// these no-op stubs.
+beforeEach(() => {
+  qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  vi.clearAllMocks()
+  Element.prototype.hasPointerCapture = vi.fn(() => false) as never
+  Element.prototype.setPointerCapture = vi.fn() as never
+  Element.prototype.releasePointerCapture = vi.fn() as never
+})
+
+describe('DependenciesTab', () => {
+  it('shows the empty state when the project has no releases', async () => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([])
+    const depsSpy = vi
+      .spyOn(endpoints, 'listReleaseDependencies')
+      .mockResolvedValue(makeDeps('rel-1', { components: [] }))
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    expect(await screen.findByText(/No releases yet/i)).toBeInTheDocument()
+    expect(depsSpy).not.toHaveBeenCalled()
+  })
+
+  it('renders the dependencies of the most recent release by default', async () => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
+      makeRelease({
+        created_at: '2026-04-01T00:00:00Z',
+        id: 'rel-old',
+        tag: '0.9.0',
+      }),
+      makeRelease({
+        created_at: '2026-05-01T00:00:00Z',
+        id: 'rel-new',
+        tag: '1.0.0',
+      }),
+    ])
+    const depsSpy = vi
+      .spyOn(endpoints, 'listReleaseDependencies')
+      .mockResolvedValue(makeDeps('rel-new'))
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    expect(await screen.findByText('express')).toBeInTheDocument()
+    expect(screen.getByText('4.18.2')).toBeInTheDocument()
+    expect(screen.getByText('MIT')).toBeInTheDocument()
+    // ``listReleaseDependencies`` should have targeted the newest release.
+    expect(depsSpy).toHaveBeenCalledWith(
+      'org',
+      'proj-1',
+      'rel-new',
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('shows an empty-table message when the selected release has no SBoM', async () => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
+      makeRelease(),
+    ])
+    vi.spyOn(endpoints, 'listReleaseDependencies').mockResolvedValue(
+      makeDeps('rel-1', { components: [] }),
+    )
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    expect(
+      await screen.findByText(/No SBoM has been ingested/i),
+    ).toBeInTheDocument()
+  })
+
+  it('refetches dependencies when the user switches release', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
+      makeRelease({
+        created_at: '2026-05-01T00:00:00Z',
+        id: 'rel-new',
+        tag: '1.0.0',
+      }),
+      makeRelease({
+        created_at: '2026-04-01T00:00:00Z',
+        id: 'rel-old',
+        tag: '0.9.0',
+      }),
+    ])
+    const depsSpy = vi
+      .spyOn(endpoints, 'listReleaseDependencies')
+      .mockImplementation(async (_org, _project, releaseId) =>
+        makeDeps(releaseId, {
+          components: [
+            {
+              ecosystem: 'npm',
+              groups: [],
+              hashes: {},
+              identifiers: [],
+              license: null,
+              name: `library-for-${releaseId}`,
+              purl_name: `pkg:npm/library-for-${releaseId}`,
+              scope: null,
+              version: '1.0.0',
+            },
+          ],
+        }),
+      )
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    await screen.findByText('library-for-rel-new')
+
+    const trigger = screen.getByRole('combobox', { name: /release/i })
+    await user.click(trigger)
+    const oldOption = await screen.findByRole('option', { name: '0.9.0' })
+    await user.click(oldOption)
+
+    await waitFor(() => {
+      expect(depsSpy).toHaveBeenCalledWith(
+        'org',
+        'proj-1',
+        'rel-old',
+        expect.any(AbortSignal),
+      )
+    })
+    await screen.findByText('library-for-rel-old')
+  })
+
+  it('renders scope and group chips when present on a component', async () => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
+      makeRelease(),
+    ])
+    vi.spyOn(endpoints, 'listReleaseDependencies').mockResolvedValue(
+      makeDeps('rel-1', {
+        components: [
+          {
+            ecosystem: 'pypi',
+            groups: ['dev', 'test'],
+            hashes: {},
+            identifiers: [{ kind: 'purl', value: 'pkg:pypi/pytest' }],
+            license: 'MIT',
+            name: 'pytest',
+            purl_name: 'pkg:pypi/pytest',
+            scope: 'optional',
+            version: '8.0.0',
+          },
+        ],
+      }),
+    )
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    // The chip ARIA labels are the stable contract — the styling
+    // classes can change without breaking this assertion.
+    expect(await screen.findByLabelText('scope: optional')).toBeInTheDocument()
+    expect(screen.getByLabelText('group: dev')).toBeInTheDocument()
+    expect(screen.getByLabelText('group: test')).toBeInTheDocument()
+  })
+
+  it('shows an em-dash when neither scope nor groups are present', async () => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
+      makeRelease(),
+    ])
+    vi.spyOn(endpoints, 'listReleaseDependencies').mockResolvedValue(
+      makeDeps('rel-1'),
+    )
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    await screen.findByText('express')
+    // No chips rendered — the cell shows the placeholder dash.
+    expect(screen.queryByLabelText(/^scope:/)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/^group:/)).not.toBeInTheDocument()
+  })
+})
+
+// Lint hint: keep `within` referenced so the helper survives future
+// edits that add cell-scoped assertions.
+void within

--- a/src/components/dependencies/__tests__/DependenciesTab.test.tsx
+++ b/src/components/dependencies/__tests__/DependenciesTab.test.tsx
@@ -231,6 +231,37 @@ describe('DependenciesTab', () => {
     expect(screen.getByLabelText('group: test')).toBeInTheDocument()
   })
 
+  it('shows an error message when the releases query fails', async () => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockRejectedValue(
+      new Error('boom'),
+    )
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    expect(
+      await screen.findByText(/Failed to load releases/i),
+    ).toBeInTheDocument()
+  })
+
+  it('shows an error message when the dependencies query fails', async () => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
+      makeRelease(),
+    ])
+    vi.spyOn(endpoints, 'listReleaseDependencies').mockRejectedValue(
+      new Error('boom'),
+    )
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    expect(
+      await screen.findByText(/Failed to load dependencies/i),
+    ).toBeInTheDocument()
+  })
+
   it('shows an em-dash when neither scope nor groups are present', async () => {
     vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
       makeRelease(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1070,6 +1070,32 @@ export interface Release {
   title: string
   updated_at?: null | string
 }
+export interface ReleaseDependenciesResponse {
+  components: ReleaseDependencyComponent[]
+  release_id: string
+}
+
+export interface ReleaseDependencyComponent {
+  description?: null | string
+  ecosystem: string
+  groups: string[]
+  hashes: Record<string, string>
+  identifiers: ReleaseDependencyIdentifier[]
+  license?: null | string
+  name: string
+  purl_name: string
+  scope?: null | ReleaseDependencyScope
+  supplier?: null | string
+  version: string
+}
+
+export interface ReleaseDependencyIdentifier {
+  kind: string
+  value: string
+}
+
+export type ReleaseDependencyScope = 'excluded' | 'optional' | 'required'
+
 export interface ReleaseLink {
   label?: null | string
   type: string


### PR DESCRIPTION
## Summary

Replace the placeholder Dependencies tab on the project page with a real component that lists the SBoM components ingested for the selected release. Dropdown defaults to the most-recently-created release; switching releases refetches dependencies. Components render in an `AdminTable` with name + ecosystem + version + license + usage chips (scope / group attribution) + identifier columns.

This PR is in **DRAFT until [AWeber-Imbi/imbi-api#399](https://github.com/AWeber-Imbi/imbi-api/pull/399) lands** — the `/releases/{release_id}/dependencies` endpoint and the `scope` / `groups` response fields ship there.

## Problem

The Dependencies tab was a placeholder. With SBoM ingest on the API side, we now have real data to surface — and the UI needs to expose the per-release usage attribution (scope + groups) so users can distinguish runtime dependencies from dev-group dependencies.

## Solution

**New types** (`src/types/index.ts`) — hand-written rather than pulled from `api-generated.ts` so this PR doesn't require a coordinated codegen refresh:

- `ReleaseDependencyComponent` (with `scope` + `groups`)
- `ReleaseDependencyIdentifier`
- `ReleaseDependenciesResponse`
- `ReleaseDependencyScope`

After imbi-api#399 deploys, run `npm run codegen:fetch` to replace these with generated equivalents.

**New endpoint wrappers** (`src/api/endpoints.ts`):

- `listProjectReleases(orgSlug, projectId)` — drives the dropdown.
- `listReleaseDependencies(orgSlug, projectId, releaseId)` — fetches the dependencies payload.

**`DependenciesTab` component** (`src/components/dependencies/DependenciesTab.tsx`) — Radix Select for the release picker + AdminTable for the components. Scope is rendered as a color-coded chip (green = required, amber = optional, slate = excluded); each group name becomes a blue chip alongside. Both chips carry stable `aria-label`s (`scope: optional`, `group: dev`) for the test assertions.

**Vitest spec** (`src/components/dependencies/__tests__/DependenciesTab.test.tsx`) — covers empty-state, populated-state, release-switch refetch, scope/group chip rendering, and the em-dash placeholder when neither is present. Stubs `Element.prototype.hasPointerCapture` so userEvent can drive the Radix Select under jsdom.

## Companion PRs

- **Requires:** [imbi-api#399](https://github.com/AWeber-Imbi/imbi-api/pull/399) — `/dependencies` endpoint
- **Transitively requires:** [imbi-common#132](https://github.com/AWeber-Imbi/imbi-common/pull/132) — graph models
- **Sister PR:** [imbi-gateway#31](https://github.com/AWeber-Imbi/imbi-gateway/pull/31) — webhook action

Merge order: imbi-common → imbi-api → (imbi-gateway in parallel) → this.

## Test plan

- [ ] CI green (`npm run lint && npm test`)
- [ ] After imbi-api#399 is consumable, run `npm run codegen:fetch` against the live API and replace the hand-written types in `src/types/index.ts` with generated ones (separate follow-up PR or amended commit on this branch)
- [ ] Click through the Dependencies tab for a project with an ingested SBoM: dropdown defaults to newest release, switching refetches, scope + group chips render

🤖 Generated with [Claude Code](https://claude.com/claude-code)