### PR TITLE
Add template menu to New document button

### DIFF
--- a/src/components/documents/DocumentsPinboard.tsx
+++ b/src/components/documents/DocumentsPinboard.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useMemo, useState } from 'react'
 
-import { ArrowUpRight, Pin, Plus } from 'lucide-react'
+import { ArrowUpRight, Pin } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
@@ -13,7 +12,7 @@ import {
 import { IconTooltip } from '@/components/ui/tooltip'
 import { UserDisplay } from '@/components/ui/user-display'
 import { cn } from '@/lib/utils'
-import type { Document } from '@/types'
+import type { Document, DocumentTemplate } from '@/types'
 
 import { DocumentsFilterRail } from './DocumentsFilterRail'
 import {
@@ -24,13 +23,16 @@ import {
   uniqueTagsFromDocuments,
 } from './documentsHelpers'
 import { DocumentTagChip } from './DocumentTagChip'
+import { NewDocumentMenu } from './NewDocumentMenu'
 
 interface Props {
   displayNames?: Map<string, string>
   documents: Document[]
-  onCreate: () => void
+  onCreate: (template?: DocumentTemplate) => void
   onOpen: (documentId: string) => void
   onTogglePin: (document: Document) => void
+  orgSlug: string
+  projectTypeSlugs?: string[]
 }
 
 export function DocumentsPinboard({
@@ -39,6 +41,8 @@ export function DocumentsPinboard({
   onCreate,
   onOpen,
   onTogglePin,
+  orgSlug,
+  projectTypeSlugs,
 }: Props) {
   const [active, setActive] = useState<Set<string>>(new Set())
   const [search, setSearch] = useState('')
@@ -98,14 +102,12 @@ export function DocumentsPinboard({
               ))}
             </div>
           )}
-          <Button
-            className={cn('gap-1.5', pinned.length === 0 && 'ml-auto')}
-            onClick={onCreate}
-            size="sm"
-          >
-            <Plus className="size-3" />
-            New document
-          </Button>
+          <NewDocumentMenu
+            className={cn(pinned.length === 0 && 'ml-auto')}
+            onCreate={onCreate}
+            orgSlug={orgSlug}
+            projectTypeSlugs={projectTypeSlugs}
+          />
         </section>
 
         <section>

--- a/src/components/documents/DocumentsPinboardEmpty.tsx
+++ b/src/components/documents/DocumentsPinboardEmpty.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { EntityIcon } from '@/components/ui/entity-icon'
 import type { DocumentTemplate } from '@/types'
 
+import { filterTemplatesByProjectType } from './documentsHelpers'
 import { DocumentTagChip } from './DocumentTagChip'
 
 interface Props {
@@ -29,16 +30,10 @@ export function DocumentsPinboardEmpty({
     queryKey: ['documentTemplates', orgSlug],
   })
 
-  const projectTypeSet =
-    projectTypeSlugs && projectTypeSlugs.length
-      ? new Set(projectTypeSlugs)
-      : undefined
-
-  const visibleTemplates = templates.filter((t) => {
-    if (!t.project_type_slugs || t.project_type_slugs.length === 0) return true
-    if (!projectTypeSet) return false
-    return t.project_type_slugs.some((s) => projectTypeSet.has(s))
-  })
+  const visibleTemplates = filterTemplatesByProjectType(
+    templates,
+    projectTypeSlugs,
+  )
 
   return (
     <div className="border-tertiary bg-primary flex flex-col items-center gap-4 rounded-lg border px-10 py-14 text-center">

--- a/src/components/documents/NewDocumentMenu.tsx
+++ b/src/components/documents/NewDocumentMenu.tsx
@@ -40,11 +40,7 @@ export function NewDocumentMenu({
   orgSlug,
   projectTypeSlugs,
 }: Props) {
-  const {
-    data: templates = [],
-    error,
-    isLoading,
-  } = useQuery<DocumentTemplate[]>({
+  const { data: templates = [], isLoading } = useQuery<DocumentTemplate[]>({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listDocumentTemplates(orgSlug, signal),
     queryKey: ['documentTemplates', orgSlug],
@@ -56,7 +52,8 @@ export function NewDocumentMenu({
   )
 
   // Nothing to choose between — keep the fast path as a plain button.
-  if (!isLoading && !error && visibleTemplates.length === 0) {
+  // (On error we get no templates, so degrade rather than show an empty menu.)
+  if (!isLoading && visibleTemplates.length === 0) {
     return (
       <Button
         className={cn('gap-1.5', className)}

--- a/src/components/documents/NewDocumentMenu.tsx
+++ b/src/components/documents/NewDocumentMenu.tsx
@@ -1,0 +1,159 @@
+import { useQuery } from '@tanstack/react-query'
+import { ChevronDown, FilePlus2, Plus, StickyNote } from 'lucide-react'
+
+import { listDocumentTemplates } from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { EntityIcon } from '@/components/ui/entity-icon'
+import { cn } from '@/lib/utils'
+import type { DocumentTemplate } from '@/types'
+
+import { filterTemplatesByProjectType } from './documentsHelpers'
+import { DocumentTagChip } from './DocumentTagChip'
+
+interface Props {
+  className?: string
+  onCreate: (template?: DocumentTemplate) => void
+  orgSlug: string
+  projectTypeSlugs?: string[]
+}
+
+const ITEM_CLASS =
+  'flex cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2'
+
+/**
+ * "New document" control on the populated Documents tab. Opens a menu led by a
+ * blank-document option (today's one-click default), then lists the templates
+ * available to this project. When there are no templates it degrades to a plain
+ * button that creates a blank document directly.
+ */
+export function NewDocumentMenu({
+  className,
+  onCreate,
+  orgSlug,
+  projectTypeSlugs,
+}: Props) {
+  const {
+    data: templates = [],
+    error,
+    isLoading,
+  } = useQuery<DocumentTemplate[]>({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => listDocumentTemplates(orgSlug, signal),
+    queryKey: ['documentTemplates', orgSlug],
+  })
+
+  const visibleTemplates = filterTemplatesByProjectType(
+    templates,
+    projectTypeSlugs,
+  )
+
+  // Nothing to choose between — keep the fast path as a plain button.
+  if (!isLoading && !error && visibleTemplates.length === 0) {
+    return (
+      <Button
+        className={cn('gap-1.5', className)}
+        onClick={() => onCreate()}
+        size="sm"
+      >
+        <Plus className="size-3" />
+        New document
+      </Button>
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className={cn('group gap-1.5', className)} size="sm">
+          <Plus className="size-3" />
+          New document
+          <ChevronDown className="size-3 transition-transform duration-150 group-data-[state=open]:rotate-180" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80 p-1.5">
+        <BlankDocumentItem onSelect={() => onCreate()} />
+        <TemplateMenuList onSelect={onCreate} templates={visibleTemplates} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function BlankDocumentItem({ onSelect }: { onSelect: () => void }) {
+  return (
+    <DropdownMenuItem className={ITEM_CLASS} onSelect={onSelect}>
+      <FilePlus2 className="text-secondary size-4 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="text-primary text-[13.5px] font-medium">
+          Blank document
+        </div>
+        <div className="text-tertiary text-xs">Start from an empty editor</div>
+      </div>
+    </DropdownMenuItem>
+  )
+}
+
+function TemplateIcon({ icon }: { icon?: null | string }) {
+  if (icon) return <EntityIcon className="size-4" icon={icon} />
+  return <StickyNote className="size-4" />
+}
+
+function TemplateMenuItem({
+  onSelect,
+  template,
+}: {
+  onSelect: (template: DocumentTemplate) => void
+  template: DocumentTemplate
+}) {
+  return (
+    <DropdownMenuItem
+      className={ITEM_CLASS}
+      onSelect={() => onSelect(template)}
+    >
+      <span className="text-secondary inline-flex size-4 shrink-0 items-center justify-center">
+        <TemplateIcon icon={template.icon} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-primary text-[13.5px] font-medium">
+          {template.name}
+        </div>
+        {template.description && (
+          <div className="text-tertiary truncate text-xs">
+            {template.description}
+          </div>
+        )}
+      </div>
+      {!!template.tags?.length && (
+        <DocumentTagChip size="sm" tag={template.tags[0]} />
+      )}
+    </DropdownMenuItem>
+  )
+}
+
+function TemplateMenuList({
+  onSelect,
+  templates,
+}: {
+  onSelect: (template: DocumentTemplate) => void
+  templates: DocumentTemplate[]
+}) {
+  if (templates.length === 0) return null
+  return (
+    <>
+      <DropdownMenuSeparator className="bg-tertiary mx-2" />
+      <DropdownMenuLabel className="text-overline text-tertiary px-2.5 pt-1 pb-1.5 uppercase">
+        From a template
+      </DropdownMenuLabel>
+      {templates.map((t) => (
+        <TemplateMenuItem key={t.id} onSelect={onSelect} template={t} />
+      ))}
+    </>
+  )
+}

--- a/src/components/documents/ProjectDocumentsTab.tsx
+++ b/src/components/documents/ProjectDocumentsTab.tsx
@@ -335,6 +335,8 @@ export function ProjectDocumentsTab({
       onCreate={handleCreate}
       onOpen={(id) => navigateToView({ documentId: id, kind: 'reading' })}
       onTogglePin={togglePin}
+      orgSlug={orgSlug}
+      projectTypeSlugs={projectTypeSlugs}
     />
   )
 }

--- a/src/components/documents/documentsHelpers.ts
+++ b/src/components/documents/documentsHelpers.ts
@@ -1,5 +1,5 @@
 import { LABEL_SWATCHES } from '@/lib/chip-colors'
-import type { Document, TagRef } from '@/types'
+import type { Document, DocumentTemplate, TagRef } from '@/types'
 
 /**
  * Deterministic color for a tag slug. Stable hash keeps each tag on the same
@@ -110,6 +110,25 @@ function truncate(s: string, max: number): string {
 }
 
 export const EMPTY_ACTIVE: ReadonlySet<string> = new Set()
+
+/**
+ * Templates with no project-type restriction apply everywhere; otherwise a
+ * template is only offered when it targets one of this project's types.
+ */
+export function filterTemplatesByProjectType(
+  templates: DocumentTemplate[],
+  projectTypeSlugs?: string[],
+): DocumentTemplate[] {
+  const set =
+    projectTypeSlugs && projectTypeSlugs.length
+      ? new Set(projectTypeSlugs)
+      : undefined
+  return templates.filter((t) => {
+    if (!t.project_type_slugs || t.project_type_slugs.length === 0) return true
+    if (!set) return false
+    return t.project_type_slugs.some((s) => set.has(s))
+  })
+}
 
 export function tagCounts(documents: Document[]): Record<string, number> {
   const counts: Record<string, number> = {}


### PR DESCRIPTION
## Summary

On the populated **Documents** tab, the "New document" button created a blank document with no way to pick a template — only the empty state offered them. This makes the button a dropdown menu (Approach B from the [design handoff](https://api.anthropic.com/v1/design/h/CfODEr2mhXNOPCJn6jdmCg)): **Blank document** keeps today's one-click default, followed by the templates available to this project, each with its icon, one-line description, and tag chip.

## Problem

Templates were only reachable from the empty state. Once a project had at least one document, there was no path to create a document from a template.

## Solution

- **`NewDocumentMenu`** — a dropdown built on the existing Radix `DropdownMenu`, so outside-click, Escape, and arrow-key navigation come for free. It fetches templates with the same query the empty state uses, filters them to the project's types, and **degrades to a plain one-click button when there are no templates** (preserving the fast blank-doc path).
- Extracted **`filterTemplatesByProjectType`** into `documentsHelpers` and reused it in the empty state (the predicate was inline there).
- Threaded `orgSlug` / `projectTypeSlugs` through `DocumentsPinboard` so the menu can fetch and filter; widened `onCreate` to accept an optional template. `ProjectDocumentsTab.handleCreate` already routed an optional template into the create view, so selection flows end-to-end.

## Verification

- `tsc --noEmit`, `oxfmt --check`, and the `fallow` complexity gate all pass; no new lint errors.
- Verified visually in Chrome against the real `DocumentsPinboard` (seeded query cache, no backend): the menu opens with **Blank document**, a divider, a **FROM A TEMPLATE** group, and the three templates with their Lucide icons, truncated descriptions, and color-coded tag chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)