### PR TITLE
Bump version to 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imbi-ui-v2",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imbi-ui-v2",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imbi-ui-v2",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps `imbi-ui` from 2.6.0 → 2.7.0 so the UI version lines up with `imbi-common` 2.7.0 and the upcoming `imbi-api` 2.7.0 release.

No code changes — `package.json` and `package-lock.json` only.

## Verification

- pre-commit hooks (oxfmt, audit) clean