### PR TITLE
Request the API same-origin so a public host stays self-consistent

### DIFF
--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -26,6 +26,13 @@ describe('api client base URL resolution', () => {
     expect(client.API_URL).toBe('https://imbi.internal/api')
   })
 
+  it('trims a trailing slash from API_URL so callback URLs avoid `//`', async () => {
+    w.__IMBI_API_URL__ = 'https://imbi.internal/api/'
+    vi.resetModules()
+    const client = await import('../client')
+    expect(client.API_URL).toBe('https://imbi.internal/api')
+  })
+
   it('handles a root-mounted API (no prefix) as a same-origin root', async () => {
     w.__IMBI_API_URL__ = 'https://imbi.internal'
     vi.resetModules()

--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The injected host (imbi.internal) is deliberately different from the
+// jsdom document origin (http://localhost) so the assertions prove the
+// request base is rebuilt same-origin rather than reusing the injected host.
+const w = window as unknown as { __IMBI_API_URL__?: string }
+
+describe('api client base URL resolution', () => {
+  afterEach(() => {
+    delete w.__IMBI_API_URL__
+    vi.resetModules()
+  })
+
+  it('uses a same-origin path for requests, dropping the injected host', async () => {
+    w.__IMBI_API_URL__ = 'https://imbi.internal/api'
+    vi.resetModules()
+    const client = await import('../client')
+    expect(client.API_BASE_URL).toBe('/api')
+    expect(client.apiUrl('/projects')).toBe('/api/projects')
+  })
+
+  it('keeps the absolute injected URL for IdP callback display', async () => {
+    w.__IMBI_API_URL__ = 'https://imbi.internal/api'
+    vi.resetModules()
+    const client = await import('../client')
+    expect(client.API_URL).toBe('https://imbi.internal/api')
+  })
+
+  it('handles a root-mounted API (no prefix) as a same-origin root', async () => {
+    w.__IMBI_API_URL__ = 'https://imbi.internal'
+    vi.resetModules()
+    const client = await import('../client')
+    expect(client.API_BASE_URL).toBe('')
+    expect(client.apiUrl('/auth/token')).toBe('/auth/token')
+  })
+
+  it('falls back to VITE_API_URL verbatim when not injected (dev)', async () => {
+    delete w.__IMBI_API_URL__
+    vi.resetModules()
+    const client = await import('../client')
+    // src/test/setup.ts stubs VITE_API_URL=http://localhost:8000
+    expect(client.API_BASE_URL).toBe('http://localhost:8000')
+    expect(client.API_URL).toBe('http://localhost:8000')
+  })
+})

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,7 @@
 import { useAuthStore } from '@/stores/authStore'
 import type { TokenResponse } from '@/types'
 
-function resolveApiBaseUrl(): string {
+function resolveInjectedApiUrl(): string {
   // index.html injects `{{env "IMBI_API_URL"}}`; when served without a
   // templater (e.g. Vite dev) the placeholder reaches the browser literally,
   // so detect the unsubstituted form and fall back.
@@ -12,10 +12,36 @@ function resolveApiBaseUrl(): string {
   return import.meta.env.VITE_API_URL
 }
 
-export const API_BASE_URL = resolveApiBaseUrl()
-if (!API_BASE_URL) {
+// The configured API URL exactly as injected (absolute in deployment).
+// Used to build the IdP callback URLs an admin registers with a provider.
+export const API_URL = resolveInjectedApiUrl()
+if (!API_URL) {
   throw new Error('IMBI_API_URL (or VITE_API_URL) is required')
 }
+
+// Base path for same-origin API requests. The SPA may be served from more
+// than one host (e.g. an internal host plus a public host that fronts the
+// MCP OAuth login), so requests must target the document's own origin
+// rather than the injected host — otherwise a page served from the public
+// host would call the unreachable internal API URL. We keep only the path
+// of the injected (production) URL; the Vite-dev fallback is used verbatim
+// so a cross-origin dev server still works.
+function resolveApiBasePath(): string {
+  const runtime = window.__IMBI_API_URL__
+  if (runtime && !runtime.includes('{{')) {
+    try {
+      return new URL(runtime, window.location.origin).pathname.replace(
+        /\/+$/,
+        '',
+      )
+    } catch {
+      return runtime
+    }
+  }
+  return import.meta.env.VITE_API_URL
+}
+
+export const API_BASE_URL = resolveApiBasePath()
 
 export const apiUrl = (path: string): string =>
   path.startsWith('/') ? `${API_BASE_URL}${path}` : `${API_BASE_URL}/${path}`

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -12,9 +12,13 @@ function resolveInjectedApiUrl(): string {
   return import.meta.env.VITE_API_URL
 }
 
-// The configured API URL exactly as injected (absolute in deployment).
-// Used to build the IdP callback URLs an admin registers with a provider.
-export const API_URL = resolveInjectedApiUrl()
+// The configured API URL as injected (absolute in deployment), with any
+// trailing slash trimmed so the callback URLs built from it concatenate
+// cleanly (e.g. `${API_URL}/auth/oauth/.../callback`). A slash-terminated
+// IMBI_API_URL would otherwise yield a `//` that breaks exact OAuth redirect
+// URI matching. Used to build the IdP callback URLs an admin registers with a
+// provider.
+export const API_URL = resolveInjectedApiUrl()?.replace(/\/+$/, '')
 if (!API_URL) {
   throw new Error('IMBI_API_URL (or VITE_API_URL) is required')
 }

--- a/src/components/admin/AuthProvidersManagement.tsx
+++ b/src/components/admin/AuthProvidersManagement.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 
-import { API_BASE_URL } from '@/api/client'
+import { API_URL } from '@/api/client'
 import {
   createAuthProvider,
   deleteAuthProvider,
@@ -70,7 +70,7 @@ const APP_TYPE_DESCRIPTIONS: Record<OAuthAppType, string> = {
 const APP_TYPE_ORDER: OAuthAppType[] = ['google', 'github', 'oidc']
 
 const callbackUrlForType = (appType: OAuthAppType): string =>
-  `${API_BASE_URL}/auth/oauth/${appType}/callback`
+  `${API_URL}/auth/oauth/${appType}/callback`
 
 const copyToClipboard = async (value: string, label: string) => {
   try {

--- a/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
+++ b/src/components/admin/third-party-services/OAuth2ApplicationForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 import { AlertCircle } from 'lucide-react'
 
-import { API_BASE_URL } from '@/api/client'
+import { API_URL } from '@/api/client'
 import { FormHeader } from '@/components/admin/form-header'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -27,7 +27,7 @@ import type {
 } from '@/types'
 
 const callbackUrlForSlug = (slug: string): string =>
-  slug ? `${API_BASE_URL}/me/identities/${slug}/callback` : ''
+  slug ? `${API_URL}/me/identities/${slug}/callback` : ''
 
 interface OAuth2ApplicationFormProps {
   application: null | ServiceApplication


### PR DESCRIPTION
## Summary

The injected `IMBI_API_URL` was doing double duty: it was both the **request base** for every API call *and* the **absolute URL** shown for IdP callback configuration in the admin UI. When the SPA is served from a second (public) host, reusing the injected *internal* host as the request base routes that host's traffic back through the internal host and breaks the same-origin OAuth flow.

This splits the two concerns.

## What changed (`src/api/client.ts`)

- `API_BASE_URL` is now the injected URL's **path only** → requests go to whichever origin served the page (**same-origin**). A page served from the public host calls the public host; an internal page calls the internal host.
- New `API_URL` export keeps the **absolute** injected value, used only for *displaying* IdP callback URLs.
- Dev still falls back to `VITE_API_URL` verbatim.
- `AuthProvidersManagement.tsx` and `third-party-services/OAuth2ApplicationForm.tsx` switched from `API_BASE_URL` → `API_URL` for the callback-URL display strings.

## Pairs with

AWeber-Imbi/imbi-api#421 (host-aware OAuth issuer/callbacks). Together they let a trusted second host serve a self-consistent OAuth flow without repointing `IMBI_API_URL`.

## Tests

- New `src/api/__tests__/client.test.ts` (4): same-origin path, absolute `API_URL` preserved, root-mounted API, dev `VITE_API_URL` fallback.
- `oxlint` 0 errors, `oxfmt --check` clean, `tsc` clean, vitest passes (369 tests; one unrelated `icon-sets` suite failure was a local node_modules-symlink artifact, not present in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)