### PR TITLE
Fix Cmd+Shift+A browser conflict and improve Keystroke badge polish

### DIFF
--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -588,7 +588,7 @@ export function CommandBar() {
               type="text"
               value={input}
             />
-            {!input && !inputFocused && <Keystroke value="Ctrl+Shift+A" />}
+            {!input && !inputFocused && <Keystroke value="Ctrl+K" />}
             {mode === 'assistant' && isStreaming ? (
               <Button
                 aria-label="Stop generating"

--- a/src/components/ui/keystroke.tsx
+++ b/src/components/ui/keystroke.tsx
@@ -26,13 +26,13 @@ export function Keystroke({
     : { alt: 'Alt', ctrl: 'Ctrl', shift: 'Shift' }
   const keys = value.split('+')
   return (
-    <span className={className}>
+    <span className={`inline-flex gap-0.5 ${className ?? ''}`}>
       {keys.map((key, i) => {
         const lower = key.trim().toLowerCase()
         const display = glyphs[lower] ?? keyGlyphs[key] ?? key
         return (
           <kbd
-            className="border-muted-foreground/40 text-muted-foreground inline-flex items-center rounded border px-1 font-mono text-[10px] leading-none"
+            className="border-muted-foreground/40 text-muted-foreground inline-flex items-center rounded border px-1 py-0.5 font-mono text-xs leading-none"
             key={i}
           >
             {display}

--- a/src/hooks/__tests__/useAssistantShortcut.test.tsx
+++ b/src/hooks/__tests__/useAssistantShortcut.test.tsx
@@ -26,16 +26,16 @@ function Harness() {
         type="text"
         value={value}
       />
-      {!value && !focused && <span data-testid="badge">⌘⇧A</span>}
+      {!value && !focused && <span data-testid="badge">⌘K</span>}
     </div>
   )
 }
 
 describe('useAssistantShortcut', () => {
-  it('focuses the assistant input when Ctrl+Shift+A is pressed', async () => {
+  it('focuses the assistant input when Ctrl+K is pressed', async () => {
     const user = userEvent.setup()
     render(<Harness />)
-    await user.keyboard('{Control>}{Shift>}A{/Shift}{/Control}')
+    await user.keyboard('{Control>}k{/Control}')
     expect(screen.getByTestId('assistant-input')).toHaveFocus()
   })
 
@@ -43,7 +43,7 @@ describe('useAssistantShortcut', () => {
     const user = userEvent.setup()
     render(<Harness />)
     expect(screen.getByTestId('expanded')).toHaveTextContent('closed')
-    await user.keyboard('{Control>}{Shift>}A{/Shift}{/Control}')
+    await user.keyboard('{Control>}k{/Control}')
     expect(screen.getByTestId('expanded')).toHaveTextContent('open')
   })
 

--- a/src/hooks/useAssistantShortcut.ts
+++ b/src/hooks/useAssistantShortcut.ts
@@ -7,7 +7,7 @@ export function useAssistantShortcut(
 ) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'A' && e.shiftKey && (e.metaKey || e.ctrlKey)) {
+      if (e.key === 'k' && !e.shiftKey && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
         if (!isExpanded) setExpanded(true)
         ref.current?.focus()


### PR DESCRIPTION
## Summary

- Switch assistant bar shortcut from `Cmd+Shift+A` to `Cmd+K` —
  `Cmd+Shift+A` conflicts with Chrome's built-in tab search
- `Keystroke` badges now use `text-xs` (up from `text-[10px]`) and
  `py-0.5` vertical padding, making the `/` badge proportional to the
  adjacent search icon
- `gap-0.5` between keys so multi-key sequences like `⌘K` have
  breathing room

## Test plan

- [ ] `Cmd+K` / `Ctrl+K` focuses and expands the CommandBar
- [ ] `Cmd+Shift+A` no longer triggers the CommandBar
- [ ] `/` badge in project search looks proportional to the magnifying glass icon
- [ ] `⌘K` badge in CommandBar input has visible gap between keys
- [ ] Both badges still hide on focus and when the input has a value

🤖 Generated with [Claude Code](https://claude.com/claude-code)