### PR TITLE
Add Integrations panel to Project Settings

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -45,6 +45,8 @@ import type {
   IdentityConnectionStartRequest,
   IdentityConnectionStartResponse,
   InstalledPlugin,
+  Integration,
+  IntegrationCreate,
   LifecyclePreviewResponse,
   LinkDefinition,
   LinkDefinitionCreate,
@@ -1575,6 +1577,41 @@ export const deleteProjectDocument = (
 ) =>
   apiClient.delete<void>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}`,
+  )
+
+// Project integrations (EXISTS_IN edges). One row per third-party
+// service the project exists in; `createProjectService` also persists
+// the optional dashboard URL into the project's links.
+export const listProjectServices = async (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<Integration[]> => {
+  const response = await apiClient.get<Integration[]>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/services/`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const createProjectService = (
+  orgSlug: string,
+  projectId: string,
+  data: IntegrationCreate,
+) =>
+  apiClient.post<Integration>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/services/`,
+    data,
+  )
+
+export const deleteProjectService = (
+  orgSlug: string,
+  projectId: string,
+  serviceSlug: string,
+) =>
+  apiClient.delete<void>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/services/${encodeURIComponent(serviceSlug)}`,
   )
 
 // Document comments. Hand-written like the document endpoints above; the

--- a/src/components/IntegrationsCard.tsx
+++ b/src/components/IntegrationsCard.tsx
@@ -1,0 +1,314 @@
+import { useMemo, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { ExternalLink, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  createProjectService,
+  deleteProjectService,
+  listProjectServices,
+  listThirdPartyServices,
+} from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+interface IntegrationsCardProps {
+  orgSlug: string
+  projectId: string
+}
+
+const EMPTY_FORM = {
+  canonicalUrl: '',
+  dashboardUrl: '',
+  identifier: '',
+  serviceSlug: '',
+}
+
+export function IntegrationsCard({
+  orgSlug,
+  projectId,
+}: IntegrationsCardProps) {
+  const queryClient = useQueryClient()
+  const [addOpen, setAddOpen] = useState(false)
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [deleteTarget, setDeleteTarget] = useState<null | string>(null)
+
+  const { data: services = [] } = useQuery({
+    enabled: !!orgSlug && !!projectId,
+    queryFn: ({ signal }) => listProjectServices(orgSlug, projectId, signal),
+    queryKey: ['projectServices', orgSlug, projectId],
+  })
+
+  const { data: thirdPartyServices = [] } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => listThirdPartyServices(orgSlug, signal),
+    queryKey: ['thirdPartyServices', orgSlug],
+  })
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({
+      queryKey: ['projectServices', orgSlug, projectId],
+    })
+    // The dashboard URL is mirrored into the project's links, so refresh
+    // the project view too.
+    queryClient.invalidateQueries({
+      queryKey: ['project', orgSlug, projectId],
+    })
+  }
+
+  // Services the project does not already exist in — can't connect the
+  // same service twice.
+  const connectableServices = useMemo(() => {
+    const connected = new Set(services.map((s) => s.third_party_service_slug))
+    return thirdPartyServices.filter((s) => !connected.has(s.slug))
+  }, [services, thirdPartyServices])
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createProjectService(orgSlug, projectId, {
+        canonical_url: form.canonicalUrl.trim() || null,
+        dashboard_url: form.dashboardUrl.trim() || null,
+        identifier: form.identifier.trim(),
+        third_party_service_slug: form.serviceSlug,
+      }),
+    onError: (error) => {
+      toast.error(`Failed to add integration: ${extractApiErrorDetail(error)}`)
+    },
+    onSuccess: () => {
+      toast.success('Integration added')
+      setAddOpen(false)
+      setForm(EMPTY_FORM)
+      invalidate()
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (serviceSlug: string) =>
+      deleteProjectService(orgSlug, projectId, serviceSlug),
+    onError: (error) => {
+      toast.error(
+        `Failed to remove integration: ${extractApiErrorDetail(error)}`,
+      )
+    },
+    onSuccess: () => {
+      toast.success('Integration removed')
+      invalidate()
+    },
+  })
+
+  const canSubmit =
+    !!form.serviceSlug && !!form.identifier.trim() && !createMutation.isPending
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between">
+        <div className="space-y-1.5">
+          <CardTitle>Integrations</CardTitle>
+          <CardDescription>
+            Third-party services this project exists in, with the stable
+            identifier and the canonical API and dashboard URLs.
+          </CardDescription>
+        </div>
+        <Button
+          disabled={connectableServices.length === 0}
+          onClick={() => {
+            setForm(EMPTY_FORM)
+            setAddOpen(true)
+          }}
+          size="sm"
+          variant="outline"
+        >
+          <Plus className="size-4" />
+          Add
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {services.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            This project is not connected to any third-party services.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Service</TableHead>
+                <TableHead>Identifier</TableHead>
+                <TableHead>API URL</TableHead>
+                <TableHead>Dashboard URL</TableHead>
+                <TableHead className="w-12" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {services.map((svc) => (
+                <TableRow key={svc.third_party_service_slug}>
+                  <TableCell>{svc.third_party_service_name}</TableCell>
+                  <TableCell className="font-mono text-sm">
+                    {svc.identifier}
+                  </TableCell>
+                  <TableCell>
+                    <UrlCell url={svc.canonical_url} />
+                  </TableCell>
+                  <TableCell>
+                    <UrlCell url={svc.dashboard_url} />
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      aria-label={`Remove ${svc.third_party_service_name} integration`}
+                      onClick={() =>
+                        setDeleteTarget(svc.third_party_service_slug)
+                      }
+                      size="sm"
+                      variant="ghost"
+                    >
+                      <Trash2 className="size-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+
+      <Dialog onOpenChange={setAddOpen} open={addOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Integration</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 p-6">
+            <div className="space-y-2">
+              <Label htmlFor="integration-service">Service</Label>
+              <Select
+                onValueChange={(value) =>
+                  setForm((f) => ({ ...f, serviceSlug: value }))
+                }
+                value={form.serviceSlug}
+              >
+                <SelectTrigger id="integration-service">
+                  <SelectValue placeholder="Select a service…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {connectableServices.map((svc) => (
+                    <SelectItem key={svc.slug} value={svc.slug}>
+                      {svc.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="integration-identifier">Identifier</Label>
+              <Input
+                id="integration-identifier"
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, identifier: e.target.value }))
+                }
+                placeholder="e.g. 134741 or conv:account"
+                value={form.identifier}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="integration-canonical">API URL</Label>
+              <Input
+                id="integration-canonical"
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, canonicalUrl: e.target.value }))
+                }
+                placeholder="Canonical API URL (returns JSON)"
+                value={form.canonicalUrl}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="integration-dashboard">Dashboard URL</Label>
+              <Input
+                id="integration-dashboard"
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, dashboardUrl: e.target.value }))
+                }
+                placeholder="Human dashboard URL (optional)"
+                value={form.dashboardUrl}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => setAddOpen(false)} variant="outline">
+              Cancel
+            </Button>
+            <Button
+              disabled={!canSubmit}
+              onClick={() => createMutation.mutate()}
+            >
+              Add
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        confirmLabel="Remove"
+        description={
+          deleteTarget
+            ? `This disconnects the ${deleteTarget} integration and removes its dashboard link.`
+            : ''
+        }
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget)
+          setDeleteTarget(null)
+        }}
+        open={!!deleteTarget}
+        title="Remove integration?"
+      />
+    </Card>
+  )
+}
+
+function UrlCell({ url }: { url?: null | string }) {
+  if (!url) {
+    return <span className="text-muted-foreground">—</span>
+  }
+  return (
+    <a
+      className="text-primary inline-flex items-center gap-1 hover:underline"
+      href={url}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <span className="max-w-[18rem] truncate">{url}</span>
+      <ExternalLink className="size-3 shrink-0" />
+    </a>
+  )
+}

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -18,6 +18,7 @@ import {
 import { EditEnvironmentsCard } from '@/components/EditEnvironmentsCard'
 import { EditIdentifiersCard } from '@/components/EditIdentifiersCard'
 import { EditLinksCard } from '@/components/EditLinksCard'
+import { IntegrationsCard } from '@/components/IntegrationsCard'
 import { ProjectPluginsSection } from '@/components/project/ProjectPluginsSection'
 import { Button } from '@/components/ui/button'
 import {
@@ -253,6 +254,8 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
         identifiers={project.identifiers || {}}
         onPatch={(entries) => patch('/identifiers', entries)}
       />
+
+      <IntegrationsCard orgSlug={orgSlug} projectId={project.id} />
 
       <ProjectPluginsSection orgSlug={orgSlug} projectId={project.id} />
 

--- a/src/components/__tests__/IntegrationsCard.test.tsx
+++ b/src/components/__tests__/IntegrationsCard.test.tsx
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import { IntegrationsCard } from '@/components/IntegrationsCard'
+import { render, screen } from '@/test/utils'
+
+vi.mock('@/api/endpoints', () => ({
+  createProjectService: vi.fn(),
+  deleteProjectService: vi.fn(),
+  listProjectServices: vi.fn(),
+  listThirdPartyServices: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+describe('IntegrationsCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(endpoints.listThirdPartyServices).mockResolvedValue([])
+  })
+
+  it('renders a row per connected service with its URLs', async () => {
+    vi.mocked(endpoints.listProjectServices).mockResolvedValue([
+      {
+        canonical_url: 'https://api.aweber.ghe.com/repositories/138841',
+        dashboard_url: 'https://aweber.ghe.com/org/webform',
+        identifier: '138841',
+        third_party_service_name: 'GitHub',
+        third_party_service_slug: 'github',
+      },
+    ])
+
+    render(<IntegrationsCard orgSlug="aweber" projectId="p1" />)
+
+    expect(await screen.findByText('GitHub')).toBeInTheDocument()
+    expect(screen.getByText('138841')).toBeInTheDocument()
+    expect(
+      screen.getByText('https://api.aweber.ghe.com/repositories/138841'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('https://aweber.ghe.com/org/webform'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows an empty state when the project exists in no services', async () => {
+    vi.mocked(endpoints.listProjectServices).mockResolvedValue([])
+
+    render(<IntegrationsCard orgSlug="aweber" projectId="p1" />)
+
+    expect(
+      await screen.findByText(/not connected to any third-party services/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a dash when a URL is absent', async () => {
+    vi.mocked(endpoints.listProjectServices).mockResolvedValue([
+      {
+        canonical_url: null,
+        dashboard_url: null,
+        identifier: 'cc:webform',
+        third_party_service_name: 'SonarQube',
+        third_party_service_slug: 'sonarqube',
+      },
+    ])
+
+    render(<IntegrationsCard orgSlug="aweber" projectId="p1" />)
+
+    expect(await screen.findByText('SonarQube')).toBeInTheDocument()
+    // both canonical + dashboard cells render the em-dash placeholder
+    expect(screen.getAllByText('—')).toHaveLength(2)
+  })
+})

--- a/src/types/api-generated.ts
+++ b/src/types/api-generated.ts
@@ -3326,8 +3326,10 @@ export interface components {
             third_party_service_slug: string;
             /** Identifier */
             identifier: string;
-            /** Canonical Link */
-            canonical_link?: string | null;
+            /** Canonical Url */
+            canonical_url?: string | null;
+            /** Dashboard Url */
+            dashboard_url?: string | null;
         };
         /**
          * ExistsInResponse
@@ -3340,8 +3342,10 @@ export interface components {
             third_party_service_name: string;
             /** Identifier */
             identifier: string;
-            /** Canonical Link */
-            canonical_link?: string | null;
+            /** Canonical Url */
+            canonical_url?: string | null;
+            /** Dashboard Url */
+            dashboard_url?: string | null;
         };
         /**
          * FormatType

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,12 @@ export interface EnvironmentCreate {
   sort_order?: null | number
 }
 
+// Integration (EXISTS_IN edge) types — a project's relationship to a
+// third-party service: stable identifier + canonical API URL, plus the
+// human dashboard URL (read from / written to the project's links).
+export type Integration = Schemas['ExistsInResponse']
+export type IntegrationCreate = Schemas['ExistsInCreate']
+
 // Per-plugin outcome returned by the archive / unarchive endpoints, one
 // entry per lifecycle plugin assigned to the project. `failed` is the
 // case worth surfacing — e.g. a GitHub repo transfer that left the repo
@@ -227,12 +233,6 @@ export interface Project {
   viewer_closed_pr_count?: number
   viewer_open_pr_count?: number
 }
-
-// Integration (EXISTS_IN edge) types — a project's relationship to a
-// third-party service: stable identifier + canonical API URL, plus the
-// human dashboard URL (read from / written to the project's links).
-export type Integration = Schemas['ExistsInResponse']
-export type IntegrationCreate = Schemas['ExistsInCreate']
 
 // `ProjectCreate` stays hand-written: the UI sends `environment_slugs` (a
 // flat slug list) whereas the generated `ProjectCreate` expects an

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,10 @@ export interface Project {
     team?: RelationshipLink
   }
   score?: null | number
+  // Read-only EXISTS_IN connections (third-party service relationships).
+  // Maintained via the project-services endpoints / Integrations panel,
+  // not by editing `identifiers`.
+  services?: Integration[]
   slug: string
   team: {
     name: string
@@ -223,6 +227,12 @@ export interface Project {
   viewer_closed_pr_count?: number
   viewer_open_pr_count?: number
 }
+
+// Integration (EXISTS_IN edge) types — a project's relationship to a
+// third-party service: stable identifier + canonical API URL, plus the
+// human dashboard URL (read from / written to the project's links).
+export type Integration = Schemas['ExistsInResponse']
+export type IntegrationCreate = Schemas['ExistsInCreate']
 
 // `ProjectCreate` stays hand-written: the UI sends `environment_slugs` (a
 // flat slug list) whereas the generated `ProjectCreate` expects an


### PR DESCRIPTION
> **Draft** — depends on AWeber-Imbi/imbi-api#423 (the
> `/services` `dashboard_url` fold + project `services` surface).

## Summary

Adds an **Integrations** panel to Project Settings: a table of the
project's third-party-service connections (`EXISTS_IN` edges) with
add / remove.

## Problem

A project's `EXISTS_IN` relationships had no UI — the `/services`
endpoints existed but nothing consumed them, and there was no way to
link an existing project to an existing repo/service from the UI.

## Solution

- `IntegrationsCard`: table of service / identifier / API URL /
  dashboard URL, with an add dialog (service picker + fields) and a
  per-row remove (`ConfirmDialog`), backed by `listProjectServices` /
  `createProjectService` / `deleteProjectService`. Wired into
  `ProjectSettingsTab` beside Links and Identifiers.
- Types: `Integration` / `IntegrationCreate` aliases and
  `Project.services`.
- **Codegen note:** `api-generated.ts` was **hand-edited** for the
  `ExistsIn` schemas (`canonical_url` + `dashboard_url`) instead of a
  full regen, to keep this PR's diff small. The generated file is stale
  — see AWeber-Imbi/imbi-ui#403 — and these edits should be reconciled
  by a proper `npm run codegen:fetch` once the API ships.

## Companion PRs

Part of `exists-in-edge-management` (plan:
`imbi-orchestration/plans/exists-in-edge-management.md`).
- AWeber-Imbi/imbi-common#150
- AWeber-Imbi/imbi-api#423 (prerequisite)
- AWeber-Imbi/imbi-plugin-github#25
