### PR TITLE
Fetch current user via GET /users/me to carry permissions

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -137,8 +137,10 @@ export const refreshToken = () =>
 
 export const logoutAuth = () => apiClient.post<void>('/auth/logout', {})
 
-export const getUserByUsername = (username: string, signal?: AbortSignal) =>
-  apiClient.get<UserResponse>(`/users/${username}`, undefined, signal)
+// GET /users/me resolves the caller from their token and, unlike
+// /users/{email}, includes the effective `permissions` set the UI gates on.
+export const getCurrentUser = (signal?: AbortSignal) =>
+  apiClient.get<UserResponse>('/users/me', undefined, signal)
 
 export const getProjects = async (
   orgSlug: string,

--- a/src/hooks/__tests__/useAuth.test.tsx
+++ b/src/hooks/__tests__/useAuth.test.tsx
@@ -24,7 +24,7 @@ import { useAuth } from '../useAuth'
 
 // fallow-ignore-next-line unresolved-import
 vi.mock('@/api/endpoints', () => ({
-  getUserByUsername: vi.fn(),
+  getCurrentUser: vi.fn(),
   loginWithPassword: vi.fn(),
   logoutAuth: vi.fn(),
   refreshToken: vi.fn(),
@@ -164,7 +164,7 @@ describe('useAuth', () => {
     // Let the bootstrap refresh attempt settle.
     await waitFor(() => expect(endpoints.refreshToken).toHaveBeenCalled())
 
-    expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
+    expect(endpoints.getCurrentUser).not.toHaveBeenCalled()
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBeNull()
     expect(latestLocation.pathname).toBe('/login')
     expect(result.current.isAuthenticated).toBe(false)
@@ -180,20 +180,19 @@ describe('useAuth', () => {
       '/projects',
     )
     expect(endpoints.refreshToken).toHaveBeenCalledOnce()
-    expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
+    expect(endpoints.getCurrentUser).not.toHaveBeenCalled()
   })
 
   it('valid access token: fetches currentUser once, does not refresh', async () => {
     setValidAccess()
-    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.getCurrentUser).mockResolvedValue(validUser as never)
 
     const { Wrapper } = setupEnv('/dashboard')
     const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
 
     await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
-    expect(endpoints.getUserByUsername).toHaveBeenCalledTimes(1)
-    expect(endpoints.getUserByUsername).toHaveBeenCalledWith(
-      'user@example.com',
+    expect(endpoints.getCurrentUser).toHaveBeenCalledTimes(1)
+    expect(endpoints.getCurrentUser).toHaveBeenCalledWith(
       expect.any(AbortSignal),
     )
     expect(endpoints.refreshToken).not.toHaveBeenCalled()
@@ -209,14 +208,14 @@ describe('useAuth', () => {
       refresh_token: 'rt-new',
       token_type: 'bearer',
     } as never)
-    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.getCurrentUser).mockResolvedValue(validUser as never)
 
     const { Wrapper } = setupEnv('/dashboard')
     const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
 
     await waitFor(() => expect(result.current.isAuthenticated).toBe(true))
     expect(endpoints.refreshToken).toHaveBeenCalledTimes(1)
-    expect(endpoints.getUserByUsername).toHaveBeenCalled()
+    expect(endpoints.getCurrentUser).toHaveBeenCalled()
     expect(latestLocation.pathname).toBe('/dashboard')
     expect(useAuthStore.getState().accessToken).toBe(newToken)
   })
@@ -233,7 +232,7 @@ describe('useAuth', () => {
     expect(sessionStorage.getItem('imbi_redirect_after_login')).toBe(
       '/projects?filter=x',
     )
-    expect(endpoints.getUserByUsername).not.toHaveBeenCalled()
+    expect(endpoints.getCurrentUser).not.toHaveBeenCalled()
   })
 
   it('expired access + no valid cookie: refresh attempted, redirects, saves path', async () => {
@@ -261,7 +260,7 @@ describe('useAuth', () => {
       refresh_token: 'rt-new',
       token_type: 'bearer',
     } as never)
-    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.getCurrentUser).mockResolvedValue(validUser as never)
 
     const { Wrapper } = setupEnv('/dashboard')
     function Consumer() {
@@ -291,7 +290,7 @@ describe('useAuth', () => {
     // refactor MUST keep at minimum this clearTokens side effect; lifting the
     // translated error to a stable signal is a bonus but not required.
     setValidAccess()
-    vi.mocked(endpoints.getUserByUsername).mockRejectedValue(
+    vi.mocked(endpoints.getCurrentUser).mockRejectedValue(
       new ApiError(401, 'Unauthorized', {
         detail: 'user not found or inactive',
       }),
@@ -301,7 +300,7 @@ describe('useAuth', () => {
     renderHook(() => useAuth(), { wrapper: Wrapper })
 
     await waitFor(() => expect(useAuthStore.getState().accessToken).toBeNull())
-    expect(endpoints.getUserByUsername).toHaveBeenCalledTimes(1)
+    expect(endpoints.getCurrentUser).toHaveBeenCalledTimes(1)
   })
 
   it('currentUser 401 with any other detail: surfaces error as-is, does not clear tokens', async () => {
@@ -309,7 +308,7 @@ describe('useAuth', () => {
     const apiErr = new ApiError(401, 'Unauthorized', {
       detail: 'some generic auth failure',
     })
-    vi.mocked(endpoints.getUserByUsername).mockRejectedValue(apiErr)
+    vi.mocked(endpoints.getCurrentUser).mockRejectedValue(apiErr)
 
     const { Wrapper } = setupEnv('/dashboard')
     const { result } = renderHook(() => useAuth(), { wrapper: Wrapper })
@@ -328,7 +327,7 @@ describe('useAuth', () => {
       refresh_token: 'rt-new',
       token_type: 'bearer',
     } as never)
-    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.getCurrentUser).mockResolvedValue(validUser as never)
 
     const { qc, Wrapper } = setupEnv('/login')
     const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
@@ -373,7 +372,7 @@ describe('useAuth', () => {
 
   it('logout success: clearTokens, queryClient.clear, window.location.href = /login', async () => {
     setValidAccess()
-    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.getCurrentUser).mockResolvedValue(validUser as never)
     vi.mocked(endpoints.logoutAuth).mockResolvedValue(undefined as never)
 
     const { qc, Wrapper } = setupEnv('/dashboard')
@@ -393,7 +392,7 @@ describe('useAuth', () => {
 
   it('logout failure: same cleanup as success (onError path)', async () => {
     setValidAccess()
-    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.getCurrentUser).mockResolvedValue(validUser as never)
     vi.mocked(endpoints.logoutAuth).mockRejectedValue(new Error('server down'))
 
     const { qc, Wrapper } = setupEnv('/dashboard')
@@ -413,7 +412,7 @@ describe('useAuth', () => {
 
   it('refreshToken mutation success: setTokens and user re-populates', async () => {
     setValidAccess()
-    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.getCurrentUser).mockResolvedValue(validUser as never)
     const newToken = makeJwt({ exp: Math.floor(Date.now() / 1000) + 7200 })
     vi.mocked(endpoints.refreshToken).mockResolvedValue({
       access_token: newToken,
@@ -437,7 +436,7 @@ describe('useAuth', () => {
 
   it('refreshToken mutation failure on a protected route: clears tokens, redirects with saved path', async () => {
     setValidAccess()
-    vi.mocked(endpoints.getUserByUsername).mockResolvedValue(validUser as never)
+    vi.mocked(endpoints.getCurrentUser).mockResolvedValue(validUser as never)
     vi.mocked(endpoints.refreshToken).mockRejectedValue(new Error('boom'))
 
     const { Wrapper } = setupEnv('/projects')

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { ApiError, apiUrl } from '@/api/client'
 import {
-  getUserByUsername,
+  getCurrentUser,
   loginWithPassword,
   logoutAuth,
   refreshToken as refreshTokenApi,
@@ -37,12 +37,11 @@ export function useAuth(): UseAuthReturn {
   } = useQuery<UserResponse>({
     enabled: !!accessToken && !isTokenExpired(),
     queryFn: async ({ signal }) => {
-      const username = getUsername()
-      if (!username) {
-        throw new Error('No username found in token')
-      }
       try {
-        return await getUserByUsername(username, signal)
+        // /users/me resolves the caller from the bearer token; no username
+        // needed. getUsername() is still used in the queryKey below so the
+        // cache is keyed per-user and clearTokens() invalidates it.
+        return await getCurrentUser(signal)
       } catch (error) {
         console.error('[Auth] Error fetching user:', error)
         if (error instanceof ApiError && error.status === 401) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1341,8 +1341,9 @@ export interface UseAuthReturn {
 }
 
 // `UserResponse` stays hand-written: it's a UI-side extension of `User`
-// (inherits `username`, `user_type`, etc.) which the backend `UserResponse`
-// doesn't expose.
+// (inherits `username`, `user_type`, etc.). `permissions` and `is_admin` are
+// populated by GET /users/me (the backend's CurrentUserResponse); other
+// optional fields (`groups`, `roles`) are not yet exposed by the API.
 export interface UserResponse extends User {
   avatar_url?: null | string
   created_at?: string


### PR DESCRIPTION
## Summary

Fixes permission-gated UI controls being hidden for non-admin users. `useAuth` fetched the current user via `GET /users/{username}`, whose `UserResponse` never included a `permissions` field — so `user.permissions` was always `undefined`, fell back to `[]`, and every `permissions.includes(...)` check failed. Only `is_admin` users ever saw controls like **Recompute Score** and **Sync Deployments** on the project settings tab.

Pairs with the backend change (imbi-api #407), which added `GET /users/me` returning the caller's profile plus effective `permissions` (`CurrentUserResponse`).

## Problem

`GET /users/{email}` deliberately does not expose permissions (to avoid disclosing one user's grants to another), so the UI had no source for the current user's permission set.

## Solution

- Add `getCurrentUser()` calling `GET /users/me`; remove the now-orphaned `getUserByUsername()`.
- Point `useAuth`'s `currentUser` query at `getCurrentUser`. The caller is resolved from the bearer token, so no username argument is needed; the username is retained in the query key for per-user cache identity and `clearTokens()` invalidation.
- Update the `UserResponse` type comment: `permissions`/`is_admin` now come from the backend via `/users/me`.
- Update `useAuth` tests for the new endpoint and call signature.

## Testing

- `useAuth` suite (16 tests) and `ProjectSettingsTab` suite (5 tests) pass.
- `tsc --noEmit` and `oxlint` clean.