### PR TITLE
Use native links for clickable rows, cards, and nav

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 
 import {
   Bot,
@@ -246,6 +246,7 @@ export function Admin() {
     const isActive = currentSection === sectionDef.id
     return (
       <Button
+        asChild
         className={`h-auto w-full items-start justify-start rounded-lg text-left transition-colors ${
           isCollapsed ? 'justify-center px-3 py-3' : 'px-4 py-3'
         } ${
@@ -254,21 +255,22 @@ export function Admin() {
             : 'text-secondary hover:bg-secondary hover:text-primary'
         }`}
         key={sectionDef.id}
-        onClick={() => navigate(`/admin/${sectionDef.id}`)}
         title={isCollapsed ? sectionDef.label : undefined}
         variant="ghost"
       >
-        <Icon className="mt-0.5 size-5 shrink-0" />
-        {!isCollapsed && (
-          <>
-            <div
-              className={`min-w-0 flex-1 font-medium ${isActive ? 'text-amber-text' : ''}`}
-            >
-              {sectionDef.label}
-            </div>
-            {isActive && <ChevronRight className="mt-0.5 size-4 shrink-0" />}
-          </>
-        )}
+        <Link to={`/admin/${sectionDef.id}`}>
+          <Icon className="mt-0.5 size-5 shrink-0" />
+          {!isCollapsed && (
+            <>
+              <div
+                className={`min-w-0 flex-1 font-medium ${isActive ? 'text-amber-text' : ''}`}
+              >
+                {sectionDef.label}
+              </div>
+              {isActive && <ChevronRight className="mt-0.5 size-4 shrink-0" />}
+            </>
+          )}
+        </Link>
       </Button>
     )
   }
@@ -343,12 +345,13 @@ export function Admin() {
                 )}
                 {isSubPage ? (
                   <Button
+                    asChild
                     className="hover:text-amber-text h-auto p-0 text-xl font-semibold no-underline hover:no-underline"
-                    onClick={() => navigate(`/admin/${currentSection}`)}
-                    type="button"
                     variant="link"
                   >
-                    {currentSectionData?.label}
+                    <Link to={`/admin/${currentSection}`}>
+                      {currentSectionData?.label}
+                    </Link>
                   </Button>
                 ) : (
                   <h1 className="text-primary text-xl font-semibold">

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useEffect, useState } from 'react'
 
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import {
   closestCenter,
@@ -370,18 +370,12 @@ export function Dashboard({
     ),
     // fallow-ignore-next-line complexity
     'stat-open-prs': () => (
-      <Card
-        className="hover:border-secondary relative flex h-full cursor-pointer flex-col transition-colors"
-        onClick={() => navigate('/projects?view=list&has_open_prs=1')}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault()
-            navigate('/projects?view=list&has_open_prs=1')
-          }
-        }}
-        role="link"
-        tabIndex={0}
-      >
+      <Card className="hover:border-secondary relative flex h-full cursor-pointer flex-col transition-colors">
+        <Link
+          aria-label="View total open pull requests"
+          className="focus-visible:ring-ring absolute inset-0 rounded-lg focus-visible:ring-2 focus-visible:outline-none"
+          to="/projects?view=list&has_open_prs=1"
+        />
         <GitPullRequest className="text-tertiary absolute top-6 right-6 size-9 shrink-0" />
         <CardHeader className="pb-2">
           <CardTitle className="text-secondary font-normal">
@@ -413,8 +407,8 @@ export function Dashboard({
     ),
     'stat-total-projects': () => (
       <StatWidget
+        href="/projects"
         icon="📁"
-        onClick={() => navigate('/projects')}
         title="Total Projects"
         value={projectCount.toLocaleString()}
       />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 
-import { useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import {
   Activity,
@@ -99,18 +99,20 @@ export function Navigation({ currentView }: NavigationProps) {
           {/* Logo and Brand */}
           <div className="flex items-center gap-8">
             <Button
+              asChild
               className="hover:bg-secondary h-auto rounded-lg px-2 py-1.5 transition-all"
-              onClick={() => navigate('/dashboard')}
               variant="ghost"
             >
-              <img
-                alt="Imbi"
-                className="size-8"
-                src={isDarkMode ? logoDark : logoLight}
-              />
-              <span className="text-primary" style={{ fontWeight: 800 }}>
-                Imbi
-              </span>
+              <Link to="/dashboard">
+                <img
+                  alt="Imbi"
+                  className="size-8"
+                  src={isDarkMode ? logoDark : logoLight}
+                />
+                <span className="text-primary" style={{ fontWeight: 800 }}>
+                  Imbi
+                </span>
+              </Link>
             </Button>
 
             {/* Navigation Items */}
@@ -120,17 +122,19 @@ export function Navigation({ currentView }: NavigationProps) {
                 const isActive = activeView === item.id
                 return (
                   <Button
+                    asChild
                     className={`h-auto rounded-lg px-4 py-2 transition-colors ${
                       isActive
                         ? 'bg-amber-bg text-amber-text hover:bg-amber-bg hover:text-amber-text'
                         : 'text-secondary hover:bg-secondary hover:text-primary'
                     }`}
                     key={item.id}
-                    onClick={() => navigate(item.path)}
                     variant="ghost"
                   >
-                    <Icon className="size-4" />
-                    <span>{item.label}</span>
+                    <Link to={item.path}>
+                      <Icon className="size-4" />
+                      <span>{item.label}</span>
+                    </Link>
                   </Button>
                 )
               })}

--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react'
-import {
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { useDeferredValue, useEffect, useMemo, useState } from 'react'
 
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -75,7 +69,6 @@ interface FilterPopoverProps {
 }
 
 interface ProjectListRowProps {
-  onSelect: (id: string) => void
   project: ProjectListItem
 }
 
@@ -246,15 +239,6 @@ export function ProjectsView() {
       .map(([slug, label]) => ({ label, slug }))
       .sort((a, b) => a.label.localeCompare(b.label))
   }, [projects])
-
-  // Stable ref so the memoized ``ProjectListRow`` can actually skip
-  // re-renders when only the parent's input/filter state changes.
-  const handleProjectSelect = useCallback(
-    (projectId: string) => {
-      navigate(`/projects/${projectId}`)
-    },
-    [navigate],
-  )
 
   const driftedProjectIds = useMemo(() => {
     const ids = new Set<string>()
@@ -477,10 +461,14 @@ export function ProjectsView() {
             )
             return (
               <Card
-                className="flex min-h-56 cursor-pointer flex-col p-5 transition-shadow hover:shadow-md"
+                className="relative flex min-h-56 cursor-pointer flex-col p-5 transition-shadow hover:shadow-md"
                 key={`card-${project.id}`}
-                onClick={() => handleProjectSelect(project.id)}
               >
+                <Link
+                  aria-label={`View ${project.name}`}
+                  className="focus-visible:ring-ring absolute inset-0 rounded-lg focus-visible:ring-2 focus-visible:outline-none"
+                  to={`/projects/${project.id}`}
+                />
                 <div className="mb-3 flex items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <h3 className="text-primary mb-1 truncate font-medium">
@@ -519,7 +507,7 @@ export function ProjectsView() {
                       <DriftCell inline project={project} />
                     </div>
                     {isProjectDeployable(project) && envs.length > 0 && (
-                      <div className="ml-auto flex flex-wrap items-center gap-2">
+                      <div className="relative z-10 ml-auto flex flex-wrap items-center gap-2">
                         {envs.map((env) => (
                           <EnvDeploymentHover
                             env={env}
@@ -603,11 +591,7 @@ export function ProjectsView() {
             }}
           >
             {filteredProjects.map((project) => (
-              <ProjectListRow
-                key={`row-${project.id}`}
-                onSelect={handleProjectSelect}
-                project={project}
-              />
+              <ProjectListRow key={`row-${project.id}`} project={project} />
             ))}
           </div>
         </Card>
@@ -1204,14 +1188,15 @@ function StatBadge({
 // returns the same array between renders), the row skips its render.
 // fallow-ignore-next-line complexity
 const ProjectListRow = React.memo(function ProjectListRow({
-  onSelect,
   project,
 }: ProjectListRowProps) {
   return (
-    <div
-      className="hover:bg-secondary flex cursor-pointer items-center transition-colors"
-      onClick={() => onSelect(project.id)}
-    >
+    <div className="hover:bg-secondary relative flex cursor-pointer items-center transition-colors">
+      <Link
+        aria-label={`View ${project.name}`}
+        className="focus-visible:ring-ring absolute inset-0 focus-visible:ring-2 focus-visible:outline-none"
+        to={`/projects/${project.id}`}
+      />
       <div className="w-65 shrink-0 px-6 py-4">
         <p className="text-primary font-medium">{project.name}</p>
         {(project.project_types ?? []).length > 0 && (

--- a/src/components/admin/AssistantManagement.tsx
+++ b/src/components/admin/AssistantManagement.tsx
@@ -34,7 +34,7 @@ type Filter = 'all' | 'disabled' | 'enabled' | 'issues'
 const MCP_SERVERS_KEY = ['mcp-servers']
 
 export function AssistantManagement() {
-  const { goToCreate, goToEdit, goToList, slug, viewMode } = useAdminNav()
+  const { editPath, goToCreate, goToList, slug, viewMode } = useAdminNav()
   const queryClient = useQueryClient()
   const [searchQuery, setSearchQuery] = useState('')
   const [filter, setFilter] = useState<Filter>('all')
@@ -243,6 +243,7 @@ export function AssistantManagement() {
               },
               {
                 header: 'Enabled',
+                interactive: true,
                 key: 'enabled',
                 render: (srv) => (
                   <span
@@ -268,10 +269,10 @@ export function AssistantManagement() {
                 : 'No MCP servers configured yet.'
             }
             getDeleteLabel={(srv) => srv.name}
+            getRowHref={(srv) => editPath(srv.slug)}
             getRowKey={(srv) => srv.slug}
             isDeleting={deleteMutation.isPending}
             onDelete={(srv) => deleteMutation.mutate(srv.id)}
-            onRowClick={(srv) => goToEdit(srv.slug)}
             rows={filtered}
           />
           <div className="text-tertiary flex items-center justify-between text-xs">

--- a/src/components/admin/BlueprintManagement.tsx
+++ b/src/components/admin/BlueprintManagement.tsx
@@ -55,6 +55,7 @@ interface BlueprintKey {
 
 export function BlueprintManagement() {
   const {
+    editPath,
     goToCreate,
     goToEdit,
     goToList,
@@ -179,10 +180,6 @@ export function BlueprintManagement() {
   }
 
   const handleEditClick = (key: BlueprintKey) => {
-    goToEdit(`${key.type}:${key.slug}`)
-  }
-
-  const handleViewClick = (key: BlueprintKey) => {
     goToEdit(`${key.type}:${key.slug}`)
   }
 
@@ -471,18 +468,14 @@ export function BlueprintManagement() {
             : 'No blueprints created yet'
         }
         getDeleteLabel={(bp) => bp.name}
+        getRowHref={(bp) =>
+          bp.slug ? editPath(`${blueprintPathType(bp)}:${bp.slug}`) : undefined
+        }
         getRowKey={(bp) => `${blueprintPathType(bp)}/${bp.slug}`}
         isDeleting={deleteMutation.isPending}
         onDelete={(bp) => {
           if (!bp.slug) return
           deleteMutation.mutate({
-            slug: bp.slug,
-            type: blueprintPathType(bp),
-          })
-        }}
-        onRowClick={(bp) => {
-          if (!bp.slug) return
-          handleViewClick({
             slug: bp.slug,
             type: blueprintPathType(bp),
           })

--- a/src/components/admin/DocumentTemplateManagement.tsx
+++ b/src/components/admin/DocumentTemplateManagement.tsx
@@ -28,8 +28,8 @@ export function DocumentTemplateManagement() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug
   const {
+    editPath,
     goToCreate,
-    goToEdit,
     goToList,
     slug: selectedSlug,
     viewMode,
@@ -269,10 +269,10 @@ export function DocumentTemplateManagement() {
               : 'No document templates created yet.'
         }
         getDeleteLabel={(nt) => nt.name}
+        getRowHref={(nt) => editPath(nt.slug)}
         getRowKey={(nt) => nt.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(nt) => goToEdit(nt.slug)}
         rows={filteredDocumentTemplates}
       />
     </AdminSection>

--- a/src/components/admin/EnvironmentManagement.tsx
+++ b/src/components/admin/EnvironmentManagement.tsx
@@ -27,6 +27,7 @@ export function EnvironmentManagement() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug
   const {
+    editPath,
     goToCreate,
     goToEdit,
     goToList,
@@ -253,10 +254,10 @@ export function EnvironmentManagement() {
               : 'No environments created yet.'
         }
         getDeleteLabel={(env) => env.name}
+        getRowHref={(env) => editPath(env.slug)}
         getRowKey={(env) => env.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(env) => goToEdit(env.slug)}
         rows={filteredEnvironments}
       />
     </AdminSection>

--- a/src/components/admin/LinkDefinitionManagement.tsx
+++ b/src/components/admin/LinkDefinitionManagement.tsx
@@ -28,8 +28,8 @@ export function LinkDefinitionManagement() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug
   const {
+    editPath,
     goToCreate,
-    goToEdit,
     goToList,
     slug: selectedSlug,
     viewMode,
@@ -255,10 +255,10 @@ export function LinkDefinitionManagement() {
               : 'No link definitions created yet.'
         }
         getDeleteLabel={(ld) => ld.name}
+        getRowHref={(ld) => editPath(ld.slug)}
         getRowKey={(ld) => ld.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(ld) => goToEdit(ld.slug)}
         rows={filteredLinkDefinitions}
       />
     </AdminSection>

--- a/src/components/admin/OrganizationManagement.tsx
+++ b/src/components/admin/OrganizationManagement.tsx
@@ -23,6 +23,7 @@ import { OrganizationForm } from './organizations/OrganizationForm'
 
 export function OrganizationManagement() {
   const {
+    editPath,
     goToCreate,
     goToEdit,
     goToList,
@@ -270,10 +271,10 @@ export function OrganizationManagement() {
             : 'No organizations created yet.'
         }
         getDeleteLabel={(org) => org.name}
+        getRowHref={(org) => editPath(org.slug)}
         getRowKey={(org) => org.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(org) => goToEdit(org.slug)}
         rows={filteredOrgs}
       />
     </AdminSection>

--- a/src/components/admin/PluginsManagement.tsx
+++ b/src/components/admin/PluginsManagement.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 
-import { useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ChevronRight, CirclePlay, Package, PowerOff } from 'lucide-react'
@@ -195,7 +195,6 @@ function DisabledList({ parentLoading, plugins }: DisabledListProps) {
 }
 
 function EnabledList({ error, isError, isLoading, plugins }: EnabledListProps) {
-  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [pluginToDisable, setPluginToDisable] =
     useState<InstalledPlugin | null>(null)
@@ -266,11 +265,15 @@ function EnabledList({ error, isError, isLoading, plugins }: EnabledListProps) {
             <TableBody>
               {plugins.map((plugin) => (
                 <TableRow
-                  className="hover:bg-secondary/40 cursor-pointer"
+                  className="hover:bg-secondary/40 relative cursor-pointer"
                   key={plugin.slug}
-                  onClick={() => navigate(`/admin/plugins/${plugin.slug}`)}
                 >
                   <TableCell>
+                    <Link
+                      aria-label={`View ${plugin.name}`}
+                      className="focus-visible:ring-ring absolute inset-0 rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+                      to={`/admin/plugins/${plugin.slug}`}
+                    />
                     <div className="font-medium">{plugin.name}</div>
                     <div className="text-secondary text-xs">
                       {plugin.description}
@@ -306,7 +309,7 @@ function EnabledList({ error, isError, isLoading, plugins }: EnabledListProps) {
                       ))}
                     </div>
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="relative z-10">
                     <Button
                       disabled={disableMutation.isPending}
                       onClick={(e) => {

--- a/src/components/admin/ProjectTypeManagement.tsx
+++ b/src/components/admin/ProjectTypeManagement.tsx
@@ -26,8 +26,8 @@ export function ProjectTypeManagement() {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug
   const {
+    editPath,
     goToCreate,
-    goToEdit,
     goToList,
     slug: selectedPtSlug,
     viewMode,
@@ -223,10 +223,10 @@ export function ProjectTypeManagement() {
               : 'No project types created yet.'
         }
         getDeleteLabel={(pt) => pt.name}
+        getRowHref={(pt) => editPath(pt.slug)}
         getRowKey={(pt) => pt.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(pt) => goToEdit(pt.slug)}
         rows={filteredProjectTypes}
       />
     </AdminSection>

--- a/src/components/admin/RoleManagement.tsx
+++ b/src/components/admin/RoleManagement.tsx
@@ -31,8 +31,9 @@ type Role = Awaited<ReturnType<typeof getRoles>>[number]
 
 export function RoleManagement() {
   const {
+    detailPath,
+    editPath,
     goToCreate,
-    goToDetail,
     goToEdit,
     goToList,
     slug: selectedRoleSlug,
@@ -254,12 +255,12 @@ export function RoleManagement() {
           searchQuery ? 'No roles match your search' : 'No roles created yet'
         }
         getDeleteLabel={(role) => role.name}
+        getRowHref={(role) =>
+          isSystemRole(role) ? detailPath(role.slug) : editPath(role.slug)
+        }
         getRowKey={(role) => role.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(role) =>
-          isSystemRole(role) ? goToDetail(role.slug) : goToEdit(role.slug)
-        }
         rows={filteredRoles}
       />
     </AdminSection>

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -57,8 +57,8 @@ const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
 
 export function ScoringPolicyManagement() {
   const {
+    editPath,
     goToCreate,
-    goToEdit,
     goToList,
     slug: selectedSlug,
     viewMode,
@@ -332,10 +332,10 @@ export function ScoringPolicyManagement() {
               : 'No scoring policies defined yet.'
           }
           getDeleteLabel={(p) => p.name}
+          getRowHref={(p) => editPath(p.slug)}
           getRowKey={(p) => p.slug}
           isDeleting={deleteMutation.isPending}
           onDelete={(p) => deleteMutation.mutate(p.slug)}
-          onRowClick={(p) => goToEdit(p.slug)}
           rows={filteredPolicies}
         />
       </AdminSection>

--- a/src/components/admin/ServiceAccountManagement.tsx
+++ b/src/components/admin/ServiceAccountManagement.tsx
@@ -36,8 +36,8 @@ type StatusFilter = 'active' | 'all' | 'inactive'
 
 export function ServiceAccountManagement() {
   const {
+    editPath,
     goToCreate,
-    goToEdit,
     goToList,
     slug: selectedAccountSlug,
     viewMode,
@@ -92,10 +92,6 @@ export function ServiceAccountManagement() {
 
   const handleDelete = (account: ServiceAccount) => {
     deleteMutation.mutate(account.slug)
-  }
-
-  const handleViewClick = (account: ServiceAccount) => {
-    goToEdit(account.slug)
   }
 
   const handleSave = (data: ServiceAccountCreate) => {
@@ -247,10 +243,10 @@ export function ServiceAccountManagement() {
             : 'No service accounts created yet'
         }
         getDeleteLabel={(account) => account.display_name}
+        getRowHref={(account) => editPath(account.slug)}
         getRowKey={(account) => account.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(account) => handleViewClick(account)}
         rows={filteredAccounts}
       />
 

--- a/src/components/admin/TeamManagement.tsx
+++ b/src/components/admin/TeamManagement.tsx
@@ -21,8 +21,8 @@ import { TeamForm } from './teams/TeamForm'
 export function TeamManagement() {
   const { selectedOrganization } = useOrganization()
   const {
+    detailPath,
     goToCreate,
-    goToDetail,
     goToEdit,
     goToList,
     slug: selectedTeamSlug,
@@ -289,10 +289,10 @@ export function TeamManagement() {
               : 'No teams created yet.'
         }
         getDeleteLabel={(team) => team.name}
+        getRowHref={(team) => detailPath(team.slug)}
         getRowKey={(team) => team.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(team) => goToDetail(team.slug)}
         rows={filteredTeams}
       />
     </AdminSection>

--- a/src/components/admin/ThirdPartyServiceManagement.tsx
+++ b/src/components/admin/ThirdPartyServiceManagement.tsx
@@ -30,8 +30,8 @@ import { ThirdPartyServiceForm } from './third-party-services/ThirdPartyServiceF
 export function ThirdPartyServiceManagement() {
   const { selectedOrganization } = useOrganization()
   const {
+    detailPath,
     goToCreate,
-    goToDetail,
     goToEdit,
     goToList,
     slug: selectedSlug,
@@ -277,10 +277,10 @@ export function ThirdPartyServiceManagement() {
               : 'No third-party services created yet.'
         }
         getDeleteLabel={(svc) => svc.name}
+        getRowHref={(svc) => detailPath(svc.slug)}
         getRowKey={(svc) => svc.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={(svc) => deleteMutation.mutate(svc.slug)}
-        onRowClick={(svc) => goToDetail(svc.slug)}
         rows={filteredServices}
       />
     </AdminSection>

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -40,6 +40,7 @@ type UserFilter = 'admins' | 'all' | 'users'
 export function UserManagement() {
   const queryClient = useQueryClient()
   const {
+    editPath,
     goToCreate,
     goToEdit,
     goToList,
@@ -135,10 +136,6 @@ export function UserManagement() {
   })
 
   const handleEditClick = (user: AdminUser) => {
-    goToEdit(user.email)
-  }
-
-  const handleViewClick = (user: AdminUser) => {
     goToEdit(user.email)
   }
 
@@ -306,6 +303,7 @@ export function UserManagement() {
             cellAlign: 'center',
             header: 'Status',
             headerAlign: 'center',
+            interactive: true,
             key: 'status',
             render: (user) => (
               <button
@@ -342,8 +340,8 @@ export function UserManagement() {
             ? 'No users match your filters'
             : 'No users created yet'
         }
+        getRowHref={(user) => editPath(user.email)}
         getRowKey={(user) => user.email}
-        onRowClick={(user) => handleViewClick(user)}
         rows={filteredUsers}
       />
     </AdminSection>

--- a/src/components/admin/WebhookManagement.tsx
+++ b/src/components/admin/WebhookManagement.tsx
@@ -23,6 +23,7 @@ import { WebhookForm, type WebhookSaveData } from './webhooks/WebhookForm'
 export function WebhookManagement() {
   const { selectedOrganization } = useOrganization()
   const {
+    editPath,
     goToCreate,
     goToEdit,
     goToList,
@@ -248,10 +249,10 @@ export function WebhookManagement() {
               : 'No webhooks created yet.'
         }
         getDeleteLabel={(wh) => wh.name}
+        getRowHref={(wh) => editPath(wh.slug)}
         getRowKey={(wh) => wh.slug}
         isDeleting={deleteMutation.isPending}
         onDelete={handleDelete}
-        onRowClick={(wh) => goToEdit(wh.slug)}
         rows={filteredWebhooks}
       />
     </AdminSection>

--- a/src/components/dashboard/widgets/MyPullRequestCountsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestCountsWidget.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
 import { GitMerge } from 'lucide-react'
@@ -11,7 +11,6 @@ import { useGithubLogin } from '@/hooks/useGithubLogin'
 
 // fallow-ignore-next-line complexity
 export function MyPullRequestCountsWidget() {
-  const navigate = useNavigate()
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug ?? ''
 
@@ -44,19 +43,12 @@ export function MyPullRequestCountsWidget() {
   const openCount = openData?.total ?? 0
 
   return (
-    <Card
-      aria-label="View my open pull requests"
-      className="hover:border-secondary relative flex h-full cursor-pointer flex-col transition-colors"
-      onClick={() => navigate('/projects?view=list&has_my_open_prs=1')}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          navigate('/projects?view=list&has_my_open_prs=1')
-        }
-      }}
-      role="link"
-      tabIndex={0}
-    >
+    <Card className="hover:border-secondary relative flex h-full cursor-pointer flex-col transition-colors">
+      <Link
+        aria-label="View my open pull requests"
+        className="focus-visible:ring-ring absolute inset-0 rounded-lg focus-visible:ring-2 focus-visible:outline-none"
+        to="/projects?view=list&has_my_open_prs=1"
+      />
       <GitMerge className="text-tertiary absolute top-6 right-6 size-9" />
       <CardHeader className="pb-2">
         <CardTitle className="text-secondary font-normal">
@@ -76,9 +68,8 @@ export function MyPullRequestCountsWidget() {
           <>
             <p className="text-tertiary text-3xl">—</p>
             <a
-              className="text-action mt-1 block text-xs hover:underline"
+              className="text-action relative z-10 mt-1 block text-xs hover:underline"
               href="/settings/connections"
-              onClick={(event) => event.stopPropagation()}
             >
               Connect GitHub
             </a>

--- a/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
+++ b/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 
-import { useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import type { InfiniteData } from '@tanstack/react-query'
@@ -165,7 +165,6 @@ function DeploymentRow({
   deployment: OperationsLogRecord
   projectsBySlug: Map<string, Project>
 }) {
-  const navigate = useNavigate()
   const project = projectsBySlug.get(d.project_slug)
   const projectLabel = project
     ? `${project.team.slug}/${project.slug}`
@@ -174,16 +173,14 @@ function DeploymentRow({
   const StatusIcon = inProgress ? Clock : CheckCircle
   const statusVariant: BadgeProps['variant'] = inProgress ? 'info' : 'success'
   const statusLabel = inProgress ? 'In Progress' : 'Success'
+  const to = project
+    ? `/projects/${project.id}`
+    : `/operations-log?entry=${encodeURIComponent(d.id)}`
 
   return (
-    <button
-      className="border-input bg-background hover:border-secondary w-full rounded-lg border p-3 text-left transition-colors"
-      onClick={() =>
-        project
-          ? navigate(`/projects/${project.id}`)
-          : navigate(`/operations-log?entry=${encodeURIComponent(d.id)}`)
-      }
-      type="button"
+    <Link
+      className="border-input bg-background hover:border-secondary block w-full rounded-lg border p-3 text-left transition-colors"
+      to={to}
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 flex-1 items-start gap-3">
@@ -217,7 +214,7 @@ function DeploymentRow({
         </div>
         <ChevronRight className="text-tertiary size-4 shrink-0" />
       </div>
-    </button>
+    </Link>
   )
 }
 

--- a/src/components/dashboard/widgets/StatWidget.tsx
+++ b/src/components/dashboard/widgets/StatWidget.tsx
@@ -1,7 +1,12 @@
+import { Link } from 'react-router-dom'
+
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 
 interface StatWidgetProps {
+  // When set, the card renders a real link so cmd/ctrl/middle-click open a
+  // new tab. Takes precedence over onClick.
+  href?: string
   icon: string
   isError?: boolean
   isLoading?: boolean
@@ -12,6 +17,7 @@ interface StatWidgetProps {
 
 // fallow-ignore-next-line complexity
 export function StatWidget({
+  href,
   icon,
   isError = false,
   isLoading = false,
@@ -19,12 +25,13 @@ export function StatWidget({
   title,
   value,
 }: StatWidgetProps) {
+  const clickable = !!href || !!onClick
   return (
     <Card
-      className={`relative flex h-full flex-col${onClick ? ' hover:border-secondary cursor-pointer transition-colors' : ''}`}
-      onClick={onClick}
+      className={`relative flex h-full flex-col${clickable ? ' hover:border-secondary cursor-pointer transition-colors' : ''}`}
+      onClick={href ? undefined : onClick}
       onKeyDown={
-        onClick
+        !href && onClick
           ? (event) => {
               if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault()
@@ -33,9 +40,16 @@ export function StatWidget({
             }
           : undefined
       }
-      role={onClick ? 'link' : undefined}
-      tabIndex={onClick ? 0 : undefined}
+      role={!href && onClick ? 'link' : undefined}
+      tabIndex={!href && onClick ? 0 : undefined}
     >
+      {href && (
+        <Link
+          aria-label={title}
+          className="focus-visible:ring-ring absolute inset-0 rounded-lg focus-visible:ring-2 focus-visible:outline-none"
+          to={href}
+        />
+      )}
       <div className="absolute top-6 right-6 text-4xl">{icon}</div>
       <CardHeader className="pb-2">
         <CardTitle className="text-secondary font-normal">{title}</CardTitle>

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -428,7 +428,7 @@ function AdminTableRow<T>({
         >
           {href && colIndex === 0 && (
             <Link
-              aria-label={`Edit ${label}`}
+              aria-label={label ? `Open ${label}` : 'Open item'}
               className="focus-visible:ring-ring absolute inset-0 rounded-sm focus-visible:ring-2 focus-visible:outline-none"
               to={href}
             />

--- a/src/components/ui/admin-table.tsx
+++ b/src/components/ui/admin-table.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent, type ReactNode, useEffect, useState } from 'react'
 
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { Trash2 } from 'lucide-react'
 
@@ -45,6 +45,10 @@ export interface AdminTableColumn<T> {
   cellAlign?: 'center' | 'left' | 'right'
   header: string
   headerAlign?: 'center' | 'left' | 'right'
+  // When the cell renders its own interactive content (links, buttons,
+  // toggles), set this so the cell stacks above the row link overlay and
+  // stays clickable.
+  interactive?: boolean
   key: string
   render: (row: T) => ReactNode
 }
@@ -67,12 +71,15 @@ interface AdminTableProps<T> {
   columns: AdminTableColumn<T>[]
   emptyMessage?: string
   getDeleteLabel?: (row: T) => string
+  // Returns the destination for a row. When provided, the row renders a real
+  // anchor so cmd/ctrl/middle-click and the browser context menu work
+  // natively. Return undefined to make a row non-navigable.
+  getRowHref?: (row: T) => string | undefined
   getRowKey: (row: T) => string
   getRowLabel?: (row: T) => string
   isDeleting?: boolean
   isRowClickable?: (row: T) => boolean
   onDelete?: (row: T) => void
-  onRowClick?: (row: T) => void
   rows: T[]
 }
 
@@ -88,18 +95,51 @@ const CELL_ALIGN: Record<string, string> = {
   right: 'text-right',
 }
 
+interface AdminRowActionsProps<T> {
+  actions?: (row: T) => ReactNode
+  deleteCheck: CanDeleteResult
+  isDeleting: boolean
+  label: string
+  onDelete?: (row: T) => void
+  onDeleteClick: (
+    row: T,
+    e: MouseEvent<HTMLButtonElement>,
+    deleteCheck: CanDeleteResult,
+  ) => void
+  row: T
+}
+
+interface AdminTableRowProps<T> {
+  actions?: (row: T) => ReactNode
+  canDelete?: (row: T) => CanDeleteResult
+  columns: AdminTableColumn<T>[]
+  getDeleteLabel?: (row: T) => string
+  getRowHref?: (row: T) => string | undefined
+  getRowLabel?: (row: T) => string
+  isDeleting: boolean
+  isRowClickable?: (row: T) => boolean
+  onDelete?: (row: T) => void
+  onDeleteClick: (
+    row: T,
+    e: MouseEvent<HTMLButtonElement>,
+    deleteCheck: CanDeleteResult,
+  ) => void
+  row: T
+  showActions: boolean
+}
+
 export function AdminTable<T>({
   actions,
   canDelete,
   columns,
   emptyMessage = 'No items found.',
   getDeleteLabel,
+  getRowHref,
   getRowKey,
   getRowLabel,
   isDeleting = false,
   isRowClickable,
   onDelete,
-  onRowClick,
   rows,
 }: AdminTableProps<T>) {
   const navigate = useNavigate()
@@ -282,92 +322,23 @@ export function AdminTable<T>({
                   </TableCell>
                 </TableRow>
               ) : (
-                rows.map((row) => {
-                  const key = getRowKey(row)
-                  const label = getRowLabel
-                    ? getRowLabel(row)
-                    : getDeleteLabel
-                      ? getDeleteLabel(row)
-                      : ''
-                  const deleteCheck = canDelete
-                    ? canDelete(row)
-                    : { allowed: true }
-                  const canDeleteRow = deleteCheck.allowed
-                  const deleteReason = deleteCheck.reason
-                  const rowClickable =
-                    onRowClick && (isRowClickable ? isRowClickable(row) : true)
-
-                  return (
-                    <TableRow
-                      aria-label={rowClickable ? `Edit ${label}` : undefined}
-                      className={cn(rowClickable && 'cursor-pointer')}
-                      key={key}
-                      onClick={rowClickable ? () => onRowClick(row) : undefined}
-                      onKeyDown={
-                        rowClickable
-                          ? (e) => {
-                              if (e.currentTarget !== e.target) return
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault()
-                                onRowClick(row)
-                              }
-                            }
-                          : undefined
-                      }
-                      tabIndex={rowClickable ? 0 : undefined}
-                    >
-                      {columns.map((col) => (
-                        <TableCell
-                          className={CELL_ALIGN[col.cellAlign ?? 'left']}
-                          key={col.key}
-                        >
-                          {col.render(row)}
-                        </TableCell>
-                      ))}
-                      {showActions && (
-                        <TableCell
-                          className="text-right"
-                          onClick={(e) => e.stopPropagation()}
-                          onKeyDown={(e) => e.stopPropagation()}
-                        >
-                          <div className="flex items-center justify-end gap-2">
-                            {actions && actions(row)}
-                            {onDelete && (
-                              <TooltipProvider delayDuration={200}>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <span className="inline-flex">
-                                      <Button
-                                        aria-label={`Delete ${label}`}
-                                        className={cn(
-                                          'text-destructive hover:bg-destructive/10 hover:text-destructive',
-                                          isDeleting &&
-                                            'pointer-events-none opacity-30',
-                                          !canDeleteRow && 'opacity-30',
-                                        )}
-                                        disabled={isDeleting}
-                                        onClick={(e) =>
-                                          handleDeleteClick(row, e, deleteCheck)
-                                        }
-                                        size="sm"
-                                        variant="ghost"
-                                      >
-                                        <Trash2 className="size-4" />
-                                      </Button>
-                                    </span>
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    <p>{deleteReason ?? 'Delete'}</p>
-                                  </TooltipContent>
-                                </Tooltip>
-                              </TooltipProvider>
-                            )}
-                          </div>
-                        </TableCell>
-                      )}
-                    </TableRow>
-                  )
-                })
+                rows.map((row) => (
+                  <AdminTableRow
+                    actions={actions}
+                    canDelete={canDelete}
+                    columns={columns}
+                    getDeleteLabel={getDeleteLabel}
+                    getRowHref={getRowHref}
+                    getRowLabel={getRowLabel}
+                    isDeleting={isDeleting}
+                    isRowClickable={isRowClickable}
+                    key={getRowKey(row)}
+                    onDelete={onDelete}
+                    onDeleteClick={handleDeleteClick}
+                    row={row}
+                    showActions={showActions}
+                  />
+                ))
               )}
             </TableBody>
           </Table>
@@ -375,4 +346,117 @@ export function AdminTable<T>({
       </Card>
     </>
   )
+}
+
+function AdminRowActions<T>({
+  actions,
+  deleteCheck,
+  isDeleting,
+  label,
+  onDelete,
+  onDeleteClick,
+  row,
+}: AdminRowActionsProps<T>) {
+  return (
+    <TableCell
+      className="relative z-10 text-right"
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-end gap-2">
+        {actions && actions(row)}
+        {onDelete && (
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    aria-label={`Delete ${label}`}
+                    className={cn(
+                      'text-destructive hover:bg-destructive/10 hover:text-destructive',
+                      isDeleting && 'pointer-events-none opacity-30',
+                      !deleteCheck.allowed && 'opacity-30',
+                    )}
+                    disabled={isDeleting}
+                    onClick={(e) => onDeleteClick(row, e, deleteCheck)}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{deleteCheck.reason ?? 'Delete'}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
+    </TableCell>
+  )
+}
+
+function AdminTableRow<T>({
+  actions,
+  canDelete,
+  columns,
+  getDeleteLabel,
+  getRowHref,
+  getRowLabel,
+  isDeleting,
+  isRowClickable,
+  onDelete,
+  onDeleteClick,
+  row,
+  showActions,
+}: AdminTableRowProps<T>) {
+  const label = resolveLabel(row, getRowLabel, getDeleteLabel)
+  const deleteCheck = canDelete ? canDelete(row) : { allowed: true }
+  const clickable = isRowClickable ? isRowClickable(row) : true
+  const href = getRowHref && clickable ? getRowHref(row) : undefined
+
+  return (
+    <TableRow className={cn(href && 'relative cursor-pointer')}>
+      {columns.map((col, colIndex) => (
+        <TableCell
+          className={cn(
+            CELL_ALIGN[col.cellAlign ?? 'left'],
+            col.interactive && 'relative z-10',
+          )}
+          key={col.key}
+        >
+          {href && colIndex === 0 && (
+            <Link
+              aria-label={`Edit ${label}`}
+              className="focus-visible:ring-ring absolute inset-0 rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+              to={href}
+            />
+          )}
+          {col.render(row)}
+        </TableCell>
+      ))}
+      {showActions && (
+        <AdminRowActions
+          actions={actions}
+          deleteCheck={deleteCheck}
+          isDeleting={isDeleting}
+          label={label}
+          onDelete={onDelete}
+          onDeleteClick={onDeleteClick}
+          row={row}
+        />
+      )}
+    </TableRow>
+  )
+}
+
+function resolveLabel<T>(
+  row: T,
+  getRowLabel?: (row: T) => string,
+  getDeleteLabel?: (row: T) => string,
+): string {
+  if (getRowLabel) return getRowLabel(row)
+  if (getDeleteLabel) return getDeleteLabel(row)
+  return ''
 }

--- a/src/hooks/useAdminNav.ts
+++ b/src/hooks/useAdminNav.ts
@@ -5,10 +5,14 @@ import { useNavigate, useParams } from 'react-router-dom'
 export type ViewMode = 'create' | 'detail' | 'edit' | 'list'
 
 interface AdminNavState {
+  createPath: string
+  detailPath: (slug: string) => string
+  editPath: (slug: string) => string
   goToCreate: () => void
   goToDetail: (slug: string) => void
   goToEdit: (slug: string) => void
   goToList: () => void
+  listPath: string
   slug: null | string
   viewMode: ViewMode
 }
@@ -33,21 +37,34 @@ export function useAdminNav(): AdminNavState {
 
   const base = section ? `/admin/${section}` : '/admin'
 
-  const goToList = useCallback(() => navigate(base), [navigate, base])
+  const listPath = base
+  const createPath = `${base}/new`
+
+  const detailPath = useCallback(
+    (s: string) => `${base}/${encodeURIComponent(s)}`,
+    [base],
+  )
+
+  const editPath = useCallback(
+    (s: string) => `${base}/${encodeURIComponent(s)}/edit`,
+    [base],
+  )
+
+  const goToList = useCallback(() => navigate(listPath), [navigate, listPath])
 
   const goToCreate = useCallback(
-    () => navigate(`${base}/new`),
-    [navigate, base],
+    () => navigate(createPath),
+    [navigate, createPath],
   )
 
   const goToDetail = useCallback(
-    (s: string) => navigate(`${base}/${encodeURIComponent(s)}`),
-    [navigate, base],
+    (s: string) => navigate(detailPath(s)),
+    [navigate, detailPath],
   )
 
   const goToEdit = useCallback(
-    (s: string) => navigate(`${base}/${encodeURIComponent(s)}/edit`),
-    [navigate, base],
+    (s: string) => navigate(editPath(s)),
+    [navigate, editPath],
   )
 
   useEffect(() => {
@@ -75,10 +92,14 @@ export function useAdminNav(): AdminNavState {
   }, [viewMode, itemSlug, goToEdit, goToList])
 
   return {
+    createPath,
+    detailPath,
+    editPath,
     goToCreate,
     goToDetail,
     goToEdit,
     goToList,
+    listPath,
     slug: itemSlug,
     viewMode,
   }


### PR DESCRIPTION
## Summary

Clickable table rows, cards, and nav items navigated via `useNavigate()` on `onClick` handlers, so cmd/ctrl+click, middle-click, and the browser's "Open link in new tab" context menu did nothing. This renders real `<a>` anchors everywhere navigation happens, so those behaviors work natively (and keyboard/AT users get real links).

## Problem

`cmd+click` to open in a new tab only works on real anchor elements. Across the app, rows/cards used `<div onClick={() => navigate(...)}>`, which the browser can't treat as a link — no new-tab, no middle-click, no "copy link address", no status-bar URL preview.

## Solution

- **`useAdminNav`** — expose path builders (`listPath`/`createPath`/`detailPath`/`editPath`); the existing `goTo*` navigators now delegate to them.
- **`AdminTable`** — new `getRowHref` prop. Rows render a stretched-link overlay `<Link>` (row is `relative`, anchor is `absolute inset-0`) so the whole row is a real link. A new `interactive` column flag raises cells that have their own controls above the overlay; the actions column is raised automatically. Row rendering was extracted into `AdminTableRow`/`AdminRowActions`, and the now-unused `onRowClick` fallback was removed.
- Migrated all 13 `AdminTable` admin pages plus the hand-rolled **PluginsManagement** table to `getRowHref`.
- **ProjectsView** grid cards and list rows, **Dashboard** "Total Open PRs" card, **StatWidget** (new `href` prop), **MyPullRequestCountsWidget**, and **RecentDeploymentsWidget** rows now render anchors. Where a card had a nested `<a>` or a Radix HoverCard, the overlay technique is used (and the interactive child is z-raised) to avoid invalid nested anchors.
- Top nav (logo + items), admin sidebar, and the section breadcrumb use `<Button asChild><Link>`.

React Router's `<Link>` handles SPA navigation on plain left-click and lets the browser handle modified clicks — so both behaviors come for free with no modifier-key interception.

### Out of scope
The user-menu dropdown items (Profile/Settings) remain `onClick` — they're Radix `DropdownMenuItem`s where new-tab is an unusual expectation.

## Verification
- `npm run lint` — 0 errors
- `tsc --noEmit` — clean
- `npm run test` — 346/346 pass
- `npm run build` — succeeds

## Manual testing recommended
Worth a quick visual pass that the stretched-link overlay holds up against the dense table/card styling, and that in-cell toggles (Assistant enable, User status) and the project-card env hovercards still respond.