### PR TITLE
Add "Sync Commits & Tags" button to Project Doctor

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -889,6 +889,47 @@ export const runProjectAnalysis = (orgSlug: string, projectId: string) =>
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/analysis/run`,
   )
 
+export interface CommitSyncEnqueueResponse {
+  enqueued: boolean
+}
+
+export type CommitSyncState =
+  | 'failed'
+  | 'idle'
+  | 'queued'
+  | 'running'
+  | 'success'
+
+export interface CommitSyncStatus {
+  commits_synced: null | number
+  error: null | string
+  last_synced_at: null | string
+  requested_by: null | string
+  status: CommitSyncState
+  tags_synced: null | number
+}
+
+// Enqueue a full commit + tag history backfill (background job). 202 +
+// {enqueued} — false when debounced or queueing is unavailable.
+export const syncProjectCommitsAndTags = (
+  orgSlug: string,
+  projectId: string,
+): Promise<CommitSyncEnqueueResponse> =>
+  apiClient.post<CommitSyncEnqueueResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/commits/sync`,
+  )
+
+export const getProjectCommitSyncStatus = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<CommitSyncStatus> =>
+  apiClient.get<CommitSyncStatus>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/commits/sync-status`,
+    undefined,
+    signal,
+  )
+
 export interface ScoreTrend {
   current: null | number
   delta: null | number

--- a/src/components/ProjectDoctorTab.tsx
+++ b/src/components/ProjectDoctorTab.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/collapsible'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAuth } from '@/hooks/useAuth'
+import { useCommitSync } from '@/hooks/useCommitSync'
 import { useProjectDeploymentResync } from '@/hooks/useDeploymentResync'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { extractApiErrorDetail } from '@/lib/apiError'
@@ -107,6 +108,10 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
 
   const resyncMutation = useProjectDeploymentResync(orgSlug, project.id)
 
+  // Shares the deployment:write gate: the backend requires a GitHub
+  // deployment plugin (eligibility) plus a connected commit-sync plugin.
+  const commitSync = useCommitSync(orgSlug, project.id, canResyncDeployments)
+
   const report = reportQuery.data
   const results = report?.results ?? []
 
@@ -146,6 +151,16 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
                 variant="outline"
               >
                 {resyncMutation.isPending ? 'Syncing...' : 'Sync Deployments'}
+              </Button>
+            )}
+            {canResyncDeployments && (
+              <Button
+                disabled={commitSync.isSyncing}
+                onClick={() => commitSync.sync()}
+                size="sm"
+                variant="outline"
+              >
+                {commitSync.isSyncing ? 'Syncing...' : 'Sync Commits & Tags'}
               </Button>
             )}
           </CardContent>

--- a/src/hooks/__tests__/useCommitSync.test.tsx
+++ b/src/hooks/__tests__/useCommitSync.test.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from 'react'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import type { CommitSyncStatus } from '@/api/endpoints'
+
+import { useCommitSync } from '../useCommitSync'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return {
+    ...actual,
+    getProjectCommitSyncStatus: vi.fn(),
+    syncProjectCommitsAndTags: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}))
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { gcTime: 0, retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+async function renderAndSync(enqueued: boolean) {
+  vi.mocked(endpoints.getProjectCommitSyncStatus).mockResolvedValue(status())
+  vi.mocked(endpoints.syncProjectCommitsAndTags).mockResolvedValue({
+    enqueued,
+  })
+  const { result } = renderHook(() => useCommitSync('acme', 'p1', true), {
+    wrapper: makeWrapper(),
+  })
+  await act(async () => {
+    result.current.sync()
+  })
+  return result
+}
+
+function status(overrides: Partial<CommitSyncStatus> = {}): CommitSyncStatus {
+  return {
+    commits_synced: null,
+    error: null,
+    last_synced_at: null,
+    requested_by: null,
+    status: 'idle',
+    tags_synced: null,
+    ...overrides,
+  }
+}
+
+describe('useCommitSync', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('enqueues and toasts success when accepted', async () => {
+    await renderAndSync(true)
+    await waitFor(() =>
+      expect(endpoints.syncProjectCommitsAndTags).toHaveBeenCalledWith(
+        'acme',
+        'p1',
+      ),
+    )
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith('Commit & tag sync started'),
+    )
+  })
+
+  it('shows an info toast when a sync is already running', async () => {
+    await renderAndSync(false)
+    await waitFor(() => expect(toast.info).toHaveBeenCalled())
+  })
+
+  it('reports isSyncing while the status is active', async () => {
+    vi.mocked(endpoints.getProjectCommitSyncStatus).mockResolvedValue(
+      status({ status: 'running' }),
+    )
+    const { result } = renderHook(() => useCommitSync('acme', 'p1', true), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+  })
+})

--- a/src/hooks/useCommitSync.ts
+++ b/src/hooks/useCommitSync.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import type { CommitSyncState, CommitSyncStatus } from '@/api/endpoints'
+import {
+  getProjectCommitSyncStatus,
+  syncProjectCommitsAndTags,
+} from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+const POLL_MS = 3000
+
+// Drives the Project Doctor "Sync Commits & Tags" button: enqueues the
+// background job and polls the project's sync-status while a run is in
+// flight, toasting the terminal result so the user gets feedback even
+// though the work happens off-request.
+export function useCommitSync(
+  orgSlug: string,
+  projectId: string,
+  enabled: boolean,
+) {
+  const queryClient = useQueryClient()
+
+  const statusQuery = useQuery({
+    enabled: enabled && !!orgSlug && !!projectId,
+    queryFn: ({ signal }): Promise<CommitSyncStatus> =>
+      getProjectCommitSyncStatus(orgSlug, projectId, signal),
+    queryKey: ['commitSyncStatus', orgSlug, projectId],
+    // Poll only while a run is queued/running; settle back to idle.
+    refetchInterval: (query) =>
+      isActive(query.state.data?.status) ? POLL_MS : false,
+  })
+
+  // Toast the terminal result when a poll observes the run leaving the
+  // active state. The ref guards against toasting stale state on mount.
+  const previous = useRef<CommitSyncState | undefined>(undefined)
+  useEffect(() => {
+    const data = statusQuery.data
+    if (!data) return
+    if (isActive(previous.current) && !isActive(data.status)) {
+      announceTerminal(data)
+    }
+    previous.current = data.status
+  }, [statusQuery.data])
+
+  const mutation = useMutation({
+    mutationFn: () => syncProjectCommitsAndTags(orgSlug, projectId),
+    onError: (err) =>
+      toast.error(
+        extractApiErrorDetail(err) ?? 'Failed to start commit & tag sync',
+      ),
+    onSuccess: (res) => {
+      if (res.enqueued) {
+        toast.success('Commit & tag sync started')
+        void queryClient.invalidateQueries({
+          queryKey: ['commitSyncStatus', orgSlug, projectId],
+        })
+      } else {
+        toast.info('A commit & tag sync is already in progress')
+      }
+    },
+  })
+
+  const isSyncing = mutation.isPending || isActive(statusQuery.data?.status)
+  return { isSyncing, sync: mutation.mutate }
+}
+
+// Announce a run's terminal outcome once it leaves the active state.
+function announceTerminal(data: CommitSyncStatus): void {
+  if (data.status === 'success') {
+    toast.success(
+      `Synced ${data.commits_synced ?? 0} commit(s) and ${data.tags_synced ?? 0} tag(s)`,
+    )
+  } else if (data.status === 'failed') {
+    toast.error(`Commit & tag sync failed: ${data.error ?? 'unknown error'}`)
+  }
+}
+
+function isActive(state: CommitSyncState | undefined): boolean {
+  return state === 'queued' || state === 'running'
+}


### PR DESCRIPTION
## Summary
Adds a fourth Utility Functions action in Project Doctor that triggers the on-demand commit/tag history backfill and surfaces its progress.

## Problem
There's no UI to backfill a project's commit/tag history; it only fills in from push webhooks.

## Solution
- `endpoints.ts`: `syncProjectCommitsAndTags` (POST `.../commits/sync`) and `getProjectCommitSyncStatus` (GET `.../commits/sync-status`) + types.
- `useCommitSync` hook: enqueues the job, then polls sync-status every 3s while a run is queued/running and toasts the terminal result (the work runs off-request as a background job).
- `ProjectDoctorTab`: a "Sync Commits & Tags" button gated on the same `project:deployment:write` permission as Sync Deployments; disabled and showing "Syncing…" while a run is active.

## Notes
- Depends on imbi-api #427 for the endpoints. Release held for the coordinated bump.
- 3 hook tests; oxlint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)