### PR TITLE
Fix relationship editing 405 by using per-target edge endpoints

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -301,14 +301,22 @@ export const getProjectRelationships = (
     signal,
   )
 
-export const setProjectRelationships = (
+export const addProjectRelationship = (
   orgSlug: string,
   projectId: string,
-  dependsOn: string[],
+  targetId: string,
 ) =>
-  apiClient.put<ProjectRelationshipsResponse>(
-    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/relationships`,
-    { depends_on: dependsOn },
+  apiClient.post<void>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/relationships/${encodeURIComponent(targetId)}`,
+  )
+
+export const removeProjectRelationship = (
+  orgSlug: string,
+  projectId: string,
+  targetId: string,
+) =>
+  apiClient.delete<void>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/relationships/${encodeURIComponent(targetId)}`,
   )
 
 export const createProject = (orgSlug: string, project: ProjectCreate) =>

--- a/src/components/EditRelationshipsDialog.tsx
+++ b/src/components/EditRelationshipsDialog.tsx
@@ -134,13 +134,22 @@ export function EditRelationshipsDialog({
   const mutation = useMutation({
     // The bulk PUT was retired in favor of per-target edges, so apply the
     // diff as individual POST (add) / DELETE (remove) calls in parallel.
-    mutationFn: () =>
-      Promise.all([
+    mutationFn: async () => {
+      const results = await Promise.allSettled([
         ...added.map((id) => addProjectRelationship(orgSlug, projectId, id)),
         ...removed.map((id) =>
           removeProjectRelationship(orgSlug, projectId, id),
         ),
-      ]),
+      ])
+
+      const failures = results.filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected',
+      )
+      if (failures.length > 0) {
+        throw failures[0].reason
+      }
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['project-relationships', orgSlug, projectId],

--- a/src/components/EditRelationshipsDialog.tsx
+++ b/src/components/EditRelationshipsDialog.tsx
@@ -3,7 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Search } from 'lucide-react'
 
-import { getProjects, setProjectRelationships } from '@/api/endpoints'
+import {
+  addProjectRelationship,
+  getProjects,
+  removeProjectRelationship,
+} from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -128,8 +132,15 @@ export function EditRelationshipsDialog({
   const changeCount = added.length + removed.length
 
   const mutation = useMutation({
+    // The bulk PUT was retired in favor of per-target edges, so apply the
+    // diff as individual POST (add) / DELETE (remove) calls in parallel.
     mutationFn: () =>
-      setProjectRelationships(orgSlug, projectId, [...selected]),
+      Promise.all([
+        ...added.map((id) => addProjectRelationship(orgSlug, projectId, id)),
+        ...removed.map((id) =>
+          removeProjectRelationship(orgSlug, projectId, id),
+        ),
+      ]),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['project-relationships', orgSlug, projectId],


### PR DESCRIPTION
## Summary

The **Edit Relationships** dialog on the project dependencies tab fails in production with `405 Method Not Allowed`, so dependency changes never save.

## Problem

The dialog's save path calls the bulk `PUT /organizations/{org}/projects/{id}/relationships` endpoint (`setProjectRelationships`). That endpoint was **removed in imbi-api #233** ("Remove PUT endpoints in favor of PATCH") in favor of per-target edges:

- `POST /…/relationships/{target_id}` — add one `DEPENDS_ON` edge (idempotent, 204)
- `DELETE /…/relationships/{target_id}` — remove one edge (204)
- `GET /…/relationships` — unchanged (read)

The UI was never updated, so the now-nonexistent `PUT` returns 405 and edits are silently lost.

Observed: `PUT https://imbi.aweber.io/api/organizations/aweber/projects/ELK2DsLiyvh2XuxC6jq0S/relationships 405 (Method Not Allowed)`

## Solution

- Replace `setProjectRelationships` (bulk PUT) with `addProjectRelationship` (POST) and `removeProjectRelationship` (DELETE), both targeting `/relationships/{target_id}` and returning 204.
- The dialog already computes the `added`/`removed` diff between the current and selected dependencies — feed that diff into parallel `POST`/`DELETE` calls (`Promise.all`) instead of the dead bulk replace. On any failure the existing error UI shows and the dialog stays open; succeeded edges persist and a retry is safe (POST is idempotent).

## Verification

- `npm run lint` — 0 errors
- `npm run build` — TypeScript compile clean
- `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)