### PR TITLE
Honor OAuth return_to on login for MCP browser login

### DIFF
--- a/src/lib/postLoginRedirect.test.ts
+++ b/src/lib/postLoginRedirect.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  isSafeReturnTo,
+  performPostLoginRedirect,
+  resolvePostLoginTarget,
+} from './postLoginRedirect'
+
+const origin = window.location.origin
+
+describe('isSafeReturnTo', () => {
+  it('accepts root-relative paths', () => {
+    expect(isSafeReturnTo('/dashboard')).toBe(true)
+    expect(isSafeReturnTo('/auth/authorize?x=1')).toBe(true)
+  })
+
+  it('rejects scheme-relative and backslash tricks', () => {
+    expect(isSafeReturnTo('//evil.example')).toBe(false)
+    expect(isSafeReturnTo('/\\evil.example')).toBe(false)
+  })
+
+  it('accepts same-origin absolute URLs', () => {
+    expect(isSafeReturnTo(`${origin}/api/auth/authorize?x=1`)).toBe(true)
+  })
+
+  it('rejects cross-origin absolute URLs', () => {
+    expect(isSafeReturnTo('https://evil.example/steal')).toBe(false)
+  })
+
+  it('rejects empty and non-URL values', () => {
+    expect(isSafeReturnTo('')).toBe(false)
+    expect(isSafeReturnTo('javascript:alert(1)')).toBe(false)
+  })
+})
+
+describe('resolvePostLoginTarget', () => {
+  it('prefers a valid return_to param', () => {
+    expect(resolvePostLoginTarget('/a', '/b')).toBe('/a')
+  })
+
+  it('falls back to the stored path when return_to is unsafe', () => {
+    expect(resolvePostLoginTarget('https://evil.example', '/b')).toBe('/b')
+  })
+
+  it('defaults to the dashboard when nothing is safe', () => {
+    expect(resolvePostLoginTarget(null, '//evil')).toBe('/dashboard')
+    expect(resolvePostLoginTarget(null, null)).toBe('/dashboard')
+  })
+})
+
+describe('performPostLoginRedirect', () => {
+  const realLocation = window.location
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: realLocation,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('uses a full-page load for absolute URLs', () => {
+    const assign = vi.fn()
+    // jsdom forbids spying on location.assign; replace location wholesale.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { assign },
+    })
+    const navigate = vi.fn()
+    performPostLoginRedirect(`${origin}/api/auth/authorize`, navigate)
+    expect(assign).toHaveBeenCalledWith(`${origin}/api/auth/authorize`)
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('uses client-side navigation for relative paths', () => {
+    const navigate = vi.fn()
+    performPostLoginRedirect('/dashboard', navigate)
+    expect(navigate).toHaveBeenCalledWith('/dashboard', { replace: true })
+  })
+})

--- a/src/lib/postLoginRedirect.ts
+++ b/src/lib/postLoginRedirect.ts
@@ -1,0 +1,59 @@
+/**
+ * Post-login redirect handling, including the OAuth `return_to` used by the
+ * MCP login flow.
+ *
+ * When an MCP client starts an OAuth login, the API's `/authorize` endpoint
+ * bounces the browser here with `?return_to=<absolute /authorize URL>`. After
+ * the user authenticates we must navigate back to that URL with a *full-page*
+ * load (not a client-side route change) so the `SameSite=Strict` access
+ * cookie is sent and `/authorize` can mint the authorization code.
+ *
+ * `return_to` is caller-controlled, so it is validated to prevent an open
+ * redirect: only same-origin absolute URLs or root-relative paths are allowed.
+ */
+
+export function isSafeReturnTo(target: string): boolean {
+  if (!target) return false
+  // Root-relative path, but not a scheme-relative ("//host") or backslash trick.
+  if (target.startsWith('/')) {
+    return !target.startsWith('//') && !target.startsWith('/\\')
+  }
+  try {
+    return new URL(target).origin === window.location.origin
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Navigate to a validated post-login target. Absolute (same-origin) URLs use a
+ * full-page load so cookies are sent to the API; relative paths stay in-SPA.
+ */
+export function performPostLoginRedirect(
+  target: string,
+  navigate: (to: string, opts?: { replace?: boolean }) => void,
+): void {
+  if (isAbsoluteUrl(target)) {
+    window.location.assign(target)
+  } else {
+    navigate(target, { replace: true })
+  }
+}
+
+/**
+ * Resolve the best post-login destination from a `return_to` query param and
+ * any stored redirect path, falling back to the dashboard.
+ */
+export function resolvePostLoginTarget(
+  returnToParam: null | string,
+  storedPath: null | string,
+): string {
+  for (const candidate of [returnToParam, storedPath]) {
+    if (candidate && isSafeReturnTo(candidate)) return candidate
+  }
+  return '/dashboard'
+}
+
+function isAbsoluteUrl(target: string): boolean {
+  return /^https?:\/\//i.test(target)
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -14,6 +14,10 @@ import { useTheme } from '@/contexts/ThemeContext'
 import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import {
+  performPostLoginRedirect,
+  resolvePostLoginTarget,
+} from '@/lib/postLoginRedirect'
 import { queryKeys } from '@/lib/queryKeys'
 
 const REMEMBERED_EMAIL_KEY = 'imbi_remembered_email'
@@ -60,20 +64,18 @@ export function LoginPage() {
 
   useEffect(() => {
     if (isAuthenticated) {
-      // Check if there's a stored redirect path from a 401
-      const redirectPath = sessionStorage.getItem('imbi_redirect_after_login')
-
-      if (redirectPath) {
-        // Clear the stored path
-        sessionStorage.removeItem('imbi_redirect_after_login')
-        console.log('[Login] Redirecting to stored path:', redirectPath)
-        navigate(redirectPath, { replace: true })
-      } else {
-        // Default to dashboard
-        navigate('/dashboard', { replace: true })
-      }
+      // Prefer an OAuth `return_to` (MCP login bounces here with it), then a
+      // path stored on a prior 401. Absolute same-origin URLs (the API
+      // /authorize endpoint) trigger a full-page load so the access cookie is
+      // sent; relative paths stay in-SPA.
+      const target = resolvePostLoginTarget(
+        searchParams.get('return_to'),
+        sessionStorage.getItem('imbi_redirect_after_login'),
+      )
+      sessionStorage.removeItem('imbi_redirect_after_login')
+      performPostLoginRedirect(target, navigate)
     }
-  }, [isAuthenticated, navigate])
+  }, [isAuthenticated, navigate, searchParams])
 
   const handlePasswordLogin = async (credentials: {
     email: string

--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -5,6 +5,10 @@ import { useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { useAuth } from '@/hooks/useAuth'
+import {
+  performPostLoginRedirect,
+  resolvePostLoginTarget,
+} from '@/lib/postLoginRedirect'
 import { useAuthStore } from '@/stores/authStore'
 
 export function OAuthCallbackPage() {
@@ -55,12 +59,15 @@ export function OAuthCallbackPage() {
 
   useEffect(() => {
     if (user) {
-      // Check for redirect path from 401 or OAuth flow
-      const returnTo =
-        sessionStorage.getItem('imbi_redirect_after_login') || '/dashboard'
+      // Redirect path from a 401 or the OAuth/MCP-login flow. An absolute
+      // same-origin URL (the API /authorize endpoint) triggers a full-page
+      // load so the access cookie is sent; relative paths stay in-SPA.
+      const target = resolvePostLoginTarget(
+        null,
+        sessionStorage.getItem('imbi_redirect_after_login'),
+      )
       sessionStorage.removeItem('imbi_redirect_after_login')
-      console.log('[OAuth] Redirecting to:', returnTo)
-      navigate(returnTo, { replace: true })
+      performPostLoginRedirect(target, navigate)
     }
   }, [user, navigate])
 


### PR DESCRIPTION
## Summary

Completes the MCP OAuth login flow on the UI side. The API `/authorize` endpoint (AWeber-Imbi/imbi-api#413) bounces unauthenticated users to the SPA login with a `return_to` pointing back at `/authorize`. After the user logs in, the SPA must return there with a **full-page load** so the `SameSite=Strict` access cookie is sent and `/authorize` can mint the authorization code.

## Changes

- New `src/lib/postLoginRedirect.ts`:
  - `isSafeReturnTo` — validates the target (same-origin absolute URL **or** root-relative path only), preventing an open redirect from the caller-controlled `return_to`.
  - `resolvePostLoginTarget` — picks the `return_to` param, then any stored path, else `/dashboard`.
  - `performPostLoginRedirect` — full-page `window.location.assign` for absolute (same-origin) URLs; in-SPA `navigate` for relative paths.
- `LoginPage` and `OAuthCallbackPage` use the helper for their post-login redirect (covers both password and OAuth-through-login round-trips).

## Tests

`src/lib/postLoginRedirect.test.ts` — safe/unsafe return_to (relative, scheme-relative, backslash, same/cross-origin, javascript:), target resolution precedence, and full-page-vs-SPA navigation. 10 tests pass; oxlint + tsc clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)