### PR TITLE
Document comments: discussion UX, rich (mdx-editor) composer, and activity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@icons-pack/react-simple-icons": "^13.11.2",
+        "@mdxeditor/editor": "^4.0.1",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-alert-dialog": "^1.1.4",
         "@radix-ui/react-checkbox": "^1.1.3",
@@ -472,6 +473,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
+      "integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/commands": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
@@ -482,6 +495,286 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-angular": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
+      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.3"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-go": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
+      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/go": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-jinja": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-less": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
+      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-liquid": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
+      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-vue": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
+      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
@@ -498,6 +791,37 @@
         "style-mod": "^4.0.0"
       }
     },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
+      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-angular": "^0.1.0",
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-go": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-less": "^6.0.0",
+        "@codemirror/lang-liquid": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sass": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-vue": "^0.1.1",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.4.0"
+      }
+    },
     "node_modules/@codemirror/legacy-modes": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.3.tgz",
@@ -505,6 +829,41 @@
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/merge": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.12.1.tgz",
+      "integrity": "sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/highlight": "^1.0.0",
+        "style-mod": "^4.1.0"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {
@@ -1432,6 +1791,21 @@
         "@floating-ui/utils": "^0.2.11"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
@@ -1585,11 +1959,299 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lexical/clipboard": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.35.0.tgz",
+      "integrity": "sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.35.0",
+        "@lexical/list": "0.35.0",
+        "@lexical/selection": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/code": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.35.0.tgz",
+      "integrity": "sha512-ox4DZwETQ9IA7+DS6PN8RJNwSAF7RMjL7YTVODIqFZ5tUFIf+5xoCHbz7Fll0Bvixlp12hVH90xnLwTLRGpkKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0",
+        "prismjs": "^1.30.0"
+      }
+    },
+    "node_modules/@lexical/devtools-core": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.35.0.tgz",
+      "integrity": "sha512-C2wwtsMCR6ZTfO0TqpSM17RLJWyfHmifAfCTjFtOJu15p3M6NO/nHYK5Mt7YMQteuS89mOjB4ng8iwoLEZ6QpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.35.0",
+        "@lexical/link": "0.35.0",
+        "@lexical/mark": "0.35.0",
+        "@lexical/table": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.35.0.tgz",
+      "integrity": "sha512-SL6mT5pcqrt6hEbJ16vWxip5+r3uvMd0bQV5UUxuk+cxIeuP86iTgRh0HFR7SM2dRTYovL6/tM/O+8QLAUGTIg==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/hashtag": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.35.0.tgz",
+      "integrity": "sha512-LYJWzXuO2ZjKsvQwrLkNZiS2TsjwYkKjlDgtugzejquTBQ/o/nfSn/MmVx6EkYLOYizaJemmZbz3IBh+u732FA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/history": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.35.0.tgz",
+      "integrity": "sha512-onjDRLLxGbCfHexSxxrQaDaieIHyV28zCDrbxR5dxTfW8F8PxjuNyuaG0z6o468AXYECmclxkP+P4aT6poHEpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/html": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.35.0.tgz",
+      "integrity": "sha512-rXGFE5S5rKsg3tVnr1s4iEgOfCApNXGpIFI3T2jGEShaCZ5HLaBY9NVBXnE9Nb49e9bkDkpZ8FZd1qokCbQXbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/link": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.35.0.tgz",
+      "integrity": "sha512-+0Wx6cBwO8TfdMzpkYFacsmgFh8X1rkiYbq3xoLvk3qV8upYxaMzK1s8Q1cpKmWyI0aZrU6z7fiK4vUqB7+69w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/list": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.35.0.tgz",
+      "integrity": "sha512-owsmc8iwgExBX8sFe8fKTiwJVhYULt9hD1RZ/HwfaiEtRZZkINijqReOBnW2mJfRxBzhFSWc4NG3ISB+fHYzqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/mark": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.35.0.tgz",
+      "integrity": "sha512-W0hwMTAVeexvpk9/+J6n1G/sNkpI/Meq1yeDazahFLLAwXLHtvhIAq2P/klgFknDy1hr8X7rcsQuN/bqKcKHYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/markdown": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.35.0.tgz",
+      "integrity": "sha512-BlNyXZAt4gWidMw0SRWrhBETY1BpPglFBZI7yzfqukFqgXRh7HUQA28OYeI/nsx9pgNob8TiUduUwShqqvOdEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/code": "0.35.0",
+        "@lexical/link": "0.35.0",
+        "@lexical/list": "0.35.0",
+        "@lexical/rich-text": "0.35.0",
+        "@lexical/text": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/offset": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.35.0.tgz",
+      "integrity": "sha512-DRE4Df6qYf2XiV6foh6KpGNmGAv2ANqt3oVXpyS6W8hTx3+cUuAA1APhCZmLNuU107um4zmHym7taCu6uXW5Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/overflow": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.35.0.tgz",
+      "integrity": "sha512-B25YvnJQTGlZcrNv7b0PJBLWq3tl8sql497OHfYYLem7EOMPKKDGJScJAKM/91D4H/mMAsx5gnA/XgKobriuTg==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/plain-text": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.35.0.tgz",
+      "integrity": "sha512-lwBCUNMJf7Gujp2syVWMpKRahfbTv5Wq+H3HK1Q1gKH1P2IytPRxssCHvexw9iGwprSyghkKBlbF3fGpEdIJvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.35.0",
+        "@lexical/selection": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/react": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.35.0.tgz",
+      "integrity": "sha512-uYAZSqumH8tRymMef+A0f2hQvMwplKK9DXamcefnk3vSNDHHqRWQXpiUo6kD+rKWuQmMbVa5RW4xRQebXEW+1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.8",
+        "@lexical/devtools-core": "0.35.0",
+        "@lexical/dragon": "0.35.0",
+        "@lexical/hashtag": "0.35.0",
+        "@lexical/history": "0.35.0",
+        "@lexical/link": "0.35.0",
+        "@lexical/list": "0.35.0",
+        "@lexical/mark": "0.35.0",
+        "@lexical/markdown": "0.35.0",
+        "@lexical/overflow": "0.35.0",
+        "@lexical/plain-text": "0.35.0",
+        "@lexical/rich-text": "0.35.0",
+        "@lexical/table": "0.35.0",
+        "@lexical/text": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "@lexical/yjs": "0.35.0",
+        "lexical": "0.35.0",
+        "react-error-boundary": "^3.1.4"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/rich-text": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.35.0.tgz",
+      "integrity": "sha512-qEHu8g7vOEzz9GUz1VIUxZBndZRJPh9iJUFI+qTDHj+tQqnd5LCs+G9yz6jgNfiuWWpezTp0i1Vz/udNEuDPKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.35.0",
+        "@lexical/selection": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/selection": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.35.0.tgz",
+      "integrity": "sha512-mMtDE7Q0nycXdFTTH/+ta6EBrBwxBB4Tg8QwsGntzQ1Cq//d838dpXpFjJOqHEeVHUqXpiuj+cBG8+bvz/rPRw==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/table": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.35.0.tgz",
+      "integrity": "sha512-9jlTlkVideBKwsEnEkqkdg7A3mije1SvmfiqoYnkl1kKJCLA5iH90ywx327PU0p+bdnURAytWUeZPXaEuEl2OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.35.0",
+        "@lexical/utils": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/text": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.35.0.tgz",
+      "integrity": "sha512-uaMh46BkysV8hK8wQwp5g/ByZW+2hPDt8ahAErxtf8NuzQem1FHG/f5RTchmFqqUDVHO3qLNTv4AehEGmXv8MA==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/utils": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.35.0.tgz",
+      "integrity": "sha512-2H393EYDnFznYCDFOW3MHiRzwEO5M/UBhtUjvTT+9kc+qhX4U3zc8ixQalo5UmZ5B2nh7L/inXdTFzvSRXtsRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/list": "0.35.0",
+        "@lexical/selection": "0.35.0",
+        "@lexical/table": "0.35.0",
+        "lexical": "0.35.0"
+      }
+    },
+    "node_modules/@lexical/yjs": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.35.0.tgz",
+      "integrity": "sha512-3DSP7QpmTGYU9bN/yljP0PIao4tNIQtsR4ycauWNSawxs/GQCZtSmAPcLRnCm6qpqsDDjUtKjO/1Ej8FRp0m0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/offset": "0.35.0",
+        "@lexical/selection": "0.35.0",
+        "lexical": "0.35.0"
+      },
+      "peerDependencies": {
+        "yjs": ">=13.5.22"
+      }
+    },
     "node_modules/@lezer/common": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
       "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
       "license": "MIT"
+    },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.5.tgz",
+      "integrity": "sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/go": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
+      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.3",
@@ -1598,6 +2260,50 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
@@ -1609,11 +2315,170 @@
         "@lezer/common": "^1.0.0"
       }
     },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
+      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
+    },
+    "node_modules/@mdxeditor/editor": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@mdxeditor/editor/-/editor-4.0.1.tgz",
+      "integrity": "sha512-5CKZAIqrXLNjR+Vwi0IL6ihlFxIO9mhfWoQt9eGEwAgrVITbQ18MC7gPPYylen+jylSedTCjpk7bdnKz7HYqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/commands": "^6.2.4",
+        "@codemirror/lang-markdown": "^6.2.3",
+        "@codemirror/language-data": "^6.5.1",
+        "@codemirror/merge": "^6.4.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.23.0",
+        "@lexical/clipboard": "^0.35.0",
+        "@lexical/link": "^0.35.0",
+        "@lexical/list": "^0.35.0",
+        "@lexical/markdown": "^0.35.0",
+        "@lexical/plain-text": "^0.35.0",
+        "@lexical/react": "^0.35.0",
+        "@lexical/rich-text": "^0.35.0",
+        "@lexical/selection": "^0.35.0",
+        "@lexical/utils": "^0.35.0",
+        "@mdxeditor/gurx": "^1.2.4",
+        "@radix-ui/colors": "^3.0.0",
+        "@radix-ui/react-dialog": "^1.1.11",
+        "@radix-ui/react-icons": "^1.3.2",
+        "@radix-ui/react-popover": "^1.1.11",
+        "@radix-ui/react-popper": "^1.2.4",
+        "@radix-ui/react-select": "^2.2.2",
+        "@radix-ui/react-toggle-group": "^1.1.7",
+        "@radix-ui/react-toolbar": "^1.1.7",
+        "@radix-ui/react-tooltip": "^1.2.4",
+        "classnames": "^2.3.2",
+        "cm6-theme-basic-light": "^0.2.0",
+        "codemirror": "^6.0.1",
+        "downshift": "^7.6.0",
+        "js-yaml": "4.1.1",
+        "lexical": "^0.35.0",
+        "mdast-util-directive": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-frontmatter": "^2.0.1",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-highlight-mark": "^1.2.2",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "micromark-extension-directive": "^3.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.1",
+        "micromark-extension-highlight-mark": "^1.2.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs": "^3.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.1",
+        "micromark-util-symbol": "^2.0.0",
+        "react-hook-form": "^7.56.1",
+        "unidiff": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">= 18 || >= 19",
+        "react-dom": ">= 18 || >= 19"
+      }
+    },
+    "node_modules/@mdxeditor/gurx": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@mdxeditor/gurx/-/gurx-1.2.4.tgz",
+      "integrity": "sha512-9ZykIFYhKaXaaSPCs1cuI+FvYDegJjbKwmA4ASE/zY+hJY6EYqvoye4esiO85CjhOw9aoD/izD/CU78/egVqmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">= 18 || >= 19",
+        "react-dom": ">= 18 || >= 19"
+      }
     },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
@@ -2312,6 +3177,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/colors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
+      "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
@@ -2721,6 +3592,15 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@radix-ui/react-id": {
@@ -3253,6 +4133,112 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-roving-focus": "1.1.11",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5204,9 +6190,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5218,9 +6202,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -5650,6 +6632,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/cm6-theme-basic-light": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cm6-theme-basic-light/-/cm6-theme-basic-light-0.2.0.tgz",
+      "integrity": "sha512-1prg2gv44sYfpHscP26uLT/ePrh0mlmVwMSoSd3zYKQ92Ab3jPRLzyCnpyOCQLJbK+YdNs4HvMRqMNYdy4pMhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
     "node_modules/cmdk": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
@@ -5664,6 +6658,21 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/colorette": {
@@ -5682,6 +6691,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
+      "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -6068,6 +7083,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -6075,6 +7099,22 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/downshift": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.2.tgz",
+      "integrity": "sha512-iOv+E1Hyt3JDdL9yYcOgW7nZ7GQ2Uz6YbggwXvKUSleetYhU2nXD482Rz6CzvM4lvI1At34BYruKAL4swRGxaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.8",
+        "compute-scroll-into-view": "^2.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -6426,6 +7466,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -6539,6 +7593,19 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -6598,6 +7665,14 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -7103,6 +8178,17 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/its-fine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
@@ -7139,7 +8225,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7262,6 +8347,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -7275,6 +8369,34 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lexical": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.35.0.tgz",
+      "integrity": "sha512-3VuV8xXhh5xJA6tzvfDvE0YBCMkIZUmxtRilJQDDdCgJCc+eut6qAv2qbN+pbqvarqcQqPN1UF+8YvsjmyOZpw==",
+      "license": "MIT"
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lie": {
@@ -7695,6 +8817,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7765,6 +8899,27 @@
         "remove-accents": "0.5.0"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -7815,6 +8970,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-gfm": {
@@ -7911,6 +9096,32 @@
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-highlight-mark": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-highlight-mark/-/mdast-util-highlight-mark-1.2.2.tgz",
+      "integrity": "sha512-OYumVoytj+B9YgwzBhBcYUCLYHIPvJtAvwnMyKhUXbfUFuER5S+FDZyu9fadUxm2TCT5fRYK3jQXh2ioWAxrMw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-highlight-mark": "1.2.0"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
@@ -8138,6 +9349,41 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-extension-directive": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
+      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
@@ -8259,6 +9505,122 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-highlight-mark": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-highlight-mark/-/micromark-extension-highlight-mark-1.2.0.tgz",
+      "integrity": "sha512-huGtbd/9kQsMk8u7nrVMaS5qH/47yDG6ZADggo5Owz5JoY8wdfQjfuy118/QiYNCvdFuFDbzT0A7K7Hp2cBsXA==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "uvu": "^0.5.6"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -8300,6 +9662,33 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -8503,6 +9892,31 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
@@ -8680,6 +10094,15 @@
         "obliterator": "^2.0.1"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -8739,6 +10162,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obliterator": {
       "version": "2.0.5",
@@ -9160,13 +10592,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
-      "peer": true
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
@@ -9177,6 +10610,23 @@
         "is-promise": "^2.1.0",
         "lie": "^3.0.2"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -9239,6 +10689,44 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.76.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.1.tgz",
+      "integrity": "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "9.1.0",
@@ -9638,6 +11126,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -9959,6 +11459,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -10322,6 +11828,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unidiff": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unidiff/-/unidiff-1.0.4.tgz",
+      "integrity": "sha512-ynU0vsAXw0ir8roa+xPCUHmnJ5goc5BTM2Kuc3IJd8UwgaeRs7VSD5+eeaQL+xp1JtB92hu/Zy/Lgy7RZcr1pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "diff": "^5.1.0"
+      }
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -10358,6 +11873,19 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -10517,6 +12045,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/vfile": {
@@ -10951,6 +12497,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.30",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
+      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@icons-pack/react-simple-icons": "^13.11.2",
+    "@mdxeditor/editor": "^4.0.1",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-checkbox": "^1.1.3",

--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -33,6 +33,13 @@ type ActivityItem =
 
 type AvatarColor = keyof typeof DOT_CLASS
 
+interface DocumentCommentPayload extends Record<string, unknown> {
+  action?: string
+  document_id?: string
+  excerpt?: string
+  kind?: string
+}
+
 interface ProjectChangePayload extends Record<string, unknown> {
   field: string
   new: unknown
@@ -277,6 +284,8 @@ function EventEntry({
     isProjectChangePayload(entry.payload)
   ) {
     body = renderProjectChangeBody(entry.payload)
+  } else if (entry.type === 'document-comment') {
+    body = renderDocumentCommentBody(entry.payload)
   } else {
     body = renderGenericEventBody(entry)
   }
@@ -400,6 +409,24 @@ function OpsEntry({
       name={name}
       ts={item.ts}
     />
+  )
+}
+
+// fallow-ignore-next-line complexity
+function renderDocumentCommentBody(payload: unknown): React.ReactNode {
+  const p: DocumentCommentPayload = isPlainObject(payload) ? payload : {}
+  const action =
+    p.action === 'replied'
+      ? 'replied to a comment'
+      : p.kind === 'inline'
+        ? 'added an inline comment'
+        : 'commented on a document'
+  const excerpt = typeof p.excerpt === 'string' ? p.excerpt.trim() : ''
+  return (
+    <span>
+      <span className="text-secondary">{action}</span>
+      {excerpt && <span className="text-tertiary"> — “{excerpt}”</span>}
+    </span>
   )
 }
 

--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react'
 
+import { Link } from 'react-router-dom'
+
 import { useQuery } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import { History, LoaderCircle } from 'lucide-react'
@@ -38,6 +40,7 @@ interface DocumentCommentPayload extends Record<string, unknown> {
   document_id?: string
   excerpt?: string
   kind?: string
+  thread_id?: string
 }
 
 interface ProjectChangePayload extends Record<string, unknown> {
@@ -161,6 +164,7 @@ export function ProjectActivityLog({ orgSlug, projectId, projectSlug }: Props) {
                       displayNames={displayNames}
                       item={item}
                       key={`event-${item.data.id}-${i}`}
+                      projectId={projectId}
                     />
                   ) : (
                     <OpsEntry
@@ -179,6 +183,18 @@ export function ProjectActivityLog({ orgSlug, projectId, projectSlug }: Props) {
       )}
     </div>
   )
+}
+
+/** Deep-link to a comment's document, focusing the thread via ?thread=. */
+// fallow-ignore-next-line complexity
+function commentHref(projectId: string, payload: unknown): string | undefined {
+  const p: DocumentCommentPayload = isPlainObject(payload) ? payload : {}
+  const documentId = typeof p.document_id === 'string' ? p.document_id : ''
+  if (!documentId) return undefined
+  const base = `/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}`
+  return typeof p.thread_id === 'string' && p.thread_id
+    ? `${base}?thread=${encodeURIComponent(p.thread_id)}`
+    : base
 }
 
 function dayKey(d: Date): string {
@@ -223,17 +239,21 @@ function EntryRow({
   avatarColor,
   body,
   email,
+  href,
   name,
   ts,
 }: {
   avatarColor: AvatarColor
   body: React.ReactNode
   email: string
+  href?: string
   name: string
   ts: Date
 }) {
   return (
-    <div className="relative flex gap-3 py-3">
+    <div
+      className={`relative flex gap-3 py-3 ${href ? 'hover:bg-secondary/40 -mx-2 rounded-md px-2' : ''}`}
+    >
       <div className="relative flex w-4 shrink-0 flex-col items-center">
         <div
           className={`ring-primary relative z-10 mt-1.5 size-2 shrink-0 rounded-full ring-2 ${DOT_CLASS[avatarColor]}`}
@@ -251,6 +271,13 @@ function EntryRow({
         </div>
         <div className="text-secondary mt-0.5 text-sm">{body}</div>
       </div>
+      {href && (
+        <Link
+          aria-label="Open comment"
+          className="absolute inset-0"
+          to={href}
+        />
+      )}
     </div>
   )
 }
@@ -271,14 +298,17 @@ function EnvChip({ env }: { env?: Environment }) {
 function EventEntry({
   displayNames,
   item,
+  projectId,
 }: {
   displayNames: Map<string, string>
   item: ActivityItem & { kind: 'event' }
+  projectId: string
 }) {
   const entry = item.data
   const name = getDisplayName(entry.attributed_to, displayNames)
 
   let body: React.ReactNode
+  let href: string | undefined
   if (
     entry.type === 'project-change' &&
     isProjectChangePayload(entry.payload)
@@ -286,6 +316,7 @@ function EventEntry({
     body = renderProjectChangeBody(entry.payload)
   } else if (entry.type === 'document-comment') {
     body = renderDocumentCommentBody(entry.payload)
+    href = commentHref(projectId, entry.payload)
   } else {
     body = renderGenericEventBody(entry)
   }
@@ -295,6 +326,7 @@ function EventEntry({
       avatarColor="info"
       body={body}
       email={entry.attributed_to}
+      href={href}
       name={name}
       ts={item.ts}
     />

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -154,27 +154,46 @@ export function DocumentsPinboardReader({
   const lastVisit = useCommentLastVisit(orgSlug, projectId, document.id)
 
   // Deep-link: ?thread=<id> (e.g. from the activity feed) scrolls to and
-  // flashes a page thread, or shows + focuses an inline one.
+  // flashes a page thread; for an inline one it shows + focuses the reader
+  // and scrolls to the highlight (which only renders once the overlay is on,
+  // hence the rAF retry).
   const [searchParams] = useSearchParams()
   const focusThreadId = searchParams.get('thread')
   const setFocusedId = inline.setFocusedId
   // fallow-ignore-next-line complexity
   useEffect(() => {
     if (!focusThreadId || comments.length === 0) return
-    if (inlineThreads.some((t) => t.id === focusThreadId)) {
+    const isInline = inlineThreads.some((t) => t.id === focusThreadId)
+    if (isInline) {
       setShowComments(true)
       setFocusedId(focusThreadId)
-      return
     }
-    const el = window.document.getElementById(`comment-thread-${focusThreadId}`)
-    if (!el) return
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-    el.classList.add('comment-thread-flash')
-    const timer = window.setTimeout(
-      () => el.classList.remove('comment-thread-flash'),
-      1800,
-    )
-    return () => window.clearTimeout(timer)
+    let raf = 0
+    let tries = 0
+    let cleanup: (() => void) | undefined
+    const attempt = () => {
+      const target = isInline
+        ? articleRef.current?.querySelector(
+            `.comment-highlight[data-thread-id="${focusThreadId}"]`,
+          )
+        : window.document.getElementById(`comment-thread-${focusThreadId}`)
+      if (target instanceof HTMLElement) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        target.classList.add('comment-thread-flash')
+        const timer = window.setTimeout(
+          () => target.classList.remove('comment-thread-flash'),
+          1800,
+        )
+        cleanup = () => window.clearTimeout(timer)
+      } else if (tries++ < 30) {
+        raf = requestAnimationFrame(attempt)
+      }
+    }
+    raf = requestAnimationFrame(attempt)
+    return () => {
+      cancelAnimationFrame(raf)
+      cleanup?.()
+    }
   }, [comments.length, focusThreadId, inlineThreads, setFocusedId])
 
   const handleSubmitDraft = (body: string, mentions: string[]) => {

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -83,6 +83,7 @@ interface Props {
   projectId: string
 }
 
+// fallow-ignore-next-line complexity
 export function DocumentsPinboardReader({
   allDocuments,
   comments,
@@ -111,9 +112,12 @@ export function DocumentsPinboardReader({
   const articleRef = useRef<HTMLDivElement>(null)
   const marginRef = useRef<HTMLDivElement>(null)
 
+  // The Open/Resolved/All filter applies to inline comments only — the page
+  // discussion is a flat, non-resolvable feed.
   const commentCounts = useMemo(() => {
-    const open = comments.filter((t) => !t.resolved).length
-    return { all: comments.length, open, resolved: comments.length - open }
+    const inline = comments.filter((t) => t.kind === 'inline')
+    const open = inline.filter((t) => !t.resolved).length
+    return { all: inline.length, open, resolved: inline.length - open }
   }, [comments])
 
   const pageThreads = useMemo(
@@ -206,34 +210,36 @@ export function DocumentsPinboardReader({
               All documents
             </Button>
             <div className="ml-auto flex items-center gap-1">
-              <SegmentedControl
-                ariaLabel="Comment filter"
-                className="mr-1"
-                onValueChange={(v) => setCommentFilter(v as CommentFilter)}
-                value={commentFilter}
-              >
-                <SegmentedControlItem value="open">
-                  <CircleDot className="size-3" />
-                  Open
-                  <span className="text-tertiary tabular-nums">
-                    {commentCounts.open}
-                  </span>
-                </SegmentedControlItem>
-                <SegmentedControlItem value="resolved">
-                  <CheckCircle2 className="size-3" />
-                  Resolved
-                  <span className="text-tertiary tabular-nums">
-                    {commentCounts.resolved}
-                  </span>
-                </SegmentedControlItem>
-                <SegmentedControlItem value="all">
-                  <List className="size-3" />
-                  All
-                  <span className="text-tertiary tabular-nums">
-                    {commentCounts.all}
-                  </span>
-                </SegmentedControlItem>
-              </SegmentedControl>
+              {showComments && (
+                <SegmentedControl
+                  ariaLabel="Comment filter"
+                  className="mr-1"
+                  onValueChange={(v) => setCommentFilter(v as CommentFilter)}
+                  value={commentFilter}
+                >
+                  <SegmentedControlItem value="open">
+                    <CircleDot className="size-3" />
+                    Open
+                    <span className="text-tertiary tabular-nums">
+                      {commentCounts.open}
+                    </span>
+                  </SegmentedControlItem>
+                  <SegmentedControlItem value="resolved">
+                    <CheckCircle2 className="size-3" />
+                    Resolved
+                    <span className="text-tertiary tabular-nums">
+                      {commentCounts.resolved}
+                    </span>
+                  </SegmentedControlItem>
+                  <SegmentedControlItem value="all">
+                    <List className="size-3" />
+                    All
+                    <span className="text-tertiary tabular-nums">
+                      {commentCounts.all}
+                    </span>
+                  </SegmentedControlItem>
+                </SegmentedControl>
+              )}
               <Button
                 className="gap-1.5"
                 onClick={() => setShowComments((v) => !v)}
@@ -474,7 +480,6 @@ export function DocumentsPinboardReader({
             busy={commentsBusy}
             currentUserEmail={currentUserEmail}
             displayNames={displayNames}
-            filter={commentFilter}
             lastVisit={lastVisit}
             onAcknowledge={onAcknowledgeComment}
             onCreateThread={onCreateThread}

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+import { useSearchParams } from 'react-router-dom'
+
 import {
   ArrowLeft,
   CheckCircle2,
@@ -150,6 +152,30 @@ export function DocumentsPinboardReader({
   )
 
   const lastVisit = useCommentLastVisit(orgSlug, projectId, document.id)
+
+  // Deep-link: ?thread=<id> (e.g. from the activity feed) scrolls to and
+  // flashes a page thread, or shows + focuses an inline one.
+  const [searchParams] = useSearchParams()
+  const focusThreadId = searchParams.get('thread')
+  const setFocusedId = inline.setFocusedId
+  // fallow-ignore-next-line complexity
+  useEffect(() => {
+    if (!focusThreadId || comments.length === 0) return
+    if (inlineThreads.some((t) => t.id === focusThreadId)) {
+      setShowComments(true)
+      setFocusedId(focusThreadId)
+      return
+    }
+    const el = window.document.getElementById(`comment-thread-${focusThreadId}`)
+    if (!el) return
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    el.classList.add('comment-thread-flash')
+    const timer = window.setTimeout(
+      () => el.classList.remove('comment-thread-flash'),
+      1800,
+    )
+    return () => window.clearTimeout(timer)
+  }, [comments.length, focusThreadId, inlineThreads, setFocusedId])
 
   const handleSubmitDraft = (body: string, mentions: string[]) => {
     if (!inline.draft) return

--- a/src/components/documents/comments/BottomDiscussion.tsx
+++ b/src/components/documents/comments/BottomDiscussion.tsx
@@ -49,31 +49,6 @@ export function BottomDiscussion({
         </span>
       </h2>
 
-      {threads.length === 0 ? (
-        <div className="text-tertiary text-[13.5px]">No comments yet.</div>
-      ) : (
-        <div className="flex flex-col gap-3">
-          {threads.map((thread) => (
-            <CommentThreadView
-              busy={busy}
-              currentUserEmail={currentUserEmail}
-              displayNames={displayNames}
-              key={thread.id}
-              lastVisit={lastVisit}
-              onAcknowledge={(commentId) => onAcknowledge(thread.id, commentId)}
-              onDelete={(commentId) => onDelete(thread.id, commentId)}
-              onEdit={(commentId, body, mentions) =>
-                onEdit(thread.id, commentId, body, mentions)
-              }
-              onReply={(body, mentions) => onReply(thread.id, body, mentions)}
-              onResolve={(resolved) => onResolve(thread.id, resolved)}
-              resolvable={false}
-              thread={thread}
-            />
-          ))}
-        </div>
-      )}
-
       {composing ? (
         <LazyRichComposer
           autoFocus
@@ -98,6 +73,31 @@ export function BottomDiscussion({
             <MessageSquarePlus className="size-3.5" />
             Add a comment
           </Button>
+        </div>
+      )}
+
+      {threads.length === 0 ? (
+        <div className="text-tertiary text-[13.5px]">No comments yet.</div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {threads.map((thread) => (
+            <CommentThreadView
+              busy={busy}
+              currentUserEmail={currentUserEmail}
+              displayNames={displayNames}
+              key={thread.id}
+              lastVisit={lastVisit}
+              onAcknowledge={(commentId) => onAcknowledge(thread.id, commentId)}
+              onDelete={(commentId) => onDelete(thread.id, commentId)}
+              onEdit={(commentId, body, mentions) =>
+                onEdit(thread.id, commentId, body, mentions)
+              }
+              onReply={(body, mentions) => onReply(thread.id, body, mentions)}
+              onResolve={(resolved) => onResolve(thread.id, resolved)}
+              resolvable={false}
+              thread={thread}
+            />
+          ))}
         </div>
       )}
     </section>

--- a/src/components/documents/comments/BottomDiscussion.tsx
+++ b/src/components/documents/comments/BottomDiscussion.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from 'react'
+import { useState } from 'react'
 
 import { MessageSquarePlus, MessagesSquare } from 'lucide-react'
 
@@ -6,13 +6,7 @@ import { Button } from '@/components/ui/button'
 import type { CommentThread, CommentThreadHandlers } from '@/types/comments'
 
 import { CommentThreadView } from './CommentThreadView'
-
-// Lazy-loaded: the Lexical bundle is only fetched when a composer opens.
-const RichCommentComposer = lazy(() =>
-  import('./RichCommentComposer').then((m) => ({
-    default: m.RichCommentComposer,
-  })),
-)
+import { LazyRichComposer } from './LazyRichComposer'
 
 export type CommentFilter = 'all' | 'open' | 'resolved'
 
@@ -81,24 +75,18 @@ export function BottomDiscussion({
       )}
 
       {composing ? (
-        <Suspense
-          fallback={
-            <div className="text-tertiary text-[13px]">Loading editor…</div>
-          }
-        >
-          <RichCommentComposer
-            autoFocus
-            busy={busy}
-            displayNames={displayNames}
-            onCancel={() => setComposing(false)}
-            onSubmit={(body, mentions) => {
-              onCreateThread(body, mentions)
-              setComposing(false)
-            }}
-            placeholder="Add a comment to the discussion…"
-            submitLabel="Comment"
-          />
-        </Suspense>
+        <LazyRichComposer
+          autoFocus
+          busy={busy}
+          displayNames={displayNames}
+          onCancel={() => setComposing(false)}
+          onSubmit={(body, mentions) => {
+            onCreateThread(body, mentions)
+            setComposing(false)
+          }}
+          placeholder="Add a comment to the discussion…"
+          submitLabel="Comment"
+        />
       ) : (
         <div>
           <Button

--- a/src/components/documents/comments/BottomDiscussion.tsx
+++ b/src/components/documents/comments/BottomDiscussion.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from 'react'
+import { useState } from 'react'
 
-import { MessagesSquare } from 'lucide-react'
+import { MessageSquarePlus, MessagesSquare } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import type { CommentThread, CommentThreadHandlers } from '@/types/comments'
 
 import { CommentComposer } from './CommentComposer'
@@ -13,16 +14,20 @@ interface Props extends CommentThreadHandlers {
   busy?: boolean
   currentUserEmail: string
   displayNames?: Map<string, string>
-  filter: CommentFilter
   lastVisit?: number
   threads: CommentThread[]
 }
 
+/**
+ * The page-level discussion feed. Unlike inline comments, discussion threads
+ * are a flat, always-visible conversation — they are not resolvable and are
+ * not filtered. The composer follows the Confluence pattern: a collapsed
+ * "Add a comment" trigger at the bottom that expands into the form on click.
+ */
 export function BottomDiscussion({
   busy = false,
   currentUserEmail,
   displayNames,
-  filter,
   lastVisit,
   onAcknowledge,
   onCreateThread,
@@ -32,13 +37,7 @@ export function BottomDiscussion({
   onResolve,
   threads,
 }: Props) {
-  const visible = useMemo(
-    () =>
-      threads.filter((t) =>
-        filter === 'all' ? true : filter === 'open' ? !t.resolved : t.resolved,
-      ),
-    [threads, filter],
-  )
+  const [composing, setComposing] = useState(false)
 
   return (
     <section className="mt-8 flex flex-col gap-4">
@@ -50,21 +49,11 @@ export function BottomDiscussion({
         </span>
       </h2>
 
-      <CommentComposer
-        busy={busy}
-        displayNames={displayNames}
-        onSubmit={onCreateThread}
-        placeholder="Add a comment to the discussion…"
-        submitLabel="Comment"
-      />
-
-      {visible.length === 0 ? (
-        <div className="text-tertiary py-7 text-center text-[13.5px]">
-          No comments in this view.
-        </div>
+      {threads.length === 0 ? (
+        <div className="text-tertiary text-[13.5px]">No comments yet.</div>
       ) : (
         <div className="flex flex-col gap-3">
-          {visible.map((thread) => (
+          {threads.map((thread) => (
             <CommentThreadView
               busy={busy}
               currentUserEmail={currentUserEmail}
@@ -78,9 +67,37 @@ export function BottomDiscussion({
               }
               onReply={(body, mentions) => onReply(thread.id, body, mentions)}
               onResolve={(resolved) => onResolve(thread.id, resolved)}
+              resolvable={false}
               thread={thread}
             />
           ))}
+        </div>
+      )}
+
+      {composing ? (
+        <CommentComposer
+          autoFocus
+          busy={busy}
+          displayNames={displayNames}
+          onCancel={() => setComposing(false)}
+          onSubmit={(body, mentions) => {
+            onCreateThread(body, mentions)
+            setComposing(false)
+          }}
+          placeholder="Add a comment to the discussion…"
+          submitLabel="Comment"
+        />
+      ) : (
+        <div>
+          <Button
+            className="gap-1.5"
+            onClick={() => setComposing(true)}
+            size="sm"
+            variant="ghost"
+          >
+            <MessageSquarePlus className="size-3.5" />
+            Add a comment
+          </Button>
         </div>
       )}
     </section>

--- a/src/components/documents/comments/BottomDiscussion.tsx
+++ b/src/components/documents/comments/BottomDiscussion.tsx
@@ -1,12 +1,18 @@
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 
 import { MessageSquarePlus, MessagesSquare } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import type { CommentThread, CommentThreadHandlers } from '@/types/comments'
 
-import { CommentComposer } from './CommentComposer'
 import { CommentThreadView } from './CommentThreadView'
+
+// Lazy-loaded: the Lexical bundle is only fetched when a composer opens.
+const RichCommentComposer = lazy(() =>
+  import('./RichCommentComposer').then((m) => ({
+    default: m.RichCommentComposer,
+  })),
+)
 
 export type CommentFilter = 'all' | 'open' | 'resolved'
 
@@ -75,18 +81,24 @@ export function BottomDiscussion({
       )}
 
       {composing ? (
-        <CommentComposer
-          autoFocus
-          busy={busy}
-          displayNames={displayNames}
-          onCancel={() => setComposing(false)}
-          onSubmit={(body, mentions) => {
-            onCreateThread(body, mentions)
-            setComposing(false)
-          }}
-          placeholder="Add a comment to the discussion…"
-          submitLabel="Comment"
-        />
+        <Suspense
+          fallback={
+            <div className="text-tertiary text-[13px]">Loading editor…</div>
+          }
+        >
+          <RichCommentComposer
+            autoFocus
+            busy={busy}
+            displayNames={displayNames}
+            onCancel={() => setComposing(false)}
+            onSubmit={(body, mentions) => {
+              onCreateThread(body, mentions)
+              setComposing(false)
+            }}
+            placeholder="Add a comment to the discussion…"
+            submitLabel="Comment"
+          />
+        </Suspense>
       ) : (
         <div>
           <Button

--- a/src/components/documents/comments/CommentComposer.tsx
+++ b/src/components/documents/comments/CommentComposer.tsx
@@ -115,32 +115,34 @@ export function CommentComposer({
   const empty = !text.trim()
 
   return (
-    <div className="relative flex flex-col gap-1.5">
-      <Textarea
-        className="min-h-9 resize-none text-[13.5px]"
-        onChange={(e) => {
-          setText(e.target.value)
-          grow()
-          mentions.refresh(e.target)
-        }}
-        onKeyDown={onKeyDown}
-        onKeyUp={(e) => {
-          // Don't undo the navigation/selection/dismiss the popover just did.
-          if (mentions.open && POPOVER_KEYS.has(e.key)) return
-          mentions.refresh(e.currentTarget)
-        }}
-        placeholder={placeholder}
-        ref={ref}
-        rows={1}
-        value={text}
-      />
-      {mentions.open && (
-        <MentionPopover
-          active={mentions.active}
-          matches={mentions.matches}
-          onPick={mentions.pick}
+    <div className="flex flex-col gap-1.5">
+      <div className="relative">
+        <Textarea
+          className="min-h-19 resize-none text-[13.5px]"
+          onChange={(e) => {
+            setText(e.target.value)
+            grow()
+            mentions.refresh(e.target)
+          }}
+          onKeyDown={onKeyDown}
+          onKeyUp={(e) => {
+            // Don't undo the navigation/selection/dismiss the popover just did.
+            if (mentions.open && POPOVER_KEYS.has(e.key)) return
+            mentions.refresh(e.currentTarget)
+          }}
+          placeholder={placeholder}
+          ref={ref}
+          rows={3}
+          value={text}
         />
-      )}
+        {mentions.open && (
+          <MentionPopover
+            active={mentions.active}
+            matches={mentions.matches}
+            onPick={mentions.pick}
+          />
+        )}
+      </div>
       <div className="flex items-center justify-between">
         <span className="text-tertiary text-[11px]">
           {empty ? '' : 'Cmd + Enter to send · @ to mention'}
@@ -180,7 +182,7 @@ function MentionPopover({
   onPick: (candidate: MentionCandidate) => void
 }) {
   return (
-    <div className="border-tertiary bg-primary absolute top-9 left-0 z-20 flex w-64 flex-col gap-0.5 rounded-md border p-1 shadow-md">
+    <div className="border-tertiary bg-primary absolute top-full left-0 z-20 mt-1 flex w-64 flex-col gap-0.5 rounded-md border p-1 shadow-md">
       {matches.map((candidate, i) => (
         <button
           className={

--- a/src/components/documents/comments/CommentComposer.tsx
+++ b/src/components/documents/comments/CommentComposer.tsx
@@ -1,10 +1,10 @@
 import type { KeyboardEvent } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { Button } from '@/components/ui/button'
 import { Gravatar } from '@/components/ui/gravatar'
 import { Textarea } from '@/components/ui/textarea'
 
+import { ComposerActions, isSubmitChord } from './ComposerActions'
 import type { MentionCandidate } from './mentions'
 import { resolveMentions } from './mentions'
 import { useMentionAutocomplete } from './useMentionAutocomplete'
@@ -143,33 +143,16 @@ export function CommentComposer({
           />
         )}
       </div>
-      <div className="flex items-center justify-between">
-        <span className="text-tertiary text-[11px]">
-          {empty ? '' : 'Cmd + Enter to send · @ to mention'}
-        </span>
-        <div className="flex items-center gap-2">
-          {onCancel && (
-            <Button onClick={onCancel} size="sm" type="button" variant="ghost">
-              Cancel
-            </Button>
-          )}
-          <Button
-            disabled={empty || busy}
-            onClick={submit}
-            size="sm"
-            type="button"
-          >
-            {submitLabel}
-          </Button>
-        </div>
-      </div>
+      <ComposerActions
+        busy={busy}
+        empty={empty}
+        hint="Cmd + Enter to send · @ to mention"
+        onCancel={onCancel}
+        onSubmit={submit}
+        submitLabel={submitLabel}
+      />
     </div>
   )
-}
-
-/** Cmd/Ctrl-Enter submits the composer. */
-function isSubmitChord(e: KeyboardEvent<HTMLTextAreaElement>): boolean {
-  return e.key === 'Enter' && (e.metaKey || e.ctrlKey)
 }
 
 function MentionPopover({

--- a/src/components/documents/comments/CommentThreadView.tsx
+++ b/src/components/documents/comments/CommentThreadView.tsx
@@ -18,6 +18,8 @@ interface Props {
   onEdit: (commentId: string, body: string, mentions: string[]) => void
   onReply: (body: string, mentions: string[]) => void
   onResolve: (resolved: boolean) => void
+  /** Inline threads can be resolved; the page discussion cannot. */
+  resolvable?: boolean
   thread: CommentThread
 }
 
@@ -29,6 +31,7 @@ interface ResolveBarProps {
   resolvedBy: null | string
 }
 
+// fallow-ignore-next-line complexity
 export function CommentThreadView({
   busy = false,
   currentUserEmail,
@@ -39,6 +42,7 @@ export function CommentThreadView({
   onEdit,
   onReply,
   onResolve,
+  resolvable = true,
   thread,
 }: Props) {
   const root = thread.comments[0]
@@ -52,13 +56,15 @@ export function CommentThreadView({
 
   return (
     <div className="border-tertiary bg-primary flex flex-col gap-3 rounded-lg border p-4">
-      <ResolveBar
-        busy={busy}
-        displayNames={displayNames}
-        onResolve={onResolve}
-        resolved={thread.resolved}
-        resolvedBy={thread.resolved_by}
-      />
+      {resolvable && (
+        <ResolveBar
+          busy={busy}
+          displayNames={displayNames}
+          onResolve={onResolve}
+          resolved={thread.resolved}
+          resolvedBy={thread.resolved_by}
+        />
+      )}
 
       <CommentItem
         busy={busy}
@@ -89,7 +95,7 @@ export function CommentThreadView({
         </div>
       )}
 
-      {!thread.resolved && (
+      {(!resolvable || !thread.resolved) && (
         <CommentComposer
           busy={busy}
           displayNames={displayNames}

--- a/src/components/documents/comments/CommentThreadView.tsx
+++ b/src/components/documents/comments/CommentThreadView.tsx
@@ -99,6 +99,7 @@ export function CommentThreadView({
         <LazyRichComposer
           busy={busy}
           displayNames={displayNames}
+          minHeight={76}
           onSubmit={onReply}
           placeholder="Reply…"
           submitLabel="Reply"

--- a/src/components/documents/comments/CommentThreadView.tsx
+++ b/src/components/documents/comments/CommentThreadView.tsx
@@ -55,7 +55,10 @@ export function CommentThreadView({
     new Date(comment.created_at).getTime() > lastVisit
 
   return (
-    <div className="border-tertiary bg-primary flex flex-col gap-3 rounded-lg border p-4">
+    <div
+      className="border-tertiary bg-primary flex scroll-mt-24 flex-col gap-3 rounded-lg border p-4"
+      id={`comment-thread-${thread.id}`}
+    >
       {resolvable && (
         <ResolveBar
           busy={busy}

--- a/src/components/documents/comments/CommentThreadView.tsx
+++ b/src/components/documents/comments/CommentThreadView.tsx
@@ -4,8 +4,8 @@ import { Button } from '@/components/ui/button'
 import { UserDisplay } from '@/components/ui/user-display'
 import type { CommentThread } from '@/types/comments'
 
-import { CommentComposer } from './CommentComposer'
 import { CommentItem } from './CommentItem'
+import { LazyRichComposer } from './LazyRichComposer'
 
 interface Props {
   busy?: boolean
@@ -96,7 +96,7 @@ export function CommentThreadView({
       )}
 
       {(!resolvable || !thread.resolved) && (
-        <CommentComposer
+        <LazyRichComposer
           busy={busy}
           displayNames={displayNames}
           onSubmit={onReply}

--- a/src/components/documents/comments/ComposerActions.tsx
+++ b/src/components/documents/comments/ComposerActions.tsx
@@ -1,0 +1,49 @@
+import type { KeyboardEvent } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  busy: boolean
+  empty: boolean
+  /** Hint shown to the left of the buttons while the composer is non-empty. */
+  hint: string
+  onCancel?: () => void
+  onSubmit: () => void
+  submitLabel: string
+}
+
+/** Shared footer row for comment composers: a hint plus Cancel/submit. */
+export function ComposerActions({
+  busy,
+  empty,
+  hint,
+  onCancel,
+  onSubmit,
+  submitLabel,
+}: Props) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-tertiary text-[11px]">{empty ? '' : hint}</span>
+      <div className="flex items-center gap-2">
+        {onCancel && (
+          <Button onClick={onCancel} size="sm" type="button" variant="ghost">
+            Cancel
+          </Button>
+        )}
+        <Button
+          disabled={empty || busy}
+          onClick={onSubmit}
+          size="sm"
+          type="button"
+        >
+          {submitLabel}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/** Cmd/Ctrl-Enter submits a composer. */
+export function isSubmitChord(e: KeyboardEvent<HTMLElement>): boolean {
+  return e.key === 'Enter' && (e.metaKey || e.ctrlKey)
+}

--- a/src/components/documents/comments/LazyRichComposer.tsx
+++ b/src/components/documents/comments/LazyRichComposer.tsx
@@ -1,0 +1,27 @@
+import { lazy, Suspense } from 'react'
+
+import type { RichCommentComposerProps } from './RichCommentComposer'
+
+// The type import above is erased at build time, so this module does not pull
+// the heavy Lexical bundle in eagerly — only the dynamic import() below does.
+const RichCommentComposer = lazy(() =>
+  import('./RichCommentComposer').then((m) => ({
+    default: m.RichCommentComposer,
+  })),
+)
+
+/**
+ * Lazy-loads the mdx-editor composer so the Lexical bundle is fetched only
+ * when a composer actually mounts. Drop-in for any comment input.
+ */
+export function LazyRichComposer(props: RichCommentComposerProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className="text-tertiary text-[13px]">Loading editor…</div>
+      }
+    >
+      <RichCommentComposer {...props} />
+    </Suspense>
+  )
+}

--- a/src/components/documents/comments/MarginCommentCard.tsx
+++ b/src/components/documents/comments/MarginCommentCard.tsx
@@ -7,8 +7,8 @@ import { UserDisplay } from '@/components/ui/user-display'
 import { cn } from '@/lib/utils'
 import type { CommentThread } from '@/types/comments'
 
-import { CommentComposer } from './CommentComposer'
 import { CommentThreadView } from './CommentThreadView'
+import { LazyRichComposer } from './LazyRichComposer'
 
 interface Props {
   busy?: boolean
@@ -88,10 +88,11 @@ export const MarginCommentCard = forwardRef<HTMLDivElement, Props>(
         )}
 
         {draft ? (
-          <CommentComposer
+          <LazyRichComposer
             autoFocus
             busy={busy}
             displayNames={displayNames}
+            minHeight={96}
             onCancel={onCancelDraft}
             onSubmit={(body, mentions) => onSubmitDraft?.(body, mentions)}
             placeholder="Add your comment…"

--- a/src/components/documents/comments/RichCommentComposer.tsx
+++ b/src/components/documents/comments/RichCommentComposer.tsx
@@ -99,9 +99,9 @@ export function RichCommentComposer({
           toolbarPlugin({
             toolbarContents: () => (
               <>
-                <BoldItalicUnderlineToggles />
+                <BoldItalicUnderlineToggles options={['Bold', 'Italic']} />
                 <Separator />
-                <ListsToggle />
+                <ListsToggle options={['bullet', 'number']} />
                 <Separator />
                 <CreateLink />
                 <CodeToggle />

--- a/src/components/documents/comments/RichCommentComposer.tsx
+++ b/src/components/documents/comments/RichCommentComposer.tsx
@@ -1,0 +1,120 @@
+import type { KeyboardEvent } from 'react'
+import { useRef, useState } from 'react'
+
+import {
+  BoldItalicUnderlineToggles,
+  CodeToggle,
+  CreateLink,
+  linkDialogPlugin,
+  linkPlugin,
+  listsPlugin,
+  ListsToggle,
+  markdownShortcutPlugin,
+  MDXEditor,
+  type MDXEditorMethods,
+  quotePlugin,
+  Separator,
+  toolbarPlugin,
+} from '@mdxeditor/editor'
+import '@mdxeditor/editor/style.css'
+
+import { ComposerActions, isSubmitChord } from './ComposerActions'
+import { resolveMentions } from './mentions'
+
+interface Props {
+  autoFocus?: boolean
+  busy?: boolean
+  /** Email → display_name, used to resolve typed @mentions on submit. */
+  displayNames?: Map<string, string>
+  onCancel?: () => void
+  onSubmit: (body: string, mentions: string[]) => void
+  placeholder?: string
+  submitLabel?: string
+}
+
+/**
+ * A WYSIWYG markdown composer built on `@mdxeditor/editor` (Lexical), with a
+ * minimal toolbar. This is a spike: if it feels right we generalize it for
+ * every markdown input (project descriptions, ops-log notes). It is
+ * lazy-loaded so the Lexical bundle is only fetched when a composer opens.
+ *
+ * The editor emits markdown, so typed `@Display Name` text round-trips and is
+ * resolved to emails on submit via `resolveMentions` — the same persistence
+ * path as the plain composer. The `@`-autocomplete popover is not ported yet
+ * (a Lexical mention plugin is a follow-up).
+ */
+export function RichCommentComposer({
+  autoFocus = false,
+  busy = false,
+  displayNames,
+  onCancel,
+  onSubmit,
+  placeholder = 'Add a comment…',
+  submitLabel = 'Comment',
+}: Props) {
+  const ref = useRef<MDXEditorMethods>(null)
+  const [text, setText] = useState('')
+  const empty = !text.trim()
+
+  const submit = () => {
+    const trimmed = text.trim()
+    if (!trimmed || busy) return
+    onSubmit(trimmed, resolveMentions(trimmed, displayNames ?? new Map()))
+    ref.current?.setMarkdown('')
+    setText('')
+  }
+
+  // Lexical owns Enter; intercept Cmd/Ctrl-Enter (submit) and Escape (cancel)
+  // on the capture phase before it reaches the editor.
+  const onKeyDownCapture = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (isSubmitChord(e)) {
+      e.preventDefault()
+      submit()
+    } else if (e.key === 'Escape') {
+      onCancel?.()
+    }
+  }
+
+  return (
+    <div
+      className="ds-mdx flex flex-col gap-1.5"
+      onKeyDownCapture={onKeyDownCapture}
+    >
+      <MDXEditor
+        autoFocus={autoFocus}
+        contentEditableClassName="ds-mdx-content"
+        markdown=""
+        onChange={setText}
+        placeholder={placeholder}
+        plugins={[
+          listsPlugin(),
+          quotePlugin(),
+          linkPlugin(),
+          linkDialogPlugin(),
+          markdownShortcutPlugin(),
+          toolbarPlugin({
+            toolbarContents: () => (
+              <>
+                <BoldItalicUnderlineToggles />
+                <Separator />
+                <ListsToggle />
+                <Separator />
+                <CreateLink />
+                <CodeToggle />
+              </>
+            ),
+          }),
+        ]}
+        ref={ref}
+      />
+      <ComposerActions
+        busy={busy}
+        empty={empty}
+        hint="Cmd + Enter to send"
+        onCancel={onCancel}
+        onSubmit={submit}
+        submitLabel={submitLabel}
+      />
+    </div>
+  )
+}

--- a/src/components/documents/comments/RichCommentComposer.tsx
+++ b/src/components/documents/comments/RichCommentComposer.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent } from 'react'
+import type { CSSProperties, KeyboardEvent } from 'react'
 import { useRef, useState } from 'react'
 
 import {
@@ -26,6 +26,8 @@ export interface RichCommentComposerProps {
   busy?: boolean
   /** Email → display_name, used to resolve typed @mentions on submit. */
   displayNames?: Map<string, string>
+  /** Default content height in px; the user can drag to resize from there. */
+  minHeight?: number
   onCancel?: () => void
   onSubmit: (body: string, mentions: string[]) => void
   placeholder?: string
@@ -47,6 +49,7 @@ export function RichCommentComposer({
   autoFocus = false,
   busy = false,
   displayNames,
+  minHeight = 152,
   onCancel,
   onSubmit,
   placeholder = 'Add a comment…',
@@ -79,6 +82,7 @@ export function RichCommentComposer({
     <div
       className="ds-mdx flex flex-col gap-1.5"
       onKeyDownCapture={onKeyDownCapture}
+      style={{ '--ds-mdx-min-h': `${minHeight}px` } as CSSProperties}
     >
       <MDXEditor
         autoFocus={autoFocus}

--- a/src/components/documents/comments/RichCommentComposer.tsx
+++ b/src/components/documents/comments/RichCommentComposer.tsx
@@ -21,7 +21,7 @@ import '@mdxeditor/editor/style.css'
 import { ComposerActions, isSubmitChord } from './ComposerActions'
 import { resolveMentions } from './mentions'
 
-interface Props {
+export interface RichCommentComposerProps {
   autoFocus?: boolean
   busy?: boolean
   /** Email → display_name, used to resolve typed @mentions on submit. */
@@ -51,7 +51,7 @@ export function RichCommentComposer({
   onSubmit,
   placeholder = 'Add a comment…',
   submitLabel = 'Comment',
-}: Props) {
+}: RichCommentComposerProps) {
   const ref = useRef<MDXEditorMethods>(null)
   const [text, setText] = useState('')
   const empty = !text.trim()

--- a/src/index.css
+++ b/src/index.css
@@ -491,6 +491,11 @@
     flex-shrink: 0;
   }
 
+  /* Brief ring when a thread is deep-linked from the activity feed. */
+  .comment-thread-flash {
+    animation: comment-thread-flash 1.8s ease-out;
+  }
+
   /* Theme the mdx-editor rich composer onto the design tokens. Mapping the
      editor's semantic vars to our --ds-* tokens makes it dark-mode aware
      without depending on the editor's own .dark-theme class. */
@@ -536,6 +541,18 @@
   .ds-mdx .mdxeditor [role='toolbar'] {
     padding: 3px;
     min-height: 0;
+  }
+}
+
+@keyframes comment-thread-flash {
+  0% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  15% {
+    box-shadow: 0 0 0 2px var(--ds-border-accent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -523,7 +523,7 @@
   }
 
   .ds-mdx .ds-mdx-content {
-    min-height: 76px;
+    min-height: 152px;
     padding: 6px 10px;
     font-size: 13.5px;
     background: var(--ds-bg-primary);

--- a/src/index.css
+++ b/src/index.css
@@ -523,10 +523,13 @@
   }
 
   .ds-mdx .ds-mdx-content {
-    min-height: 152px;
+    min-height: var(--ds-mdx-min-h, 152px);
     padding: 6px 10px;
     font-size: 13.5px;
     background: var(--ds-bg-primary);
+    /* User-adjustable height: drag the bottom-right handle. */
+    resize: vertical;
+    overflow: auto;
   }
 
   /* Compact the toolbar to match the dense UI. */

--- a/src/index.css
+++ b/src/index.css
@@ -514,6 +514,9 @@
     --accentBorder: var(--ds-border-accent);
     --accentSolid: var(--color-primary);
     --accentSolidHover: var(--color-primary);
+    /* White content surface (dark surface in dark mode) so the editor reads
+       as an input field rather than blending into the page. */
+    background: var(--ds-bg-primary);
     border: 0.5px solid var(--ds-border-tertiary);
     border-radius: 0.375rem;
     font-family: inherit;
@@ -523,6 +526,7 @@
     min-height: 76px;
     padding: 6px 10px;
     font-size: 13.5px;
+    background: var(--ds-bg-primary);
   }
 
   /* Compact the toolbar to match the dense UI. */

--- a/src/index.css
+++ b/src/index.css
@@ -490,6 +490,46 @@
     background: var(--color-activity-info-dot);
     flex-shrink: 0;
   }
+
+  /* Theme the mdx-editor rich composer onto the design tokens. Mapping the
+     editor's semantic vars to our --ds-* tokens makes it dark-mode aware
+     without depending on the editor's own .dark-theme class. */
+  .ds-mdx .mdxeditor {
+    --baseBg: var(--ds-bg-primary);
+    --basePageBg: var(--ds-bg-primary);
+    --baseBgSubtle: var(--ds-bg-secondary);
+    --baseBgHover: var(--ds-bg-secondary);
+    --baseBgActive: var(--ds-bg-tertiary);
+    --baseText: var(--ds-text-primary);
+    --baseTextContrast: var(--ds-text-primary);
+    --baseBorder: var(--ds-border-tertiary);
+    --baseBorderHover: var(--ds-border-secondary);
+    --baseLine: var(--ds-border-tertiary);
+    --accentText: var(--ds-action-fg);
+    --accentTextContrast: var(--ds-text-primary);
+    --accentBg: var(--ds-action-bg);
+    --accentBgSubtle: var(--ds-action-bg);
+    --accentBgHover: var(--ds-action-bg-hover);
+    --accentBgActive: var(--ds-action-bg-hover);
+    --accentBorder: var(--ds-border-accent);
+    --accentSolid: var(--color-primary);
+    --accentSolidHover: var(--color-primary);
+    border: 0.5px solid var(--ds-border-tertiary);
+    border-radius: 0.375rem;
+    font-family: inherit;
+  }
+
+  .ds-mdx .ds-mdx-content {
+    min-height: 76px;
+    padding: 6px 10px;
+    font-size: 13.5px;
+  }
+
+  /* Compact the toolbar to match the dense UI. */
+  .ds-mdx .mdxeditor [role='toolbar'] {
+    padding: 3px;
+    min-height: 0;
+  }
 }
 
 @keyframes slide-in-right {


### PR DESCRIPTION
Follow-up work on the Document Comments feature (after #394/#395/#397), refining the page-discussion UX, introducing a WYSIWYG markdown composer, and surfacing comment activity. Stacks on the merged comment stack; pairs with imbi-api #420 (comment events emission).

## Discussion UX
- **Inline overlay defaults hidden.** The show/hide toggle controls only the inline reader (highlights + right-margin cards); the bottom **Discussion feed is always visible**.
- **Discussion threads are not resolvable.** Resolve/reopen is gated behind a `resolvable` prop on `CommentThreadView` (default `true`, so inline cards keep it); the discussion passes `false`.
- **Open/Resolved/All filter is inline-only** — it shows only when the inline reader is open and its counts reflect inline threads. The discussion feed is unfiltered.
- **Confluence-style composer:** a collapsed "Add a comment" trigger **above** the existing threads, expanding into the editor on click.

## Rich markdown composer (mdx-editor spike)
- Adds `@mdxeditor/editor` v4 (Lexical) as a WYSIWYG composer with a minimal toolbar: **bold, italic, bullet/numbered lists, link, inline code** (no underline/checklist).
- **Lazy-loaded** (`LazyRichComposer`) so the ~148 KB-gzip Lexical bundle is a separate chunk, fetched only when a composer mounts.
- Used for the **discussion composer, thread replies, and inline-comment drafts**. The plain `CommentComposer` (with `@`-mention autocomplete) remains for the comment-**edit** flow.
- **Themed** by mapping mdx-editor's semantic CSS vars onto our `--ds-*` tokens (dark-mode aware without its own theme class); white content surface.
- **Adjustable height** — user-resizable (drag handle) with a `minHeight` default (discussion 152px, replies 76px, inline draft 96px).
- Mentions still **persist** (typed `@Name` → resolved on submit); the autocomplete popover in the rich editor is a deferred follow-up (Lexical mention plugin).

## Activity
- `ProjectActivityLog` renders the `document-comment` events emitted by imbi-api #420: *"commented on a document" / "added an inline comment" / "replied to a comment"* with an excerpt.
- Those entries **deep-link** to `/projects/{projectId}/documents/{documentId}?thread={threadId}`. On arrival the reader scrolls to and flashes the page thread, or shows + focuses + scrolls to the inline highlight.

## Notes
- A few presentational components carry `// fallow-ignore-next-line complexity`, consistent with existing suppressions in the file.
- No unit tests for the mdx-editor composer / activity renderer / deep-link (Lexical-in-jsdom is awkward); behavior verified manually against the Okteto stack.
- Verified locally: oxfmt, oxlint (0 errors), `tsc`, 394 vitest, production build (chunk split confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)