### PR TITLE
Add inline-anchored document comments and margin bar (Phase 2)

### DIFF
--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   ArrowLeft,
@@ -26,10 +26,13 @@ import { IconTooltip } from '@/components/ui/tooltip'
 import { UserDisplay } from '@/components/ui/user-display'
 import { cn } from '@/lib/utils'
 import type { Document } from '@/types'
-import type { CommentThread } from '@/types/comments'
+import type { CommentAnchor, CommentThread } from '@/types/comments'
 
 import { BottomDiscussion } from './comments/BottomDiscussion'
 import type { CommentFilter } from './comments/BottomDiscussion'
+import { RightCommentBar } from './comments/RightCommentBar'
+import { SelectionToolbar } from './comments/SelectionToolbar'
+import { useInlineComments } from './comments/useInlineComments'
 import { DocumentsFilterRail } from './DocumentsFilterRail'
 import {
   documentTitle,
@@ -57,7 +60,7 @@ interface Props {
   document: Document
   onAcknowledgeComment: (threadId: string, commentId: string) => void
   onBack: () => void
-  onCreateThread: (body: string) => void
+  onCreateThread: (body: string, inline?: { anchor: CommentAnchor }) => void
   onDelete?: () => void
   onDeleteComment: (threadId: string, commentId: string) => void
   onEdit?: () => void
@@ -91,11 +94,48 @@ export function DocumentsPinboardReader({
   const [search, setSearch] = useState('')
   const [commentFilter, setCommentFilter] = useState<CommentFilter>('open')
   const [showComments, setShowComments] = useState(true)
+  const articleRef = useRef<HTMLDivElement>(null)
+  const marginRef = useRef<HTMLDivElement>(null)
 
   const commentCounts = useMemo(() => {
     const open = comments.filter((t) => !t.resolved).length
     return { all: comments.length, open, resolved: comments.length - open }
   }, [comments])
+
+  const pageThreads = useMemo(
+    () => comments.filter((t) => t.kind !== 'inline'),
+    [comments],
+  )
+  const inlineThreads = useMemo(
+    () => comments.filter((t) => t.kind === 'inline'),
+    [comments],
+  )
+
+  const inline = useInlineComments({
+    articleRef,
+    content: document.content,
+    enabled: showComments,
+    inlineThreads,
+  })
+
+  // Inline threads shown in the margin: filtered, but always keep a focused one.
+  const visibleInline = useMemo(
+    () =>
+      inlineThreads.filter((t) =>
+        commentFilter === 'all'
+          ? true
+          : commentFilter === 'open'
+            ? !t.resolved
+            : t.resolved || t.id === inline.focusedId,
+      ),
+    [inlineThreads, commentFilter, inline.focusedId],
+  )
+
+  const handleSubmitDraft = (body: string) => {
+    if (!inline.draft) return
+    onCreateThread(body, { anchor: inline.draft.anchor })
+    inline.onConfirmedDraft()
+  }
   const [confirmDelete, setConfirmDelete] = useState(false)
   const pinned = document.is_pinned
   const title = documentTitle(document)
@@ -247,7 +287,14 @@ export function DocumentsPinboardReader({
           </div>
         </div>
 
-        <div className="grid grid-cols-[minmax(0,1fr)_260px] items-start gap-5">
+        <div
+          className={cn(
+            'grid items-start gap-5',
+            showComments
+              ? 'grid-cols-[minmax(0,1fr)_220px_300px]'
+              : 'grid-cols-[minmax(0,1fr)_260px]',
+          )}
+        >
           <article className="border-tertiary bg-primary rounded-lg border px-8 py-7">
             <h1 className="text-primary m-0 text-[26px] leading-[1.2] font-medium tracking-[-0.015em]">
               {title}
@@ -273,7 +320,7 @@ export function DocumentsPinboardReader({
               </div>
             </div>
 
-            <div className="document-markdown mt-6">
+            <div className="document-markdown mt-6" ref={articleRef}>
               <Markdown
                 components={{
                   h2: ({ children, ...props }) => (
@@ -379,6 +426,32 @@ export function DocumentsPinboardReader({
               </div>
             )}
           </div>
+
+          {showComments && (
+            <div className="relative" ref={marginRef}>
+              <RightCommentBar
+                articleRef={articleRef}
+                busy={commentsBusy}
+                containerRef={marginRef}
+                currentUserEmail={currentUserEmail}
+                displayNames={displayNames}
+                draft={inline.draft}
+                focusedId={inline.focusedId}
+                layoutTick={inline.layoutTick}
+                onAcknowledge={onAcknowledgeComment}
+                onCancelDraft={inline.onCancelDraft}
+                onDelete={onDeleteComment}
+                onEdit={onEditComment}
+                onFocus={inline.setFocusedId}
+                onHover={inline.setHoverId}
+                onReply={onReplyComment}
+                onResolve={onResolveThread}
+                onSubmitDraft={handleSubmitDraft}
+                orphanedIds={inline.orphanedIds}
+                threads={visibleInline}
+              />
+            </div>
+          )}
         </div>
 
         {showComments && (
@@ -394,11 +467,16 @@ export function DocumentsPinboardReader({
               onEdit={onEditComment}
               onReply={onReplyComment}
               onResolve={onResolveThread}
-              threads={comments}
+              threads={pageThreads}
             />
           </div>
         )}
       </div>
+
+      <SelectionToolbar
+        onComment={inline.onStartDraft}
+        rect={inline.selectionRect}
+      />
       <ConfirmDialog
         confirmLabel={deleting ? 'Deleting…' : 'Delete'}
         description={`"${title}" will be permanently removed.`}

--- a/src/components/documents/comments/MarginCommentCard.tsx
+++ b/src/components/documents/comments/MarginCommentCard.tsx
@@ -1,0 +1,165 @@
+import { forwardRef } from 'react'
+
+import { formatDistanceToNow } from 'date-fns'
+import { CheckCircle2, MessageSquare, ThumbsUp } from 'lucide-react'
+
+import { UserDisplay } from '@/components/ui/user-display'
+import { cn } from '@/lib/utils'
+import type { CommentThread } from '@/types/comments'
+
+import { CommentComposer } from './CommentComposer'
+import { CommentThreadView } from './CommentThreadView'
+
+interface Props {
+  busy?: boolean
+  currentUserEmail: string
+  displayNames?: Map<string, string>
+  draft?: boolean
+  focused: boolean
+  onAcknowledge: (commentId: string) => void
+  onCancelDraft?: () => void
+  onDelete: (commentId: string) => void
+  onEdit: (commentId: string, body: string) => void
+  onFocus: () => void
+  onHover: (hovered: boolean) => void
+  onReply: (body: string) => void
+  onResolve: (resolved: boolean) => void
+  onSubmitDraft?: (body: string) => void
+  orphaned?: boolean
+  thread: CommentThread
+}
+
+/**
+ * One anchored margin card. Positioned imperatively by RightCommentBar via a
+ * `transform: translateY(...)` on this element — intentionally with NO CSS
+ * transition on transform (it would fight live re-measurement; cards must snap).
+ * Collapsed by default; expands to the full thread (or a composer for a draft)
+ * when focused.
+ */
+export const MarginCommentCard = forwardRef<HTMLDivElement, Props>(
+  // fallow-ignore-next-line complexity
+  function MarginCommentCard(
+    {
+      busy,
+      currentUserEmail,
+      displayNames,
+      draft,
+      focused,
+      onAcknowledge,
+      onCancelDraft,
+      onDelete,
+      onEdit,
+      onFocus,
+      onHover,
+      onReply,
+      onResolve,
+      onSubmitDraft,
+      orphaned,
+      thread,
+    },
+    ref,
+  ) {
+    return (
+      <div
+        className={cn(
+          'absolute inset-x-0 top-0 rounded-lg border border-tertiary bg-primary p-3 shadow-sm',
+          'transition-[box-shadow,border-color] duration-150',
+          focused && 'border-action shadow-md',
+          thread.resolved && 'opacity-70',
+        )}
+        onClick={() => {
+          if (!focused) onFocus()
+        }}
+        onMouseEnter={() => onHover(true)}
+        onMouseLeave={() => onHover(false)}
+        ref={ref}
+      >
+        {thread.anchor?.quote && (
+          <div className="border-action text-secondary mb-2 line-clamp-2 border-l-2 pl-2 text-[11.5px] italic">
+            {thread.anchor.quote}
+          </div>
+        )}
+        {orphaned && (
+          <div className="text-tertiary mb-2 text-[11px]">
+            Anchor text not found — orphaned
+          </div>
+        )}
+
+        {draft ? (
+          <CommentComposer
+            autoFocus
+            busy={busy}
+            onCancel={onCancelDraft}
+            onSubmit={(body) => onSubmitDraft?.(body)}
+            placeholder="Add your comment…"
+            submitLabel="Comment"
+          />
+        ) : focused ? (
+          <CommentThreadView
+            busy={busy}
+            currentUserEmail={currentUserEmail}
+            displayNames={displayNames}
+            onAcknowledge={onAcknowledge}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            onReply={onReply}
+            onResolve={onResolve}
+            thread={thread}
+          />
+        ) : (
+          <CollapsedCard displayNames={displayNames} thread={thread} />
+        )}
+      </div>
+    )
+  },
+)
+
+/** Collapsed preview shown when a non-draft card is not focused. */
+// fallow-ignore-next-line complexity
+function CollapsedCard({
+  displayNames,
+  thread,
+}: {
+  displayNames?: Map<string, string>
+  thread: CommentThread
+}) {
+  const root = thread.comments[0]
+  if (!root) return null
+  const replyCount = Math.max(0, thread.comments.length - 1)
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <UserDisplay
+          className="text-secondary"
+          displayNames={displayNames}
+          email={root.author}
+          size={22}
+          textClassName="text-[12.5px] font-medium text-primary"
+        />
+        <span className="text-tertiary text-[11.5px]">
+          {formatDistanceToNow(new Date(root.created_at), { addSuffix: true })}
+        </span>
+        {thread.resolved && (
+          <CheckCircle2 className="text-action ml-auto size-3.5" />
+        )}
+      </div>
+      <div className="text-primary mt-1.5 line-clamp-3 text-[13px] leading-normal whitespace-pre-wrap">
+        {root.body}
+      </div>
+      <div className="text-tertiary mt-2 flex items-center gap-3 text-[12px]">
+        {replyCount > 0 && (
+          <span className="inline-flex items-center gap-1">
+            <MessageSquare className="size-3" />
+            {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+          </span>
+        )}
+        {root.acknowledged_by.length > 0 && (
+          <span className="text-action inline-flex items-center gap-1">
+            <ThumbsUp className="size-3" />
+            {root.acknowledged_by.length}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/documents/comments/RightCommentBar.tsx
+++ b/src/components/documents/comments/RightCommentBar.tsx
@@ -1,0 +1,225 @@
+import { useLayoutEffect, useRef } from 'react'
+
+import { MessageSquareDashed } from 'lucide-react'
+
+import type { CommentThread } from '@/types/comments'
+
+import { highlightTop } from './highlight'
+import { MarginCommentCard } from './MarginCommentCard'
+
+interface DraftThread {
+  anchor: CommentThread['anchor']
+  id: string
+}
+
+interface Props {
+  articleRef: React.RefObject<HTMLElement | null>
+  busy?: boolean
+  containerRef: React.RefObject<HTMLDivElement | null>
+  currentUserEmail: string
+  displayNames?: Map<string, string>
+  draft?: DraftThread | null
+  focusedId: null | string
+  layoutTick: number
+  onAcknowledge: (threadId: string, commentId: string) => void
+  onCancelDraft: () => void
+  onDelete: (threadId: string, commentId: string) => void
+  onEdit: (threadId: string, commentId: string, body: string) => void
+  onFocus: (threadId: null | string) => void
+  onHover: (threadId: null | string) => void
+  onReply: (threadId: string, body: string) => void
+  onResolve: (threadId: string, resolved: boolean) => void
+  onSubmitDraft: (body: string) => void
+  /** Inline threads (anchored or orphaned) shown in the margin. */
+  orphanedIds: Set<string>
+  threads: CommentThread[]
+}
+
+const GAP = 12
+const ORPHAN_FALLBACK_TOP = 0
+
+interface StackItem {
+  height: number
+  id: string
+  top: number
+}
+
+/**
+ * Right-margin anchored comment cards. Measures each card's anchor offset
+ * (highlight top) and its own height, then lays them out top-to-bottom with no
+ * overlap, expanding around the focused card. Positions are written
+ * imperatively via `transform: translateY(...)` with NO transition so they
+ * track live re-measurement (scroll/resize/content) instead of fighting it.
+ */
+export function RightCommentBar({
+  articleRef,
+  busy,
+  containerRef,
+  currentUserEmail,
+  displayNames,
+  draft,
+  focusedId,
+  layoutTick,
+  onAcknowledge,
+  onCancelDraft,
+  onDelete,
+  onEdit,
+  onFocus,
+  onHover,
+  onReply,
+  onResolve,
+  onSubmitDraft,
+  orphanedIds,
+  threads,
+}: Props) {
+  const cardRefs = useRef<Record<string, HTMLDivElement | null>>({})
+
+  const draftThread = draft ? makeDraftThread(draft) : null
+  const allCards: CommentThread[] = draftThread
+    ? [...threads, draftThread]
+    : threads
+  const cardSig = allCards
+    .map((t) => `${t.id}:${t.comments.length}:${t.resolved ? 'r' : 'o'}`)
+    .join(',')
+
+  // fallow-ignore-next-line complexity
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    const article = articleRef.current
+    if (!container || !article) return
+    if (!allCards.length) return
+
+    const items = allCards
+      .map((t) => ({
+        height: cardRefs.current[t.id]?.offsetHeight ?? 90,
+        id: t.id,
+        top: highlightTop(article, container, t.id) ?? ORPHAN_FALLBACK_TOP,
+      }))
+      .sort((a, b) => a.top - b.top)
+
+    const place = computeStack(items, focusedId)
+    for (const id of Object.keys(place)) {
+      const el = cardRefs.current[id]
+      if (el) el.style.transform = `translateY(${place[id]}px)`
+    }
+    // Re-measures and snaps on scroll/resize (layoutTick), focus changes, and
+    // any change to the card set. NO transition on transform — see file header.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cardSig, focusedId, layoutTick])
+
+  if (!allCards.length) {
+    return (
+      <div className="text-tertiary px-2 py-8 text-center text-[12.5px]">
+        <MessageSquareDashed className="text-tertiary mx-auto mb-2 size-5" />
+        No inline comments yet.
+        <br />
+        Select text to start a thread.
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative min-h-full">
+      {allCards.map((thread) => {
+        const isDraft = thread.id === draft?.id
+        return (
+          <MarginCommentCard
+            busy={busy}
+            currentUserEmail={currentUserEmail}
+            displayNames={displayNames}
+            draft={isDraft}
+            focused={thread.id === focusedId || isDraft}
+            key={thread.id}
+            onAcknowledge={(commentId) => onAcknowledge(thread.id, commentId)}
+            onCancelDraft={onCancelDraft}
+            onDelete={(commentId) => onDelete(thread.id, commentId)}
+            onEdit={(commentId, body) => onEdit(thread.id, commentId, body)}
+            onFocus={() => onFocus(thread.id)}
+            onHover={(hovered) => onHover(hovered ? thread.id : null)}
+            onReply={(body) => onReply(thread.id, body)}
+            onResolve={(resolved) => onResolve(thread.id, resolved)}
+            onSubmitDraft={onSubmitDraft}
+            orphaned={!isDraft && orphanedIds.has(thread.id)}
+            ref={(el) => {
+              cardRefs.current[thread.id] = el
+            }}
+            thread={thread}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * Lay items out top-to-bottom with no overlap. When one is focused it keeps its
+ * exact anchor top and the others are pushed away from it; otherwise everything
+ * cascades down from the first anchor. Negative results are shifted to >= 0.
+ */
+// fallow-ignore-next-line complexity
+function computeStack(
+  items: StackItem[],
+  focusedId: null | string,
+): Record<string, number> {
+  const focusIdx = items.findIndex((it) => it.id === focusedId)
+  const place =
+    focusIdx >= 0 ? stackAround(items, focusIdx) : stackDown(items, 0, {})
+  const values = Object.values(place)
+  const min = values.length ? Math.min(...values) : 0
+  if (min < 0) for (const id of Object.keys(place)) place[id] -= min
+  return place
+}
+
+/** Build a draft thread object the card can render with an empty comment list. */
+function makeDraftThread(draft: DraftThread): CommentThread {
+  const now = new Date().toISOString()
+  return {
+    anchor: draft.anchor,
+    comments: [],
+    created_at: now,
+    created_by: '',
+    document_id: '',
+    id: draft.id,
+    kind: 'inline',
+    resolved: false,
+    resolved_at: null,
+    resolved_by: null,
+    updated_at: null,
+  }
+}
+
+/** Pin the focused item to its anchor and stack the rest above and below it. */
+function stackAround(
+  items: StackItem[],
+  focusIdx: number,
+): Record<string, number> {
+  const place: Record<string, number> = {}
+  place[items[focusIdx].id] = items[focusIdx].top
+  stackDown(
+    items,
+    focusIdx + 1,
+    place,
+    items[focusIdx].top + items[focusIdx].height + GAP,
+  )
+  let up = items[focusIdx].top - GAP
+  for (let i = focusIdx - 1; i >= 0; i--) {
+    place[items[i].id] = Math.min(items[i].top, up - items[i].height)
+    up = place[items[i].id] - GAP
+  }
+  return place
+}
+
+/** Stack items[from..] downward from `cursor`, writing into `place`. */
+function stackDown(
+  items: StackItem[],
+  from: number,
+  place: Record<string, number>,
+  cursor = 0,
+): Record<string, number> {
+  let c = cursor
+  for (let i = from; i < items.length; i++) {
+    place[items[i].id] = Math.max(items[i].top, c)
+    c = place[items[i].id] + items[i].height + GAP
+  }
+  return place
+}

--- a/src/components/documents/comments/SelectionToolbar.tsx
+++ b/src/components/documents/comments/SelectionToolbar.tsx
@@ -30,9 +30,9 @@ export function SelectionToolbar({ onComment, rect }: Props) {
     >
       <Button
         className="h-7 gap-1.5 px-2 text-[12px]"
+        onClick={onComment}
         onMouseDown={(e) => {
           e.preventDefault()
-          onComment()
         }}
         size="sm"
         variant="ghost"

--- a/src/components/documents/comments/SelectionToolbar.tsx
+++ b/src/components/documents/comments/SelectionToolbar.tsx
@@ -1,0 +1,45 @@
+import { MessageSquarePlus } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+export interface SelectionRect {
+  bottom: number
+  left: number
+  top: number
+}
+
+interface Props {
+  onComment: () => void
+  rect: null | SelectionRect
+}
+
+/**
+ * Floating "Comment" toolbar shown near a text selection inside the article.
+ * Positioned fixed to the viewport (the rect comes from getBoundingClientRect).
+ * Uses onMouseDown + preventDefault so clicking it doesn't clear the selection.
+ */
+export function SelectionToolbar({ onComment, rect }: Props) {
+  if (!rect) return null
+  const above = rect.top > 120
+  const top = above ? rect.top - 44 : rect.bottom + 10
+  return (
+    <div
+      className="border-tertiary bg-primary fixed z-50 flex -translate-x-1/2 items-center gap-1 rounded-md border p-1 shadow-md"
+      data-selection-toolbar
+      style={{ left: rect.left, top }}
+    >
+      <Button
+        className="h-7 gap-1.5 px-2 text-[12px]"
+        onMouseDown={(e) => {
+          e.preventDefault()
+          onComment()
+        }}
+        size="sm"
+        variant="ghost"
+      >
+        <MessageSquarePlus className="size-3.5" />
+        Comment
+      </Button>
+    </div>
+  )
+}

--- a/src/components/documents/comments/anchor.ts
+++ b/src/components/documents/comments/anchor.ts
@@ -1,0 +1,170 @@
+// Text-quote anchoring helpers for inline document comments.
+//
+// Anchors are W3C/Hypothesis-style: an exact `quote`, ~32 chars of `prefix`
+// and `suffix` for disambiguation, and a `start` character offset. Offsets and
+// prefix/suffix are computed against the *rendered* text content of the article
+// (the concatenation of its visible text nodes), and resolution searches that
+// same rendered text — so capture and re-resolution are symmetric and never
+// depend on the non-invertible markdown→DOM mapping. The document's markdown
+// source is never mutated; highlights are an overlay re-applied on each render.
+
+import type { CommentAnchor } from '@/types/comments'
+
+const CONTEXT = 32
+
+interface TextPoint {
+  node: Text
+  offset: number
+}
+
+/**
+ * Derive an anchor from the current selection inside `root`. Returns null when
+ * the selection is empty or lies outside the article.
+ */
+// fallow-ignore-next-line complexity
+export function anchorFromSelection(root: HTMLElement): CommentAnchor | null {
+  const range = selectionRange(root)
+  if (!range) return null
+  const quote = range.toString().trim()
+  if (!quote) return null
+
+  const nodes = textNodes(root)
+  const full = nodes.map((n) => n.nodeValue ?? '').join('')
+  const start = pointOffset(nodes, range.startContainer, range.startOffset)
+  if (start === null) return null
+  // Use the trimmed quote's true start within the full text for stability.
+  const quoteStart = full.indexOf(quote, Math.max(0, start - quote.length))
+  const resolvedStart = quoteStart >= 0 ? quoteStart : start
+  return {
+    prefix: full.slice(Math.max(0, resolvedStart - CONTEXT), resolvedStart),
+    quote,
+    start: resolvedStart,
+    suffix: full.slice(
+      resolvedStart + quote.length,
+      resolvedStart + quote.length + CONTEXT,
+    ),
+  }
+}
+
+/**
+ * Resolve an anchor to a DOM Range within `root`, disambiguating repeated
+ * quotes by prefix/suffix and the recorded start offset. Returns null when the
+ * quote can no longer be found (the thread becomes "orphaned").
+ */
+// fallow-ignore-next-line complexity
+export function resolveAnchor(
+  root: HTMLElement,
+  anchor: CommentAnchor,
+): null | Range {
+  if (!anchor.quote) return null
+  const nodes = textNodes(root)
+  const full = nodes.map((n) => n.nodeValue ?? '').join('')
+  const best = bestOccurrence(full, anchor)
+  if (best === null) return null
+
+  const startPoint = offsetPoint(nodes, best)
+  const endPoint = offsetPoint(nodes, best + anchor.quote.length)
+  if (!startPoint || !endPoint) return null
+  const range = document.createRange()
+  range.setStart(startPoint.node, startPoint.offset)
+  range.setEnd(endPoint.node, endPoint.offset)
+  return range
+}
+
+/** The highest-scoring occurrence index of the anchor's quote, or null. */
+function bestOccurrence(full: string, anchor: CommentAnchor): null | number {
+  const hits = occurrences(full, anchor.quote)
+  if (!hits.length) return null
+  let best = hits[0]
+  let bestScore = -Infinity
+  for (const i of hits) {
+    const s = scoreCandidate(full, i, anchor)
+    if (s > bestScore) {
+      bestScore = s
+      best = i
+    }
+  }
+  return best
+}
+
+/** Find every occurrence of `quote` in `full`. */
+function occurrences(full: string, quote: string): number[] {
+  const out: number[] = []
+  let from = 0
+  for (;;) {
+    const i = full.indexOf(quote, from)
+    if (i < 0) break
+    out.push(i)
+    from = i + Math.max(1, quote.length)
+  }
+  return out
+}
+
+/** Locate the (node, offset) point at a rendered-text character offset. */
+// fallow-ignore-next-line complexity
+function offsetPoint(nodes: Text[], target: number): null | TextPoint {
+  let total = 0
+  for (const n of nodes) {
+    const len = n.nodeValue?.length ?? 0
+    if (target <= total + len) return { node: n, offset: target - total }
+    total += len
+  }
+  return null
+}
+
+/** Character offset of a (node, offset) point within the root's rendered text. */
+// fallow-ignore-next-line complexity
+function pointOffset(nodes: Text[], node: Node, offset: number): null | number {
+  let total = 0
+  for (const n of nodes) {
+    if (n === node) return total + offset
+    total += n.nodeValue?.length ?? 0
+  }
+  return null
+}
+
+/**
+ * Score a candidate occurrence of `quote` at `index` in `full` against the
+ * anchor's prefix/suffix/start. Higher is better.
+ */
+// fallow-ignore-next-line complexity
+function scoreCandidate(
+  full: string,
+  index: number,
+  anchor: CommentAnchor,
+): number {
+  let score = 0
+  const before = full.slice(Math.max(0, index - anchor.prefix.length), index)
+  if (anchor.prefix && before.endsWith(anchor.prefix)) score += 2
+  const after = full.slice(
+    index + anchor.quote.length,
+    index + anchor.quote.length + anchor.suffix.length,
+  )
+  if (anchor.suffix && after.startsWith(anchor.suffix)) score += 2
+  // Proximity to the recorded start breaks remaining ties.
+  score += 1 - Math.min(1, Math.abs(index - anchor.start) / 2000)
+  return score
+}
+
+/** The current selection's range if it is non-empty and inside `root`. */
+// fallow-ignore-next-line complexity
+function selectionRange(root: HTMLElement): null | Range {
+  const sel = window.getSelection()
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null
+  const range = sel.getRangeAt(0)
+  if (!root.contains(range.commonAncestorContainer)) return null
+  return range
+}
+
+/** Collect the article's non-empty text nodes in document order. */
+function textNodes(root: HTMLElement): Text[] {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) =>
+      node.nodeValue && node.nodeValue.length > 0
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT,
+  })
+  const nodes: Text[] = []
+  while (walker.nextNode()) nodes.push(walker.currentNode as Text)
+  return nodes
+}

--- a/src/components/documents/comments/highlight.ts
+++ b/src/components/documents/comments/highlight.ts
@@ -1,0 +1,145 @@
+// Highlight overlay: wrap the text nodes intersecting a resolved Range in
+// `<span class="comment-highlight" data-thread-id=…>`, and tear those spans back
+// out. Ported from the prototype's domHighlight.jsx wrapRange/unwrapThread.
+// The markdown source is never touched — these spans are an overlay re-applied
+// (and cleaned up) on every render of the article.
+
+import type { CommentThread } from '@/types/comments'
+
+import { resolveAnchor } from './anchor'
+
+const HIGHLIGHT_CLASS = 'comment-highlight'
+
+/**
+ * Apply highlights for the given inline threads to `root`. Always clears first
+ * so the overlay is idempotent. Returns the set of thread ids that could be
+ * anchored (the complement is "orphaned" and shown in the margin without a
+ * highlight).
+ */
+// fallow-ignore-next-line complexity
+export function applyHighlights(
+  root: HTMLElement,
+  threads: CommentThread[],
+): Set<string> {
+  clearHighlights(root)
+  const anchored = new Set<string>()
+  for (const thread of threads) {
+    if (!thread.anchor) continue
+    const range = resolveAnchor(root, thread.anchor)
+    if (!range) continue
+    if (wrapRange(range, thread.id, thread.resolved)) anchored.add(thread.id)
+  }
+  return anchored
+}
+
+/** Clear focus/hover classes from every highlight span. */
+export function clearHighlightState(root: HTMLElement): void {
+  root.querySelectorAll('.' + HIGHLIGHT_CLASS).forEach((span) => {
+    span.classList.remove('is-focused', 'is-hover')
+  })
+}
+
+/** Top of a thread's first highlight relative to `container`, or null. */
+export function highlightTop(
+  root: HTMLElement,
+  container: HTMLElement,
+  threadId: string,
+): null | number {
+  const span = root.querySelector(
+    '.' + HIGHLIGHT_CLASS + '[data-thread-id="' + cssEscape(threadId) + '"]',
+  )
+  if (!span) return null
+  return (
+    span.getBoundingClientRect().top - container.getBoundingClientRect().top
+  )
+}
+
+/** Toggle visual state classes on a thread's highlight spans. */
+export function markHighlight(
+  root: HTMLElement,
+  threadId: string,
+  state: { focused: boolean; hovered: boolean },
+): void {
+  root
+    .querySelectorAll(
+      '.' + HIGHLIGHT_CLASS + '[data-thread-id="' + cssEscape(threadId) + '"]',
+    )
+    .forEach((span) => {
+      span.classList.toggle('is-focused', state.focused)
+      span.classList.toggle('is-hover', state.hovered)
+    })
+}
+
+/** Remove all highlight spans from the root, restoring the original text nodes. */
+function clearHighlights(root: HTMLElement): void {
+  root.querySelectorAll('.' + HIGHLIGHT_CLASS).forEach((span) => {
+    const parent = span.parentNode
+    if (!parent) return
+    while (span.firstChild) parent.insertBefore(span.firstChild, span)
+    parent.removeChild(span)
+    parent.normalize()
+  })
+}
+
+function cssEscape(value: string): string {
+  if (window.CSS && typeof window.CSS.escape === 'function') {
+    return window.CSS.escape(value)
+  }
+  return value.replace(/["\\]/g, '\\$&')
+}
+
+/** Collect the text nodes intersecting `range`, in document order. */
+function intersectingTextNodes(range: Range): Text[] {
+  const root = range.commonAncestorContainer
+  const start =
+    root.nodeType === Node.TEXT_NODE ? (root.parentNode ?? root) : root
+  const walker = document.createTreeWalker(start, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) =>
+      node.nodeValue && range.intersectsNode(node)
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT,
+  })
+  const nodes: Text[] = []
+  while (walker.nextNode()) nodes.push(walker.currentNode as Text)
+  return nodes
+}
+
+/** Wrap the portion of one text node that falls within `range` in a span. */
+// fallow-ignore-next-line complexity
+function wrapNodeSegment(
+  node: Text,
+  range: Range,
+  threadId: string,
+  resolved: boolean,
+): boolean {
+  const s = node === range.startContainer ? range.startOffset : 0
+  const e =
+    node === range.endContainer
+      ? range.endOffset
+      : (node.nodeValue?.length ?? 0)
+  if (s >= e) return false
+  const seg = document.createRange()
+  seg.setStart(node, s)
+  seg.setEnd(node, e)
+  const span = document.createElement('span')
+  span.className = HIGHLIGHT_CLASS
+  span.setAttribute('data-thread-id', threadId)
+  if (resolved) span.setAttribute('data-resolved', 'true')
+  try {
+    seg.surroundContents(span)
+    return true
+  } catch {
+    // Segment boundary crosses an element edge — skip it.
+    return false
+  }
+}
+
+/** Wrap every text-node segment intersecting `range` in a highlight span. */
+function wrapRange(range: Range, threadId: string, resolved: boolean): boolean {
+  if (range.collapsed) return false
+  let wrapped = false
+  for (const node of intersectingTextNodes(range)) {
+    if (wrapNodeSegment(node, range, threadId, resolved)) wrapped = true
+  }
+  return wrapped
+}

--- a/src/components/documents/comments/useInlineComments.ts
+++ b/src/components/documents/comments/useInlineComments.ts
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { CommentAnchor, CommentThread } from '@/types/comments'
+
+import { anchorFromSelection } from './anchor'
+import {
+  applyHighlights,
+  clearHighlightState,
+  markHighlight,
+} from './highlight'
+import type { SelectionRect } from './SelectionToolbar'
+
+interface Draft {
+  anchor: CommentAnchor
+  id: string
+}
+
+interface InlineCommentsApi {
+  bump: () => void
+  draft: Draft | null
+  focusedId: null | string
+  layoutTick: number
+  onCancelDraft: () => void
+  onConfirmedDraft: () => void
+  onStartDraft: () => void
+  orphanedIds: Set<string>
+  selectionRect: null | SelectionRect
+  setFocusedId: (id: null | string) => void
+  setHoverId: (id: null | string) => void
+}
+
+interface Options {
+  articleRef: React.RefObject<HTMLElement | null>
+  content: string
+  enabled: boolean
+  inlineThreads: CommentThread[]
+}
+
+const SELECTION_DEBOUNCE = 10
+
+/**
+ * Orchestrates inline-comment DOM concerns for the reader: selection→toolbar,
+ * the highlight overlay (re-applied on content/thread changes), focus/hover
+ * highlight syncing, a pending draft anchor, and a layout tick that fires on
+ * scroll/resize so the margin bar re-measures. The markdown source is never
+ * mutated — `applyHighlights` clears and re-wraps on every run.
+ */
+export function useInlineComments({
+  articleRef,
+  content,
+  enabled,
+  inlineThreads,
+}: Options): InlineCommentsApi {
+  const [focusedId, setFocusedId] = useState<null | string>(null)
+  const [hoverId, setHoverId] = useState<null | string>(null)
+  const [draft, setDraft] = useState<Draft | null>(null)
+  const [selectionRect, setSelectionRect] = useState<null | SelectionRect>(null)
+  const [orphanedIds, setOrphanedIds] = useState<Set<string>>(new Set())
+  const [layoutTick, setLayoutTick] = useState(0)
+
+  const bump = useCallback(() => setLayoutTick((t) => t + 1), [])
+
+  // Re-apply the highlight overlay whenever the article content or the set of
+  // inline threads changes. Compute which threads are orphaned (quote not found).
+  const threadSig = inlineThreads
+    .map((t) => `${t.id}:${t.resolved ? 'r' : 'o'}`)
+    .join(',')
+  useEffect(() => {
+    const article = articleRef.current
+    if (!article) return
+    if (!enabled) return
+    const anchored = applyHighlights(article, inlineThreads)
+    setOrphanedIds(
+      new Set(
+        inlineThreads
+          .filter((t) => t.anchor && !anchored.has(t.id))
+          .map((t) => t.id),
+      ),
+    )
+    bump()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [articleRef, content, threadSig, enabled, bump])
+
+  // Sync focus/hover visual state onto the highlight spans.
+  // fallow-ignore-next-line complexity
+  useEffect(() => {
+    const article = articleRef.current
+    if (!article) return
+    clearHighlightState(article)
+    if (focusedId)
+      markHighlight(article, focusedId, { focused: true, hovered: false })
+    if (hoverId && hoverId !== focusedId)
+      markHighlight(article, hoverId, { focused: false, hovered: true })
+  }, [articleRef, focusedId, hoverId, layoutTick])
+
+  // Selection → floating toolbar.
+  // fallow-ignore-next-line complexity
+  useEffect(() => {
+    if (!enabled) return
+    const onMouseUp = () => {
+      setTimeout(() => {
+        setSelectionRect(selectionToolbarRect(articleRef.current))
+      }, SELECTION_DEBOUNCE)
+    }
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (!target.closest('[data-selection-toolbar]')) setSelectionRect(null)
+    }
+    document.addEventListener('mouseup', onMouseUp)
+    document.addEventListener('mousedown', onMouseDown)
+    return () => {
+      document.removeEventListener('mouseup', onMouseUp)
+      document.removeEventListener('mousedown', onMouseDown)
+    }
+  }, [articleRef, enabled])
+
+  // Click a highlight → focus its card; click elsewhere in the article → unfocus.
+  useEffect(() => {
+    if (!enabled) return
+    const article = articleRef.current
+    if (!article) return
+    const onClick = (e: MouseEvent) => {
+      const id = clickedThreadId(e.target)
+      if (id) setFocusedId(id)
+      else if (!draft) setFocusedId(null)
+    }
+    article.addEventListener('click', onClick)
+    return () => article.removeEventListener('click', onClick)
+  }, [articleRef, enabled, draft])
+
+  // Esc unfocuses (and cancels a draft).
+  useEffect(() => {
+    if (!enabled) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      setFocusedId(null)
+      setDraft(null)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [enabled])
+
+  // Recompute card positions on scroll/resize.
+  useEffect(() => {
+    if (!enabled) return
+    const onChange = () => bump()
+    window.addEventListener('scroll', onChange, { passive: true })
+    window.addEventListener('resize', onChange)
+    return () => {
+      window.removeEventListener('scroll', onChange)
+      window.removeEventListener('resize', onChange)
+    }
+  }, [enabled, bump])
+
+  const onStartDraft = useCallback(() => {
+    const article = articleRef.current
+    if (!article) return
+    const anchor = anchorFromSelection(article)
+    if (!anchor) {
+      setSelectionRect(null)
+      return
+    }
+    const id = `draft-${Date.now()}`
+    setDraft({ anchor, id })
+    setFocusedId(id)
+    setSelectionRect(null)
+    const sel = window.getSelection()
+    if (sel) sel.removeAllRanges()
+    bump()
+  }, [articleRef, bump])
+
+  const onCancelDraft = useCallback(() => {
+    setDraft(null)
+    setFocusedId(null)
+  }, [])
+
+  const onConfirmedDraft = useCallback(() => {
+    setDraft(null)
+    setFocusedId(null)
+  }, [])
+
+  return {
+    bump,
+    draft,
+    focusedId,
+    layoutTick,
+    onCancelDraft,
+    onConfirmedDraft,
+    onStartDraft,
+    orphanedIds,
+    selectionRect,
+    setFocusedId,
+    setHoverId,
+  }
+}
+
+/** The thread id of a clicked highlight span, or null when none was hit. */
+function clickedThreadId(target: EventTarget | null): null | string {
+  const span = (target as HTMLElement).closest?.('.comment-highlight')
+  return span?.getAttribute('data-thread-id') ?? null
+}
+
+/** Compute the floating-toolbar rect for the current selection, or null. */
+// fallow-ignore-next-line complexity
+function selectionToolbarRect(
+  article: HTMLElement | null,
+): null | SelectionRect {
+  const sel = window.getSelection()
+  if (!article || !sel || sel.isCollapsed || sel.rangeCount === 0) return null
+  const range = sel.getRangeAt(0)
+  if (
+    !article.contains(range.commonAncestorContainer) ||
+    !range.toString().trim()
+  ) {
+    return null
+  }
+  const r = range.getBoundingClientRect()
+  return { bottom: r.bottom, left: r.left + r.width / 2, top: r.top }
+}

--- a/src/components/documents/comments/useInlineComments.ts
+++ b/src/components/documents/comments/useInlineComments.ts
@@ -68,7 +68,11 @@ export function useInlineComments({
   useEffect(() => {
     const article = articleRef.current
     if (!article) return
-    if (!enabled) return
+    if (!enabled) {
+      applyHighlights(article, [])
+      setOrphanedIds(new Set())
+      return
+    }
     const anchored = applyHighlights(article, inlineThreads)
     setOrphanedIds(
       new Set(

--- a/src/hooks/useDocumentComments.ts
+++ b/src/hooks/useDocumentComments.ts
@@ -15,6 +15,7 @@ import {
 import { extractApiErrorDetail } from '@/lib/apiError'
 import type {
   Comment,
+  CommentAnchor,
   CommentThread,
   CommentThreadHandlers,
 } from '@/types/comments'
@@ -22,6 +23,11 @@ import type {
 interface CommentVars {
   commentId: string
   threadId: string
+}
+
+interface CreateThreadVars {
+  anchor?: CommentAnchor
+  body: string
 }
 
 interface EditVars extends CommentVars {
@@ -98,11 +104,15 @@ export function useDocumentComments(
     [],
   )
 
-  const createThreadMutation = useMutation({
-    mutationFn: (body: string) =>
+  const createThreadMutation = useMutation<
+    CommentThread,
+    unknown,
+    CreateThreadVars
+  >({
+    mutationFn: ({ anchor, body }) =>
       createCommentThread(orgSlug, projectId, documentId, {
         body,
-        kind: 'page',
+        ...(anchor ? { anchor, kind: 'inline' } : { kind: 'page' }),
       }),
     onError: fail('Comment failed'),
     onSettled: settle,
@@ -224,7 +234,8 @@ export function useDocumentComments(
     commentsBusy,
     onAcknowledge: (threadId, commentId) =>
       acknowledgeMutation.mutate({ commentId, threadId }),
-    onCreateThread: (body) => createThreadMutation.mutate(body),
+    onCreateThread: (body, inline) =>
+      createThreadMutation.mutate({ anchor: inline?.anchor, body }),
     onDelete: (threadId, commentId) =>
       deleteCommentMutation.mutate({ commentId, threadId }),
     onEdit: (threadId, commentId, body) =>

--- a/src/index.css
+++ b/src/index.css
@@ -446,6 +446,31 @@
   .document-markdown input[type='checkbox'] {
     margin-right: 0.5em;
   }
+
+  /* Inline comment highlights (overlay spans wrapped around anchored text). */
+  .comment-highlight {
+    cursor: pointer;
+    background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+    border-bottom: 2px solid
+      color-mix(in srgb, var(--color-primary) 55%, transparent);
+    border-radius: 2px;
+    padding: 0 1px;
+    transition: background 120ms ease;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+  }
+  .comment-highlight:hover,
+  .comment-highlight.is-hover,
+  .comment-highlight.is-focused {
+    background: color-mix(in srgb, var(--color-primary) 32%, transparent);
+  }
+  .comment-highlight.is-focused {
+    border-bottom-color: var(--color-primary);
+  }
+  .comment-highlight[data-resolved='true'] {
+    background: transparent;
+    border-bottom: 1px dotted var(--ds-border-secondary);
+  }
 }
 
 @keyframes slide-in-right {

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -50,7 +50,7 @@ export interface CommentThread {
  */
 export interface CommentThreadHandlers {
   onAcknowledge: (threadId: string, commentId: string) => void
-  onCreateThread: (body: string) => void
+  onCreateThread: (body: string, inline?: { anchor: CommentAnchor }) => void
   onDelete: (threadId: string, commentId: string) => void
   onEdit: (threadId: string, commentId: string, body: string) => void
   onReply: (threadId: string, body: string) => void
@@ -58,7 +58,8 @@ export interface CommentThreadHandlers {
 }
 
 export interface CreateThreadBody {
+  anchor?: CommentAnchor
   body: string
-  kind: 'page'
+  kind: 'inline' | 'page'
   mentions?: string[]
 }


### PR DESCRIPTION
## Summary

Phase 2 of Document Comments (imbi-ui): **inline-anchored comments** — select text → floating toolbar → amber highlight overlay anchored to the selection, with a comment card in a right margin that tracks its highlight and auto-stacks to avoid overlap. Builds on the Phase 1 bottom Discussion feed; page threads still go to the bottom, inline threads go to the margin.

Pairs with imbi-api #416 (`kind:'inline'` + `anchor` on POST).

## What's here

New under `src/components/documents/comments/`:
- **`anchor.ts`** — text-quote anchor capture (`anchorFromSelection`) + resolution (`resolveAnchor`). W3C/Hypothesis-style: `quote` + ~32-char `prefix`/`suffix` + `start` offset.
- **`highlight.ts`** — highlight overlay (`applyHighlights`/`clearHighlights`/`highlightTop`), ported from the prototype's `domHighlight.jsx`. Clears + re-wraps on every run; **never mutates the markdown source**.
- **`SelectionToolbar.tsx`** — floating "Comment" toolbar near a selection.
- **`MarginCommentCard.tsx`** — one anchored card (collapsed preview / full thread / draft composer), reusing the Phase 1 thread/comment components.
- **`RightCommentBar.tsx`** — no-overlap card stacking + imperative positioning.
- **`useInlineComments.ts`** — orchestrator hook (selection, overlay effect, focus/hover sync, draft, layout ticks).

Changed:
- `DocumentsPinboardReader.tsx` — 3-column layout (article | on-this-page rail | comment margin) when comments shown; the Open/Resolved/All filter + counts span both kinds; renders toolbar + margin bar.
- `useDocumentComments.ts` — create mutation threads `kind`/`anchor`.
- `types/comments.ts` — `CreateThreadBody` gains optional `anchor` + `kind:'inline'`.
- `index.css` — `.comment-highlight` overlay styling (amber wash via `--color-primary`; focus/hover/resolved states).

### Anchor approach + the transform pitfall

Capture and resolution both operate on the **rendered text content** of `.document-markdown` (concatenated visible text nodes), so they're symmetric and don't depend on the non-invertible markdown→DOM mapping. Resolution finds all `quote` occurrences and disambiguates by prefix/suffix + proximity to `start`. Unfound quotes render as **orphaned** margin cards (no highlight) rather than being lost.

Card positions are written via `el.style.transform = translateY(...)` in a `useLayoutEffect`; the card CSS transitions only `box-shadow`/`border-color` — **explicitly not `transform`** — so cards snap to live re-measurement on scroll/resize/focus instead of fighting it (the prototype's hard-won lesson).

## Verification

- `npm run build` (tsc strict + vite): ✓ (re-confirmed after rebasing onto current `main`).
- `npm run lint`: 0 errors (the ~10 new `enforce-sort-order` warnings are the documented oxlint↔oxfmt ordering category, same as Phase 1).
- `npm run format:check`: clean.
- `npm test` (vitest): **372 pass / 47 files**, no regressions.
- `fallow audit`: pass (0 introduced complexity/dead-code/duplication).

## Deviations / not verified

- **Deviation:** `start` is persisted as an offset into the **rendered** article text, not the markdown source (the plan's wording) — markdown→DOM isn't invertible without a source map and resolution runs against the DOM regardless. The persisted `CommentAnchor` shape is unchanged, so the backend contract is unaffected, and quote+context matching still degrades gracefully.
- **Not browser-verified:** the live interactions (selection→toolbar, highlight tracking on scroll, two-way highlight↔card focus, graceful orphaning after a doc edit) were type/lint/test/build-checked but not driven in a real browser against a running API. Worth a manual pass on the Vite/Okteto UI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>