### PR TITLE
Wire lifecycle delete checkbox + surface failed lifecycle results

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -28,6 +28,7 @@
         "ScoreRollupRow",
         "GlobalScoreEvent",
         "MonthlyImprovementRow",
+        "previewProjectLifecycle",
         "TeamScoreSeries"
       ]
     },

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -43,6 +43,7 @@ import type {
   IdentityConnectionStartRequest,
   IdentityConnectionStartResponse,
   InstalledPlugin,
+  LifecyclePreviewResponse,
   LinkDefinition,
   LinkDefinitionCreate,
   LocalAuthConfig,
@@ -78,6 +79,8 @@ import type {
   PluginUpdate,
   Project,
   ProjectCreate,
+  ProjectDeletedResponse,
+  ProjectMutationResponse,
   ProjectRelationshipsResponse,
   ProjectType,
   ProjectTypeCreate,
@@ -318,16 +321,51 @@ export const patchProject = (
   orgSlug: string,
   projectId: string,
   operations: PatchOperation[],
-) =>
-  apiClient.patch<Project>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
+  options?: { transferRepository?: boolean },
+) => {
+  // ``transfer_repository`` is the opt-in for the relocate dispatch
+  // (lifecycle plugins moving the backing remote when project types
+  // change).  Default is ``false`` so the URL only carries the param
+  // when a caller explicitly opted in.
+  const query =
+    options?.transferRepository === true ? '?transfer_repository=true' : ''
+  return apiClient.patch<ProjectMutationResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}${query}`,
     operations,
   )
+}
 
-export const deleteProject = (orgSlug: string, projectId: string) =>
-  apiClient.delete<void>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}`,
+export const deleteProject = (
+  orgSlug: string,
+  projectId: string,
+  options?: { deleteRepository?: boolean },
+) => {
+  // ``delete_repository`` defaults server-side to ``true`` so the
+  // common case (delete project + remote together) needs no flag.
+  // Only emit the param when the operator explicitly opted *out*.
+  const query =
+    options?.deleteRepository === false ? '?delete_repository=false' : ''
+  return apiClient.delete<ProjectDeletedResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}${query}`,
   )
+}
+
+export const previewProjectLifecycle = (
+  orgSlug: string,
+  projectId: string,
+  projectTypeSlugs: string[],
+  signal?: AbortSignal,
+) => {
+  const params = new URLSearchParams()
+  for (const slug of projectTypeSlugs) {
+    params.append('project_type_slugs', slug)
+  }
+  return apiClient.get<LifecyclePreviewResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/lifecycle/preview?${params.toString()}`,
+    undefined,
+    signal,
+  )
+}
 
 export const archiveProject = (orgSlug: string, projectId: string) =>
   apiClient.post<ArchiveProjectResponse>(

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -27,6 +27,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
@@ -51,6 +52,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   const { patch, scheduleScoreRefresh } = useProjectPatch(orgSlug, project.id)
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [deleteRepository, setDeleteRepository] = useState(true)
   const [showArchiveConfirm, setShowArchiveConfirm] = useState(false)
   const isArchived = project.archived === true
 
@@ -65,9 +67,37 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   }
 
   const deleteMutation = useMutation({
-    mutationFn: () => deleteProject(orgSlug, project.id),
+    mutationFn: () => deleteProject(orgSlug, project.id, { deleteRepository }),
     onError: mutationErrorHandler('delete project'),
-    onSuccess: () => navigate('/'),
+    onSuccess: (data) => {
+      // Delete commits before the lifecycle dispatch runs, so a plugin
+      // failure (e.g. the GitHub repo delete) does not roll back the
+      // project removal -- surface it instead of swallowing.
+      const failed = (data?.lifecycle_results ?? []).filter(
+        (result) => result.status === 'failed',
+      )
+      if (failed.length > 0) {
+        toast.warning(
+          `Project deleted, but ${failed.length} integration${
+            failed.length > 1 ? 's' : ''
+          } failed`,
+          {
+            description: (
+              <ul className="mt-1 space-y-0.5">
+                {failed.map((result) => (
+                  <li key={result.plugin_id}>
+                    <span className="font-medium">{result.plugin_slug}</span>:{' '}
+                    {result.message ?? 'unknown error'}
+                  </li>
+                ))}
+              </ul>
+            ),
+            duration: 10000,
+          },
+        )
+      }
+      navigate('/')
+    },
   })
 
   const archiveMutation = useMutation({
@@ -130,6 +160,16 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
     queryFn: ({ signal }) => listProjectPlugins(orgSlug, project.id, signal),
     queryKey: ['projectPlugins', orgSlug, project.id],
   })
+
+  // Whether any lifecycle plugin is assigned to the project (project-
+  // level or via project type).  Drives the "Also delete the associated
+  // repository" checkbox in the delete-project flow: when no lifecycle
+  // plugin is present the checkbox is suppressed because there is no
+  // remote to delete.
+  const hasLifecyclePlugin = useMemo(
+    () => projectPlugins.some((assignment) => assignment.tab === 'lifecycle'),
+    [projectPlugins],
+  )
 
   // Pick the project's deployment plugin (project-level or inherited)
   // and only render the resync card when its manifest opts in. Multiple
@@ -336,6 +376,21 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
                 placeholder={project.slug}
                 value={deleteConfirmSlug}
               />
+              {hasLifecyclePlugin ? (
+                <label className="text-secondary flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={deleteRepository}
+                    disabled={deleteMutation.isPending}
+                    onCheckedChange={(checked) =>
+                      setDeleteRepository(checked === true)
+                    }
+                  />
+                  <span>
+                    Also delete the associated repository -- uncheck to keep the
+                    remote in place after retiring the project.
+                  </span>
+                </label>
+              ) : null}
               <div className="flex gap-2">
                 <Button
                   disabled={
@@ -353,6 +408,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
                   onClick={() => {
                     setShowDeleteConfirm(false)
                     setDeleteConfirmSlug('')
+                    setDeleteRepository(true)
                   }}
                   size="sm"
                   variant="outline"

--- a/src/components/__tests__/ProjectSettingsTab.test.tsx
+++ b/src/components/__tests__/ProjectSettingsTab.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/api/endpoints', async () => {
   return {
     ...actual,
     archiveProject: vi.fn(),
+    deleteProject: vi.fn(),
     listEnvironments: vi.fn(),
     listLinkDefinitions: vi.fn(),
     listProjectPlugins: vi.fn(),
@@ -28,7 +29,7 @@ vi.mock('@/api/endpoints', async () => {
 })
 
 vi.mock('sonner', () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }))
 
 // Isolate the archive card: the surrounding editor cards do their own
@@ -162,6 +163,117 @@ describe('ProjectSettingsTab archive lifecycle results', () => {
       expect(toast.success).toHaveBeenCalledWith('Project restored')
     })
     expect(toast.error).not.toHaveBeenCalled()
+  })
+})
+
+describe('ProjectSettingsTab delete flow', () => {
+  let toast: {
+    error: ReturnType<typeof vi.fn>
+    success: ReturnType<typeof vi.fn>
+    warning: ReturnType<typeof vi.fn>
+  }
+
+  const LIFECYCLE_PLUGIN = {
+    default: true,
+    label: 'GitHub',
+    options: {},
+    plugin_id: 'lc-1',
+    plugin_slug: 'github-lifecycle',
+    source: 'project',
+    tab: 'lifecycle',
+  } as PluginAssignmentResponse
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockAuthUser = { is_admin: false, permissions: [] }
+    vi.mocked(endpoints.listEnvironments).mockResolvedValue([])
+    vi.mocked(endpoints.listLinkDefinitions).mockResolvedValue([])
+    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([])
+    toast = (await import('sonner')).toast as unknown as typeof toast
+  })
+
+  it('omits the "Also delete repository" checkbox without a lifecycle plugin', async () => {
+    // No lifecycle plugins → checkbox is suppressed because there is
+    // no remote for the operator to keep behind.
+    const { findByRole, queryByLabelText } = renderTab()
+    fireEvent.click(await findByRole('button', { name: 'Delete Project' }))
+    expect(queryByLabelText(/Also delete the associated repository/)).toBeNull()
+  })
+
+  it('passes deleteRepository=true by default when checkbox is present', async () => {
+    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([
+      LIFECYCLE_PLUGIN,
+    ])
+    vi.mocked(endpoints.deleteProject).mockResolvedValue({
+      lifecycle_results: [],
+    })
+
+    const { findByPlaceholderText, findByRole } = renderTab()
+    fireEvent.click(await findByRole('button', { name: 'Delete Project' }))
+    fireEvent.change(await findByPlaceholderText('demo'), {
+      target: { value: 'demo' },
+    })
+    fireEvent.click(await findByRole('button', { name: 'Confirm Delete' }))
+
+    await waitFor(() => {
+      expect(endpoints.deleteProject).toHaveBeenCalledWith('acme', 'p1', {
+        deleteRepository: true,
+      })
+    })
+  })
+
+  it('sends deleteRepository=false when the operator unchecks the box', async () => {
+    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([
+      LIFECYCLE_PLUGIN,
+    ])
+    vi.mocked(endpoints.deleteProject).mockResolvedValue({
+      lifecycle_results: [],
+    })
+
+    const { findAllByRole, findByPlaceholderText, findByRole } = renderTab()
+    fireEvent.click(await findByRole('button', { name: 'Delete Project' }))
+    // The Radix Checkbox renders as a button with role="checkbox".
+    const checkboxes = await findAllByRole('checkbox')
+    fireEvent.click(checkboxes[0])
+    fireEvent.change(await findByPlaceholderText('demo'), {
+      target: { value: 'demo' },
+    })
+    fireEvent.click(await findByRole('button', { name: 'Confirm Delete' }))
+
+    await waitFor(() => {
+      expect(endpoints.deleteProject).toHaveBeenCalledWith('acme', 'p1', {
+        deleteRepository: false,
+      })
+    })
+  })
+
+  it('surfaces a failed lifecycle delete result as a warning toast', async () => {
+    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([
+      LIFECYCLE_PLUGIN,
+    ])
+    vi.mocked(endpoints.deleteProject).mockResolvedValue({
+      lifecycle_results: [
+        {
+          artifacts: {},
+          message: '401 from GitHub',
+          plugin_id: 'lc-1',
+          plugin_slug: 'github-lifecycle',
+          status: 'failed',
+        },
+      ],
+    })
+
+    const { findByPlaceholderText, findByRole } = renderTab()
+    fireEvent.click(await findByRole('button', { name: 'Delete Project' }))
+    fireEvent.change(await findByPlaceholderText('demo'), {
+      target: { value: 'demo' },
+    })
+    fireEvent.click(await findByRole('button', { name: 'Confirm Delete' }))
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalledTimes(1)
+    })
+    expect(toast.warning.mock.calls[0][0]).toContain('1 integration failed')
   })
 })
 

--- a/src/hooks/__tests__/useProjectPatch.test.tsx
+++ b/src/hooks/__tests__/useProjectPatch.test.tsx
@@ -148,6 +148,70 @@ describe('useProjectPatch', () => {
     expect(toast.error).toHaveBeenCalled()
   })
 
+  it('toasts a failure when the PATCH response carries a failed lifecycle result', async () => {
+    // The Imbi state change succeeded but the GitHub plugin's
+    // ``on_project_updated`` (e.g. repo rename) failed -- surface it so
+    // the operator can fix the sync rather than discover the drift
+    // hours later.  ``ok``/``skipped`` results are deliberately silent.
+    vi.spyOn(endpoints, 'patchProject').mockResolvedValue({
+      ...baseProject,
+      lifecycle_results: [
+        {
+          artifacts: {},
+          message: '404 Not Found',
+          plugin_id: 'lc-1',
+          plugin_slug: 'github-lifecycle',
+          status: 'failed',
+        },
+        {
+          artifacts: {},
+          message: 'ok',
+          plugin_id: 'lc-2',
+          plugin_slug: 'other',
+          status: 'ok',
+        },
+      ],
+    } as never)
+
+    const { result } = renderHook(() => useProjectPatch('o', 'p1'), {
+      wrapper: wrapper(qc),
+    })
+
+    await act(async () => {
+      await result.current.patch('/slug', 'beta')
+    })
+
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toContain(
+      '1 integration failed',
+    )
+  })
+
+  it('stays silent when every lifecycle result is ok or skipped', async () => {
+    vi.spyOn(endpoints, 'patchProject').mockResolvedValue({
+      ...baseProject,
+      lifecycle_results: [
+        {
+          artifacts: {},
+          message: 'Updated o/r',
+          plugin_id: 'lc-1',
+          plugin_slug: 'github-lifecycle',
+          status: 'ok',
+        },
+      ],
+    } as never)
+
+    const { result } = renderHook(() => useProjectPatch('o', 'p1'), {
+      wrapper: wrapper(qc),
+    })
+
+    await act(async () => {
+      await result.current.patch('/slug', 'beta')
+    })
+
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
   it('tracks pendingPath during the mutation', async () => {
     let resolveIt!: (v: unknown) => void
     vi.spyOn(endpoints, 'patchProject').mockImplementation(

--- a/src/hooks/useProjectPatch.ts
+++ b/src/hooks/useProjectPatch.ts
@@ -6,7 +6,12 @@ import { toast } from 'sonner'
 import { patchProject } from '@/api/endpoints'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { applyJsonPatch } from '@/lib/json-patch'
-import type { PatchOperation, Project } from '@/types'
+import type {
+  LifecycleInvocation,
+  PatchOperation,
+  Project,
+  ProjectMutationResponse,
+} from '@/types'
 
 const SCORE_REFRESH_INITIAL_DELAY = 3_000
 const SCORE_REFRESH_MAX_ATTEMPTS = 5
@@ -95,7 +100,16 @@ export function useProjectPatch(
           }
         }
 
-        await patchProject(orgSlug, projectId, [op])
+        const response: ProjectMutationResponse = await patchProject(
+          orgSlug,
+          projectId,
+          [op],
+        )
+        // Lifecycle plugins (e.g. GitHub repo rename / description sync)
+        // run after the project write commits.  Surface failed ones so
+        // they're not silent; ``ok``/``skipped`` results are noise from
+        // the operator's perspective.
+        reportLifecycleFailures(response.lifecycle_results)
         // The server PATCH response may echo fields in a different shape than
         // GET returns (e.g. environments as a map vs. an array). Invalidate
         // so the next read comes from the canonical GET.
@@ -130,4 +144,29 @@ function buildOp(path: string, value: unknown): PatchOperation {
   // it if present. Required so first-time sets for blueprint-defined
   // attributes succeed against an RFC 6902 strict server.
   return { op: 'add', path, value }
+}
+
+// Toast the slugs of any lifecycle plugins that reported a ``failed``
+// invocation -- the Imbi state change succeeded, but a third-party
+// sync (e.g. the GitHub plugin renaming the repo) didn't, and the
+// operator needs to know.
+function reportLifecycleFailures(
+  results: LifecycleInvocation[] | undefined,
+): void {
+  if (!results || results.length === 0) {
+    return
+  }
+  const failed = results.filter((r) => r.status === 'failed')
+  if (failed.length === 0) {
+    return
+  }
+  toast.error(
+    `${failed.length} integration${failed.length > 1 ? 's' : ''} failed`,
+    {
+      description: failed
+        .map((r) => `${r.plugin_slug}: ${r.message ?? 'unknown error'}`)
+        .join('\n'),
+      duration: 10_000,
+    },
+  )
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,11 +14,11 @@ export interface AgeScoringPolicyCreate extends ScoringPolicyCreateBase {
   category: 'age'
 }
 
-// Response from POST .../archive and .../unarchive: the updated project
-// plus the per-plugin lifecycle results.
-export interface ArchiveProjectResponse extends Project {
-  lifecycle_results?: LifecycleInvocation[]
-}
+// Back-compat alias: the archive / unarchive endpoints originally
+// shipped this response type, and downstream components import it by
+// name.  Identical shape to ``ProjectMutationResponse`` -- prefer the
+// new name in fresh code.
+export type ArchiveProjectResponse = ProjectMutationResponse
 
 export interface AttributeScoringPolicy extends ScoringPolicyBase {
   attribute_name: string
@@ -76,6 +76,21 @@ export interface LifecycleInvocation {
   plugin_id: string
   plugin_slug: string
   status: 'failed' | 'ok' | 'skipped'
+}
+
+// One row of the ``GET /projects/{id}/lifecycle/preview`` response --
+// per-plugin "would the project-type change move my target?" answer
+// the UI uses to gate the "Also move repository to ..." opt-in.
+export interface LifecyclePreviewEntry {
+  current_target: null | RelocationTarget
+  next_target: null | RelocationTarget
+  plugin_id: string
+  plugin_slug: string
+  would_relocate: boolean
+}
+
+export interface LifecyclePreviewResponse {
+  previews: LifecyclePreviewEntry[]
 }
 
 export type LinkDefinition = Schemas['LinkDefinitionResponse']
@@ -212,6 +227,16 @@ export interface ProjectCreate {
   team_slug: string
 }
 
+// Response from DELETE /projects/{id} (post-2.7).  Body carries only
+// the per-plugin lifecycle results -- the project node is gone by the
+// time the response is built.  Empty ``lifecycle_results`` means the
+// delete short-circuited the plugin dispatch
+// (``?delete_repository=false``) or the project had no lifecycle
+// plugins assigned.
+export interface ProjectDeletedResponse {
+  lifecycle_results: LifecycleInvocation[]
+}
+
 // Activity feed projection for the dashboard — not a 1:1 backend shape.
 export interface ProjectFeedEntry {
   display_name: string
@@ -226,6 +251,15 @@ export interface ProjectFeedEntry {
   what: 'created' | 'updated' | 'updated facts'
   when?: string
   who: string
+}
+
+// Response from project create / patch / archive / unarchive: the
+// updated project plus the per-plugin lifecycle results.  All four
+// endpoints share this shape post-`imbi-api` 2.7 -- the older
+// ``ArchiveProjectResponse`` alias is kept above for components still
+// referencing it by name.
+export interface ProjectMutationResponse extends Project {
+  lifecycle_results?: LifecycleInvocation[]
 }
 
 export type ProjectType = Schemas['ProjectTypeResponse']
@@ -272,6 +306,17 @@ export interface ReleaseInfo {
   deployed_at: string
   performed_by?: null | string
   tag?: null | string
+}
+
+// Where a lifecycle plugin would route the project's external link --
+// mirror of the API's ``RelocationTarget``.  The UI compares two
+// targets by ``identifier`` to decide whether a hypothetical
+// project-type change would actually move the repo (``would_relocate``
+// on :type:`LifecyclePreviewEntry`).
+export interface RelocationTarget {
+  display: null | string
+  identifier: string
+  link_key: string
 }
 
 // Scoring policy types — discriminated union on `category`. See


### PR DESCRIPTION
## Summary

Surfaces the new `imbi-api` 2.8 lifecycle response shapes in the UI so operators can opt out of remote deletion and so failed `on_project_updated` / `on_project_deleted` plugin invocations do not silently drift from Imbi's authoritative state.

### Delete UX (`ProjectSettingsTab.tsx`)
- "Also delete the associated repository" checkbox in the typed-slug confirmation, **checked by default**, gated on the project having any lifecycle plugin assigned. Unchecking sends `delete_repository=false` so the remote survives the retire.
- Warning toast surfaces failed delete `lifecycle_results` per plugin.

### Inline patch sync (`useProjectPatch.ts`)
- Single error toast when any patch lifecycle result reports `status='failed'`. `ok`/`skipped` stay silent.

### API layer
- `deleteProject(orgSlug, id, { deleteRepository })` query param + new `ProjectDeletedResponse` return type.
- `patchProject(orgSlug, id, ops, { transferRepository })` query param + new `ProjectMutationResponse` return type.
- New `previewProjectLifecycle(orgSlug, projectId, projectTypeSlugs)` client for `GET /projects/{id}/lifecycle/preview` (no consumer yet — see "Deferred" below; added to `.fallowrc.json` ignoreExports until the relocate dialog ships).
- New types: `ProjectMutationResponse`, `ProjectDeletedResponse`, `RelocationTarget`, `LifecyclePreviewEntry`, `LifecyclePreviewResponse`. `ArchiveProjectResponse` is now a back-compat alias.

## Deferred to follow-up

The project-type-edit relocate-preview dialog (would call `previewProjectLifecycle` then PATCH with `transferRepository=true`) is **intentionally not in this PR**. The slug-rename / description-sync / delete-with-repo wiring above is the user-visible payoff of the cross-repo lifecycle work; the project-type relocate flow can ship behind it once the dialog UX is designed.

## Why

Final repo in the chain (`imbi-common#138` → `imbi-plugin-github#22/#23` → `imbi-api#406/#409/#410`). With this landed, operators get the full create / sync / delete UX flowing through to GitHub via the lifecycle plugin contract.

## Test plan

- [x] 6 new tests added (4 in `ProjectSettingsTab.test.tsx`, 2 in `useProjectPatch.test.tsx`); full 317-test suite still green.
- [x] `npm run format:check` clean.
- [x] `npm run lint` — 0 errors (1909 pre-existing warnings unchanged).
- [x] pre-commit fallow audit: 0 dead exports, 0 new complexity findings (the existing `ProjectSettingsTab` complexity warning is inherited and not changed by this PR).