### PR TITLE
Fix ClickHouse storage size on the admin dashboard

### DIFF
--- a/src/components/admin/AdminOverview.tsx
+++ b/src/components/admin/AdminOverview.tsx
@@ -142,7 +142,7 @@ function deriveScores(projects: { score: null | number; slug: string }[]) {
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
-  const units = ['KB', 'MB', 'GB', 'TB']
+  const units = ['KiB', 'MiB', 'GiB', 'TiB']
   let value = bytes / 1024
   let i = 0
   while (value >= 1024 && i < units.length - 1) {
@@ -392,7 +392,9 @@ function DatastoreRow({ ds }: { ds: DatastoreStatus }) {
         </div>
         {ok && ds.size_bytes != null && (
           <div className="text-tertiary font-mono text-[11px]">
-            {formatBytes(ds.size_bytes)}
+            {ds.total_bytes != null
+              ? `${formatBytes(ds.size_bytes)} of ${formatBytes(ds.total_bytes)}`
+              : formatBytes(ds.size_bytes)}
           </div>
         )}
       </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -495,6 +495,9 @@ export interface CurrentReleaseEnvironment {
   environment: { name: string; slug: string }
   external_run_url: null | string
   last_event_at: null | string
+  // Deployer of the latest event when observed from a remote (e.g. the
+  // GitHub actor); null for in-product deploys.
+  performed_by?: null | string
   release: null | Release
 }
 
@@ -523,6 +526,7 @@ export interface DatastoreStatus {
   role: string
   size_bytes?: null | number
   status: 'error' | 'ok'
+  total_bytes?: null | number
 }
 
 export type DeploymentAction = 'deploy' | 'redeploy'
@@ -1329,6 +1333,9 @@ export interface SchemaProperty {
   colorRange?: Record<string, string>
   defaultValue?: string
   description?: string
+  // Human-readable display transform applied to the rendered value
+  // (serialized as `x-display.format`; see DISPLAY_FORMATS).
+  displayFormat?: string
   editable?: boolean
   enumValues?: string[]
   format?: string


### PR DESCRIPTION
## Summary

Fixes the ClickHouse row in the admin Overview's System Health card, which was both mislabeled and undercounting.

## Problem

1. **Wrong units.** `formatBytes` divides by 1024 (binary) but labeled the result with decimal units (`KB`/`MB`/`GB`), so the displayed "170.2 MB" was actually 170.2 MiB.
2. **Missing data.** The API only reported the Imbi application database, hiding the `system.*` footprint — ~170 MiB shown against a ~4.6 GiB reality.

## Solution

- Relabel `formatBytes` units as IEC binary (`KiB`/`MiB`/`GiB`/`TiB`) to match the `/1024` divisor and the values ClickHouse (`formatReadableSize`) and Postgres (`pg_size_pretty`) report.
- Add `total_bytes` to `DatastoreStatus` and render `"<app> of <total>"` when present (e.g. `169.7 MiB of 4.6 GiB`), falling back to the single value for Postgres/Valkey.

Requires the API change in AWeber-Imbi/imbi-api#434, which adds `total_bytes` to the `/admin/dashboard/status` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)