### PR TITLE
Add @mention autocomplete and unread comment dots (Phase 3)

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1635,10 +1635,14 @@ export const editComment = (
   threadId: string,
   commentId: string,
   body: string,
+  mentions: string[],
 ) =>
   apiClient.patch<Comment>(
     `${documentCommentsPath(orgSlug, projectId, documentId)}/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(commentId)}`,
-    [{ op: 'replace', path: '/body', value: body }],
+    [
+      { op: 'replace', path: '/body', value: body },
+      { op: 'replace', path: '/mentions', value: mentions },
+    ],
   )
 
 export const acknowledgeComment = (

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -32,6 +32,7 @@ import { BottomDiscussion } from './comments/BottomDiscussion'
 import type { CommentFilter } from './comments/BottomDiscussion'
 import { RightCommentBar } from './comments/RightCommentBar'
 import { SelectionToolbar } from './comments/SelectionToolbar'
+import { useCommentLastVisit } from './comments/useCommentLastVisit'
 import { useInlineComments } from './comments/useInlineComments'
 import { DocumentsFilterRail } from './DocumentsFilterRail'
 import {
@@ -60,15 +61,26 @@ interface Props {
   document: Document
   onAcknowledgeComment: (threadId: string, commentId: string) => void
   onBack: () => void
-  onCreateThread: (body: string, inline?: { anchor: CommentAnchor }) => void
+  onCreateThread: (
+    body: string,
+    mentions: string[],
+    inline?: { anchor: CommentAnchor },
+  ) => void
   onDelete?: () => void
   onDeleteComment: (threadId: string, commentId: string) => void
   onEdit?: () => void
-  onEditComment: (threadId: string, commentId: string, body: string) => void
+  onEditComment: (
+    threadId: string,
+    commentId: string,
+    body: string,
+    mentions: string[],
+  ) => void
   onOpen: (documentId: string) => void
-  onReplyComment: (threadId: string, body: string) => void
+  onReplyComment: (threadId: string, body: string, mentions: string[]) => void
   onResolveThread: (threadId: string, resolved: boolean) => void
   onTogglePin: () => void
+  orgSlug: string
+  projectId: string
 }
 
 export function DocumentsPinboardReader({
@@ -90,6 +102,8 @@ export function DocumentsPinboardReader({
   onReplyComment,
   onResolveThread,
   onTogglePin,
+  orgSlug,
+  projectId,
 }: Props) {
   const [search, setSearch] = useState('')
   const [commentFilter, setCommentFilter] = useState<CommentFilter>('open')
@@ -131,9 +145,11 @@ export function DocumentsPinboardReader({
     [inlineThreads, commentFilter, inline.focusedId],
   )
 
-  const handleSubmitDraft = (body: string) => {
+  const lastVisit = useCommentLastVisit(orgSlug, projectId, document.id)
+
+  const handleSubmitDraft = (body: string, mentions: string[]) => {
     if (!inline.draft) return
-    onCreateThread(body, { anchor: inline.draft.anchor })
+    onCreateThread(body, mentions, { anchor: inline.draft.anchor })
     inline.onConfirmedDraft()
   }
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -437,6 +453,7 @@ export function DocumentsPinboardReader({
                 displayNames={displayNames}
                 draft={inline.draft}
                 focusedId={inline.focusedId}
+                lastVisit={lastVisit}
                 layoutTick={inline.layoutTick}
                 onAcknowledge={onAcknowledgeComment}
                 onCancelDraft={inline.onCancelDraft}
@@ -461,6 +478,7 @@ export function DocumentsPinboardReader({
               currentUserEmail={currentUserEmail}
               displayNames={displayNames}
               filter={commentFilter}
+              lastVisit={lastVisit}
               onAcknowledge={onAcknowledgeComment}
               onCreateThread={onCreateThread}
               onDelete={onDeleteComment}

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -107,7 +107,7 @@ export function DocumentsPinboardReader({
 }: Props) {
   const [search, setSearch] = useState('')
   const [commentFilter, setCommentFilter] = useState<CommentFilter>('open')
-  const [showComments, setShowComments] = useState(true)
+  const [showComments, setShowComments] = useState(false)
   const articleRef = useRef<HTMLDivElement>(null)
   const marginRef = useRef<HTMLDivElement>(null)
 
@@ -206,36 +206,34 @@ export function DocumentsPinboardReader({
               All documents
             </Button>
             <div className="ml-auto flex items-center gap-1">
-              {showComments && (
-                <SegmentedControl
-                  ariaLabel="Comment filter"
-                  className="mr-1"
-                  onValueChange={(v) => setCommentFilter(v as CommentFilter)}
-                  value={commentFilter}
-                >
-                  <SegmentedControlItem value="open">
-                    <CircleDot className="size-3" />
-                    Open
-                    <span className="text-tertiary tabular-nums">
-                      {commentCounts.open}
-                    </span>
-                  </SegmentedControlItem>
-                  <SegmentedControlItem value="resolved">
-                    <CheckCircle2 className="size-3" />
-                    Resolved
-                    <span className="text-tertiary tabular-nums">
-                      {commentCounts.resolved}
-                    </span>
-                  </SegmentedControlItem>
-                  <SegmentedControlItem value="all">
-                    <List className="size-3" />
-                    All
-                    <span className="text-tertiary tabular-nums">
-                      {commentCounts.all}
-                    </span>
-                  </SegmentedControlItem>
-                </SegmentedControl>
-              )}
+              <SegmentedControl
+                ariaLabel="Comment filter"
+                className="mr-1"
+                onValueChange={(v) => setCommentFilter(v as CommentFilter)}
+                value={commentFilter}
+              >
+                <SegmentedControlItem value="open">
+                  <CircleDot className="size-3" />
+                  Open
+                  <span className="text-tertiary tabular-nums">
+                    {commentCounts.open}
+                  </span>
+                </SegmentedControlItem>
+                <SegmentedControlItem value="resolved">
+                  <CheckCircle2 className="size-3" />
+                  Resolved
+                  <span className="text-tertiary tabular-nums">
+                    {commentCounts.resolved}
+                  </span>
+                </SegmentedControlItem>
+                <SegmentedControlItem value="all">
+                  <List className="size-3" />
+                  All
+                  <span className="text-tertiary tabular-nums">
+                    {commentCounts.all}
+                  </span>
+                </SegmentedControlItem>
+              </SegmentedControl>
               <Button
                 className="gap-1.5"
                 onClick={() => setShowComments((v) => !v)}
@@ -245,15 +243,15 @@ export function DocumentsPinboardReader({
                 {showComments ? (
                   <>
                     <EyeOff className="size-3" />
-                    Hide comments
+                    Hide inline comments
                   </>
                 ) : (
                   <>
                     <Eye className="size-3" />
-                    Show comments
-                    {commentCounts.all > 0 && (
+                    Show inline comments
+                    {inlineThreads.length > 0 && (
                       <span className="text-tertiary tabular-nums">
-                        {commentCounts.all}
+                        {inlineThreads.length}
                       </span>
                     )}
                   </>
@@ -471,24 +469,22 @@ export function DocumentsPinboardReader({
           )}
         </div>
 
-        {showComments && (
-          <div className="grid grid-cols-[minmax(0,1fr)_260px] gap-5">
-            <BottomDiscussion
-              busy={commentsBusy}
-              currentUserEmail={currentUserEmail}
-              displayNames={displayNames}
-              filter={commentFilter}
-              lastVisit={lastVisit}
-              onAcknowledge={onAcknowledgeComment}
-              onCreateThread={onCreateThread}
-              onDelete={onDeleteComment}
-              onEdit={onEditComment}
-              onReply={onReplyComment}
-              onResolve={onResolveThread}
-              threads={pageThreads}
-            />
-          </div>
-        )}
+        <div className="grid grid-cols-[minmax(0,1fr)_260px] gap-5">
+          <BottomDiscussion
+            busy={commentsBusy}
+            currentUserEmail={currentUserEmail}
+            displayNames={displayNames}
+            filter={commentFilter}
+            lastVisit={lastVisit}
+            onAcknowledge={onAcknowledgeComment}
+            onCreateThread={onCreateThread}
+            onDelete={onDeleteComment}
+            onEdit={onEditComment}
+            onReply={onReplyComment}
+            onResolve={onResolveThread}
+            threads={pageThreads}
+          />
+        </div>
       </div>
 
       <SelectionToolbar

--- a/src/components/documents/ProjectDocumentsTab.tsx
+++ b/src/components/documents/ProjectDocumentsTab.tsx
@@ -334,6 +334,8 @@ export function ProjectDocumentsTab({
         onReplyComment={comments.onReply}
         onResolveThread={comments.onResolve}
         onTogglePin={() => togglePin(selectedDocument)}
+        orgSlug={orgSlug}
+        projectId={projectId}
       />
     )
   }

--- a/src/components/documents/comments/BottomDiscussion.tsx
+++ b/src/components/documents/comments/BottomDiscussion.tsx
@@ -14,6 +14,7 @@ interface Props extends CommentThreadHandlers {
   currentUserEmail: string
   displayNames?: Map<string, string>
   filter: CommentFilter
+  lastVisit?: number
   threads: CommentThread[]
 }
 
@@ -22,6 +23,7 @@ export function BottomDiscussion({
   currentUserEmail,
   displayNames,
   filter,
+  lastVisit,
   onAcknowledge,
   onCreateThread,
   onDelete,
@@ -50,6 +52,7 @@ export function BottomDiscussion({
 
       <CommentComposer
         busy={busy}
+        displayNames={displayNames}
         onSubmit={onCreateThread}
         placeholder="Add a comment to the discussion…"
         submitLabel="Comment"
@@ -67,10 +70,13 @@ export function BottomDiscussion({
               currentUserEmail={currentUserEmail}
               displayNames={displayNames}
               key={thread.id}
+              lastVisit={lastVisit}
               onAcknowledge={(commentId) => onAcknowledge(thread.id, commentId)}
               onDelete={(commentId) => onDelete(thread.id, commentId)}
-              onEdit={(commentId, body) => onEdit(thread.id, commentId, body)}
-              onReply={(body) => onReply(thread.id, body)}
+              onEdit={(commentId, body, mentions) =>
+                onEdit(thread.id, commentId, body, mentions)
+              }
+              onReply={(body, mentions) => onReply(thread.id, body, mentions)}
               onResolve={(resolved) => onResolve(thread.id, resolved)}
               thread={thread}
             />

--- a/src/components/documents/comments/CommentComposer.tsx
+++ b/src/components/documents/comments/CommentComposer.tsx
@@ -1,15 +1,22 @@
 import type { KeyboardEvent } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { Gravatar } from '@/components/ui/gravatar'
 import { Textarea } from '@/components/ui/textarea'
+
+import type { MentionCandidate } from './mentions'
+import { resolveMentions } from './mentions'
+import { useMentionAutocomplete } from './useMentionAutocomplete'
 
 interface Props {
   autoFocus?: boolean
   busy?: boolean
+  /** Email → display_name, used both for @mention autocomplete and resolution. */
+  displayNames?: Map<string, string>
   initial?: string
   onCancel?: () => void
-  onSubmit: (body: string) => void
+  onSubmit: (body: string, mentions: string[]) => void
   placeholder?: string
   submitLabel?: string
 }
@@ -17,13 +24,18 @@ interface Props {
 const MAX_HEIGHT = 220
 
 /**
- * Plain-text comment composer. Cmd/Ctrl-Enter submits, Escape cancels (when a
- * cancel handler is supplied), and the textarea auto-grows up to a max height.
- * No @mention autocomplete in Phase 1 — that lands in Phase 3.
+ * Plain-text comment composer with @mention autocomplete. Typing `@` opens a
+ * popover of users (filtered by name/email); ↑/↓ navigate, Enter/Tab select,
+ * Esc closes it. Cmd/Ctrl-Enter submits and the textarea auto-grows up to a max
+ * height. Mentioned display names are resolved to emails (against
+ * `displayNames`) and handed to `onSubmit` alongside the body text. The mention
+ * state machine lives in `useMentionAutocomplete`.
  */
+// fallow-ignore-next-line complexity
 export function CommentComposer({
   autoFocus = false,
   busy = false,
+  displayNames,
   initial = '',
   onCancel,
   onSubmit,
@@ -33,56 +45,97 @@ export function CommentComposer({
   const [text, setText] = useState(initial)
   const ref = useRef<HTMLTextAreaElement>(null)
 
-  const grow = (el: HTMLTextAreaElement) => {
+  const candidates = useMemo<MentionCandidate[]>(() => {
+    if (!displayNames) return []
+    return [...displayNames].map(([email, display_name]) => ({
+      display_name,
+      email,
+    }))
+  }, [displayNames])
+
+  const grow = () => {
+    const el = ref.current
+    if (!el) return
     el.style.height = 'auto'
     el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT)}px`
   }
 
+  // Set the value and (optionally) restore the caret + grow on the next frame.
+  const setValue = (next: string, caret?: number) => {
+    setText(next)
+    requestAnimationFrame(() => {
+      const el = ref.current
+      if (!el) return
+      if (caret !== undefined) {
+        el.focus()
+        el.setSelectionRange(caret, caret)
+      }
+      grow()
+    })
+  }
+
+  const mentions = useMentionAutocomplete(ref, candidates, text, setValue)
+
   useEffect(() => {
     const el = ref.current
     if (!el) return
-    grow(el)
+    grow()
     if (autoFocus) {
       el.focus()
       el.setSelectionRange(el.value.length, el.value.length)
     }
   }, [autoFocus])
 
+  // fallow-ignore-next-line complexity
   const submit = () => {
     const trimmed = text.trim()
     if (!trimmed || busy) return
-    onSubmit(trimmed)
+    onSubmit(trimmed, resolveMentions(trimmed, displayNames ?? new Map()))
     setText('')
+    mentions.close()
     if (ref.current) ref.current.style.height = 'auto'
   }
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    const action = keyAction(e)
-    if (!action) return
-    e.preventDefault()
-    if (action === 'submit') submit()
-    else onCancel?.()
+    if (mentions.onKeyDown(e)) return
+    if (e.key === 'Escape') {
+      onCancel?.()
+      return
+    }
+    if (isSubmitChord(e)) {
+      e.preventDefault()
+      submit()
+    }
   }
 
   const empty = !text.trim()
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="relative flex flex-col gap-1.5">
       <Textarea
         className="min-h-9 resize-none text-[13.5px]"
         onChange={(e) => {
           setText(e.target.value)
-          grow(e.target)
+          grow()
+          mentions.refresh(e.target)
         }}
         onKeyDown={onKeyDown}
+        onKeyUp={(e) => mentions.refresh(e.currentTarget)}
         placeholder={placeholder}
         ref={ref}
         rows={1}
         value={text}
       />
+      {mentions.open && (
+        <MentionPopover
+          active={mentions.active}
+          matches={mentions.matches}
+          onPick={mentions.pick}
+        />
+      )}
       <div className="flex items-center justify-between">
         <span className="text-tertiary text-[11px]">
-          {empty ? '' : 'Cmd + Enter to send'}
+          {empty ? '' : 'Cmd + Enter to send · @ to mention'}
         </span>
         <div className="flex items-center gap-2">
           {onCancel && (
@@ -104,12 +157,46 @@ export function CommentComposer({
   )
 }
 
-/** Map a keydown to a composer action: Cmd/Ctrl-Enter submits, Escape cancels. */
-// fallow-ignore-next-line complexity
-function keyAction(
-  e: KeyboardEvent<HTMLTextAreaElement>,
-): 'cancel' | 'submit' | null {
-  if (e.key === 'Escape') return 'cancel'
-  const submitChord = e.key === 'Enter' && (e.metaKey || e.ctrlKey)
-  return submitChord ? 'submit' : null
+/** Cmd/Ctrl-Enter submits the composer. */
+function isSubmitChord(e: KeyboardEvent<HTMLTextAreaElement>): boolean {
+  return e.key === 'Enter' && (e.metaKey || e.ctrlKey)
+}
+
+function MentionPopover({
+  active,
+  matches,
+  onPick,
+}: {
+  active: number
+  matches: MentionCandidate[]
+  onPick: (candidate: MentionCandidate) => void
+}) {
+  return (
+    <div className="border-tertiary bg-primary absolute top-9 left-0 z-20 flex w-64 flex-col gap-0.5 rounded-md border p-1 shadow-md">
+      {matches.map((candidate, i) => (
+        <button
+          className={
+            i === active
+              ? 'bg-secondary flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[13px]'
+              : 'hover:bg-secondary flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[13px]'
+          }
+          key={candidate.email}
+          onMouseDown={(e) => {
+            e.preventDefault()
+            onPick(candidate)
+          }}
+          type="button"
+        >
+          <Gravatar
+            className="shrink-0 rounded-full"
+            email={candidate.email}
+            size={18}
+          />
+          <span className="text-primary truncate">
+            {candidate.display_name}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
 }

--- a/src/components/documents/comments/CommentComposer.tsx
+++ b/src/components/documents/comments/CommentComposer.tsx
@@ -23,6 +23,9 @@ interface Props {
 
 const MAX_HEIGHT = 220
 
+/** Keys the open mention popover consumes; refresh must not undo their effect. */
+const POPOVER_KEYS = new Set(['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Tab'])
+
 /**
  * Plain-text comment composer with @mention autocomplete. Typing `@` opens a
  * popover of users (filtered by name/email); ↑/↓ navigate, Enter/Tab select,
@@ -121,7 +124,11 @@ export function CommentComposer({
           mentions.refresh(e.target)
         }}
         onKeyDown={onKeyDown}
-        onKeyUp={(e) => mentions.refresh(e.currentTarget)}
+        onKeyUp={(e) => {
+          // Don't undo the navigation/selection/dismiss the popover just did.
+          if (mentions.open && POPOVER_KEYS.has(e.key)) return
+          mentions.refresh(e.currentTarget)
+        }}
         placeholder={placeholder}
         ref={ref}
         rows={1}

--- a/src/components/documents/comments/CommentComposer.tsx
+++ b/src/components/documents/comments/CommentComposer.tsx
@@ -96,6 +96,7 @@ export function CommentComposer({
     if (ref.current) ref.current.style.height = 'auto'
   }
 
+  // fallow-ignore-next-line complexity
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (mentions.onKeyDown(e)) return
     if (e.key === 'Escape') {

--- a/src/components/documents/comments/CommentItem.tsx
+++ b/src/components/documents/comments/CommentItem.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { formatDistanceToNow } from 'date-fns'
 import { Pencil, Reply, ThumbsUp, Trash2 } from 'lucide-react'
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils'
 import type { Comment } from '@/types/comments'
 
 import { CommentComposer } from './CommentComposer'
+import { parseBody } from './mentions'
 
 interface ActionsProps {
   ackCount: number
@@ -29,8 +30,10 @@ interface Props {
   displayNames?: Map<string, string>
   onAcknowledge: () => void
   onDelete: () => void
-  onEdit: (body: string) => void
+  onEdit: (body: string, mentions: string[]) => void
   onReply?: () => void
+  /** Show an unread dot — comment is newer than the viewer's last visit. */
+  unread?: boolean
 }
 
 export function CommentItem({
@@ -42,6 +45,7 @@ export function CommentItem({
   onDelete,
   onEdit,
   onReply,
+  unread = false,
 }: Props) {
   const [editing, setEditing] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -65,25 +69,35 @@ export function CommentItem({
           })}
           {comment.edited && ' · edited'}
         </span>
+        {unread && (
+          <span
+            aria-label="New since your last visit"
+            className="comment-unread-dot"
+            title="New since your last visit"
+          />
+        )}
       </div>
 
       {editing ? (
         <CommentComposer
           autoFocus
           busy={busy}
+          displayNames={displayNames}
           initial={comment.body}
           onCancel={() => setEditing(false)}
-          onSubmit={(body) => {
-            onEdit(body)
+          onSubmit={(body, mentions) => {
+            onEdit(body, mentions)
             setEditing(false)
           }}
           submitLabel="Save"
         />
       ) : (
         <>
-          <div className="text-primary text-[13.5px] leading-normal whitespace-pre-wrap">
-            {comment.body}
-          </div>
+          <CommentBody
+            body={comment.body}
+            displayNames={displayNames}
+            mentions={comment.mentions}
+          />
           <CommentActions
             ackCount={ackCount}
             acknowledged={acknowledged}
@@ -165,6 +179,47 @@ function CommentActions({
         />
       )}
       {mine && <OwnerActions onDelete={onDelete} onEdit={onEdit} />}
+    </div>
+  )
+}
+
+/**
+ * Render a comment body, styling `@Display Name` tokens that resolve to one of
+ * the comment's mentioned users. Matching is restricted to the comment's
+ * `mentions` (resolved emails) so unrelated `@text` is left as plain text.
+ */
+function CommentBody({
+  body,
+  displayNames,
+  mentions,
+}: {
+  body: string
+  displayNames?: Map<string, string>
+  mentions: string[]
+}) {
+  const names = useMemo(() => {
+    const m = new Map<string, string>()
+    if (!displayNames) return m
+    for (const email of mentions) {
+      const name = displayNames.get(email)
+      if (name) m.set(email, name)
+    }
+    return m
+  }, [displayNames, mentions])
+
+  const segments = useMemo(() => parseBody(body, names), [body, names])
+
+  return (
+    <div className="text-primary text-[13.5px] leading-normal whitespace-pre-wrap">
+      {segments.map((seg, i) =>
+        seg.type === 'mention' ? (
+          <span className="comment-mention" key={i}>
+            {seg.text}
+          </span>
+        ) : (
+          <span key={i}>{seg.text}</span>
+        ),
+      )}
     </div>
   )
 }

--- a/src/components/documents/comments/CommentThreadView.tsx
+++ b/src/components/documents/comments/CommentThreadView.tsx
@@ -11,10 +11,12 @@ interface Props {
   busy?: boolean
   currentUserEmail: string
   displayNames?: Map<string, string>
+  /** Epoch ms of the viewer's last visit; comments after it show unread dots. */
+  lastVisit?: number
   onAcknowledge: (commentId: string) => void
   onDelete: (commentId: string) => void
-  onEdit: (commentId: string, body: string) => void
-  onReply: (body: string) => void
+  onEdit: (commentId: string, body: string, mentions: string[]) => void
+  onReply: (body: string, mentions: string[]) => void
   onResolve: (resolved: boolean) => void
   thread: CommentThread
 }
@@ -31,6 +33,7 @@ export function CommentThreadView({
   busy = false,
   currentUserEmail,
   displayNames,
+  lastVisit,
   onAcknowledge,
   onDelete,
   onEdit,
@@ -41,6 +44,11 @@ export function CommentThreadView({
   const root = thread.comments[0]
   const replies = thread.comments.slice(1)
   if (!root) return null
+
+  const isUnread = (comment: (typeof thread.comments)[number]) =>
+    lastVisit !== undefined &&
+    comment.author !== currentUserEmail &&
+    new Date(comment.created_at).getTime() > lastVisit
 
   return (
     <div className="border-tertiary bg-primary flex flex-col gap-3 rounded-lg border p-4">
@@ -59,7 +67,8 @@ export function CommentThreadView({
         displayNames={displayNames}
         onAcknowledge={() => onAcknowledge(root.id)}
         onDelete={() => onDelete(root.id)}
-        onEdit={(body) => onEdit(root.id, body)}
+        onEdit={(body, mentions) => onEdit(root.id, body, mentions)}
+        unread={isUnread(root)}
       />
 
       {replies.length > 0 && (
@@ -73,7 +82,8 @@ export function CommentThreadView({
               key={reply.id}
               onAcknowledge={() => onAcknowledge(reply.id)}
               onDelete={() => onDelete(reply.id)}
-              onEdit={(body) => onEdit(reply.id, body)}
+              onEdit={(body, mentions) => onEdit(reply.id, body, mentions)}
+              unread={isUnread(reply)}
             />
           ))}
         </div>
@@ -82,6 +92,7 @@ export function CommentThreadView({
       {!thread.resolved && (
         <CommentComposer
           busy={busy}
+          displayNames={displayNames}
           onSubmit={onReply}
           placeholder="Reply…"
           submitLabel="Reply"

--- a/src/components/documents/comments/MarginCommentCard.tsx
+++ b/src/components/documents/comments/MarginCommentCard.tsx
@@ -16,15 +16,16 @@ interface Props {
   displayNames?: Map<string, string>
   draft?: boolean
   focused: boolean
+  lastVisit?: number
   onAcknowledge: (commentId: string) => void
   onCancelDraft?: () => void
   onDelete: (commentId: string) => void
-  onEdit: (commentId: string, body: string) => void
+  onEdit: (commentId: string, body: string, mentions: string[]) => void
   onFocus: () => void
   onHover: (hovered: boolean) => void
-  onReply: (body: string) => void
+  onReply: (body: string, mentions: string[]) => void
   onResolve: (resolved: boolean) => void
-  onSubmitDraft?: (body: string) => void
+  onSubmitDraft?: (body: string, mentions: string[]) => void
   orphaned?: boolean
   thread: CommentThread
 }
@@ -45,6 +46,7 @@ export const MarginCommentCard = forwardRef<HTMLDivElement, Props>(
       displayNames,
       draft,
       focused,
+      lastVisit,
       onAcknowledge,
       onCancelDraft,
       onDelete,
@@ -89,8 +91,9 @@ export const MarginCommentCard = forwardRef<HTMLDivElement, Props>(
           <CommentComposer
             autoFocus
             busy={busy}
+            displayNames={displayNames}
             onCancel={onCancelDraft}
-            onSubmit={(body) => onSubmitDraft?.(body)}
+            onSubmit={(body, mentions) => onSubmitDraft?.(body, mentions)}
             placeholder="Add your comment…"
             submitLabel="Comment"
           />
@@ -99,6 +102,7 @@ export const MarginCommentCard = forwardRef<HTMLDivElement, Props>(
             busy={busy}
             currentUserEmail={currentUserEmail}
             displayNames={displayNames}
+            lastVisit={lastVisit}
             onAcknowledge={onAcknowledge}
             onDelete={onDelete}
             onEdit={onEdit}

--- a/src/components/documents/comments/RightCommentBar.tsx
+++ b/src/components/documents/comments/RightCommentBar.tsx
@@ -20,16 +20,22 @@ interface Props {
   displayNames?: Map<string, string>
   draft?: DraftThread | null
   focusedId: null | string
+  lastVisit?: number
   layoutTick: number
   onAcknowledge: (threadId: string, commentId: string) => void
   onCancelDraft: () => void
   onDelete: (threadId: string, commentId: string) => void
-  onEdit: (threadId: string, commentId: string, body: string) => void
+  onEdit: (
+    threadId: string,
+    commentId: string,
+    body: string,
+    mentions: string[],
+  ) => void
   onFocus: (threadId: null | string) => void
   onHover: (threadId: null | string) => void
-  onReply: (threadId: string, body: string) => void
+  onReply: (threadId: string, body: string, mentions: string[]) => void
   onResolve: (threadId: string, resolved: boolean) => void
-  onSubmitDraft: (body: string) => void
+  onSubmitDraft: (body: string, mentions: string[]) => void
   /** Inline threads (anchored or orphaned) shown in the margin. */
   orphanedIds: Set<string>
   threads: CommentThread[]
@@ -59,6 +65,7 @@ export function RightCommentBar({
   displayNames,
   draft,
   focusedId,
+  lastVisit,
   layoutTick,
   onAcknowledge,
   onCancelDraft,
@@ -130,13 +137,16 @@ export function RightCommentBar({
             draft={isDraft}
             focused={thread.id === focusedId || isDraft}
             key={thread.id}
+            lastVisit={lastVisit}
             onAcknowledge={(commentId) => onAcknowledge(thread.id, commentId)}
             onCancelDraft={onCancelDraft}
             onDelete={(commentId) => onDelete(thread.id, commentId)}
-            onEdit={(commentId, body) => onEdit(thread.id, commentId, body)}
+            onEdit={(commentId, body, mentions) =>
+              onEdit(thread.id, commentId, body, mentions)
+            }
             onFocus={() => onFocus(thread.id)}
             onHover={(hovered) => onHover(hovered ? thread.id : null)}
-            onReply={(body) => onReply(thread.id, body)}
+            onReply={(body, mentions) => onReply(thread.id, body, mentions)}
             onResolve={(resolved) => onResolve(thread.id, resolved)}
             onSubmitDraft={onSubmitDraft}
             orphaned={!isDraft && orphanedIds.has(thread.id)}

--- a/src/components/documents/comments/__tests__/mentions.test.ts
+++ b/src/components/documents/comments/__tests__/mentions.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  filterCandidates,
+  insertMention,
+  mentionQueryAt,
+  parseBody,
+  resolveMentions,
+} from '../mentions'
+
+const PEOPLE = [
+  { display_name: 'Ada Lovelace', email: 'ada@example.com' },
+  { display_name: 'Ada', email: 'ada2@example.com' },
+  { display_name: 'Grace Hopper', email: 'grace@example.com' },
+]
+
+const NAMES = new Map(PEOPLE.map((p) => [p.email, p.display_name]))
+
+describe('mentionQueryAt', () => {
+  it('detects an @ query at the caret', () => {
+    const v = 'hi @Gra'
+    expect(mentionQueryAt(v, v.length)).toEqual({ start: 3, text: 'Gra' })
+  })
+
+  it('detects an empty query right after @', () => {
+    const v = 'hi @'
+    expect(mentionQueryAt(v, v.length)).toEqual({ start: 3, text: '' })
+  })
+
+  it('allows a single space inside a multi-word name query', () => {
+    const v = '@Ada Lov'
+    expect(mentionQueryAt(v, v.length)).toEqual({ start: 0, text: 'Ada Lov' })
+  })
+
+  it('does not trigger inside an email address', () => {
+    const v = 'mail me at foo@bar'
+    expect(mentionQueryAt(v, v.length)).toBeNull()
+  })
+
+  it('does not trigger when there is no @ before the caret', () => {
+    const v = 'plain text'
+    expect(mentionQueryAt(v, v.length)).toBeNull()
+  })
+
+  it('uses the caret position, not the end of the string', () => {
+    const v = '@Ada more text'
+    // caret right after "@Ada"
+    expect(mentionQueryAt(v, 4)).toEqual({ start: 0, text: 'Ada' })
+  })
+})
+
+describe('filterCandidates', () => {
+  it('matches on display name, case-insensitively', () => {
+    expect(filterCandidates(PEOPLE, 'gra').map((c) => c.email)).toEqual([
+      'grace@example.com',
+    ])
+  })
+
+  it('matches on email', () => {
+    expect(filterCandidates(PEOPLE, 'ada2').map((c) => c.email)).toEqual([
+      'ada2@example.com',
+    ])
+  })
+
+  it('returns everything for an empty query', () => {
+    expect(filterCandidates(PEOPLE, '')).toHaveLength(3)
+  })
+})
+
+describe('insertMention', () => {
+  it('replaces the query with @Name and a trailing space', () => {
+    const v = 'hi @Gra'
+    const q = mentionQueryAt(v, v.length)!
+    const out = insertMention(v, q, v.length, 'Grace Hopper')
+    expect(out.value).toBe('hi @Grace Hopper ')
+    expect(out.caret).toBe(out.value.length)
+  })
+
+  it('keeps text that follows the caret', () => {
+    const v = 'hi @Gra there'
+    const q = mentionQueryAt(v, 7)!
+    const out = insertMention(v, q, 7, 'Grace Hopper')
+    expect(out.value).toBe('hi @Grace Hopper  there')
+  })
+})
+
+describe('parseBody', () => {
+  it('returns a single text segment when no names are known', () => {
+    expect(parseBody('hi @Ada', new Map())).toEqual([
+      { text: 'hi @Ada', type: 'text' },
+    ])
+  })
+
+  it('styles a known mention and resolves its email', () => {
+    const segs = parseBody('cc @Grace Hopper please', NAMES)
+    expect(segs).toEqual([
+      { text: 'cc ', type: 'text' },
+      { email: 'grace@example.com', text: '@Grace Hopper', type: 'mention' },
+      { text: ' please', type: 'text' },
+    ])
+  })
+
+  it('prefers the longest matching name', () => {
+    const segs = parseBody('@Ada Lovelace ok', NAMES)
+    expect(segs[0]).toEqual({
+      email: 'ada@example.com',
+      text: '@Ada Lovelace',
+      type: 'mention',
+    })
+  })
+
+  it('leaves unknown @text as plain text', () => {
+    expect(parseBody('@Nobody here', NAMES)).toEqual([
+      { text: '@Nobody here', type: 'text' },
+    ])
+  })
+})
+
+describe('resolveMentions', () => {
+  it('collects unique emails for every mentioned name', () => {
+    const body = 'ping @Grace Hopper and @Ada'
+    expect(resolveMentions(body, NAMES).sort()).toEqual([
+      'ada2@example.com',
+      'grace@example.com',
+    ])
+  })
+
+  it('returns an empty array when nothing is mentioned', () => {
+    expect(resolveMentions('no mentions here', NAMES)).toEqual([])
+  })
+})

--- a/src/components/documents/comments/__tests__/mentions.test.ts
+++ b/src/components/documents/comments/__tests__/mentions.test.ts
@@ -114,6 +114,13 @@ describe('parseBody', () => {
       { text: '@Nobody here', type: 'text' },
     ])
   })
+
+  it('does not match a known name inside a longer word', () => {
+    // "Ada" is known but "@Adam" is a different, unknown handle.
+    expect(parseBody('@Adam said hi', NAMES)).toEqual([
+      { text: '@Adam said hi', type: 'text' },
+    ])
+  })
 })
 
 describe('resolveMentions', () => {

--- a/src/components/documents/comments/__tests__/useCommentLastVisit.test.ts
+++ b/src/components/documents/comments/__tests__/useCommentLastVisit.test.ts
@@ -1,0 +1,69 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useCommentLastVisit } from '../useCommentLastVisit'
+
+const KEY = 'imbi:comment-last-visit:acme:proj-1:doc-1'
+
+// The shared test setup stubs localStorage with a no-op mock; install a real
+// in-memory store for this suite so reads reflect writes.
+function installMemoryStorage() {
+  const store = new Map<string, string>()
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => store.clear(),
+      getItem: (k: string) => store.get(k) ?? null,
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size
+      },
+      removeItem: (k: string) => store.delete(k),
+      setItem: (k: string, v: string) => store.set(k, v),
+    },
+    writable: true,
+  })
+}
+
+describe('useCommentLastVisit', () => {
+  beforeEach(() => {
+    installMemoryStorage()
+  })
+
+  it('returns undefined on the first visit and records now', () => {
+    const before = Date.now()
+    const { result } = renderHook(() =>
+      useCommentLastVisit('acme', 'proj-1', 'doc-1'),
+    )
+    expect(result.current).toBeUndefined()
+    expect(Number(window.localStorage.getItem(KEY))).toBeGreaterThanOrEqual(
+      before,
+    )
+  })
+
+  it('returns the prior visit timestamp on a later visit', () => {
+    const prior = new Date('2026-05-28T09:00:00Z').getTime()
+    window.localStorage.setItem(KEY, String(prior))
+    const { result } = renderHook(() =>
+      useCommentLastVisit('acme', 'proj-1', 'doc-1'),
+    )
+    expect(result.current).toBe(prior)
+    // The current visit replaces the stored timestamp.
+    expect(Number(window.localStorage.getItem(KEY))).toBeGreaterThan(prior)
+  })
+
+  it('returns undefined when required ids are missing', () => {
+    const { result } = renderHook(() =>
+      useCommentLastVisit('acme', 'proj-1', ''),
+    )
+    expect(result.current).toBeUndefined()
+  })
+
+  it('ignores a corrupt stored value', () => {
+    window.localStorage.setItem(KEY, 'not-a-number')
+    const { result } = renderHook(() =>
+      useCommentLastVisit('acme', 'proj-1', 'doc-1'),
+    )
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/src/components/documents/comments/mentions.ts
+++ b/src/components/documents/comments/mentions.ts
@@ -141,7 +141,12 @@ function matchNameAt(
   names: string[],
 ): null | string {
   for (const name of names) {
-    if (body.startsWith(name, from)) return name
+    if (body.startsWith(name, from)) {
+      // Require a boundary so a short name doesn't match inside a longer word
+      // (e.g. known "Ada" must not match "@Adam").
+      const after = body[from + name.length]
+      if (after === undefined || !/[\p{L}\p{N}.-]/u.test(after)) return name
+    }
   }
   return null
 }

--- a/src/components/documents/comments/mentions.ts
+++ b/src/components/documents/comments/mentions.ts
@@ -1,0 +1,147 @@
+// Pure helpers for @mention autocomplete, insertion, and rendering.
+//
+// The client resolves @mention selections to user *emails* and sends them in a
+// `mentions: string[]` field (imbi-api #416/#417). The body text carries the
+// human-readable `@Display Name` tokens; `mentions` carries the resolved
+// emails. The backend never parses display names.
+
+/** A candidate user for mention autocomplete. */
+export interface MentionCandidate {
+  display_name: string
+  email: string
+}
+
+/** An in-progress @mention being typed: the query text and where the `@` sits. */
+export interface MentionQuery {
+  /** Index of the `@` in the textarea value. */
+  start: number
+  /** Text typed after the `@`, up to the caret. */
+  text: string
+}
+
+interface Segment {
+  email?: string
+  text: string
+  type: 'mention' | 'text'
+}
+
+const MAX_RESULTS = 6
+
+/** Rank candidates for a query: case-insensitive substring on name or email. */
+export function filterCandidates(
+  candidates: MentionCandidate[],
+  query: string,
+): MentionCandidate[] {
+  const q = query.trim().toLowerCase()
+  const matches = candidates.filter(
+    (c) =>
+      c.display_name.toLowerCase().includes(q) ||
+      c.email.toLowerCase().includes(q),
+  )
+  return matches.slice(0, MAX_RESULTS)
+}
+
+/**
+ * Replace the open mention (from `query.start` to `caret`) with
+ * `@Display Name ` and return the new value plus the caret position after it.
+ */
+export function insertMention(
+  value: string,
+  query: MentionQuery,
+  caret: number,
+  displayName: string,
+): { caret: number; value: string } {
+  const token = `@${displayName} `
+  const next = value.slice(0, query.start) + token + value.slice(caret)
+  return { caret: query.start + token.length, value: next }
+}
+
+/**
+ * Detect an open @mention at the caret. Returns the query when the text
+ * immediately before the caret is an `@` followed by mention-name characters
+ * (letters, digits, spaces, dot, hyphen) with no intervening newline; null
+ * otherwise. A trailing double-space closes the mention (the user moved on).
+ */
+export function mentionQueryAt(
+  value: string,
+  caret: number,
+): MentionQuery | null {
+  const before = value.slice(0, caret)
+  const m = before.match(/@([\p{L}\p{N}.-]*(?: [\p{L}\p{N}.-]+)*)$/u)
+  if (!m) return null
+  // Don't trigger when the `@` is glued to a preceding word (e.g. an email).
+  const at = caret - m[0].length
+  const prev = at > 0 ? value[at - 1] : ''
+  if (prev && !/\s/.test(prev)) return null
+  return { start: at, text: m[1] }
+}
+
+/**
+ * Split a comment body into plain-text and mention segments. A run of text is a
+ * mention when it reads `@Display Name` for a known display name; the longest
+ * matching name wins so "@Ada Lovelace" beats "@Ada". `mentions` (resolved
+ * emails on the comment) is used to attach the email to the segment when the
+ * display name is unambiguous.
+ */
+export function parseBody(
+  body: string,
+  knownNames: Map<string, string>,
+): Segment[] {
+  if (knownNames.size === 0) return [{ text: body, type: 'text' }]
+  const lowerToEmail = new Map<string, string>()
+  for (const [email, name] of knownNames) {
+    lowerToEmail.set(name.toLowerCase(), email)
+  }
+  // Longest names first so a longer name isn't shadowed by a prefix.
+  const names = [...knownNames.values()].sort((a, b) => b.length - a.length)
+  const segments: Segment[] = []
+  let i = 0
+  let plainStart = 0
+  // fallow-ignore-next-line complexity
+  while (i < body.length) {
+    const matched = body[i] === '@' && matchNameAt(body, i + 1, names)
+    if (!matched) {
+      i += 1
+      continue
+    }
+    if (i > plainStart)
+      segments.push({ text: body.slice(plainStart, i), type: 'text' })
+    segments.push({
+      email: lowerToEmail.get(matched.toLowerCase()),
+      text: `@${matched}`,
+      type: 'mention',
+    })
+    i += matched.length + 1
+    plainStart = i
+  }
+  if (plainStart < body.length)
+    segments.push({ text: body.slice(plainStart), type: 'text' })
+  return segments
+}
+
+/**
+ * Resolve the emails of every known display name mentioned in the body. Used to
+ * derive the `mentions` array from the composed text at submit/edit time.
+ */
+export function resolveMentions(
+  body: string,
+  knownNames: Map<string, string>,
+): string[] {
+  const emails = new Set<string>()
+  for (const segment of parseBody(body, knownNames)) {
+    if (segment.type === 'mention' && segment.email) emails.add(segment.email)
+  }
+  return [...emails]
+}
+
+/** The longest display name that appears verbatim at `body[from..]`, or null. */
+function matchNameAt(
+  body: string,
+  from: number,
+  names: string[],
+): null | string {
+  for (const name of names) {
+    if (body.startsWith(name, from)) return name
+  }
+  return null
+}

--- a/src/components/documents/comments/useCommentLastVisit.ts
+++ b/src/components/documents/comments/useCommentLastVisit.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+
+const STORAGE_PREFIX = 'imbi:comment-last-visit:'
+
+/**
+ * Per-document "last visited the comments" timestamp, persisted in
+ * localStorage and keyed by org/project/document. Comments created after the
+ * returned `lastVisit` (and not by the current user) are considered unread.
+ *
+ * The returned value is the *previous* visit's timestamp, captured once when
+ * the document is opened so dots stay stable for the whole viewing session;
+ * the current visit time is written back immediately so the next visit
+ * compares against this one. There is no server-side read model — that is an
+ * explicit future follow-up.
+ */
+export function useCommentLastVisit(
+  orgSlug: string,
+  projectId: string,
+  documentId: string,
+): number | undefined {
+  const [lastVisit, setLastVisit] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    if (!orgSlug || !projectId || !documentId) {
+      setLastVisit(undefined)
+      return
+    }
+    const key = `${STORAGE_PREFIX}${orgSlug}:${projectId}:${documentId}`
+    let previous: number | undefined
+    try {
+      const raw = window.localStorage.getItem(key)
+      previous = raw ? Number(raw) : undefined
+      if (previous !== undefined && Number.isNaN(previous)) previous = undefined
+    } catch {
+      previous = undefined
+    }
+    setLastVisit(previous)
+    try {
+      window.localStorage.setItem(key, String(Date.now()))
+    } catch {
+      // Ignore storage failures (private mode, quota) — unread dots are
+      // a best-effort enhancement, not load-bearing.
+    }
+  }, [orgSlug, projectId, documentId])
+
+  return lastVisit
+}

--- a/src/components/documents/comments/useMentionAutocomplete.ts
+++ b/src/components/documents/comments/useMentionAutocomplete.ts
@@ -1,0 +1,102 @@
+import type { KeyboardEvent, RefObject } from 'react'
+import { useMemo, useState } from 'react'
+
+import type { MentionCandidate, MentionQuery } from './mentions'
+import { filterCandidates, insertMention, mentionQueryAt } from './mentions'
+
+interface MentionAutocomplete {
+  /** The currently highlighted candidate index. */
+  active: number
+  /** Dismiss the open query (e.g. after submit). */
+  close: () => void
+  /** The visible (filtered) candidates for the open query. */
+  matches: MentionCandidate[]
+  /**
+   * Handle a keydown while the popover is open. Returns true when the key was
+   * consumed (navigation/selection/dismiss) so the composer skips its own
+   * handling.
+   */
+  onKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => boolean
+  /** True while a mention query is open at the caret. */
+  open: boolean
+  /** Insert a candidate's display name, replacing the open query. */
+  pick: (candidate: MentionCandidate) => void
+  /** Recompute the open query from the textarea's value + caret. */
+  refresh: (el: HTMLTextAreaElement) => void
+}
+
+/**
+ * @mention autocomplete state machine for a textarea. Owns the open query,
+ * candidate filtering, keyboard navigation, and caret-aware insertion; the
+ * composer wires it to `value`/`onChange` and calls `refresh` on input. Kept
+ * separate from CommentComposer so the composer stays a thin render.
+ */
+export function useMentionAutocomplete(
+  ref: RefObject<HTMLTextAreaElement | null>,
+  candidates: MentionCandidate[],
+  value: string,
+  setValue: (next: string, caret?: number) => void,
+): MentionAutocomplete {
+  const [query, setQuery] = useState<MentionQuery | null>(null)
+  const [active, setActive] = useState(0)
+
+  const matches = useMemo(
+    () => (query ? filterCandidates(candidates, query.text) : []),
+    [candidates, query],
+  )
+
+  const refresh = (el: HTMLTextAreaElement) => {
+    setQuery(mentionQueryAt(el.value, el.selectionStart))
+    setActive(0)
+  }
+
+  const pick = (candidate: MentionCandidate) => {
+    const el = ref.current
+    if (!el || !query) return
+    const next = insertMention(
+      value,
+      query,
+      el.selectionStart,
+      candidate.display_name,
+    )
+    setQuery(null)
+    setValue(next.value, next.caret)
+  }
+
+  // fallow-ignore-next-line complexity
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+    if (!query || matches.length === 0) return false
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActive((a) => (a + 1) % matches.length)
+      return true
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActive((a) => (a - 1 + matches.length) % matches.length)
+      return true
+    }
+    if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault()
+      const choice = matches[active]
+      if (choice) pick(choice)
+      return true
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      setQuery(null)
+      return true
+    }
+    return false
+  }
+
+  return {
+    active,
+    close: () => setQuery(null),
+    matches,
+    onKeyDown,
+    open: query !== null && matches.length > 0,
+    pick,
+    refresh,
+  }
+}

--- a/src/hooks/useDocumentComments.ts
+++ b/src/hooks/useDocumentComments.ts
@@ -28,14 +28,17 @@ interface CommentVars {
 interface CreateThreadVars {
   anchor?: CommentAnchor
   body: string
+  mentions: string[]
 }
 
 interface EditVars extends CommentVars {
   body: string
+  mentions: string[]
 }
 
 interface ReplyVars {
   body: string
+  mentions: string[]
   threadId: string
 }
 
@@ -109,9 +112,10 @@ export function useDocumentComments(
     unknown,
     CreateThreadVars
   >({
-    mutationFn: ({ anchor, body }) =>
+    mutationFn: ({ anchor, body, mentions }) =>
       createCommentThread(orgSlug, projectId, documentId, {
         body,
+        mentions,
         ...(anchor ? { anchor, kind: 'inline' } : { kind: 'page' }),
       }),
     onError: fail('Comment failed'),
@@ -124,8 +128,11 @@ export function useDocumentComments(
   })
 
   const replyMutation = useMutation<Comment, unknown, ReplyVars>({
-    mutationFn: ({ body, threadId }) =>
-      addCommentReply(orgSlug, projectId, documentId, threadId, { body }),
+    mutationFn: ({ body, mentions, threadId }) =>
+      addCommentReply(orgSlug, projectId, documentId, threadId, {
+        body,
+        mentions,
+      }),
     onError: fail('Reply failed'),
     onSettled: settle,
     onSuccess: (comment, { threadId }) => {
@@ -195,18 +202,27 @@ export function useDocumentComments(
     EditVars,
     { previous?: CommentThread[] }
   >({
-    mutationFn: ({ body, commentId, threadId }) =>
-      editComment(orgSlug, projectId, documentId, threadId, commentId, body),
+    mutationFn: ({ body, commentId, mentions, threadId }) =>
+      editComment(
+        orgSlug,
+        projectId,
+        documentId,
+        threadId,
+        commentId,
+        body,
+        mentions,
+      ),
     onError: (err, _vars, ctx) => {
       rollback(ctx)
       fail('Edit failed')(err)
     },
-    onMutate: ({ body, commentId, threadId }) =>
+    onMutate: ({ body, commentId, mentions, threadId }) =>
       optimistic((prev) =>
         mapComment(prev, threadId, commentId, (c) => ({
           ...c,
           body,
           edited: true,
+          mentions,
         })),
       ),
     onSettled: settle,
@@ -234,13 +250,14 @@ export function useDocumentComments(
     commentsBusy,
     onAcknowledge: (threadId, commentId) =>
       acknowledgeMutation.mutate({ commentId, threadId }),
-    onCreateThread: (body, inline) =>
-      createThreadMutation.mutate({ anchor: inline?.anchor, body }),
+    onCreateThread: (body, mentions, inline) =>
+      createThreadMutation.mutate({ anchor: inline?.anchor, body, mentions }),
     onDelete: (threadId, commentId) =>
       deleteCommentMutation.mutate({ commentId, threadId }),
-    onEdit: (threadId, commentId, body) =>
-      editMutation.mutate({ body, commentId, threadId }),
-    onReply: (threadId, body) => replyMutation.mutate({ body, threadId }),
+    onEdit: (threadId, commentId, body, mentions) =>
+      editMutation.mutate({ body, commentId, mentions, threadId }),
+    onReply: (threadId, body, mentions) =>
+      replyMutation.mutate({ body, mentions, threadId }),
     onResolve: (threadId, resolved) =>
       resolveMutation.mutate({ resolved, threadId }),
   }

--- a/src/index.css
+++ b/src/index.css
@@ -474,7 +474,7 @@
 
   /* @mention tokens inside a rendered comment body. */
   .comment-mention {
-    color: color-mix(in srgb, var(--color-primary) 75%, black);
+    color: var(--ds-text-warning);
     font-weight: 500;
     background: color-mix(in srgb, var(--color-primary) 14%, transparent);
     padding: 0 3px;

--- a/src/index.css
+++ b/src/index.css
@@ -471,6 +471,25 @@
     background: transparent;
     border-bottom: 1px dotted var(--ds-border-secondary);
   }
+
+  /* @mention tokens inside a rendered comment body. */
+  .comment-mention {
+    color: color-mix(in srgb, var(--color-primary) 75%, black);
+    font-weight: 500;
+    background: color-mix(in srgb, var(--color-primary) 14%, transparent);
+    padding: 0 3px;
+    border-radius: 3px;
+  }
+
+  /* Unread dot shown next to comments newer than the viewer's last visit. */
+  .comment-unread-dot {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-activity-info-dot);
+    flex-shrink: 0;
+  }
 }
 
 @keyframes slide-in-right {

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -50,10 +50,19 @@ export interface CommentThread {
  */
 export interface CommentThreadHandlers {
   onAcknowledge: (threadId: string, commentId: string) => void
-  onCreateThread: (body: string, inline?: { anchor: CommentAnchor }) => void
+  onCreateThread: (
+    body: string,
+    mentions: string[],
+    inline?: { anchor: CommentAnchor },
+  ) => void
   onDelete: (threadId: string, commentId: string) => void
-  onEdit: (threadId: string, commentId: string, body: string) => void
-  onReply: (threadId: string, body: string) => void
+  onEdit: (
+    threadId: string,
+    commentId: string,
+    body: string,
+    mentions: string[],
+  ) => void
+  onReply: (threadId: string, body: string, mentions: string[]) => void
   onResolve: (threadId: string, resolved: boolean) => void
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of Document Comments (imbi-ui): `@mention` autocomplete + rendering, and unread dots. **No notification delivery** (deferred per plan).

**Stacked on #395** (Phase 2). Base is `feature/document-comments-inline`; the incremental diff is just the Phase 3 commit. Will retarget to `main` once #395 merges.

Pairs with imbi-api #417 (edit JSON-Patch now accepts `/mentions`).

### Mention contract (matches imbi-api #417)

The **client** resolves `@Display Name` selections to user **emails** and sends them in a `mentions: string[]` field; the backend persists them and does not parse display names. Body text carries the human-readable `@Display Name` tokens; `mentions` carries the resolved emails.

## What's here

New under `src/components/documents/comments/`:
- **`mentions.ts`** — pure helpers: `mentionQueryAt` (caret detection), `filterCandidates`, `insertMention`, `parseBody` (text/mention segments), `resolveMentions` (display names → emails).
- **`useMentionAutocomplete.ts`** — mention state machine (open query, filtered candidates, keyboard nav, caret-aware insertion). Extracted to keep `CommentComposer` thin and pass the complexity gate without blanket suppression.
- **`useCommentLastVisit.ts`** — per-document last-visit hook backed by `localStorage`.
- `__tests__/mentions.test.ts` (17 tests) + `useCommentLastVisit.test.ts` (4 tests).

Changed:
- `CommentComposer.tsx` — `@` autocomplete popover (filter by name/email; ↑/↓/Enter/Tab/Esc + click; inserts `@Display Name` at caret), resolves selections to emails, `onSubmit(body, mentions)`. Keeps Cmd/Ctrl-Enter + auto-grow.
- `CommentItem.tsx` — `CommentBody` renders `@Display Name` tokens (matched against the comment's `mentions`, longest-name-first) as `.comment-mention` spans; adds the unread dot.
- `CommentThreadView.tsx`/`BottomDiscussion.tsx`/`MarginCommentCard.tsx`/`RightCommentBar.tsx` — thread `mentions` + `lastVisit`/unread + `displayNames` through reply/edit/draft/composer paths.
- `DocumentsPinboardReader.tsx` + `ProjectDocumentsTab.tsx` — `orgSlug`/`projectId` props; wire `useCommentLastVisit`.
- `useDocumentComments.ts` — create/reply/edit mutations carry `mentions` (incl. optimistic edit).
- `endpoints.ts` — `editComment` JSON-Patch replaces both `/body` and `/mentions`.
- `types/comments.ts` — handler signatures carry `mentions`.
- `index.css` — `.comment-mention` (amber `--color-primary`) + `.comment-unread-dot`.

### Key decisions

- **Autocomplete user list**: reused the existing `displayNames` map (email→display_name) already flowing into the comment UI from `useUserDisplayNames` (→ `listAdminUsers({is_active:true})`). No new endpoint.
- **Mention rendering**: parses the body against the comment's resolved `mentions` (longest-name-first) rather than the prototype's capitalization heuristic — avoids styling unrelated `@text`.
- **Unread storage**: `localStorage` key `imbi:comment-last-visit:<org>:<project>:<document>`; prior timestamp frozen for the session so dots stay stable; a comment is unread when `created_at > lastVisit` and not authored by the current user. No backend state (server-side read model is an explicit future follow-up).

## Verification (independently re-run on the committed tree)

- `npm run build` (tsc strict + vite): ✓
- `npm run lint`: 0 errors (the +4 `enforce-sort-order` warnings are the documented oxlint↔oxfmt category).
- `npm run format:check`: clean.
- `npm test` (vitest): **393 passed / 49 files**, incl. 21 new tests.
- `fallow audit`: pass (0 introduced complexity/dead-code/duplication).

## Not runtime-verified (honest caveat)

No live browser was driven. Caret positioning after mention insert, popover keyboard nav, and the unread-dot appearance were verified via unit tests on the pure helpers/hook + tsc/lint only — not observed in a running app. Worth a manual pass alongside the Phase 2 inline-comment QA.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>