### PR TITLE
Route config "Connect now" link to /settings/connections

### DIFF
--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+import { Link } from 'react-router-dom'
+
 import {
   useMutation,
   useQueries,
@@ -774,9 +776,9 @@ function ConfigLoadError({ error }: { error: unknown }) {
     error.status === 401 &&
     typeof detail === 'object' &&
     detail?.error === 'identity_required'
-  const startUrl =
+  const pluginId =
     isIdentityRequired && typeof detail === 'object'
-      ? detail.start_url
+      ? detail.plugin_id
       : undefined
 
   if (isIdentityRequired) {
@@ -787,16 +789,16 @@ function ConfigLoadError({ error }: { error: unknown }) {
           The configuration plugin needs an authenticated identity for your
           user.
         </div>
-        {startUrl && (
-          <a
-            className="text-amber-text inline-flex items-center text-xs font-medium hover:underline"
-            href={startUrl}
-            rel="noreferrer"
-            target="_blank"
-          >
-            Connect now →
-          </a>
-        )}
+        <Link
+          className="text-amber-text inline-flex items-center text-xs font-medium hover:underline"
+          to={
+            pluginId
+              ? `/settings/connections?connect=${encodeURIComponent(pluginId)}`
+              : '/settings/connections'
+          }
+        >
+          Connect now →
+        </Link>
       </div>
     )
   }


### PR DESCRIPTION
## Summary

On a project's **Configuration** tab, when the actor isn't connected to the identity plugin the config plugin depends on (e.g. AWS), the panel shows *"Connect your account to continue"* with a **Connect now →** link. That link previously used the backend's `start_url` (`/me/identities/{plugin_id}/start`) as a raw `href` opening in a new tab — which dropped the user on the dashboard instead of somewhere they can actually connect.

## Problem

The link's destination came from the API error's `start_url`, which doesn't land the user on a connect/reconnect UI.

## Solution

Replace the raw anchor with a client-side React Router `<Link>` to `/settings/connections`, carrying `?connect=<plugin_id>` so the connect flow auto-starts for the specific plugin — mirroring the dashboard's `UnconnectedIntegrationWidget` (`Dashboard.tsx`). `plugin_id` from the `identity_required` error is the plugin slug, which is what `SettingsConnections` keys its `?connect=` handler off of. If it doesn't match an enabled plugin, the page simply shows the connections list (still the intended destination).

## Testing

- `npx tsc --noEmit` — clean
- `oxlint` on the changed file — 0 errors (pre-existing warnings only)
- pre-commit hooks (oxlint --fix, oxfmt, audit gate) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)