### PR TITLE
Add My Teams filter to the projects list

### DIFF
--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -24,6 +24,7 @@ import { matchSorter } from 'match-sorter'
 import { getProjectsSlim, type ProjectListItem } from '@/api/endpoints'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
+import { useAuth } from '@/hooks/useAuth'
 import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { useSearchShortcut } from '@/hooks/useSearchShortcut'
 import { deriveChipColors } from '@/lib/chip-colors'
@@ -99,7 +100,21 @@ export function ProjectsView() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const { selectedOrganization } = useOrganization()
+  const { user } = useAuth()
   const orgSlug = selectedOrganization?.slug || ''
+
+  // Team slugs the current user belongs to, scoped to the selected org.
+  // Sourced from GET /users/me so the "My Teams" toggle can filter
+  // client-side with no extra request, mirroring "My PRs".
+  const myTeamSlugs = useMemo(
+    () =>
+      new Set(
+        (user?.teams ?? [])
+          .filter((t) => t.organization_slug === orgSlug)
+          .map((t) => t.team_slug),
+      ),
+    [user, orgSlug],
+  )
 
   const [storedView] = useState(() =>
     typeof window === 'undefined'
@@ -132,6 +147,7 @@ export function ProjectsView() {
   const hasDrift = searchParams.get('has_drift') === '1'
   const hasOpenPRs = searchParams.get('has_open_prs') === '1'
   const hasMyOpenPRs = searchParams.get('has_my_open_prs') === '1'
+  const hasMyTeams = searchParams.get('has_my_teams') === '1'
 
   const setViewMode = (v: 'grid' | 'list') => {
     if (typeof window !== 'undefined') {
@@ -190,6 +206,7 @@ export function ProjectsView() {
   const toggleDrift = toggleBoolParam('has_drift')
   const toggleOpenPRs = toggleBoolParam('has_open_prs')
   const toggleMyOpenPRs = toggleBoolParam('has_my_open_prs')
+  const toggleMyTeams = toggleBoolParam('has_my_teams')
 
   const toggleFilter = (param: string, slug: string) =>
     setSearchParams(
@@ -278,6 +295,9 @@ export function ProjectsView() {
     if (hasMyOpenPRs) {
       all = all.filter((p) => (p.viewer_open_pr_count ?? 0) > 0)
     }
+    if (hasMyTeams) {
+      all = all.filter((p) => myTeamSlugs.has(p.team.slug))
+    }
     if (hasDrift) {
       all = all.filter((p) => driftedProjectIds.has(p.id))
     }
@@ -325,6 +345,8 @@ export function ProjectsView() {
     hasDrift,
     hasOpenPRs,
     hasMyOpenPRs,
+    hasMyTeams,
+    myTeamSlugs,
   ])
 
   const totalOpenPRs = useMemo(
@@ -338,6 +360,10 @@ export function ProjectsView() {
         0,
       ),
     [projects],
+  )
+  const totalMyTeamProjects = useMemo(
+    () => (projects ?? []).filter((p) => myTeamSlugs.has(p.team.slug)).length,
+    [projects, myTeamSlugs],
   )
 
   const activeTeamSet = new Set(teamsParam.split(',').filter(Boolean))
@@ -411,6 +437,14 @@ export function ProjectsView() {
                 onClick={toggleMyOpenPRs}
                 value={totalMyOpenPRs}
                 variant="info"
+              />
+              <StatBadge
+                active={hasMyTeams}
+                disabled={isLoading}
+                label="My Teams"
+                onClick={toggleMyTeams}
+                value={totalMyTeamProjects}
+                variant="teal"
               />
             </div>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1438,6 +1438,15 @@ export interface TeamMember {
   last_login?: null | string
 }
 
+// Mirror of the backend `TeamMembership` model returned on
+// GET /users/me. Lets the UI offer membership-scoped filters (e.g. the
+// "My Teams" toggle on the projects list) without extra requests.
+export interface TeamMembership {
+  organization_slug: string
+  team_name: string
+  team_slug: string
+}
+
 // Third-Party Service types
 export type ThirdPartyService = Schemas['ThirdPartyServiceResponse']
 
@@ -1460,9 +1469,10 @@ export interface UseAuthReturn {
 }
 
 // `UserResponse` stays hand-written: it's a UI-side extension of `User`
-// (inherits `username`, `user_type`, etc.). `permissions` and `is_admin` are
-// populated by GET /users/me (the backend's CurrentUserResponse); other
-// optional fields (`groups`, `roles`) are not yet exposed by the API.
+// (inherits `username`, `user_type`, etc.). `permissions`, `is_admin`, and
+// `teams` are populated by GET /users/me (the backend's
+// CurrentUserResponse); other optional fields (`groups`, `roles`) are not
+// yet exposed by the API.
 export interface UserResponse extends User {
   avatar_url?: null | string
   created_at?: string
@@ -1473,6 +1483,7 @@ export interface UserResponse extends User {
   last_login?: null | string
   permissions?: string[]
   roles?: string[]
+  teams?: TeamMembership[]
   updated_at?: string
 }
 


### PR DESCRIPTION
## Summary
Add a "My Teams" toggle to the projects list, next to "My PRs", that narrows the list to projects owned by a team the current user belongs to.

## Problem
There was no quick way to see only the projects relevant to your own teams. "My PRs" works because per-project viewer PR counts ride along in the projects payload, but the UI had no knowledge of the user's team memberships.

## Solution
- Add a `TeamMembership` type and a `teams` field on `UserResponse`, populated by `GET /users/me`.
- Derive the user's team slugs from `useAuth` (scoped to the selected organization) and filter client-side via a new `has_my_teams` URL param — same mechanism as the "My PRs" toggle.
- Render a teal stat badge showing the count of matching projects.

## Dependency
Requires AWeber-Imbi/imbi-api#432 (adds `teams` to `GET /users/me`). Until that ships, the toggle degrades gracefully: the count reads `0` and the filter matches nothing — no errors.

Checks: `tsc` clean, oxlint 0 errors, 405 vitest tests passing.