### PR TITLE
Show the Imbi mark only on the latest assistant message

### DIFF
--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -501,9 +501,13 @@ export function CommandBar() {
                 <div className="h-full" />
               ) : (
                 <>
-                  {messages.map((message) => (
+                  {messages.map((message, index) => (
                     <SessionEntry
                       content={message.content}
+                      // Only the trailing assistant message marks the
+                      // conversation's resting point; older ones drop
+                      // the Imbi logo so a new turn doesn't trail one.
+                      isLatest={!isStreaming && index === messages.length - 1}
                       key={message.id}
                       onRetry={
                         message.role === 'assistant'

--- a/src/components/assistant/MessageBubble.tsx
+++ b/src/components/assistant/MessageBubble.tsx
@@ -12,18 +12,31 @@ import { cn } from '@/lib/utils'
 interface MessageActionsProps {
   content: string
   onRetry?: () => void
+  /**
+   * Whether to render the resting Imbi mark beneath the actions. Only
+   * the latest assistant message should mark the conversation's resting
+   * point; older messages keep their copy/retry but drop the mark so a
+   * new user turn doesn't trail an obsolete logo.
+   */
+  showMark?: boolean
 }
 
 interface SessionEntryProps {
   content: string
+  /**
+   * Whether this is the most-recent message in the conversation. When
+   * true and the role is ``assistant`` with ``showActions``, the resting
+   * Imbi mark is rendered beneath the actions.
+   */
+  isLatest?: boolean
   /** Retry handler; when provided, a retry button is shown. */
   onRetry?: () => void
   role: 'assistant' | 'user'
   /**
-   * Show the finished-round affordances: the copy/retry actions and the
-   * Imbi mark that signals the round is complete. Only meaningful for
-   * the assistant role; pass for completed messages, not while
-   * streaming.
+   * Show the finished-round affordances: the copy/retry actions and
+   * (when this is also the latest message) the Imbi mark that signals
+   * the round is complete. Only meaningful for the assistant role; pass
+   * for completed messages, not while streaming.
    */
   showActions?: boolean
 }
@@ -46,6 +59,7 @@ export function ImbiMark({ pulse = false }: { pulse?: boolean }) {
 
 export function SessionEntry({
   content,
+  isLatest = false,
   onRetry,
   role,
   showActions = false,
@@ -75,13 +89,19 @@ export function SessionEntry({
           </Markdown>
         </div>
       </div>
-      {showActions && <MessageActions content={content} onRetry={onRetry} />}
+      {showActions && (
+        <MessageActions
+          content={content}
+          onRetry={onRetry}
+          showMark={isLatest}
+        />
+      )}
     </div>
   )
 }
 
-/** Copy/retry actions and the Imbi mark shown beneath a finished round. */
-function MessageActions({ content, onRetry }: MessageActionsProps) {
+/** Copy/retry actions and (optionally) the resting Imbi mark. */
+function MessageActions({ content, onRetry, showMark }: MessageActionsProps) {
   const { copied, copy } = useClipboard()
   return (
     <>
@@ -115,7 +135,7 @@ function MessageActions({ content, onRetry }: MessageActionsProps) {
           </Button>
         )}
       </div>
-      <ImbiMark />
+      {showMark && <ImbiMark />}
     </>
   )
 }


### PR DESCRIPTION
## Summary

The bee logo beneath an assistant message marks where the conversation is *currently* resting. It was rendered on every finished assistant message, so a new user turn appeared right below an obsolete "we are here" marker.

## Change

Pass `isLatest` to `SessionEntry` based on the message's index in the list (and only when no stream is in flight, since the streaming pulse already covers that case). `MessageActions` only renders the resting `ImbiMark` when `showMark` is true. Copy and retry remain on every assistant message.

## Verification

Before:
- Assistant message → copy/retry → 🐝
- `> new user message`
- Assistant message → copy/retry → 🐝  ← trailing logo, looks like the resting point

After:
- Assistant message → copy/retry
- `> new user message`
- Assistant message → copy/retry → 🐝  ← only here, the current resting point

`npm run lint` and `npm run build` both clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)