### PR TITLE
Add document discussion comments (Phase 1)

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -110,6 +110,12 @@ import type {
   Webhook,
   WebhookCreate,
 } from '@/types'
+import type {
+  AddReplyBody,
+  Comment,
+  CommentThread,
+  CreateThreadBody,
+} from '@/types/comments'
 
 import { apiClient, apiUrl } from './client'
 
@@ -1525,6 +1531,101 @@ export const deleteProjectDocument = (
 ) =>
   apiClient.delete<void>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}`,
+  )
+
+// Document comments. Hand-written like the document endpoints above; the
+// comments API is not yet in the committed openapi snapshot. Base path:
+// /organizations/{orgSlug}/projects/{projectId}/documents/{documentId}/comments
+const documentCommentsPath = (
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+) =>
+  `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}/comments`
+
+export const listDocumentComments = async (
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+  signal?: AbortSignal,
+): Promise<CommentThread[]> => {
+  const response = await apiClient.get<{ data: CommentThread[] }>(
+    documentCommentsPath(orgSlug, projectId, documentId),
+    undefined,
+    signal,
+  )
+  return response?.data ?? []
+}
+
+export const createCommentThread = (
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+  body: CreateThreadBody,
+) =>
+  apiClient.post<CommentThread>(
+    documentCommentsPath(orgSlug, projectId, documentId),
+    body,
+  )
+
+export const addCommentReply = (
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+  threadId: string,
+  body: AddReplyBody,
+) =>
+  apiClient.post<Comment>(
+    `${documentCommentsPath(orgSlug, projectId, documentId)}/${encodeURIComponent(threadId)}/comments`,
+    body,
+  )
+
+export const resolveCommentThread = (
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+  threadId: string,
+  resolved: boolean,
+) =>
+  apiClient.patch<CommentThread>(
+    `${documentCommentsPath(orgSlug, projectId, documentId)}/${encodeURIComponent(threadId)}`,
+    [{ op: 'replace', path: '/resolved', value: resolved }],
+  )
+
+export const editComment = (
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+  threadId: string,
+  commentId: string,
+  body: string,
+) =>
+  apiClient.patch<Comment>(
+    `${documentCommentsPath(orgSlug, projectId, documentId)}/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(commentId)}`,
+    [{ op: 'replace', path: '/body', value: body }],
+  )
+
+export const acknowledgeComment = (
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+  threadId: string,
+  commentId: string,
+) =>
+  apiClient.post<Comment>(
+    `${documentCommentsPath(orgSlug, projectId, documentId)}/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(commentId)}/acknowledge`,
+    undefined,
+  )
+
+export const deleteComment = (
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+  threadId: string,
+  commentId: string,
+) =>
+  apiClient.delete<void>(
+    `${documentCommentsPath(orgSlug, projectId, documentId)}/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(commentId)}`,
   )
 
 // Tags (org-scoped)

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1614,7 +1614,7 @@ export const acknowledgeComment = (
 ) =>
   apiClient.post<Comment>(
     `${documentCommentsPath(orgSlug, projectId, documentId)}/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(commentId)}/acknowledge`,
-    undefined,
+    {},
   )
 
 export const deleteComment = (

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -1,16 +1,35 @@
 import { useEffect, useMemo, useState } from 'react'
 
-import { ArrowLeft, Clock, Pencil, Pin, PinOff, Trash2 } from 'lucide-react'
+import {
+  ArrowLeft,
+  CheckCircle2,
+  CircleDot,
+  Clock,
+  Eye,
+  EyeOff,
+  List,
+  Pencil,
+  Pin,
+  PinOff,
+  Trash2,
+} from 'lucide-react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
 import { IconTooltip } from '@/components/ui/tooltip'
 import { UserDisplay } from '@/components/ui/user-display'
 import { cn } from '@/lib/utils'
 import type { Document } from '@/types'
+import type { CommentThread } from '@/types/comments'
 
+import { BottomDiscussion } from './comments/BottomDiscussion'
+import type { CommentFilter } from './comments/BottomDiscussion'
 import { DocumentsFilterRail } from './DocumentsFilterRail'
 import {
   documentTitle,
@@ -30,28 +49,53 @@ interface Heading {
 
 interface Props {
   allDocuments: Document[]
+  comments: CommentThread[]
+  commentsBusy?: boolean
+  currentUserEmail: string
   deleting?: boolean
   displayNames?: Map<string, string>
   document: Document
+  onAcknowledgeComment: (threadId: string, commentId: string) => void
   onBack: () => void
+  onCreateThread: (body: string) => void
   onDelete?: () => void
+  onDeleteComment: (threadId: string, commentId: string) => void
   onEdit?: () => void
+  onEditComment: (threadId: string, commentId: string, body: string) => void
   onOpen: (documentId: string) => void
+  onReplyComment: (threadId: string, body: string) => void
+  onResolveThread: (threadId: string, resolved: boolean) => void
   onTogglePin: () => void
 }
 
 export function DocumentsPinboardReader({
   allDocuments,
+  comments,
+  commentsBusy = false,
+  currentUserEmail,
   deleting = false,
   displayNames,
   document,
+  onAcknowledgeComment,
   onBack,
+  onCreateThread,
   onDelete,
+  onDeleteComment,
   onEdit,
+  onEditComment,
   onOpen,
+  onReplyComment,
+  onResolveThread,
   onTogglePin,
 }: Props) {
   const [search, setSearch] = useState('')
+  const [commentFilter, setCommentFilter] = useState<CommentFilter>('open')
+  const [showComments, setShowComments] = useState(true)
+
+  const commentCounts = useMemo(() => {
+    const open = comments.filter((t) => !t.resolved).length
+    return { all: comments.length, open, resolved: comments.length - open }
+  }, [comments])
   const [confirmDelete, setConfirmDelete] = useState(false)
   const pinned = document.is_pinned
   const title = documentTitle(document)
@@ -106,6 +150,60 @@ export function DocumentsPinboardReader({
               All documents
             </Button>
             <div className="ml-auto flex items-center gap-1">
+              {showComments && (
+                <SegmentedControl
+                  ariaLabel="Comment filter"
+                  className="mr-1"
+                  onValueChange={(v) => setCommentFilter(v as CommentFilter)}
+                  value={commentFilter}
+                >
+                  <SegmentedControlItem value="open">
+                    <CircleDot className="size-3" />
+                    Open
+                    <span className="text-tertiary tabular-nums">
+                      {commentCounts.open}
+                    </span>
+                  </SegmentedControlItem>
+                  <SegmentedControlItem value="resolved">
+                    <CheckCircle2 className="size-3" />
+                    Resolved
+                    <span className="text-tertiary tabular-nums">
+                      {commentCounts.resolved}
+                    </span>
+                  </SegmentedControlItem>
+                  <SegmentedControlItem value="all">
+                    <List className="size-3" />
+                    All
+                    <span className="text-tertiary tabular-nums">
+                      {commentCounts.all}
+                    </span>
+                  </SegmentedControlItem>
+                </SegmentedControl>
+              )}
+              <Button
+                className="gap-1.5"
+                onClick={() => setShowComments((v) => !v)}
+                size="sm"
+                variant="ghost"
+              >
+                {showComments ? (
+                  <>
+                    <EyeOff className="size-3" />
+                    Hide comments
+                  </>
+                ) : (
+                  <>
+                    <Eye className="size-3" />
+                    Show comments
+                    {commentCounts.all > 0 && (
+                      <span className="text-tertiary tabular-nums">
+                        {commentCounts.all}
+                      </span>
+                    )}
+                  </>
+                )}
+              </Button>
+              <span className="bg-tertiary mx-1 h-5 w-px" />
               <Button
                 className="gap-1.5"
                 onClick={onTogglePin}
@@ -282,6 +380,24 @@ export function DocumentsPinboardReader({
             )}
           </div>
         </div>
+
+        {showComments && (
+          <div className="grid grid-cols-[minmax(0,1fr)_260px] gap-5">
+            <BottomDiscussion
+              busy={commentsBusy}
+              currentUserEmail={currentUserEmail}
+              displayNames={displayNames}
+              filter={commentFilter}
+              onAcknowledge={onAcknowledgeComment}
+              onCreateThread={onCreateThread}
+              onDelete={onDeleteComment}
+              onEdit={onEditComment}
+              onReply={onReplyComment}
+              onResolve={onResolveThread}
+              threads={comments}
+            />
+          </div>
+        )}
       </div>
       <ConfirmDialog
         confirmLabel={deleting ? 'Deleting…' : 'Delete'}

--- a/src/components/documents/ProjectDocumentsTab.tsx
+++ b/src/components/documents/ProjectDocumentsTab.tsx
@@ -13,6 +13,8 @@ import {
 } from '@/api/endpoints'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { LoadingState } from '@/components/ui/loading-state'
+import { useAuth } from '@/hooks/useAuth'
+import { useDocumentComments } from '@/hooks/useDocumentComments'
 import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import type { Document, DocumentTemplate } from '@/types'
@@ -99,6 +101,8 @@ export function ProjectDocumentsTab({
   })
 
   const { displayNames, isError: usersError } = useUserDisplayNames()
+  const { user } = useAuth()
+  const currentUserEmail = user?.email ?? ''
 
   useEffect(() => {
     if (usersError) {
@@ -222,6 +226,13 @@ export function ProjectDocumentsTab({
     [documents, view],
   )
 
+  const comments = useDocumentComments(
+    orgSlug,
+    projectId,
+    selectedDocument?.id ?? '',
+    currentUserEmail,
+  )
+
   const editingDocument = useMemo(
     () =>
       view.kind === 'editing'
@@ -304,15 +315,24 @@ export function ProjectDocumentsTab({
     return (
       <DocumentsPinboardReader
         allDocuments={documents}
+        comments={comments.comments}
+        commentsBusy={comments.commentsBusy}
+        currentUserEmail={currentUserEmail}
         deleting={deleteMutation.isPending}
         displayNames={displayNames}
         document={selectedDocument}
+        onAcknowledgeComment={comments.onAcknowledge}
         onBack={() => navigateToView({ kind: 'list' })}
+        onCreateThread={comments.onCreateThread}
         onDelete={() => deleteMutation.mutate(selectedDocument.id)}
+        onDeleteComment={comments.onDelete}
         onEdit={() =>
           navigateToView({ documentId: selectedDocument.id, kind: 'editing' })
         }
+        onEditComment={comments.onEdit}
         onOpen={(id) => navigateToView({ documentId: id, kind: 'reading' })}
+        onReplyComment={comments.onReply}
+        onResolveThread={comments.onResolve}
         onTogglePin={() => togglePin(selectedDocument)}
       />
     )

--- a/src/components/documents/comments/BottomDiscussion.tsx
+++ b/src/components/documents/comments/BottomDiscussion.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react'
+
+import { MessagesSquare } from 'lucide-react'
+
+import type { CommentThread, CommentThreadHandlers } from '@/types/comments'
+
+import { CommentComposer } from './CommentComposer'
+import { CommentThreadView } from './CommentThreadView'
+
+export type CommentFilter = 'all' | 'open' | 'resolved'
+
+interface Props extends CommentThreadHandlers {
+  busy?: boolean
+  currentUserEmail: string
+  displayNames?: Map<string, string>
+  filter: CommentFilter
+  threads: CommentThread[]
+}
+
+export function BottomDiscussion({
+  busy = false,
+  currentUserEmail,
+  displayNames,
+  filter,
+  onAcknowledge,
+  onCreateThread,
+  onDelete,
+  onEdit,
+  onReply,
+  onResolve,
+  threads,
+}: Props) {
+  const visible = useMemo(
+    () =>
+      threads.filter((t) =>
+        filter === 'all' ? true : filter === 'open' ? !t.resolved : t.resolved,
+      ),
+    [threads, filter],
+  )
+
+  return (
+    <section className="mt-8 flex flex-col gap-4">
+      <h2 className="text-primary m-0 flex items-center gap-2 text-[16px] font-medium">
+        <MessagesSquare className="text-secondary size-[18px]" />
+        Discussion
+        <span className="bg-secondary text-tertiary rounded px-1.5 text-[12px] tabular-nums">
+          {threads.length}
+        </span>
+      </h2>
+
+      <CommentComposer
+        busy={busy}
+        onSubmit={onCreateThread}
+        placeholder="Add a comment to the discussion…"
+        submitLabel="Comment"
+      />
+
+      {visible.length === 0 ? (
+        <div className="text-tertiary py-7 text-center text-[13.5px]">
+          No comments in this view.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {visible.map((thread) => (
+            <CommentThreadView
+              busy={busy}
+              currentUserEmail={currentUserEmail}
+              displayNames={displayNames}
+              key={thread.id}
+              onAcknowledge={(commentId) => onAcknowledge(thread.id, commentId)}
+              onDelete={(commentId) => onDelete(thread.id, commentId)}
+              onEdit={(commentId, body) => onEdit(thread.id, commentId, body)}
+              onReply={(body) => onReply(thread.id, body)}
+              onResolve={(resolved) => onResolve(thread.id, resolved)}
+              thread={thread}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/documents/comments/CommentComposer.tsx
+++ b/src/components/documents/comments/CommentComposer.tsx
@@ -1,0 +1,115 @@
+import type { KeyboardEvent } from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+interface Props {
+  autoFocus?: boolean
+  busy?: boolean
+  initial?: string
+  onCancel?: () => void
+  onSubmit: (body: string) => void
+  placeholder?: string
+  submitLabel?: string
+}
+
+const MAX_HEIGHT = 220
+
+/**
+ * Plain-text comment composer. Cmd/Ctrl-Enter submits, Escape cancels (when a
+ * cancel handler is supplied), and the textarea auto-grows up to a max height.
+ * No @mention autocomplete in Phase 1 — that lands in Phase 3.
+ */
+export function CommentComposer({
+  autoFocus = false,
+  busy = false,
+  initial = '',
+  onCancel,
+  onSubmit,
+  placeholder = 'Add a comment…',
+  submitLabel = 'Comment',
+}: Props) {
+  const [text, setText] = useState(initial)
+  const ref = useRef<HTMLTextAreaElement>(null)
+
+  const grow = (el: HTMLTextAreaElement) => {
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT)}px`
+  }
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    grow(el)
+    if (autoFocus) {
+      el.focus()
+      el.setSelectionRange(el.value.length, el.value.length)
+    }
+  }, [autoFocus])
+
+  const submit = () => {
+    const trimmed = text.trim()
+    if (!trimmed || busy) return
+    onSubmit(trimmed)
+    setText('')
+    if (ref.current) ref.current.style.height = 'auto'
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    const action = keyAction(e)
+    if (!action) return
+    e.preventDefault()
+    if (action === 'submit') submit()
+    else onCancel?.()
+  }
+
+  const empty = !text.trim()
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Textarea
+        className="min-h-9 resize-none text-[13.5px]"
+        onChange={(e) => {
+          setText(e.target.value)
+          grow(e.target)
+        }}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        ref={ref}
+        rows={1}
+        value={text}
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-tertiary text-[11px]">
+          {empty ? '' : 'Cmd + Enter to send'}
+        </span>
+        <div className="flex items-center gap-2">
+          {onCancel && (
+            <Button onClick={onCancel} size="sm" type="button" variant="ghost">
+              Cancel
+            </Button>
+          )}
+          <Button
+            disabled={empty || busy}
+            onClick={submit}
+            size="sm"
+            type="button"
+          >
+            {submitLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Map a keydown to a composer action: Cmd/Ctrl-Enter submits, Escape cancels. */
+// fallow-ignore-next-line complexity
+function keyAction(
+  e: KeyboardEvent<HTMLTextAreaElement>,
+): 'cancel' | 'submit' | null {
+  if (e.key === 'Escape') return 'cancel'
+  const submitChord = e.key === 'Enter' && (e.metaKey || e.ctrlKey)
+  return submitChord ? 'submit' : null
+}

--- a/src/components/documents/comments/CommentItem.tsx
+++ b/src/components/documents/comments/CommentItem.tsx
@@ -1,0 +1,190 @@
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+
+import { formatDistanceToNow } from 'date-fns'
+import { Pencil, Reply, ThumbsUp, Trash2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { UserDisplay } from '@/components/ui/user-display'
+import { cn } from '@/lib/utils'
+import type { Comment } from '@/types/comments'
+
+import { CommentComposer } from './CommentComposer'
+
+interface ActionsProps {
+  ackCount: number
+  acknowledged: boolean
+  mine: boolean
+  onAcknowledge: () => void
+  onDelete: () => void
+  onEdit: () => void
+  onReply?: () => void
+}
+
+interface Props {
+  busy?: boolean
+  comment: Comment
+  currentUserEmail: string
+  displayNames?: Map<string, string>
+  onAcknowledge: () => void
+  onDelete: () => void
+  onEdit: (body: string) => void
+  onReply?: () => void
+}
+
+export function CommentItem({
+  busy = false,
+  comment,
+  currentUserEmail,
+  displayNames,
+  onAcknowledge,
+  onDelete,
+  onEdit,
+  onReply,
+}: Props) {
+  const [editing, setEditing] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const mine = comment.author === currentUserEmail
+  const acknowledged = comment.acknowledged_by.includes(currentUserEmail)
+  const ackCount = comment.acknowledged_by.length
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <UserDisplay
+          className="text-secondary"
+          displayNames={displayNames}
+          email={comment.author}
+          size={22}
+          textClassName="text-[12.5px] font-medium text-primary"
+        />
+        <span className="text-tertiary text-[11.5px]">
+          {formatDistanceToNow(new Date(comment.created_at), {
+            addSuffix: true,
+          })}
+          {comment.edited && ' · edited'}
+        </span>
+      </div>
+
+      {editing ? (
+        <CommentComposer
+          autoFocus
+          busy={busy}
+          initial={comment.body}
+          onCancel={() => setEditing(false)}
+          onSubmit={(body) => {
+            onEdit(body)
+            setEditing(false)
+          }}
+          submitLabel="Save"
+        />
+      ) : (
+        <>
+          <div className="text-primary text-[13.5px] leading-normal whitespace-pre-wrap">
+            {comment.body}
+          </div>
+          <CommentActions
+            ackCount={ackCount}
+            acknowledged={acknowledged}
+            mine={mine}
+            onAcknowledge={onAcknowledge}
+            onDelete={() => setConfirmDelete(true)}
+            onEdit={() => setEditing(true)}
+            onReply={onReply}
+          />
+        </>
+      )}
+
+      <ConfirmDialog
+        confirmLabel="Delete"
+        description="This comment will be permanently removed."
+        onCancel={() => setConfirmDelete(false)}
+        onConfirm={() => {
+          setConfirmDelete(false)
+          onDelete()
+        }}
+        open={confirmDelete}
+        title="Delete comment?"
+      />
+    </div>
+  )
+}
+
+function ActionButton({
+  className,
+  icon,
+  label,
+  onClick,
+}: {
+  className?: string
+  icon: ReactNode
+  label: number | string
+  onClick: () => void
+}) {
+  return (
+    <Button
+      className={cn('h-7 gap-1 px-2 text-[12px]', className)}
+      onClick={onClick}
+      size="sm"
+      variant="ghost"
+    >
+      {icon}
+      {label}
+    </Button>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function CommentActions({
+  ackCount,
+  acknowledged,
+  mine,
+  onAcknowledge,
+  onDelete,
+  onEdit,
+  onReply,
+}: ActionsProps) {
+  return (
+    <div className="text-tertiary flex flex-wrap items-center gap-1">
+      <ActionButton
+        className={cn(acknowledged && 'text-action')}
+        icon={<ThumbsUp className="size-3" />}
+        label={ackCount > 0 ? ackCount : ''}
+        onClick={onAcknowledge}
+      />
+      {onReply && (
+        <ActionButton
+          icon={<Reply className="size-3" />}
+          label="Reply"
+          onClick={onReply}
+        />
+      )}
+      {mine && <OwnerActions onDelete={onDelete} onEdit={onEdit} />}
+    </div>
+  )
+}
+
+function OwnerActions({
+  onDelete,
+  onEdit,
+}: {
+  onDelete: () => void
+  onEdit: () => void
+}) {
+  return (
+    <>
+      <ActionButton
+        icon={<Pencil className="size-3" />}
+        label="Edit"
+        onClick={onEdit}
+      />
+      <ActionButton
+        className="text-destructive"
+        icon={<Trash2 className="size-3" />}
+        label="Delete"
+        onClick={onDelete}
+      />
+    </>
+  )
+}

--- a/src/components/documents/comments/CommentItem.tsx
+++ b/src/components/documents/comments/CommentItem.tsx
@@ -112,11 +112,13 @@ export function CommentItem({
 }
 
 function ActionButton({
+  ariaLabel,
   className,
   icon,
   label,
   onClick,
 }: {
+  ariaLabel?: string
   className?: string
   icon: ReactNode
   label: number | string
@@ -124,6 +126,7 @@ function ActionButton({
 }) {
   return (
     <Button
+      aria-label={ariaLabel}
       className={cn('h-7 gap-1 px-2 text-[12px]', className)}
       onClick={onClick}
       size="sm"
@@ -148,6 +151,7 @@ function CommentActions({
   return (
     <div className="text-tertiary flex flex-wrap items-center gap-1">
       <ActionButton
+        ariaLabel={acknowledged ? 'Remove acknowledgement' : 'Acknowledge'}
         className={cn(acknowledged && 'text-action')}
         icon={<ThumbsUp className="size-3" />}
         label={ackCount > 0 ? ackCount : ''}

--- a/src/components/documents/comments/CommentThreadView.tsx
+++ b/src/components/documents/comments/CommentThreadView.tsx
@@ -1,0 +1,150 @@
+import { Check, RotateCcw } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { UserDisplay } from '@/components/ui/user-display'
+import type { CommentThread } from '@/types/comments'
+
+import { CommentComposer } from './CommentComposer'
+import { CommentItem } from './CommentItem'
+
+interface Props {
+  busy?: boolean
+  currentUserEmail: string
+  displayNames?: Map<string, string>
+  onAcknowledge: (commentId: string) => void
+  onDelete: (commentId: string) => void
+  onEdit: (commentId: string, body: string) => void
+  onReply: (body: string) => void
+  onResolve: (resolved: boolean) => void
+  thread: CommentThread
+}
+
+interface ResolveBarProps {
+  busy: boolean
+  displayNames?: Map<string, string>
+  onResolve: (resolved: boolean) => void
+  resolved: boolean
+  resolvedBy: null | string
+}
+
+export function CommentThreadView({
+  busy = false,
+  currentUserEmail,
+  displayNames,
+  onAcknowledge,
+  onDelete,
+  onEdit,
+  onReply,
+  onResolve,
+  thread,
+}: Props) {
+  const root = thread.comments[0]
+  const replies = thread.comments.slice(1)
+  if (!root) return null
+
+  return (
+    <div className="border-tertiary bg-primary flex flex-col gap-3 rounded-lg border p-4">
+      <ResolveBar
+        busy={busy}
+        displayNames={displayNames}
+        onResolve={onResolve}
+        resolved={thread.resolved}
+        resolvedBy={thread.resolved_by}
+      />
+
+      <CommentItem
+        busy={busy}
+        comment={root}
+        currentUserEmail={currentUserEmail}
+        displayNames={displayNames}
+        onAcknowledge={() => onAcknowledge(root.id)}
+        onDelete={() => onDelete(root.id)}
+        onEdit={(body) => onEdit(root.id, body)}
+      />
+
+      {replies.length > 0 && (
+        <div className="border-tertiary flex flex-col gap-3 border-l pl-4">
+          {replies.map((reply) => (
+            <CommentItem
+              busy={busy}
+              comment={reply}
+              currentUserEmail={currentUserEmail}
+              displayNames={displayNames}
+              key={reply.id}
+              onAcknowledge={() => onAcknowledge(reply.id)}
+              onDelete={() => onDelete(reply.id)}
+              onEdit={(body) => onEdit(reply.id, body)}
+            />
+          ))}
+        </div>
+      )}
+
+      {!thread.resolved && (
+        <CommentComposer
+          busy={busy}
+          onSubmit={onReply}
+          placeholder="Reply…"
+          submitLabel="Reply"
+        />
+      )}
+    </div>
+  )
+}
+
+function ResolveBar({
+  busy,
+  displayNames,
+  onResolve,
+  resolved,
+  resolvedBy,
+}: ResolveBarProps) {
+  if (!resolved) {
+    return (
+      <div className="flex justify-end">
+        <Button
+          className="h-7 gap-1 px-2 text-[12px]"
+          disabled={busy}
+          onClick={() => onResolve(true)}
+          size="sm"
+          variant="ghost"
+        >
+          <Check className="size-3" />
+          Resolve
+        </Button>
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-tertiary inline-flex items-center gap-1.5 text-[12px]">
+        <Check className="text-action size-3.5" />
+        Resolved
+        {resolvedBy && (
+          <>
+            {' by '}
+            <UserDisplay
+              className="text-secondary"
+              displayNames={displayNames}
+              email={resolvedBy}
+              hideName
+              size={16}
+            />
+            <span className="text-secondary">
+              {displayNames?.get(resolvedBy) ?? resolvedBy.split('@')[0]}
+            </span>
+          </>
+        )}
+      </span>
+      <Button
+        className="h-7 gap-1 px-2 text-[12px]"
+        disabled={busy}
+        onClick={() => onResolve(false)}
+        size="sm"
+        variant="ghost"
+      >
+        <RotateCcw className="size-3" />
+        Reopen
+      </Button>
+    </div>
+  )
+}

--- a/src/hooks/useDocumentComments.ts
+++ b/src/hooks/useDocumentComments.ts
@@ -1,0 +1,274 @@
+import { useCallback, useMemo } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import {
+  acknowledgeComment,
+  addCommentReply,
+  createCommentThread,
+  deleteComment,
+  editComment,
+  listDocumentComments,
+  resolveCommentThread,
+} from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type {
+  Comment,
+  CommentThread,
+  CommentThreadHandlers,
+} from '@/types/comments'
+
+interface CommentVars {
+  commentId: string
+  threadId: string
+}
+
+interface EditVars extends CommentVars {
+  body: string
+}
+
+interface ReplyVars {
+  body: string
+  threadId: string
+}
+
+interface Result extends CommentThreadHandlers {
+  comments: CommentThread[]
+  commentsBusy: boolean
+}
+
+interface ThreadVars {
+  resolved: boolean
+  threadId: string
+}
+
+/**
+ * Owns the page-level comment thread query and its optimistic mutations for a
+ * single document. The query stays disabled until a documentId is supplied
+ * (i.e. while a document is being read), mirroring the document data flow in
+ * ProjectDocumentsTab. Optimistic updates are modeled on its `pinMutation`.
+ */
+export function useDocumentComments(
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+  currentUserEmail: string,
+): Result {
+  const qc = useQueryClient()
+  const commentsKey = useMemo(
+    () => ['documentComments', orgSlug, projectId, documentId] as const,
+    [orgSlug, projectId, documentId],
+  )
+
+  const { data: comments = [], isFetching: commentsBusy } = useQuery({
+    enabled: !!orgSlug && !!projectId && !!documentId,
+    queryFn: ({ signal }) =>
+      listDocumentComments(orgSlug, projectId, documentId, signal),
+    queryKey: commentsKey,
+  })
+
+  // Apply a transform to the cached threads array and snapshot it for rollback.
+  const optimistic = useCallback(
+    async (update: (prev: CommentThread[]) => CommentThread[]) => {
+      await qc.cancelQueries({ queryKey: commentsKey })
+      const previous = qc.getQueryData<CommentThread[]>(commentsKey)
+      if (previous)
+        qc.setQueryData<CommentThread[]>(commentsKey, update(previous))
+      return { previous }
+    },
+    [qc, commentsKey],
+  )
+
+  const rollback = useCallback(
+    (ctx: undefined | { previous?: CommentThread[] }) => {
+      if (ctx?.previous) qc.setQueryData(commentsKey, ctx.previous)
+    },
+    [qc, commentsKey],
+  )
+
+  const settle = useCallback(() => {
+    qc.invalidateQueries({ queryKey: commentsKey })
+  }, [qc, commentsKey])
+
+  const fail = useCallback(
+    (label: string) => (err: unknown) => {
+      toast.error(`${label}: ${extractApiErrorDetail(err)}`)
+    },
+    [],
+  )
+
+  const createThreadMutation = useMutation({
+    mutationFn: (body: string) =>
+      createCommentThread(orgSlug, projectId, documentId, {
+        body,
+        kind: 'page',
+      }),
+    onError: fail('Comment failed'),
+    onSettled: settle,
+    onSuccess: (thread) => {
+      qc.setQueryData<CommentThread[]>(commentsKey, (prev) =>
+        prev ? [...prev, thread] : [thread],
+      )
+    },
+  })
+
+  const replyMutation = useMutation<Comment, unknown, ReplyVars>({
+    mutationFn: ({ body, threadId }) =>
+      addCommentReply(orgSlug, projectId, documentId, threadId, { body }),
+    onError: fail('Reply failed'),
+    onSettled: settle,
+    onSuccess: (comment, { threadId }) => {
+      qc.setQueryData<CommentThread[]>(commentsKey, (prev) =>
+        prev?.map((t) =>
+          t.id === threadId ? { ...t, comments: [...t.comments, comment] } : t,
+        ),
+      )
+    },
+  })
+
+  const resolveMutation = useMutation<
+    CommentThread,
+    unknown,
+    ThreadVars,
+    { previous?: CommentThread[] }
+  >({
+    mutationFn: ({ resolved, threadId }) =>
+      resolveCommentThread(orgSlug, projectId, documentId, threadId, resolved),
+    onError: (err, _vars, ctx) => {
+      rollback(ctx)
+      fail('Update failed')(err)
+    },
+    onMutate: ({ resolved, threadId }) =>
+      optimistic((prev) =>
+        prev.map((t) =>
+          t.id === threadId
+            ? {
+                ...t,
+                resolved,
+                resolved_at: resolved ? new Date().toISOString() : null,
+                resolved_by: resolved ? currentUserEmail : null,
+              }
+            : t,
+        ),
+      ),
+    onSettled: settle,
+  })
+
+  const acknowledgeMutation = useMutation<
+    Comment,
+    unknown,
+    CommentVars,
+    { previous?: CommentThread[] }
+  >({
+    mutationFn: ({ commentId, threadId }) =>
+      acknowledgeComment(orgSlug, projectId, documentId, threadId, commentId),
+    onError: (err, _vars, ctx) => {
+      rollback(ctx)
+      fail('Acknowledge failed')(err)
+    },
+    onMutate: ({ commentId, threadId }) =>
+      optimistic((prev) =>
+        mapComment(prev, threadId, commentId, (c) => ({
+          ...c,
+          acknowledged_by: c.acknowledged_by.includes(currentUserEmail)
+            ? c.acknowledged_by.filter((e) => e !== currentUserEmail)
+            : [...c.acknowledged_by, currentUserEmail],
+        })),
+      ),
+    onSettled: settle,
+  })
+
+  const editMutation = useMutation<
+    Comment,
+    unknown,
+    EditVars,
+    { previous?: CommentThread[] }
+  >({
+    mutationFn: ({ body, commentId, threadId }) =>
+      editComment(orgSlug, projectId, documentId, threadId, commentId, body),
+    onError: (err, _vars, ctx) => {
+      rollback(ctx)
+      fail('Edit failed')(err)
+    },
+    onMutate: ({ body, commentId, threadId }) =>
+      optimistic((prev) =>
+        mapComment(prev, threadId, commentId, (c) => ({
+          ...c,
+          body,
+          edited: true,
+        })),
+      ),
+    onSettled: settle,
+  })
+
+  const deleteCommentMutation = useMutation<
+    void,
+    unknown,
+    CommentVars,
+    { previous?: CommentThread[] }
+  >({
+    mutationFn: ({ commentId, threadId }) =>
+      deleteComment(orgSlug, projectId, documentId, threadId, commentId),
+    onError: (err, _vars, ctx) => {
+      rollback(ctx)
+      fail('Delete failed')(err)
+    },
+    onMutate: ({ commentId, threadId }) =>
+      optimistic((prev) => removeComment(prev, threadId, commentId)),
+    onSettled: settle,
+  })
+
+  return {
+    comments,
+    commentsBusy,
+    onAcknowledge: (threadId, commentId) =>
+      acknowledgeMutation.mutate({ commentId, threadId }),
+    onCreateThread: (body) => createThreadMutation.mutate(body),
+    onDelete: (threadId, commentId) =>
+      deleteCommentMutation.mutate({ commentId, threadId }),
+    onEdit: (threadId, commentId, body) =>
+      editMutation.mutate({ body, commentId, threadId }),
+    onReply: (threadId, body) => replyMutation.mutate({ body, threadId }),
+    onResolve: (threadId, resolved) =>
+      resolveMutation.mutate({ resolved, threadId }),
+  }
+}
+
+/** True when `commentId` is the root of a thread that has no replies. */
+function isLoneRoot(thread: CommentThread, commentId: string): boolean {
+  return thread.comments.length === 1 && thread.comments[0]?.id === commentId
+}
+
+/** Replace one comment within one thread, leaving everything else untouched. */
+function mapComment(
+  threads: CommentThread[],
+  threadId: string,
+  commentId: string,
+  update: (comment: Comment) => Comment,
+): CommentThread[] {
+  return threads.map((t) =>
+    t.id === threadId
+      ? {
+          ...t,
+          comments: t.comments.map((c) => (c.id === commentId ? update(c) : c)),
+        }
+      : t,
+  )
+}
+
+/**
+ * Remove one comment from a thread. Deleting the root of a reply-less thread
+ * removes the whole thread.
+ */
+function removeComment(
+  threads: CommentThread[],
+  threadId: string,
+  commentId: string,
+): CommentThread[] {
+  return threads.flatMap((t) => {
+    if (t.id !== threadId) return [t]
+    if (isLoneRoot(t, commentId)) return []
+    return [{ ...t, comments: t.comments.filter((c) => c.id !== commentId) }]
+  })
+}

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -1,0 +1,64 @@
+// Document comment types.
+//
+// Hand-written because the comments API is not yet in the committed openapi
+// snapshot (the same reason Document/Tag are inlined in `index.ts`). Once the
+// comments endpoints are deployed, re-run `npm run codegen:fetch` and migrate
+// these to the generated `Schemas[...]` equivalents.
+
+export interface AddReplyBody {
+  body: string
+  mentions?: string[]
+}
+
+export interface Comment {
+  acknowledged_by: string[]
+  /** Author email address. */
+  author: string
+  body: string
+  created_at: string
+  edited: boolean
+  id: string
+  mentions: string[]
+  thread_id: string
+  updated_at: null | string
+}
+
+export interface CommentAnchor {
+  prefix: string
+  quote: string
+  start: number
+  suffix: string
+}
+
+export interface CommentThread {
+  anchor: CommentAnchor | null
+  comments: Comment[] // oldest-first; [0] is the root comment
+  created_at: string
+  created_by: string
+  document_id: string
+  id: string
+  kind: 'inline' | 'page'
+  resolved: boolean
+  resolved_at: null | string
+  resolved_by: null | string
+  updated_at: null | string
+}
+
+/**
+ * Callbacks for mutating a document's comment threads, produced by
+ * `useDocumentComments` and consumed by the discussion UI.
+ */
+export interface CommentThreadHandlers {
+  onAcknowledge: (threadId: string, commentId: string) => void
+  onCreateThread: (body: string) => void
+  onDelete: (threadId: string, commentId: string) => void
+  onEdit: (threadId: string, commentId: string, body: string) => void
+  onReply: (threadId: string, body: string) => void
+  onResolve: (threadId: string, resolved: boolean) => void
+}
+
+export interface CreateThreadBody {
+  body: string
+  kind: 'page'
+  mentions?: string[]
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Document Comments feature (imbi-ui side): the bottom page-level threaded **Discussion** feed on a project Document. Consumes the imbi-api endpoints (AWeber-Imbi/imbi-api#415) and imbi-common models (AWeber-Imbi/imbi-common#144).

Recreates the visual output/behavior of the Claude Design handoff using the real stack's primitives (Tailwind v4 + `--ds-*`/`--color-*` tokens, `Button`/`Textarea`/`UserDisplay`/`ConfirmDialog`/`SegmentedControl`, lucide-react, date-fns) — **not** the prototype's CSS variables.

## What's here

- **`src/types/comments.ts`** — hand-written `Comment`, `CommentThread`, `CommentAnchor`, `CreateThreadBody`, `AddReplyBody`, shared `CommentThreadHandlers`. (Re-run `npm run codegen:fetch` once the API ships to swap to generated types.)
- **`src/hooks/useDocumentComments.ts`** — `['documentComments', orgSlug, projectId, documentId]` query + six optimistic mutations (create/reply/resolve/acknowledge/edit/delete) with rollback + `sonner` error toasts, modeled on the existing `pinMutation`.
- **`src/components/documents/comments/`** — `CommentComposer` (Textarea, Cmd/Ctrl-Enter, auto-grow), `CommentItem` (UserDisplay, relative time + "· edited", author-only edit/delete via `ConfirmDialog`, acknowledge/reply), `CommentThreadView` (root + indented replies, resolve/reopen bar, reply composer hidden when resolved), `BottomDiscussion` (heading + count, root composer, filtered list).
- **`src/api/endpoints.ts`** — 7 endpoint fns mirroring the document-endpoint style.
- **`ProjectDocumentsTab.tsx`** — current user via `useAuth()`, wires the hook + handlers into the reader.
- **`DocumentsPinboardReader.tsx`** — Open/Resolved/All `SegmentedControl` with counts + Show/Hide-comments toggle in the toolbar; `<BottomDiscussion>` below the article.

Comment body renders as plain text (`whitespace-pre-wrap`) in P1; `mentions` is plumbed but always empty until P3.

## Verification

- `npm run lint` → 0 errors on changed files (the 1952 warnings are the pre-existing repo-wide tailwind `enforce-sort-order` rule).
- `npm run format:check` → clean.
- `npm run build` (tsc + vite) → ✓ built.
- Pre-commit `fallow audit` quality gate → passed (0 introduced complexity/duplication findings). The first commit attempt failed this gate; rather than bypass, the data layer was extracted into the hook, handler signatures deduplicated into `CommentThreadHandlers`, and subcomponents split out. Two trivially-simple functions use the repo's sanctioned `// fallow-ignore-next-line complexity`.

## Deferred

- **Phase 2:** inline-anchored highlights + right-margin card bar (`kind:'inline'` + `anchor`).
- **Phase 3:** @mention autocomplete + unread dots.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>