### PR TITLE
Fix Score History chart for scores below 50

### DIFF
--- a/src/components/ScoreHistoryTab.tsx
+++ b/src/components/ScoreHistoryTab.tsx
@@ -22,6 +22,7 @@ import {
   ScoreHistoryPoint,
 } from '@/api/endpoints'
 import { formatFieldKey } from '@/lib/project-field-formatting'
+import { computeScoreYAxis } from '@/lib/score-chart'
 
 type Granularity = 'day' | 'hour' | 'raw'
 type LucideIcon = React.FC<LucideProps>
@@ -682,8 +683,14 @@ function ScoreChart({
   const innerW = W - padL - padR
   const innerH = H - padT - padB
 
-  const yMin = 50
-  const yMax = 100
+  // Derive the y-axis range from the data: keep the familiar 50–100 view for
+  // healthy projects, but drop the floor below 50 when the score actually goes
+  // there so the line and area fill stay inside the plot (see computeScoreYAxis).
+  const {
+    ticks: yTicks,
+    yMax,
+    yMin,
+  } = computeScoreYAxis(points.map((p) => p.score))
 
   const xFor = (i: number) =>
     padL + (i / Math.max(points.length - 1, 1)) * innerW
@@ -705,8 +712,6 @@ function ScoreChart({
     idx,
     reason,
   }))
-
-  const yTicks = [50, 60, 70, 80, 90, 100]
 
   // 6 evenly spaced x-axis labels
   const xTickIndices =

--- a/src/lib/__tests__/score-chart.test.ts
+++ b/src/lib/__tests__/score-chart.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeScoreYAxis } from '@/lib/score-chart'
+
+describe('computeScoreYAxis', () => {
+  it('keeps the 50–100 view when every score is at or above 50', () => {
+    const { ticks, yMax, yMin } = computeScoreYAxis([53, 97, 100, 50])
+    expect(yMin).toBe(50)
+    expect(yMax).toBe(100)
+    expect(ticks).toEqual([50, 60, 70, 80, 90, 100])
+  })
+
+  it('drops the floor in steps of 10 when a score falls below 50', () => {
+    // Regression: a project that dipped to ~22 used to render below the chart
+    // floor. The floor should now extend down far enough to contain it.
+    const { ticks, yMax, yMin } = computeScoreYAxis([100, 22.09, 46.8, 53.2])
+    expect(yMin).toBe(20)
+    expect(yMax).toBe(100)
+    expect(ticks).toEqual([20, 30, 40, 50, 60, 70, 80, 90, 100])
+  })
+
+  it('floors at 0 and never goes negative for very low scores', () => {
+    const { ticks, yMin } = computeScoreYAxis([0, 3.5, 100])
+    expect(yMin).toBe(0)
+    expect(ticks[0]).toBe(0)
+    expect(ticks[ticks.length - 1]).toBe(100)
+  })
+
+  it('defaults to the 50–100 view when there are no points', () => {
+    const { ticks, yMax, yMin } = computeScoreYAxis([])
+    expect(yMin).toBe(50)
+    expect(yMax).toBe(100)
+    expect(ticks).toEqual([50, 60, 70, 80, 90, 100])
+  })
+})

--- a/src/lib/score-chart.ts
+++ b/src/lib/score-chart.ts
@@ -1,0 +1,19 @@
+// Compute the score-history chart's y-axis floor, ceiling, and tick marks from
+// the visible scores. The top is always 100. The floor is normally 50 —
+// preserving the established 50–100 view for healthy projects — but drops in
+// steps of 10 (down to 0) when a score falls below 50. Previously yMin was
+// hardcoded to 50, so sub-50 scores were plotted below the chart floor (off the
+// bottom, past the x-axis labels) and the area fill inverted where the line
+// crossed the y=50 baseline. Ticks span [yMin, 100] in increments of 10.
+export function computeScoreYAxis(scores: number[]): {
+  ticks: number[]
+  yMax: number
+  yMin: number
+} {
+  const yMax = 100
+  const dataMin = scores.length > 0 ? Math.min(...scores) : yMax
+  const yMin = Math.max(0, Math.min(50, Math.floor(dataMin / 10) * 10))
+  const ticks: number[] = []
+  for (let t = yMin; t <= yMax; t += 10) ticks.push(t)
+  return { ticks, yMax, yMin }
+}


### PR DESCRIPTION
## Summary

The **Score History** chart hardcoded its y-axis domain to `[50, 100]`. Any score below 50 was mapped to a y-coordinate *beneath* the plot floor, and because the SVG renders with `overflow: visible`, those points spilled below the x-axis labels. The area-fill polygon — which closes to the `y=50` baseline — also inverted where the line crossed below it, leaving a strange empty wedge under the curve.

This PR derives the y-axis floor and tick marks from the visible data:

- Keep the familiar **50–100** view when every score is at or above 50 (no visual change for healthy projects).
- Drop the floor in steps of 10 (down to **0**) when a score falls below 50, so the line and area fill stay inside the plot.

The top of the range remains 100.

## Changes

- New `computeScoreYAxis` helper in `src/lib/score-chart.ts`. It lives in `lib/` rather than being exported from the component file because the `react-refresh(only-export-components)` lint rule disallows exporting non-components alongside a component.
- `ScoreChart` in `src/components/ScoreHistoryTab.tsx` now uses it for `yMin`/`yMax`/`yTicks` instead of the hardcoded values.
- Unit tests in `src/lib/__tests__/score-chart.test.ts` covering the at/above-50, sub-50, floor-at-0, and empty-data cases.

## Verification

- `npm test` — 338 tests pass (4 new).
- `npm run build` — `tsc` + `vite build` clean.
- `oxlint` / `oxfmt` — clean on the changed files; `ScoreHistoryTab.tsx` warning count unchanged from `main`.

Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
