### PR TITLE
Rename plugin-assignment tab to plugin_type

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -446,10 +446,12 @@ export function ProjectDetail({
     queryFn: ({ signal }) => listProjectPlugins(orgSlug, project.id, signal),
     queryKey: ['project-plugins', orgSlug, project.id],
     select: (plugins) => ({
-      deploymentPlugin: plugins.find((a) => a.tab === 'deployment'),
-      hasConfigurationPlugin: plugins.some((a) => a.tab === 'configuration'),
-      hasLifecyclePlugin: plugins.some((a) => a.tab === 'lifecycle'),
-      hasLogsPlugin: plugins.some((a) => a.tab === 'logs'),
+      deploymentPlugin: plugins.find((a) => a.plugin_type === 'deployment'),
+      hasConfigurationPlugin: plugins.some(
+        (a) => a.plugin_type === 'configuration',
+      ),
+      hasLifecyclePlugin: plugins.some((a) => a.plugin_type === 'lifecycle'),
+      hasLogsPlugin: plugins.some((a) => a.plugin_type === 'logs'),
     }),
     staleTime: 5 * 60 * 1000,
   })

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -168,7 +168,10 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   // plugin is present the checkbox is suppressed because there is no
   // remote to delete.
   const hasLifecyclePlugin = useMemo(
-    () => projectPlugins.some((assignment) => assignment.tab === 'lifecycle'),
+    () =>
+      projectPlugins.some(
+        (assignment) => assignment.plugin_type === 'lifecycle',
+      ),
     [projectPlugins],
   )
 
@@ -179,7 +182,7 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
   const deploymentPlugin = useMemo(() => {
     const candidates = projectPlugins.filter(
       (assignment) =>
-        assignment.tab === 'deployment' &&
+        assignment.plugin_type === 'deployment' &&
         assignment.supports_deployment_sync === true,
     )
     return candidates.find((assignment) => assignment.default) ?? candidates[0]

--- a/src/components/__tests__/ProjectSettingsTab.test.tsx
+++ b/src/components/__tests__/ProjectSettingsTab.test.tsx
@@ -85,9 +85,9 @@ const DEPLOYMENT_PLUGIN = {
   options: {},
   plugin_id: 'dep-1',
   plugin_slug: 'github-deploy',
+  plugin_type: 'deployment',
   source: 'project',
   supports_deployment_sync: true,
-  tab: 'deployment',
 } as PluginAssignmentResponse
 
 function renderTab() {
@@ -179,8 +179,8 @@ describe('ProjectSettingsTab delete flow', () => {
     options: {},
     plugin_id: 'lc-1',
     plugin_slug: 'github-lifecycle',
+    plugin_type: 'lifecycle',
     source: 'project',
-    tab: 'lifecycle',
   } as PluginAssignmentResponse
 
   beforeEach(async () => {

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -64,7 +64,7 @@ import type {
   PluginAssignmentInput,
   PluginAssignmentRow,
   PluginResponse,
-  PluginTab,
+  PluginType,
 } from '@/types'
 
 import { ServicePluginEdgesCard } from './ServicePluginEdgesCard'
@@ -97,8 +97,8 @@ interface DraftAssignment {
   default: boolean
   identity_plugin_id: null | string
   options: Record<string, unknown>
+  plugin_type: PluginType
   project_type_slug: string
-  tab: PluginTab
 }
 
 interface IdentityCardProps {
@@ -784,8 +784,8 @@ function ProjectTypesCard({
         default: a.default,
         identity_plugin_id: a.identity_plugin_id ?? null,
         options: a.options,
+        plugin_type: a.plugin_type,
         project_type_slug: a.project_type_slug,
-        tab: a.tab,
       })),
     )
     setSeedHash(hash)
@@ -826,14 +826,14 @@ function ProjectTypesCard({
       default: a.default,
       identity_plugin_id: a.identity_plugin_id ?? null,
       options: a.options,
+      plugin_type: a.plugin_type,
       project_type_slug: a.project_type_slug,
-      tab: a.tab,
     }))
     return JSON.stringify(drafts) !== JSON.stringify(baseline)
   }, [drafts, existing])
 
-  const supportedTab = (manifest?.supported_tabs[0] ??
-    'configuration') as PluginTab
+  const supportedPluginType = (manifest?.supported_tabs[0] ??
+    'configuration') as PluginType
 
   const handleAdd = (slug: string) => {
     setDrafts((prev) => {
@@ -844,8 +844,8 @@ function ProjectTypesCard({
           default: true,
           identity_plugin_id: null,
           options: {},
+          plugin_type: supportedPluginType,
           project_type_slug: slug,
-          tab: supportedTab,
         },
       ]
     })
@@ -925,7 +925,7 @@ function ProjectTypesCard({
         {drafts.length === 0 ? (
           <div className="border-tertiary text-secondary rounded border border-dashed py-8 text-center text-sm">
             No project type assignments. Add one to surface this plugin under a
-            project type&apos;s {supportedTab} tab.
+            project type&apos;s {supportedPluginType} tab.
           </div>
         ) : (
           <Table>

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -184,7 +184,7 @@ export function ConfigurationTab({
   })
 
   const configAssignments =
-    assignments?.filter((a) => a.tab === 'configuration') ?? []
+    assignments?.filter((a) => a.plugin_type === 'configuration') ?? []
   const sources = configAssignments.map((a) => ({
     id: a.plugin_id,
     label: a.label,

--- a/src/components/project/LogsTab.tsx
+++ b/src/components/project/LogsTab.tsx
@@ -309,7 +309,8 @@ export function LogsTab({
     staleTime: 5 * 60_000,
   })
 
-  const logAssignments = assignments?.filter((a) => a.tab === 'logs') ?? []
+  const logAssignments =
+    assignments?.filter((a) => a.plugin_type === 'logs') ?? []
   const sources = logAssignments.map((a) => ({
     id: a.plugin_id,
     label: a.label,

--- a/src/components/project/ProjectPluginsSection.tsx
+++ b/src/components/project/ProjectPluginsSection.tsx
@@ -57,6 +57,7 @@ import type {
   PluginAssignmentCreate,
   PluginAssignmentResponse,
   PluginTab,
+  PluginType,
 } from '@/types'
 
 interface OverrideDraft extends PluginAssignmentCreate {
@@ -172,7 +173,7 @@ export function ProjectPluginsSection({
           default: d.default,
           options: d.options,
           plugin_id: d.plugin_id,
-          tab: d.tab,
+          plugin_type: d.plugin_type,
         })),
       ),
     onError: (err) => {
@@ -208,8 +209,8 @@ export function ProjectPluginsSection({
           options: {} as Record<string, unknown>,
           plugin_id: plugin.id,
           plugin_slug: plugin.plugin_slug,
+          plugin_type: selectedTab,
           source: 'project' as const,
-          tab: selectedTab,
         },
       ]
       // Auto-expand the freshly added row so the option editor is
@@ -249,10 +250,10 @@ export function ProjectPluginsSection({
               {inherited.map((a) => (
                 <div
                   className="border-tertiary bg-secondary flex items-center gap-1.5 rounded border px-2 py-1 text-xs"
-                  key={`${a.plugin_id}:${a.tab}`}
+                  key={`${a.plugin_id}:${a.plugin_type}`}
                 >
                   <span className="text-primary">{a.label}</span>
-                  <Badge variant="secondary">{a.tab}</Badge>
+                  <Badge variant="secondary">{a.plugin_type}</Badge>
                   {a.default && <span className="text-tertiary">default</span>}
                 </div>
               ))}
@@ -304,7 +305,7 @@ export function ProjectPluginsSection({
                     idx={idx}
                     inheritedOptions={
                       inheritedOptionsByKey[
-                        inheritedKey(draft.plugin_id, draft.tab)
+                        inheritedKey(draft.plugin_id, draft.plugin_type)
                       ] ?? {}
                     }
                     isExpanded={expanded.has(idx)}
@@ -430,8 +431,8 @@ function assignmentToDraft(a: PluginAssignmentResponse): OverrideDraft {
     options: a.options ?? {},
     plugin_id: a.plugin_id,
     plugin_slug: a.plugin_slug,
+    plugin_type: a.plugin_type,
     source: a.source,
-    tab: a.tab,
   }
 }
 
@@ -439,7 +440,7 @@ function buildInheritedOptionsByKey(merged: PluginAssignmentResponse[]) {
   const out: Record<string, Record<string, unknown>> = {}
   for (const a of merged) {
     if (a.source !== 'project_type') continue
-    out[inheritedKey(a.plugin_id, a.tab)] = a.options ?? {}
+    out[inheritedKey(a.plugin_id, a.plugin_type)] = a.options ?? {}
   }
   return out
 }
@@ -449,14 +450,14 @@ function draftToCompare(d: {
   label: string
   options: Record<string, unknown>
   plugin_id: string
-  tab: PluginTab
+  plugin_type: PluginType
 }) {
   return {
     default: d.default,
     label: d.label,
     options: d.options,
     plugin_id: d.plugin_id,
-    tab: d.tab,
+    plugin_type: d.plugin_type,
   }
 }
 
@@ -471,11 +472,11 @@ function hasRenderableManifest(
   return manifest.options.length > 0
 }
 
-// Composite key so the same plugin can be assigned on different tabs
-// (e.g. ``configuration`` and ``logs``) without one overwriting the
-// other in the inherited-options lookup.
-function inheritedKey(pluginId: string, tab: PluginTab) {
-  return `${pluginId}:${tab}`
+// Composite key so the same plugin can be assigned under different
+// plugin types (e.g. ``configuration`` and ``logs``) without one
+// overwriting the other in the inherited-options lookup.
+function inheritedKey(pluginId: string, pluginType: PluginType) {
+  return `${pluginId}:${pluginType}`
 }
 
 // Placeholder text shown when the override is empty: prefer the
@@ -627,7 +628,7 @@ function ProjectPluginOverrideRow({
       >
         <TableCell className="font-medium">{draft.label}</TableCell>
         <TableCell>
-          <Badge variant="secondary">{draft.tab}</Badge>
+          <Badge variant="secondary">{draft.plugin_type}</Badge>
         </TableCell>
         <TableCell className="text-secondary text-sm">
           {draft.default ? 'Yes' : 'No'}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -859,10 +859,10 @@ export interface InstalledPlugin {
   options: PluginOptionDef[]
   package_name: string
   package_version: string
-  plugin_type?: 'identity' | PluginTab
+  plugin_type?: PluginType
   requires_identity?: boolean
   slug: string
-  supported_tabs: PluginTab[]
+  supported_tabs: PluginType[]
   supports_deployment_sync?: boolean
   vertex_labels?: PluginVertexLabel[]
   // Body copy shown on the dashboard "unconnected integration" widget.
@@ -1085,15 +1085,15 @@ export interface PluginAssignmentCreate {
   identity_plugin_id?: null | string
   options?: Record<string, unknown>
   plugin_id: string
-  tab: PluginTab
+  plugin_type: PluginType
 }
 
 export interface PluginAssignmentInput {
   default: boolean
   identity_plugin_id?: null | string
   options: Record<string, unknown>
+  plugin_type: PluginType
   project_type_slug: string
-  tab: PluginTab
 }
 
 export interface PluginAssignmentResponse {
@@ -1103,18 +1103,18 @@ export interface PluginAssignmentResponse {
   options: Record<string, unknown>
   plugin_id: string
   plugin_slug: string
+  plugin_type: PluginType
   source: 'merged' | 'project' | 'project_type'
   supports_deployment_sync?: boolean
   supports_histogram?: boolean
-  tab: PluginTab
 }
 export interface PluginAssignmentRow {
   default: boolean
   identity_plugin_id?: null | string
   options: Record<string, unknown>
+  plugin_type: PluginType
   project_type_name: string
   project_type_slug: string
-  tab: PluginTab
 }
 export interface PluginConfigurationResponse {
   auth_type: 'api_token' | 'oauth2'
@@ -1198,7 +1198,19 @@ export interface PluginResponse {
   status: 'active' | 'unavailable'
   used_as_login?: boolean
 }
+// The subset of plugin types that render a project-detail tab. Not
+// every plugin type is a tab (e.g. webhook, analysis): tabs ⊆ plugins.
 export type PluginTab = 'configuration' | 'deployment' | 'lifecycle' | 'logs'
+// A plugin assignment is keyed by the plugin's type. Mirrors
+// imbi_common.plugins.PluginType (the full manifest set).
+export type PluginType =
+  | 'analysis'
+  | 'configuration'
+  | 'deployment'
+  | 'identity'
+  | 'lifecycle'
+  | 'logs'
+  | 'webhook'
 
 export interface PluginUpdate {
   // Pass an explicit empty string to clear; omitting the field leaves


### PR DESCRIPTION
## Summary

Renames the plugin-assignment field `tab` → `plugin_type` across the UI types and consumers, mirroring the imbi-api contract change.

## Problem

A plugin assignment (project-type ↔ plugin) is keyed by the plugin's **type** (`configuration`, `logs`, `deployment`, `lifecycle`, `webhook`, `analysis`). The field was named `tab` and typed against a hard-coded 4-value union, so assigning a **webhook** (or analysis) plugin failed. "Tab" conflated two concepts: the assignment key (the plugin type) and the project-detail UI tab.

## Solution

- Add a `PluginType` type mirroring `imbi_common.plugins.PluginType` (the full manifest set).
- Keep `PluginTab` as the **subset** of plugin types that render a project-detail tab (`configuration`, `logs`, `lifecycle`, `deployment`). Not all plugins are tabs; all tabs are plugins (tabs ⊆ plugins).
- Rename `tab` → `plugin_type` on `PluginAssignmentCreate` / `PluginAssignmentInput` / `PluginAssignmentResponse` / `PluginAssignmentRow`, the manifest `plugin_type`/`supported_tabs` typings, and every consumer (`ProjectDetail`, `ProjectSettingsTab`, `ProjectPluginsSection`, `ServicePluginConfiguration`, `LogsTab`, `ConfigurationTab`).
- Tab-rendering gates now match on `plugin_type`, so a webhook/analysis assignment surfaces no project-detail tab.

## Notes

- The hand-written assignment types in `src/types/index.ts` (not the generated `api-generated.ts`, which doesn't cover assignments) are the source for these components; no codegen change was required.

## Testing

- `tsc --noEmit` — clean
- `oxlint` (changed files) — clean
- `vitest run` — 402 passed