### PR TITLE
Add Assistant admin section with MCP server management

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -52,6 +52,11 @@ import type {
   LoginProviderUpdate,
   LoginRequest,
   LogResultResponse,
+  MCPServer,
+  MCPServerCreate,
+  MCPServerTestConfig,
+  MCPServerTestResult,
+  MCPServerUpdate,
   OperationsLogFilters,
   OperationsLogRecord,
   Organization,
@@ -1357,6 +1362,41 @@ export const listServiceWebhooks = async (
   )
   return Array.isArray(response) ? response : []
 }
+
+// Admin - MCP Servers (global Assistant configuration)
+export const listMcpServers = async (
+  signal?: AbortSignal,
+): Promise<MCPServer[]> => {
+  const response = await apiClient.get<MCPServer[]>(
+    '/mcp-servers/',
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const createMcpServer = (data: MCPServerCreate) =>
+  apiClient.post<MCPServer>('/mcp-servers/', data)
+
+// The MCP update endpoint takes a partial object (exclude_unset semantics),
+// not RFC-6902 json-patch — send only the changed fields.
+export const updateMcpServer = (id: string, data: MCPServerUpdate) =>
+  apiClient.patch<MCPServer>(`/mcp-servers/${encodeURIComponent(id)}`, data)
+
+export const deleteMcpServer = (id: string) =>
+  apiClient.delete<void>(`/mcp-servers/${encodeURIComponent(id)}`)
+
+// Test a saved server using its stored configuration and secrets; the
+// result is persisted onto the server (status, last_tested_at, …).
+export const testMcpServer = (id: string) =>
+  apiClient.post<MCPServerTestResult>(
+    `/mcp-servers/${encodeURIComponent(id)}/test`,
+  )
+
+// Test an unsaved configuration (create form); secrets are sent as
+// plaintext and nothing is persisted.
+export const testMcpServerConfig = (data: MCPServerTestConfig) =>
+  apiClient.post<MCPServerTestResult>('/mcp-servers/test', data)
 
 // Admin - Auth Providers (login-eligible service applications)
 export const listAuthProviders = async (

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -17,6 +17,7 @@ import {
   Network,
   Puzzle,
   Shield,
+  Sparkles,
   StickyNote,
   Target,
   Users,
@@ -27,6 +28,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { useOrganization } from '@/contexts/OrganizationContext'
 
+import { AssistantManagement } from './admin/AssistantManagement'
 import { AuthProvidersManagement } from './admin/AuthProvidersManagement'
 import { BlueprintManagement } from './admin/BlueprintManagement'
 import { DocumentTemplateManagement } from './admin/DocumentTemplateManagement'
@@ -46,6 +48,7 @@ import { UserManagement } from './admin/UserManagement'
 import { WebhookManagement } from './admin/WebhookManagement'
 
 type AdminSection =
+  | 'assistant'
   | 'blueprints'
   | 'document-templates'
   | 'environments'
@@ -64,6 +67,7 @@ type AdminSection =
   | 'webhooks'
 
 const VALID_SECTIONS: AdminSection[] = [
+  'assistant',
   'blueprints',
   'environments',
   'graph-query',
@@ -181,6 +185,13 @@ export function Admin() {
       icon: Building2,
       id: 'organizations',
       label: 'Organizations',
+      scope: 'system',
+    },
+    {
+      description: 'Configure the AI assistant and its MCP servers',
+      icon: Sparkles,
+      id: 'assistant',
+      label: 'Assistant',
       scope: 'system',
     },
     {
@@ -373,6 +384,7 @@ export function Admin() {
             {currentSection === 'scoring-policies' && (
               <ScoringPolicyManagement />
             )}
+            {currentSection === 'assistant' && <AssistantManagement />}
             {currentSection === 'oauth' && <AuthProvidersManagement />}
             {currentSection === 'graph-query' && <GraphQueryManagement />}
             {currentSection === 'plugins' && !slug && <PluginsManagement />}

--- a/src/components/admin/AssistantManagement.tsx
+++ b/src/components/admin/AssistantManagement.tsx
@@ -1,0 +1,358 @@
+import { useMemo, useState } from 'react'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { KeyRound, ScrollText, Server, ShieldCheck, Unlock } from 'lucide-react'
+
+import {
+  createMcpServer,
+  deleteMcpServer,
+  listMcpServers,
+  updateMcpServer,
+} from '@/api/endpoints'
+import { AdminTable } from '@/components/ui/admin-table'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
+import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useAdminCrud } from '@/hooks/useAdminCrud'
+import { useAdminNav } from '@/hooks/useAdminNav'
+import type { MCPServer, MCPServerUpdate } from '@/types'
+
+import { AdminSection } from './AdminSection'
+import {
+  McpServerForm,
+  type McpServerSaveData,
+} from './mcp-servers/McpServerForm'
+import { McpServerStatusPill } from './mcp-servers/McpServerStatusPill'
+
+type Filter = 'all' | 'disabled' | 'enabled' | 'issues'
+
+const MCP_SERVERS_KEY = ['mcp-servers']
+
+export function AssistantManagement() {
+  const { goToCreate, goToEdit, goToList, slug, viewMode } = useAdminNav()
+  const queryClient = useQueryClient()
+  const [searchQuery, setSearchQuery] = useState('')
+  const [filter, setFilter] = useState<Filter>('all')
+
+  const {
+    createMutation,
+    deleteMutation,
+    error,
+    isLoading,
+    items: servers,
+    updateMutation,
+  } = useAdminCrud<
+    MCPServer,
+    Parameters<typeof createMcpServer>[0],
+    { data: MCPServerUpdate; id: string },
+    string
+  >({
+    createFn: createMcpServer,
+    deleteErrorLabel: 'MCP server',
+    deleteFn: deleteMcpServer,
+    listFn: listMcpServers,
+    onMutationSuccess: goToList,
+    queryKey: MCP_SERVERS_KEY,
+    updateFn: ({ data, id }) => updateMcpServer(id, data),
+  })
+
+  // Inline enable/disable from the list, without leaving the list view.
+  const toggleMutation = useMutation({
+    mutationFn: ({ enabled, id }: { enabled: boolean; id: string }) =>
+      updateMcpServer(id, { enabled }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: MCP_SERVERS_KEY }),
+  })
+
+  const selectedServer = useMemo(
+    () => servers.find((srv) => srv.slug === slug) ?? null,
+    [servers, slug],
+  )
+
+  const filtered = servers.filter(
+    (srv) => matchesFilter(srv, filter) && matchesQuery(srv, searchQuery),
+  )
+
+  const handleSave = (payload: McpServerSaveData) => {
+    if (payload.mode === 'create') {
+      createMutation.mutate(payload.data)
+    } else {
+      updateMutation.mutate({ data: payload.data, id: payload.id })
+    }
+  }
+
+  if (viewMode === 'create' || viewMode === 'edit') {
+    return (
+      <McpServerForm
+        error={createMutation.error ?? updateMutation.error}
+        isLoading={createMutation.isPending || updateMutation.isPending}
+        onCancel={goToList}
+        onSave={handleSave}
+        server={viewMode === 'edit' ? selectedServer : null}
+      />
+    )
+  }
+
+  const filterChips: { count: number; key: Filter; label: string }[] = [
+    { count: servers.length, key: 'all', label: 'All' },
+    {
+      count: servers.filter((srv) => srv.enabled).length,
+      key: 'enabled',
+      label: 'Enabled',
+    },
+    {
+      count: servers.filter((srv) => !srv.enabled).length,
+      key: 'disabled',
+      label: 'Disabled',
+    },
+    {
+      count: servers.filter((srv) => matchesFilter(srv, 'issues')).length,
+      key: 'issues',
+      label: 'With issues',
+    },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <Tabs value="mcp">
+        <TabsList>
+          <TabsTrigger value="mcp">
+            <Server className="mr-2 size-4" />
+            MCP Servers
+            <Badge className="ml-2" variant="neutral">
+              {servers.length}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger disabled value="prompts">
+            <ScrollText className="mr-2 size-4" />
+            System Prompts
+            <Badge className="ml-2" variant="neutral">
+              Soon
+            </Badge>
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {servers.length === 0 && !isLoading && !error ? (
+        <McpEmptyState onCreate={goToCreate} />
+      ) : (
+        <AdminSection
+          createLabel="Add MCP Server"
+          error={error}
+          errorTitle="Failed to load MCP servers"
+          headerExtras={
+            <SegmentedControl
+              ariaLabel="Filter servers"
+              onValueChange={(v) => setFilter(v as Filter)}
+              value={filter}
+            >
+              {filterChips.map((chip) => (
+                <SegmentedControlItem key={chip.key} value={chip.key}>
+                  {chip.label}
+                  <span className="text-tertiary ml-1 tabular-nums">
+                    {chip.count}
+                  </span>
+                </SegmentedControlItem>
+              ))}
+            </SegmentedControl>
+          }
+          isLoading={isLoading}
+          loadingLabel="Loading MCP servers..."
+          onCreate={goToCreate}
+          onSearchChange={setSearchQuery}
+          search={searchQuery}
+          searchPlaceholder="Search servers by name, slug, or URL..."
+        >
+          <AdminTable
+            columns={[
+              {
+                header: 'Server',
+                key: 'server',
+                render: (srv) => (
+                  <div className="flex items-center gap-3">
+                    <div className="bg-secondary text-secondary flex size-9 shrink-0 items-center justify-center rounded-lg font-mono text-xs font-semibold">
+                      {monogram(srv.name)}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-primary flex items-center gap-2 font-medium">
+                        {srv.name}
+                        <span className="text-tertiary font-mono text-xs">
+                          /{srv.slug}
+                        </span>
+                      </div>
+                      {srv.description && (
+                        <div className="text-tertiary max-w-sm truncate text-sm">
+                          {srv.description}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ),
+              },
+              {
+                header: 'Endpoint',
+                key: 'endpoint',
+                render: (srv) => (
+                  <span
+                    className="text-secondary block max-w-[16rem] truncate font-mono text-xs"
+                    title={srv.url}
+                  >
+                    {srv.url.replace(/^https?:\/\//, '')}
+                  </span>
+                ),
+              },
+              {
+                header: 'Auth',
+                key: 'auth',
+                render: (srv) => {
+                  const { Icon, text } = authSummary(srv)
+                  return (
+                    <span className="text-secondary inline-flex items-center gap-1.5 text-sm">
+                      <Icon className="text-tertiary size-3.5" />
+                      {text}
+                    </span>
+                  )
+                },
+              },
+              {
+                cellAlign: 'right',
+                header: 'Tools',
+                headerAlign: 'right',
+                key: 'tools',
+                render: (srv) => (
+                  <span className="text-secondary font-mono text-sm tabular-nums">
+                    {srv.tools_discovered ?? '—'}
+                    {srv.ignored_tools.length > 0 && (
+                      <span className="text-tertiary">
+                        {' · '}
+                        {srv.ignored_tools.length} hidden
+                      </span>
+                    )}
+                  </span>
+                ),
+              },
+              {
+                header: 'Status',
+                key: 'status',
+                render: (srv) => <McpServerStatusPill server={srv} />,
+              },
+              {
+                header: 'Enabled',
+                key: 'enabled',
+                render: (srv) => (
+                  <span
+                    className="inline-flex"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <Switch
+                      aria-label={`${srv.enabled ? 'Disable' : 'Enable'} ${srv.name}`}
+                      checked={srv.enabled}
+                      disabled={toggleMutation.isPending}
+                      onCheckedChange={(enabled) =>
+                        toggleMutation.mutate({ enabled, id: srv.id })
+                      }
+                    />
+                  </span>
+                ),
+              },
+            ]}
+            emptyMessage={
+              searchQuery || filter !== 'all'
+                ? 'No servers match your filters.'
+                : 'No MCP servers configured yet.'
+            }
+            getDeleteLabel={(srv) => srv.name}
+            getRowKey={(srv) => srv.slug}
+            isDeleting={deleteMutation.isPending}
+            onDelete={(srv) => deleteMutation.mutate(srv.id)}
+            onRowClick={(srv) => goToEdit(srv.slug)}
+            rows={filtered}
+          />
+          <div className="text-tertiary flex items-center justify-between text-xs">
+            <span>
+              Showing {filtered.length} of {servers.length} servers · tools
+              surface as{' '}
+              <code className="bg-secondary rounded px-1 py-0.5 font-mono">
+                mcp_&#123;prefix&#125;_&#123;tool&#125;
+              </code>
+            </span>
+          </div>
+        </AdminSection>
+      )}
+    </div>
+  )
+}
+
+function authSummary(server: MCPServer): {
+  Icon: typeof KeyRound
+  text: string
+} {
+  switch (server.auth_type) {
+    case 'oauth_client_credentials':
+      return { Icon: ShieldCheck, text: 'OAuth · client creds' }
+    case 'static':
+      return {
+        Icon: KeyRound,
+        text: `Static · ${server.static_header ?? 'header'}`,
+      }
+    default:
+      return { Icon: Unlock, text: 'No auth' }
+  }
+}
+
+function matchesFilter(server: MCPServer, filter: Filter): boolean {
+  if (filter === 'enabled') return server.enabled
+  if (filter === 'disabled') return !server.enabled
+  if (filter === 'issues') {
+    return server.status === 'degraded' || server.status === 'unreachable'
+  }
+  return true
+}
+
+function matchesQuery(server: MCPServer, query: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  return (
+    server.name.toLowerCase().includes(q) ||
+    server.slug.toLowerCase().includes(q) ||
+    server.url.toLowerCase().includes(q) ||
+    (server.description?.toLowerCase().includes(q) ?? false)
+  )
+}
+
+function McpEmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center py-16 text-center">
+        <div className="bg-secondary text-tertiary mb-4 flex size-12 items-center justify-center rounded-xl">
+          <Server className="size-6" />
+        </div>
+        <div className="text-primary text-base font-medium">
+          No MCP servers configured
+        </div>
+        <p className="text-secondary mt-1.5 max-w-md text-sm">
+          Connect a Model Context Protocol server to give the assistant access
+          to external tools — GitHub, SonarQube, code search, anything that
+          speaks streamable-HTTP MCP.
+        </p>
+        <button
+          className="bg-action text-action-foreground hover:bg-action-hover mt-5 inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
+          onClick={onCreate}
+          type="button"
+        >
+          Add your first server
+        </button>
+      </CardContent>
+    </Card>
+  )
+}
+
+function monogram(name: string): string {
+  return (name.trim() || '?').slice(0, 2).toUpperCase()
+}

--- a/src/components/admin/__tests__/AssistantManagement.test.tsx
+++ b/src/components/admin/__tests__/AssistantManagement.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, waitFor } from '@/test/utils'
+import type { MCPServer } from '@/types'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', () => ({
+  createMcpServer: vi.fn(),
+  deleteMcpServer: vi.fn(),
+  listMcpServers: vi.fn(),
+  testMcpServer: vi.fn(),
+  testMcpServerConfig: vi.fn(),
+  updateMcpServer: vi.fn(),
+}))
+
+const sampleServer = (overrides: Partial<MCPServer> = {}): MCPServer => ({
+  auth_type: 'oauth_client_credentials',
+  created_at: '2026-01-01T00:00:00Z',
+  description: 'Read-only GitHub access.',
+  enabled: true,
+  has_oauth_client_secret: true,
+  has_static_value: false,
+  id: 'srv-1',
+  ignored_tools: [],
+  name: 'GitHub',
+  slug: 'github',
+  status: 'healthy',
+  timeout: 30,
+  tools_discovered: 18,
+  url: 'https://mcp.github.com/v1/stream',
+  verify_ssl: true,
+  ...overrides,
+})
+
+describe('AssistantManagement', () => {
+  it('lists configured servers with status and the sub-tabs', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.listMcpServers).mockResolvedValue([sampleServer()])
+    const { AssistantManagement } = await import('../AssistantManagement')
+    render(<AssistantManagement />)
+
+    await waitFor(() => expect(screen.getByText('GitHub')).toBeInTheDocument())
+    expect(screen.getByText('MCP Servers')).toBeInTheDocument()
+    expect(screen.getByText('System Prompts')).toBeInTheDocument()
+    expect(screen.getByText('Healthy')).toBeInTheDocument()
+    expect(screen.getByText('mcp.github.com/v1/stream')).toBeInTheDocument()
+    expect(
+      screen.getByRole('switch', { name: /disable github/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders an empty state when no servers are configured', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.listMcpServers).mockResolvedValue([])
+    const { AssistantManagement } = await import('../AssistantManagement')
+    render(<AssistantManagement />)
+
+    await waitFor(() =>
+      expect(screen.getByText('No MCP servers configured')).toBeInTheDocument(),
+    )
+  })
+
+  it('reflects disabled servers in the status pill', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.listMcpServers).mockResolvedValue([
+      sampleServer({ enabled: false, status: 'healthy' }),
+    ])
+    const { AssistantManagement } = await import('../AssistantManagement')
+    render(<AssistantManagement />)
+
+    // "Disabled" also labels a filter chip (a <button>); scope to the
+    // status pill, which is a <div>.
+    await waitFor(() =>
+      expect(
+        screen.getByText('Disabled', { selector: 'div' }),
+      ).toBeInTheDocument(),
+    )
+  })
+})

--- a/src/components/admin/mcp-servers/ConnectionTestPanel.tsx
+++ b/src/components/admin/mcp-servers/ConnectionTestPanel.tsx
@@ -1,0 +1,200 @@
+import { useState } from 'react'
+
+import { CheckCircle2, Loader2, Plug, PlugZap, XCircle } from 'lucide-react'
+
+import { ApiError } from '@/api/client'
+import { Button } from '@/components/ui/button'
+import { formatRelativeDate } from '@/lib/formatDate'
+import { cn } from '@/lib/utils'
+import type { MCPServer, MCPServerTestResult } from '@/types'
+
+interface ConnectionTestPanelProps {
+  // Called with each successful result, so the form can surface the
+  // discovered tool names (e.g. in the ignored-tools picker).
+  onResult?: (result: MCPServerTestResult) => void
+  // Runs the test and resolves with the result. Throws on transport error.
+  onTest: () => Promise<MCPServerTestResult>
+  // The saved server, when editing — used to show the last-tested result
+  // before the user runs a fresh test. Null on the create form.
+  server: MCPServer | null
+}
+
+type Phase =
+  | { kind: 'error'; message: string }
+  | { kind: 'idle' }
+  | { kind: 'result'; result: MCPServerTestResult }
+  | { kind: 'testing' }
+
+type Tone = 'danger' | 'neutral' | 'success'
+
+export function ConnectionTestPanel({
+  onResult,
+  onTest,
+  server,
+}: ConnectionTestPanelProps) {
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' })
+
+  const run = async () => {
+    setPhase({ kind: 'testing' })
+    try {
+      const result = await onTest()
+      setPhase({ kind: 'result', result })
+      onResult?.(result)
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? ((err.data as undefined | { detail?: string })?.detail ??
+            err.message)
+          : err instanceof Error
+            ? err.message
+            : 'Connection test failed'
+      setPhase({ kind: 'error', message })
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-secondary text-sm">
+          Verify the endpoint responds, authenticates, and lists its tools.
+        </p>
+        <Button
+          disabled={phase.kind === 'testing'}
+          onClick={run}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          {phase.kind === 'testing' ? (
+            <Loader2 className="mr-2 size-4 animate-spin" />
+          ) : (
+            <PlugZap className="mr-2 size-4" />
+          )}
+          {phase.kind === 'testing' ? 'Testing…' : 'Test connection'}
+        </Button>
+      </div>
+      <Result phase={phase} server={server} />
+    </div>
+  )
+}
+
+const TONE_CLASSES: Record<
+  Tone,
+  { container: string; icon: string; title: string }
+> = {
+  danger: {
+    container: 'border-danger/40 bg-danger',
+    icon: 'text-danger',
+    title: 'text-danger',
+  },
+  neutral: {
+    container: 'border-tertiary bg-secondary',
+    icon: 'bg-primary text-tertiary',
+    title: 'text-primary',
+  },
+  success: {
+    container: 'border-success/40 bg-success',
+    icon: 'text-success',
+    title: 'text-success',
+  },
+}
+
+function Panel({
+  icon,
+  sub,
+  title,
+  tone = 'neutral',
+}: {
+  icon: React.ReactNode
+  sub: string
+  title: string
+  tone?: Tone
+}) {
+  const classes = TONE_CLASSES[tone]
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 rounded-md border px-4 py-3',
+        classes.container,
+      )}
+    >
+      <span
+        className={cn(
+          'flex size-8 shrink-0 items-center justify-center rounded-full',
+          classes.icon,
+        )}
+      >
+        {icon}
+      </span>
+      <div className="min-w-0">
+        <div className={cn('text-sm font-medium', classes.title)}>{title}</div>
+        <div className="text-tertiary truncate text-xs">{sub}</div>
+      </div>
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function Result({ phase, server }: { phase: Phase; server: MCPServer | null }) {
+  if (phase.kind === 'testing') {
+    return (
+      <Panel
+        icon={<Loader2 className="size-4 animate-spin" />}
+        sub="Hitting endpoint, negotiating tools."
+        title="Testing connection…"
+      />
+    )
+  }
+  if (phase.kind === 'error') {
+    return (
+      <Panel
+        icon={<XCircle className="size-4" />}
+        sub={phase.message}
+        title="Connection test failed"
+        tone="danger"
+      />
+    )
+  }
+  if (phase.kind === 'result') {
+    const { result } = phase
+    if (!result.ok) {
+      return (
+        <Panel
+          icon={<XCircle className="size-4" />}
+          sub={`${result.error ?? 'Unreachable'} · ${result.latency_ms}ms`}
+          title="Connection failed"
+          tone="danger"
+        />
+      )
+    }
+    return (
+      <Panel
+        icon={<CheckCircle2 className="size-4" />}
+        sub={`${result.latency_ms}ms · ${result.tools_discovered} tools discovered · just now`}
+        title="Connection OK"
+        tone="success"
+      />
+    )
+  }
+  // Idle: show the last persisted test for a saved server, else a hint.
+  if (server?.last_tested_at) {
+    const parts = [`${server.last_tested_latency_ms ?? '—'}ms`]
+    if (server.tools_discovered != null) {
+      parts.push(`${server.tools_discovered} tools discovered`)
+    }
+    return (
+      <Panel
+        icon={<CheckCircle2 className="size-4" />}
+        sub={parts.join(' · ')}
+        title={`Last tested ${formatRelativeDate(server.last_tested_at)}`}
+      />
+    )
+  }
+  return (
+    <Panel
+      icon={<Plug className="size-4" />}
+      sub="Run a test to verify the endpoint responds and list its tools."
+      title="Not yet tested"
+    />
+  )
+}

--- a/src/components/admin/mcp-servers/IgnoredToolsEditor.tsx
+++ b/src/components/admin/mcp-servers/IgnoredToolsEditor.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+
+import { Plus, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+// Free-form list of tool names to hide from the assistant. Maps directly to
+// the server's `ignored_tools` array. An ignored tool is never registered, so
+// its namespaced name (mcp_{prefix}_{tool}) won't reach the model.
+//
+// When a connection test has discovered the server's live tools, they're
+// offered in a dropdown; names can also be typed directly (e.g. before a
+// test, or for a tool that blocks a clean test).
+interface IgnoredToolsEditorProps {
+  // Live tool names discovered by the last connection test, if any.
+  availableTools?: string[]
+  onChange: (value: string[]) => void
+  value: string[]
+}
+
+export function IgnoredToolsEditor({
+  availableTools = [],
+  onChange,
+  value,
+}: IgnoredToolsEditorProps) {
+  const [draft, setDraft] = useState('')
+
+  const add = (name: string) => {
+    const trimmed = name.trim()
+    if (trimmed && !value.includes(trimmed)) {
+      onChange([...value, trimmed])
+    }
+  }
+
+  const remove = (name: string) => {
+    onChange(value.filter((t) => t !== name))
+  }
+
+  const selectable = availableTools.filter((t) => !value.includes(t))
+
+  return (
+    <div className="space-y-3">
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {value.map((name) => (
+            <span
+              className="bg-secondary text-primary inline-flex items-center gap-1.5 rounded px-2 py-1 font-mono text-xs"
+              key={name}
+            >
+              {name}
+              <button
+                aria-label={`Remove ${name}`}
+                className="text-tertiary hover:text-destructive"
+                onClick={() => remove(name)}
+                type="button"
+              >
+                <X className="size-3.5" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {selectable.length > 0 && (
+        <Select onValueChange={(v) => add(v)} value="">
+          <SelectTrigger aria-label="Ignore a discovered tool">
+            <SelectValue placeholder="Ignore a discovered tool…" />
+          </SelectTrigger>
+          <SelectContent>
+            {selectable.map((name) => (
+              <SelectItem className="font-mono" key={name} value={name}>
+                {name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Input
+          className="font-mono"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              add(draft)
+              setDraft('')
+            }
+          }}
+          placeholder={
+            availableTools.length > 0
+              ? 'or add a tool name…'
+              : 'tool_name to ignore…'
+          }
+          value={draft}
+        />
+        <Button
+          disabled={!draft.trim()}
+          onClick={() => {
+            add(draft)
+            setDraft('')
+          }}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          <Plus className="mr-1.5 size-3.5" />
+          Add
+        </Button>
+      </div>
+
+      {availableTools.length === 0 && (
+        <p className="text-tertiary text-xs">
+          Run a connection test to list this server&apos;s tools and pick them
+          from a dropdown.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/mcp-servers/McpServerForm.tsx
+++ b/src/components/admin/mcp-servers/McpServerForm.tsx
@@ -1,0 +1,601 @@
+import { useState } from 'react'
+
+import { useQueryClient } from '@tanstack/react-query'
+import { AlertCircle, KeyRound, Plug, ShieldCheck, Unlock } from 'lucide-react'
+
+import { ApiError } from '@/api/client'
+import { testMcpServer, testMcpServerConfig } from '@/api/endpoints'
+import { FormHeader } from '@/components/admin/form-header'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ErrorBanner } from '@/components/ui/error-banner'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+import { slugify } from '@/lib/utils'
+import type {
+  MCPServer,
+  MCPServerAuthType,
+  MCPServerCreate,
+  MCPServerTestConfig,
+  MCPServerUpdate,
+} from '@/types'
+
+import { ConnectionTestPanel } from './ConnectionTestPanel'
+import { IgnoredToolsEditor } from './IgnoredToolsEditor'
+import { SecretField } from './SecretField'
+
+export type McpServerSaveData =
+  | { data: MCPServerCreate; mode: 'create' }
+  | { data: MCPServerUpdate; id: string; mode: 'edit' }
+
+interface FormState {
+  authType: MCPServerAuthType
+  description: string
+  enabled: boolean
+  icon: string
+  ignoredTools: string[]
+  name: string
+  oauthCleared: boolean
+  oauthClientId: string
+  oauthEditing: boolean
+  oauthScope: string
+  oauthTokenUrl: string
+  oauthValue: string
+  slug: string
+  slugTouched: boolean
+  staticCleared: boolean
+  staticEditing: boolean
+  staticHeader: string
+  staticValue: string
+  timeout: number
+  toolPrefix: string
+  url: string
+  verifySsl: boolean
+}
+
+interface McpServerFormProps {
+  error?: ApiError<{ detail?: string }> | Error | null
+  isLoading?: boolean
+  onCancel: () => void
+  onSave: (data: McpServerSaveData) => void
+  server: MCPServer | null
+}
+
+// fallow-ignore-next-line complexity
+export function McpServerForm({
+  error,
+  isLoading = false,
+  onCancel,
+  onSave,
+  server,
+}: McpServerFormProps) {
+  const isEditing = !!server
+  const queryClient = useQueryClient()
+  const [s, setS] = useState<FormState>(() => initialState(server))
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  // Tool names discovered by the last connection test, offered as a
+  // dropdown in the ignored-tools picker.
+  const [discoveredTools, setDiscoveredTools] = useState<string[]>([])
+
+  const set = (patch: Partial<FormState>) =>
+    setS((prev) => ({ ...prev, ...patch }))
+
+  const slugConflict =
+    error instanceof ApiError && error.status === 409 ? error : null
+
+  const handleName = (name: string) =>
+    set(isEditing || s.slugTouched ? { name } : { name, slug: slugify(name) })
+
+  const handleSave = () => {
+    const found = validate(s, server)
+    setErrors(found)
+    if (Object.keys(found).length > 0) return
+    if (isEditing && server) {
+      onSave({ data: buildUpdate(s), id: server.id, mode: 'edit' })
+    } else {
+      onSave({ data: buildCreate(s), mode: 'create' })
+    }
+  }
+
+  const runTest = async () => {
+    if (isEditing && server) {
+      const result = await testMcpServer(server.id)
+      await queryClient.invalidateQueries({ queryKey: ['mcp-servers'] })
+      return result
+    }
+    return testMcpServerConfig(buildCreate(s) as MCPServerTestConfig)
+  }
+
+  const prefix = s.toolPrefix.trim() || s.slug.trim() || '…'
+
+  return (
+    <div className="space-y-6">
+      <FormHeader
+        createLabel="Create Server"
+        isEditing={isEditing}
+        isLoading={isLoading}
+        onCancel={onCancel}
+        onSave={handleSave}
+        subtitle={
+          isEditing
+            ? `Configure the ${server.name} MCP server.`
+            : 'Connect a streamable-HTTP MCP endpoint the assistant can call.'
+        }
+        title={isEditing ? `Edit ${server.name}` : 'Add MCP Server'}
+      />
+
+      {error && !slugConflict && (
+        <ErrorBanner error={error} title="Failed to save MCP server" />
+      )}
+
+      {/* Identity */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Identity</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Field error={errors.name} label="Display name" required>
+            <Input
+              onChange={(e) => handleName(e.target.value)}
+              placeholder="GitHub"
+              value={s.name}
+            />
+          </Field>
+          <Field
+            error={errors.slug ?? slugConflict?.data?.detail}
+            help={
+              <>
+                URL-safe identifier. Used in tool names like{' '}
+                <code className="bg-secondary rounded px-1 py-0.5 font-mono">
+                  mcp_{prefix}_…
+                </code>
+                . Changing it later renames every tool this server exposes.
+              </>
+            }
+            label="Slug"
+            required
+          >
+            <Input
+              className="font-mono"
+              onChange={(e) => set({ slug: e.target.value, slugTouched: true })}
+              placeholder="github"
+              value={s.slug}
+            />
+          </Field>
+          <Field
+            error={errors.url}
+            help="Streamable-HTTP MCP endpoint."
+            label="URL"
+            required
+          >
+            <Input
+              className="font-mono"
+              onChange={(e) => set({ url: e.target.value })}
+              placeholder="https://mcp.example.com/v1/stream"
+              value={s.url}
+            />
+          </Field>
+          <Field label="Description">
+            <Textarea
+              onChange={(e) => set({ description: e.target.value })}
+              placeholder="One sentence — what this server is for."
+              value={s.description}
+            />
+          </Field>
+          <Field label="Enabled">
+            <label className="flex items-center gap-3">
+              <Switch
+                checked={s.enabled}
+                onCheckedChange={(v) => set({ enabled: v })}
+              />
+              <span className="text-secondary text-sm">
+                {s.enabled
+                  ? 'Active — the assistant can use this server.'
+                  : 'Disabled — tools hidden from the assistant.'}
+              </span>
+            </label>
+          </Field>
+        </CardContent>
+      </Card>
+
+      {/* Connection */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Connection</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Field
+            help={
+              <>
+                Tools surface to the assistant as{' '}
+                <code className="bg-secondary rounded px-1 py-0.5 font-mono">
+                  mcp_{prefix}_{'{tool}'}
+                </code>
+                . Falls back to the slug when blank.
+              </>
+            }
+            label="Tool prefix"
+          >
+            <Input
+              className="font-mono"
+              onChange={(e) => set({ toolPrefix: e.target.value })}
+              placeholder={s.slug || 'gh'}
+              value={s.toolPrefix}
+            />
+          </Field>
+          <Field label="Timeout">
+            <div className="flex items-center gap-3">
+              <Input
+                className="w-28 font-mono"
+                max={300}
+                min={1}
+                onChange={(e) =>
+                  set({ timeout: Number.parseInt(e.target.value, 10) || 0 })
+                }
+                type="number"
+                value={s.timeout}
+              />
+              <span className="text-secondary text-sm">seconds</span>
+            </div>
+          </Field>
+          <Field label="Verify SSL">
+            <label className="flex items-center gap-3">
+              <Switch
+                checked={s.verifySsl}
+                onCheckedChange={(v) => set({ verifySsl: v })}
+              />
+              <span className="text-secondary text-sm">
+                {s.verifySsl ? (
+                  'Strict — reject invalid certificates.'
+                ) : (
+                  <span className="text-warning">
+                    Insecure — for in-cluster traffic only.
+                  </span>
+                )}
+              </span>
+            </label>
+          </Field>
+        </CardContent>
+      </Card>
+
+      {/* Authentication */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Authentication</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Field label="Auth type">
+            <SegmentedControl
+              ariaLabel="Auth type"
+              onValueChange={(v) => set({ authType: v as MCPServerAuthType })}
+              value={s.authType}
+            >
+              <SegmentedControlItem value="none">
+                <Unlock className="size-3.5" />
+                None
+              </SegmentedControlItem>
+              <SegmentedControlItem value="static">
+                <KeyRound className="size-3.5" />
+                Static header
+              </SegmentedControlItem>
+              <SegmentedControlItem value="oauth_client_credentials">
+                <ShieldCheck className="size-3.5" />
+                OAuth client
+              </SegmentedControlItem>
+            </SegmentedControl>
+          </Field>
+
+          {s.authType === 'none' && (
+            <p className="bg-secondary text-secondary flex items-center gap-2 rounded-md px-3 py-2 text-sm">
+              <Plug className="size-3.5" />
+              No credentials sent. Only safe for in-cluster endpoints behind a
+              private network.
+            </p>
+          )}
+
+          {s.authType === 'static' && (
+            <>
+              <Field
+                error={errors.staticHeader}
+                help="Sent on every request. Common values: Authorization, X-Api-Key."
+                label="Header name"
+                required
+              >
+                <Input
+                  className="font-mono"
+                  onChange={(e) => set({ staticHeader: e.target.value })}
+                  placeholder="Authorization"
+                  value={s.staticHeader}
+                />
+              </Field>
+              <Field
+                error={errors.staticValue}
+                help="Encrypted and write-only — never returned by the API."
+                label="Header value"
+                required={!server?.has_static_value}
+              >
+                <SecretField
+                  cleared={s.staticCleared}
+                  editing={s.staticEditing}
+                  onCancel={() =>
+                    set({ staticEditing: false, staticValue: '' })
+                  }
+                  onChange={(v) => set({ staticValue: v })}
+                  onClear={() =>
+                    set({
+                      staticCleared: true,
+                      staticEditing: false,
+                      staticValue: '',
+                    })
+                  }
+                  onStart={() =>
+                    set({
+                      staticCleared: false,
+                      staticEditing: true,
+                      staticValue: '',
+                    })
+                  }
+                  placeholder="Bearer ghp_…"
+                  present={!!server?.has_static_value}
+                  value={s.staticValue}
+                />
+              </Field>
+            </>
+          )}
+
+          {s.authType === 'oauth_client_credentials' && (
+            <>
+              <Field error={errors.oauthTokenUrl} label="Token URL" required>
+                <Input
+                  className="font-mono"
+                  onChange={(e) => set({ oauthTokenUrl: e.target.value })}
+                  placeholder="https://example.com/oauth/token"
+                  value={s.oauthTokenUrl}
+                />
+              </Field>
+              <Field error={errors.oauthClientId} label="Client ID" required>
+                <Input
+                  className="font-mono"
+                  onChange={(e) => set({ oauthClientId: e.target.value })}
+                  placeholder="Iv1.f9e4…"
+                  value={s.oauthClientId}
+                />
+              </Field>
+              <Field
+                error={errors.oauthValue}
+                help="Encrypted and write-only — never returned by the API."
+                label="Client secret"
+                required={!server?.has_oauth_client_secret}
+              >
+                <SecretField
+                  cleared={s.oauthCleared}
+                  editing={s.oauthEditing}
+                  onCancel={() => set({ oauthEditing: false, oauthValue: '' })}
+                  onChange={(v) => set({ oauthValue: v })}
+                  onClear={() =>
+                    set({
+                      oauthCleared: true,
+                      oauthEditing: false,
+                      oauthValue: '',
+                    })
+                  }
+                  onStart={() =>
+                    set({
+                      oauthCleared: false,
+                      oauthEditing: true,
+                      oauthValue: '',
+                    })
+                  }
+                  present={!!server?.has_oauth_client_secret}
+                  value={s.oauthValue}
+                />
+              </Field>
+              <Field help="Optional. Space-separated." label="Scope">
+                <Input
+                  className="font-mono"
+                  onChange={(e) => set({ oauthScope: e.target.value })}
+                  placeholder="repo:read actions:read"
+                  value={s.oauthScope}
+                />
+              </Field>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Connection test */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Connection test</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ConnectionTestPanel
+            onResult={(result) => {
+              if (result.ok) setDiscoveredTools(result.tools)
+            }}
+            onTest={runTest}
+            server={server}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Ignored tools */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Ignored tools</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-secondary text-sm">
+            Tool names listed here are never exposed to the assistant, even when
+            the server advertises them.
+          </p>
+          <IgnoredToolsEditor
+            availableTools={discoveredTools}
+            onChange={(v) => set({ ignoredTools: v })}
+            value={s.ignoredTools}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// Fields shared by the create payload and (minus secrets) the update payload.
+// fallow-ignore-next-line complexity
+function baseFields(s: FormState) {
+  return {
+    auth_type: s.authType,
+    description: s.description.trim() || null,
+    enabled: s.enabled,
+    icon: s.icon.trim() || null,
+    ignored_tools: s.ignoredTools,
+    oauth_client_id:
+      s.authType === 'oauth_client_credentials'
+        ? s.oauthClientId.trim() || null
+        : null,
+    oauth_scope:
+      s.authType === 'oauth_client_credentials'
+        ? s.oauthScope.trim() || null
+        : null,
+    oauth_token_url:
+      s.authType === 'oauth_client_credentials'
+        ? s.oauthTokenUrl.trim() || null
+        : null,
+    static_header:
+      s.authType === 'static' ? s.staticHeader.trim() || null : null,
+    timeout: s.timeout,
+    tool_prefix: s.toolPrefix.trim() || null,
+    url: s.url.trim(),
+    verify_ssl: s.verifySsl,
+  }
+}
+
+function buildCreate(s: FormState): MCPServerCreate {
+  const data: MCPServerCreate = {
+    ...baseFields(s),
+    name: s.name.trim(),
+    slug: s.slug.trim(),
+  }
+  if (s.authType === 'static' && s.staticValue) {
+    data.static_value = s.staticValue
+  }
+  if (s.authType === 'oauth_client_credentials' && s.oauthValue) {
+    data.oauth_client_secret = s.oauthValue
+  }
+  return data
+}
+
+// Secret rules: a freshly typed value is sent; an explicit clear sends null;
+// an untouched secret is omitted so the stored ciphertext survives.
+function buildUpdate(s: FormState): MCPServerUpdate {
+  const data: MCPServerUpdate = {
+    ...baseFields(s),
+    name: s.name.trim(),
+    slug: s.slug.trim(),
+  }
+  if (s.staticValue) data.static_value = s.staticValue
+  else if (s.staticCleared) data.static_value = null
+  if (s.oauthValue) data.oauth_client_secret = s.oauthValue
+  else if (s.oauthCleared) data.oauth_client_secret = null
+  return data
+}
+
+function Field({
+  children,
+  error,
+  help,
+  label,
+  required,
+}: {
+  children: React.ReactNode
+  error?: string
+  help?: React.ReactNode
+  label: string
+  required?: boolean
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-secondary text-sm">
+        {label}
+        {required && <RequiredAsterisk />}
+      </Label>
+      {children}
+      {error && (
+        <p className="text-danger flex items-center gap-1.5 text-xs">
+          <AlertCircle className="size-3.5 shrink-0" />
+          {error}
+        </p>
+      )}
+      {help && <p className="text-tertiary text-xs">{help}</p>}
+    </div>
+  )
+}
+
+function hasOauthSecret(s: FormState, server: MCPServer | null): boolean {
+  return (
+    !!s.oauthValue || (!!server?.has_oauth_client_secret && !s.oauthCleared)
+  )
+}
+
+function hasStaticSecret(s: FormState, server: MCPServer | null): boolean {
+  return !!s.staticValue || (!!server?.has_static_value && !s.staticCleared)
+}
+
+// fallow-ignore-next-line complexity
+function initialState(server: MCPServer | null): FormState {
+  return {
+    authType: server?.auth_type ?? 'none',
+    description: server?.description ?? '',
+    enabled: server?.enabled ?? true,
+    icon: server?.icon ?? '',
+    ignoredTools: server?.ignored_tools ?? [],
+    name: server?.name ?? '',
+    oauthCleared: false,
+    oauthClientId: server?.oauth_client_id ?? '',
+    oauthEditing: false,
+    oauthScope: server?.oauth_scope ?? '',
+    oauthTokenUrl: server?.oauth_token_url ?? '',
+    oauthValue: '',
+    slug: server?.slug ?? '',
+    slugTouched: !!server,
+    staticCleared: false,
+    staticEditing: false,
+    staticHeader: server?.static_header ?? 'Authorization',
+    staticValue: '',
+    timeout: server?.timeout ?? 30,
+    toolPrefix: server?.tool_prefix ?? '',
+    url: server?.url ?? '',
+    verifySsl: server?.verify_ssl ?? true,
+  }
+}
+
+// fallow-ignore-next-line complexity
+function validate(
+  s: FormState,
+  server: MCPServer | null,
+): Record<string, string> {
+  const errors: Record<string, string> = {}
+  if (!s.name.trim()) errors.name = 'Display name is required.'
+  if (!s.slug.trim()) errors.slug = 'Slug is required.'
+  if (!s.url.trim()) errors.url = 'URL is required.'
+  if (s.authType === 'static') {
+    if (!s.staticHeader.trim()) errors.staticHeader = 'Header name is required.'
+    if (!hasStaticSecret(s, server)) {
+      errors.staticValue = 'Header value is required.'
+    }
+  }
+  if (s.authType === 'oauth_client_credentials') {
+    if (!s.oauthTokenUrl.trim()) errors.oauthTokenUrl = 'Token URL is required.'
+    if (!s.oauthClientId.trim()) errors.oauthClientId = 'Client ID is required.'
+    if (!hasOauthSecret(s, server)) {
+      errors.oauthValue = 'Client secret is required.'
+    }
+  }
+  return errors
+}

--- a/src/components/admin/mcp-servers/McpServerStatusPill.tsx
+++ b/src/components/admin/mcp-servers/McpServerStatusPill.tsx
@@ -1,0 +1,31 @@
+import { Badge, type BadgeProps } from '@/components/ui/badge'
+import type { MCPServer, MCPServerStatus } from '@/types'
+
+// The list/detail pill folds `enabled` into the runtime status: a disabled
+// server reads as "Disabled" regardless of its last health check.
+type EffectiveStatus = 'disabled' | MCPServerStatus
+
+const STATUS_META: Record<
+  EffectiveStatus,
+  { label: string; variant: BadgeProps['variant'] }
+> = {
+  degraded: { label: 'Degraded', variant: 'warning' },
+  disabled: { label: 'Disabled', variant: 'neutral' },
+  healthy: { label: 'Healthy', variant: 'success' },
+  unknown: { label: 'Not tested', variant: 'neutral' },
+  unreachable: { label: 'Unreachable', variant: 'danger' },
+}
+
+export function McpServerStatusPill({ server }: { server: MCPServer }) {
+  const meta = STATUS_META[effectiveStatus(server)]
+  return (
+    <Badge className="gap-1.5" variant={meta.variant}>
+      <span className="size-1.5 rounded-full bg-current" />
+      {meta.label}
+    </Badge>
+  )
+}
+
+function effectiveStatus(server: MCPServer): EffectiveStatus {
+  return server.enabled ? server.status : 'disabled'
+}

--- a/src/components/admin/mcp-servers/SecretField.tsx
+++ b/src/components/admin/mcp-servers/SecretField.tsx
@@ -1,0 +1,98 @@
+import { Lock, Pencil, Trash2, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+// Write-only secret field. The API never returns the value, only a
+// `present` boolean. Three states:
+//   - present & not editing  → "•••• Set" with Replace / Clear
+//   - not present & not editing → "Not set" with Set value
+//   - editing → password input with Cancel
+//
+// `value` is the in-progress plaintext (parent owns it); `cleared` records
+// that the user explicitly removed an existing secret.
+interface SecretFieldProps {
+  cleared: boolean
+  editing: boolean
+  onCancel: () => void
+  onChange: (value: string) => void
+  onClear: () => void
+  onStart: () => void
+  placeholder?: string
+  present: boolean
+  value: string
+}
+
+export function SecretField({
+  cleared,
+  editing,
+  onCancel,
+  onChange,
+  onClear,
+  onStart,
+  placeholder = 'Paste new secret…',
+  present,
+  value,
+}: SecretFieldProps) {
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <Input
+          autoComplete="new-password"
+          autoFocus
+          className="font-mono"
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          type="password"
+          value={value}
+        />
+        <Button
+          aria-label="Cancel"
+          onClick={onCancel}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+    )
+  }
+
+  const hasStored = present && !cleared
+  return (
+    <div className="border-input bg-secondary flex items-center justify-between rounded-md border px-3 py-2">
+      <span className="text-secondary inline-flex items-center gap-2 text-sm">
+        {hasStored ? (
+          <>
+            <Lock className="text-success size-3.5" />
+            <span className="text-primary font-mono tracking-widest">
+              ••••••••
+            </span>
+            <span className="text-tertiary">Set</span>
+          </>
+        ) : (
+          <span className="text-tertiary italic">Not set</span>
+        )}
+      </span>
+      <div className="flex items-center gap-1">
+        <Button onClick={onStart} size="sm" type="button" variant="outline">
+          <Pencil className="mr-1.5 size-3.5" />
+          {hasStored ? 'Replace' : 'Set value'}
+        </Button>
+        {hasStored && (
+          <Button
+            aria-label="Clear"
+            className="text-destructive hover:bg-destructive/10"
+            onClick={onClear}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -863,6 +863,81 @@ export interface LogResultResponse {
   total: null | number
 }
 
+export interface MCPServer {
+  auth_type: MCPServerAuthType
+  created_at?: null | string
+  description?: null | string
+  enabled: boolean
+  has_oauth_client_secret: boolean
+  has_static_value: boolean
+  icon?: null | string
+  id: string
+  ignored_tools: string[]
+  last_error?: null | string
+  last_tested_at?: null | string
+  last_tested_latency_ms?: null | number
+  name: string
+  oauth_client_id?: null | string
+  oauth_scope?: null | string
+  oauth_token_url?: null | string
+  slug: string
+  static_header?: null | string
+  status: MCPServerStatus
+  timeout: number
+  tool_prefix?: null | string
+  tools_discovered?: null | number
+  updated_at?: null | string
+  url: string
+  verify_ssl: boolean
+}
+
+// MCP server admin types — mirror imbi_api/endpoints/mcp_servers.py. These
+// are hand-written because the codegen snapshot predates the endpoints;
+// regenerate via `npm run codegen:fetch` once the backend snapshot includes
+// /mcp-servers, then collapse these onto `Schemas['MCPServerResponse']`.
+export type MCPServerAuthType = 'none' | 'oauth_client_credentials' | 'static'
+
+export interface MCPServerCreate {
+  auth_type?: MCPServerAuthType
+  description?: null | string
+  enabled?: boolean
+  icon?: null | string
+  ignored_tools?: string[]
+  name: string
+  oauth_client_id?: null | string
+  oauth_client_secret?: null | string
+  oauth_scope?: null | string
+  oauth_token_url?: null | string
+  slug: string
+  static_header?: null | string
+  static_value?: null | string
+  timeout?: number
+  tool_prefix?: null | string
+  url: string
+  verify_ssl?: boolean
+}
+
+export type MCPServerStatus = 'degraded' | 'healthy' | 'unknown' | 'unreachable'
+
+// Body for POST /mcp-servers/test (test an unsaved config). name/slug are
+// optional server-side; the URL and auth fields are what matter.
+export type MCPServerTestConfig = Omit<MCPServerCreate, 'name' | 'slug'> & {
+  name?: string
+  slug?: string
+}
+
+export interface MCPServerTestResult {
+  error?: null | string
+  latency_ms: number
+  ok: boolean
+  status: 'degraded' | 'healthy' | 'unreachable'
+  tested_at: string
+  tools: string[]
+  tools_discovered: number
+}
+
+export type MCPServerUpdate = Partial<MCPServerCreate>
+
 // Auth provider types — mirror the consolidated `ServiceApplication`-backed
 // shape in imbi_api/endpoints/auth_providers.py.
 export type OAuthAppType = 'github' | 'google' | 'oidc'


### PR DESCRIPTION
## Summary
Adds a global-admin **Assistant** section (between Organizations and Auth Providers) for configuring the AI assistant's MCP servers. Sub-tabs: **MCP Servers** (active) and **System Prompts** (marked *Soon*).

## What's included
- **List**: searchable, filterable (All / Enabled / Disabled / With issues) table with brand monogram, endpoint, auth summary, tool count, a health **status pill** (Healthy / Degraded / Unreachable / Disabled), inline enable/disable switch, and delete. Empty state for no servers.
- **Create/edit page** (row click → dedicated page, no drawer): identity, connection, segmented auth (none / static / oauth) with **write-only secret fields** (••• Set / Replace / Clear), an on-demand **connection test** panel, and a free-form **ignored-tools editor** with a dropdown of tools discovered by the test.
- **Inline 409** duplicate-slug error on the slug field; slug auto-derives from name on create.
- New `MCPServer*` types + `/mcp-servers` endpoints. Update uses a **partial-object PATCH** (the backend's `MCPServerUpdate`), not json-patch.
- Component tests for the list, empty state, and status pill.

## Notes / deviations from the mock
- Row click opens a **page**, not a slide-out drawer (per design feedback).
- Delete uses the existing `AdminTable` confirm for consistency, not the mock's type-to-confirm.
- `ignored_tools` is a free-form editor (no separate discovery endpoint); discovered names come from the connection test.

## Dependencies
Requires the backend changes deployed:
- AWeber-Imbi/imbi-common#135 (MCPServer health fields)
- imbi-api MCP test/status endpoints (PR linked separately)

**Merge order: imbi-common → imbi-api → imbi-ui.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)