### PR TITLE
Redesign project Environments card with dynamic edge attributes

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -262,6 +262,10 @@ export interface ProjectSchemaSection {
   description?: null | string
   name: string
   properties: Record<string, ProjectSchemaSectionProperty>
+  // `environment` for relationship (DEPLOYED_IN) blueprints whose properties
+  // describe per-environment edge attributes; `project` (default) for node
+  // blueprints describing project-level attributes.
+  scope?: 'environment' | 'project'
   slug: string
 }
 
@@ -278,6 +282,12 @@ export interface ProjectSchemaSectionProperty {
   minimum?: null | number
   title?: null | string
   type?: null | string
+  // Optional value-display transform applied to the rendered string
+  // (independent of `x-ui` color/icon resolution, which keys off the raw
+  // value). `format: "humanize"` → underscores/hyphens to spaces + Title Case.
+  'x-display'?: null | {
+    format?: null | string
+  }
   'x-ui'?: null | {
     'color-age'?: Record<string, string>
     'color-map'?: Record<string, string>
@@ -333,6 +343,21 @@ export const createProject = (orgSlug: string, project: ProjectCreate) =>
   apiClient.post<Project>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/`,
     project,
+  )
+
+// Targeted update of a project's DEPLOYED_IN edge attributes for one
+// environment (per-key set; a `null` value removes the property). Unlike a
+// project PATCH this touches only that one edge, so it's safe for inline
+// edits. Returns the updated edge properties.
+export const patchEnvironmentEdge = (
+  orgSlug: string,
+  projectId: string,
+  envSlug: string,
+  updates: Record<string, unknown>,
+) =>
+  apiClient.patch<Record<string, unknown>>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/environments/${encodeURIComponent(envSlug)}`,
+    updates,
   )
 
 export const patchProject = (

--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -538,7 +538,7 @@ function Timestamp({ ts }: { ts: Date }) {
 
 function ValueChip({ children }: { children: React.ReactNode }) {
   return (
-    <code className="bg-secondary text-primary inline rounded px-1.5 py-0.5 font-mono text-xs">
+    <code className="bg-secondary text-primary inline rounded px-1.5 py-0.5 font-mono text-xs break-all">
       {children}
     </code>
   )

--- a/src/components/ProjectAttributesSection.tsx
+++ b/src/components/ProjectAttributesSection.tsx
@@ -4,6 +4,7 @@ import type {
   ProjectSchemaResponse,
   ProjectSchemaSectionProperty,
 } from '@/api/endpoints'
+import { AttributeValue } from '@/components/ui/attribute-value'
 import {
   HoverCard,
   HoverCardContent,
@@ -12,20 +13,10 @@ import {
 import { isFieldEditable } from '@/components/ui/inline-edit/field-policy'
 import { InlineField } from '@/components/ui/inline-edit/InlineField'
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { getIcon } from '@/lib/icons'
-import {
-  COLOR_TEXT,
   formatFieldKey,
   formatFieldValue,
   resolveFieldValue,
 } from '@/lib/project-field-formatting'
-import { resolveColor, resolveIcon } from '@/lib/ui-maps'
-import type { XUiMaps } from '@/lib/ui-maps'
 import type { Project } from '@/types'
 
 interface AttributeField {
@@ -34,8 +25,6 @@ interface AttributeField {
   key: string
   label: string
   rawValue: unknown
-  title?: string
-  uiMaps: XUiMaps
   value: null | string
 }
 
@@ -53,7 +42,6 @@ interface ProjectAttributesSectionProps {
 }
 
 const LABEL_CLASS = 'text-tertiary'
-const VALUE_CLASS = 'text-primary'
 const MUTED_CLASS = 'text-tertiary'
 const DIVIDER_CLASS = 'border-tertiary'
 
@@ -68,8 +56,6 @@ const ProjectAttributeRow = memo(function ProjectAttributeRow({
     key,
     label: fieldLabel,
     rawValue,
-    title: fieldTitle,
-    uiMaps,
     value: fieldValue,
   } = field
 
@@ -78,38 +64,10 @@ const ProjectAttributeRow = memo(function ProjectAttributeRow({
     [patch, key],
   )
 
-  const mappedColor = resolveColor(uiMaps, rawValue)
-  const mappedIcon = resolveIcon(uiMaps, rawValue)
-  const FieldIcon = mappedIcon ? getIcon(mappedIcon) : null
-  const textColorClass = mappedColor
-    ? (COLOR_TEXT[mappedColor] ?? VALUE_CLASS)
-    : VALUE_CLASS
   const editable = isFieldEditable(key, def)
   const richDisplay =
     fieldValue !== null ? (
-      <span className="flex items-center gap-1.5">
-        {FieldIcon && (
-          <FieldIcon className={`size-3.5 shrink-0 ${textColorClass}`} />
-        )}
-        {fieldTitle ? (
-          <TooltipProvider delayDuration={200}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className={`text-sm ${textColorClass} cursor-help underline decoration-dotted`}
-                >
-                  {fieldValue}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>{fieldTitle}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        ) : (
-          <span className={`text-sm ${textColorClass}`}>{fieldValue}</span>
-        )}
-      </span>
+      <AttributeValue def={def} rawValue={rawValue} />
     ) : null
 
   const labelNode = fieldDescription ? (
@@ -158,35 +116,25 @@ export function ProjectAttributesSection({
   project,
   projectSchema,
 }: ProjectAttributesSectionProps) {
+  // fallow-ignore-next-line complexity
   const attributeFields = useMemo<AttributeField[]>(() => {
     if (!projectSchema) return []
     const seen = new Set<string>()
     const fields: AttributeField[] = []
     for (const section of projectSchema.sections) {
+      // Environment-scoped (relationship-blueprint) attributes are rendered
+      // per-environment in the Environments card, not as project attributes.
+      if (section.scope === 'environment') continue
       for (const [key, def] of Object.entries(section.properties)) {
         if (seen.has(key) || key === 'url') continue
         seen.add(key)
         const raw = resolveFieldValue(key, section, project)
-        const isDate = def.format === 'date-time' || def.format === 'date'
-        const xUi = def['x-ui']
         fields.push({
           def,
           description: def.description ?? undefined,
           key,
           label: def.title || formatFieldKey(key),
           rawValue: raw,
-          title:
-            isDate && raw != null
-              ? new Date(String(raw)).toLocaleString()
-              : undefined,
-          uiMaps: {
-            colorAge: xUi?.['color-age'] ?? undefined,
-            colorMap: xUi?.['color-map'] ?? undefined,
-            colorRange: xUi?.['color-range'] ?? undefined,
-            iconAge: xUi?.['icon-age'] ?? undefined,
-            iconMap: xUi?.['icon-map'] ?? undefined,
-            iconRange: xUi?.['icon-range'] ?? undefined,
-          },
           value: formatFieldValue(raw, def),
         })
       }

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -85,6 +85,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useBalancedEnvLayout } from '@/hooks/useBalancedEnvLayout'
 import { useClipboard } from '@/hooks/useClipboard'
 import { useProjectTypes, useTeams } from '@/hooks/useOrgResources'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
@@ -162,6 +163,17 @@ export function ProjectDetail({
     [project.environments],
   )
 
+  // Decides whether the Environments card nests under Project details or spans
+  // the full width below both overview columns (see hook for the rule).
+  const {
+    activityHeaderRef,
+    activityInnerRef,
+    activityMaxHeightPx,
+    detailsRef,
+    healthRef,
+    spanFull: envSpanFull,
+  } = useBalancedEnvLayout()
+
   const { data: currentReleases = [], isPending: releasesPending } = useQuery({
     enabled: !!orgSlug && !!project.id,
     queryFn: ({ signal }) => listCurrentReleases(orgSlug, project.id, signal),
@@ -177,6 +189,8 @@ export function ProjectDetail({
     {
       ciStatus: 'fail' | 'pass' | 'warn' | null
       committish: string
+      notes: null | string
+      performedBy: null | string
       runUrl: null | string
       status: string
       tag: null | string
@@ -188,6 +202,8 @@ export function ProjectDetail({
       {
         ciStatus: 'fail' | 'pass' | 'warn' | null
         committish: string
+        notes: null | string
+        performedBy: null | string
         runUrl: null | string
         status: string
         tag: null | string
@@ -203,6 +219,8 @@ export function ProjectDetail({
       out[row.environment.slug] = {
         ciStatus: ci,
         committish: row.release.committish,
+        notes: row.release.description ?? null,
+        performedBy: row.performed_by ?? null,
         runUrl: row.external_run_url,
         status: row.current_status ?? '',
         tag: row.release.tag ?? null,
@@ -1023,11 +1041,11 @@ export function ProjectDetail({
           })}
         </TabsList>
 
-        <TabsContent value="overview">
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr] lg:items-start">
+        <TabsContent className="space-y-6" value="overview">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] lg:items-start">
             {/* Left column: Details */}
             <div className="space-y-6">
-              <Card>
+              <Card ref={detailsRef}>
                 <CardHeader>
                   <CardTitle>Project details</CardTitle>
                 </CardHeader>
@@ -1106,18 +1124,22 @@ export function ProjectDetail({
                 </CardContent>
               </Card>
 
-              {/* Environments */}
-              {sortedEnvironments.length > 0 && (
+              {/* Environments — nests here when the right column is taller
+                  than Project details; otherwise drops below (see envSpanFull). */}
+              {!envSpanFull && sortedEnvironments.length > 0 && (
                 <ProjectEnvironmentsCard
                   deploymentStatus={deploymentStatus}
                   environments={sortedEnvironments}
+                  orgSlug={orgSlug}
+                  projectId={project.id}
+                  projectSchema={projectSchema}
                 />
               )}
             </div>
 
-            {/* Right column: Health score + Activity */}
+            {/* Right column: Health score + Activity. */}
             <div className="flex flex-col gap-6">
-              <Card>
+              <Card ref={healthRef}>
                 <CardHeader>
                   <CardTitle>Health &amp; compliance</CardTitle>
                 </CardHeader>
@@ -1162,8 +1184,14 @@ export function ProjectDetail({
                   )}
               </Card>
 
-              <Card className="flex flex-col" style={{ maxHeight: '600px' }}>
-                <CardHeader className="flex flex-row items-center justify-between">
+              <Card
+                className="flex min-h-0 flex-col"
+                style={{ maxHeight: `${activityMaxHeightPx}px` }}
+              >
+                <CardHeader
+                  className="flex flex-row items-center justify-between"
+                  ref={activityHeaderRef}
+                >
                   <CardTitle>Recent activity</CardTitle>
                   <button className="text-secondary hover:bg-secondary hover:text-primary inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-xs transition-colors">
                     <Filter className="size-3" />
@@ -1171,15 +1199,29 @@ export function ProjectDetail({
                   </button>
                 </CardHeader>
                 <CardContent className="min-h-0 flex-1 overflow-y-auto p-0">
-                  <ProjectActivityLog
-                    orgSlug={project.team.organization.slug}
-                    projectId={project.id}
-                    projectSlug={project.slug}
-                  />
+                  <div ref={activityInnerRef}>
+                    <ProjectActivityLog
+                      orgSlug={project.team.organization.slug}
+                      projectId={project.id}
+                      projectSlug={project.slug}
+                    />
+                  </div>
                 </CardContent>
               </Card>
             </div>
           </div>
+
+          {/* Environments — full-width row below both columns when the right
+              column is shorter than Project details. */}
+          {envSpanFull && sortedEnvironments.length > 0 && (
+            <ProjectEnvironmentsCard
+              deploymentStatus={deploymentStatus}
+              environments={sortedEnvironments}
+              orgSlug={orgSlug}
+              projectId={project.id}
+              projectSchema={projectSchema}
+            />
+          )}
         </TabsContent>
 
         {hasConfigurationPlugin && (

--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -1,32 +1,114 @@
-import { ExternalLink } from 'lucide-react'
+import {
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  LoaderCircle,
+  type LucideIcon,
+  RotateCcw,
+  XCircle,
+} from 'lucide-react'
 
+import type {
+  ProjectSchemaResponse,
+  ProjectSchemaSectionProperty,
+} from '@/api/endpoints'
+import { ActorBadge } from '@/components/ui/actor-badge'
+import { AttributeValue } from '@/components/ui/attribute-value'
+import { Badge, type BadgeProps } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EnvironmentBadge } from '@/components/ui/environment-badge'
+import { isFieldEditable } from '@/components/ui/inline-edit/field-policy'
+import { InlineField } from '@/components/ui/inline-edit/InlineField'
+import { useEnvironmentEdgePatch } from '@/hooks/useEnvironmentEdgePatch'
+import { formatFieldKey } from '@/lib/project-field-formatting'
 import { sanitizeHttpUrl } from '@/lib/utils'
-import type { Project } from '@/types'
+import type { DeploymentStatus, Project } from '@/types'
+
+interface DeploymentInfo {
+  committish: string
+  // Deployer of the latest deploy event (remote actor); null for in-product.
+  performedBy: null | string
+  status: string
+  tag: null | string
+  updated: string
+}
+
+// Shared overline label style for the per-environment attribute cells.
+const OVERLINE_CLASS =
+  'text-tertiary mb-1.5 text-[10.5px] font-semibold tracking-[0.06em] uppercase'
 
 type Environment = NonNullable<Project['environments']>[number]
 
 interface ProjectEnvironmentsCardProps {
-  deploymentStatus: Record<
-    string,
-    {
-      committish: string
-      status: string
-      tag: null | string
-      updated: string
-    }
-  >
+  deploymentStatus: Record<string, DeploymentInfo>
   environments: Environment[]
+  orgSlug: string
+  projectId: string
+  // Project schema; its ``environment``-scoped sections supply the blueprint
+  // defs (type/format + x-ui color/icon maps) for the edge attributes so they
+  // render with the same display logic as project attributes.
+  projectSchema?: ProjectSchemaResponse
 }
+
+// URL is a base edge property (always present on the DEPLOYED_IN model); used
+// when the project's blueprints don't supply an explicit def for it.
+const URL_DEF: ProjectSchemaSectionProperty = { format: 'uri', type: 'string' }
+
+// Release lifecycle states for the project -> environment deployment edge.
+// Keyed by the ``DeploymentStatus`` enum (the ``current_status`` recorded on
+// the release -> environment edge), so the badges stay in lockstep with the
+// backend enum.
+const RELEASE_STATUS: Record<
+  DeploymentStatus,
+  {
+    Icon: LucideIcon
+    label: string
+    spin?: boolean
+    variant: BadgeProps['variant']
+  }
+> = {
+  failed: { Icon: XCircle, label: 'Failed', variant: 'danger' },
+  in_progress: {
+    Icon: LoaderCircle,
+    label: 'Deploying',
+    spin: true,
+    variant: 'warning',
+  },
+  pending: { Icon: Clock, label: 'Queued', variant: 'neutral' },
+  rolled_back: { Icon: RotateCcw, label: 'Rolled back', variant: 'warning' },
+  success: { Icon: CheckCircle2, label: 'Deployed', variant: 'success' },
+}
+
+// Environment fields that are structural (the node itself) or already shown in
+// the header row. Everything else on the environment object is a dynamic,
+// blueprint-defined ``DEPLOYED_IN`` edge attribute and is surfaced in the grid.
+const RESERVED_ENV_KEYS = new Set([
+  'can_deploy',
+  'can_promote',
+  'created_at',
+  'description',
+  'icon',
+  'id',
+  'label_color',
+  'name',
+  'organization',
+  'relationships',
+  'slug',
+  'sort_order',
+  'updated_at',
+  'url',
+  'version',
+])
 
 export function ProjectEnvironmentsCard({
   deploymentStatus,
   environments,
+  orgSlug,
+  projectId,
+  projectSchema,
 }: ProjectEnvironmentsCardProps) {
-  const muted = 'text-tertiary'
-  const divider = 'border-tertiary'
-
+  const attrDefs = environmentAttributeDefs(projectSchema)
+  const { patch, pendingKey } = useEnvironmentEdgePatch(orgSlug, projectId)
   return (
     <Card>
       <CardHeader>
@@ -34,51 +116,183 @@ export function ProjectEnvironmentsCard({
       </CardHeader>
       <CardContent>
         <div className="space-y-0">
+          {/* fallow-ignore-next-line complexity */}
           {environments.map((env) => {
             const url =
               typeof env.url === 'string' ? sanitizeHttpUrl(env.url) : null
+            // Protocol/trailing-slash stripped for a shorter on-screen value.
+            const displayUrl = url
+              ? url.replace(/^https?:\/\//, '').replace(/\/$/, '')
+              : null
             const deployment = deploymentStatus[env.slug]
+            const version = deployment
+              ? (deployment.tag ?? deployment.committish)
+              : null
+            const attrs = dynamicAttributes(env)
+            const urlDef = attrDefs.url ?? URL_DEF
             return (
               <div
-                className={`flex items-center border-b py-2 ${divider} last:border-0`}
+                className="border-tertiary border-b py-4 last:border-0"
                 key={env.slug}
               >
-                <div className="w-32 shrink-0">
-                  <EnvironmentBadge
-                    label_color={env.label_color}
-                    name={env.name}
-                    slug={env.slug}
-                  />
+                <div className="flex items-center gap-x-4 gap-y-2">
+                  <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-2">
+                    <EnvironmentBadge
+                      label_color={env.label_color}
+                      name={env.name}
+                      slug={env.slug}
+                    />
+                    {deployment?.status ? (
+                      <ReleaseBadge status={deployment.status} />
+                    ) : null}
+                    {version ? (
+                      <span className="text-primary font-mono text-sm tabular-nums">
+                        {version}
+                      </span>
+                    ) : null}
+                    {deployment?.updated ? (
+                      <span className="text-tertiary text-sm">
+                        {deployment.updated}
+                      </span>
+                    ) : null}
+                  </div>
+
+                  {/* URL — pinned to the right of the header line; never wraps
+                      (clips before dropping to a new line) with a quick-open
+                      link, and inline-editable when the schema allows it. */}
+                  {isFieldEditable('url', urlDef) || displayUrl ? (
+                    <div className="ml-auto flex min-w-0 items-center gap-1.5 overflow-hidden pl-4 whitespace-nowrap">
+                      {isFieldEditable('url', urlDef) ? (
+                        <InlineField
+                          def={urlDef}
+                          display={
+                            <span className="text-primary text-sm">
+                              {displayUrl}
+                            </span>
+                          }
+                          onCommit={(v) => patch(env.slug, 'url', v)}
+                          pending={pendingKey === `${env.slug}/url`}
+                          raw={env.url ?? null}
+                        />
+                      ) : (
+                        <span className="text-primary text-sm">
+                          {displayUrl}
+                        </span>
+                      )}
+                      {url ? (
+                        <a
+                          aria-label="Open URL"
+                          className="text-warning shrink-0"
+                          href={url}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <ExternalLink className="size-3" />
+                        </a>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </div>
-                <div className="w-28 shrink-0 text-right">
-                  <span className="text-tertiary font-mono text-sm">
-                    {deployment
-                      ? (deployment.tag ?? deployment.committish)
-                      : ''}
-                  </span>
-                </div>
-                <div className="flex-1 text-right">
-                  {url ? (
-                    <a
-                      className={
-                        'text-warning inline-flex items-center gap-1.5 text-sm whitespace-nowrap hover:underline'
-                      }
-                      href={url}
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      {url}
-                      <ExternalLink className="text-warning size-3" />
-                    </a>
-                  ) : (
-                    <span className={`text-sm ${muted}`}>&mdash;</span>
-                  )}
-                </div>
+
+                {deployment?.performedBy || attrs.length > 0 ? (
+                  <div
+                    className="mt-4 grid gap-4"
+                    style={{
+                      gridTemplateColumns:
+                        'repeat(auto-fit, minmax(150px, 1fr))',
+                    }}
+                  >
+                    {/* Deployed by — read-only actor identity */}
+                    {deployment?.performedBy ? (
+                      <div className="min-w-0">
+                        <div className={OVERLINE_CLASS}>Deployed by</div>
+                        <ActorBadge actor={deployment.performedBy} />
+                      </div>
+                    ) : null}
+
+                    {/* Blueprint edge attributes — inline-editable when the
+                        schema marks them editable, else read-only. */}
+                    {attrs.map(({ key, rawValue }) => {
+                      const def = attrDefs[key]
+                      const display = (
+                        <AttributeValue
+                          def={def}
+                          fallback={
+                            <span className="text-tertiary">&mdash;</span>
+                          }
+                          rawValue={rawValue}
+                        />
+                      )
+                      return (
+                        <div className="min-w-0" key={key}>
+                          <div className={OVERLINE_CLASS}>
+                            {def?.title || formatFieldKey(key)}
+                          </div>
+                          {def && isFieldEditable(key, def) ? (
+                            <InlineField
+                              def={def}
+                              display={display}
+                              onCommit={(v) => patch(env.slug, key, v)}
+                              pending={pendingKey === `${env.slug}/${key}`}
+                              raw={rawValue}
+                            />
+                          ) : (
+                            display
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+                ) : null}
               </div>
             )
           })}
         </div>
       </CardContent>
     </Card>
+  )
+}
+
+// Blueprint-defined edge attributes for a single environment, ordered
+// deterministically by key. Membership is dynamic — whatever the project's
+// relationship blueprint declares flows through here, no hard-coded columns.
+// Raw values are returned as-is; ``AttributeValue`` applies the shared
+// formatting + x-ui display logic using the matching schema def.
+function dynamicAttributes(
+  env: Environment,
+): { key: string; rawValue: unknown }[] {
+  const record = env as Record<string, unknown>
+  return Object.keys(record)
+    .filter((key) => !RESERVED_ENV_KEYS.has(key))
+    .sort()
+    .map((key) => ({ key, rawValue: record[key] }))
+}
+
+// Merge the property defs from every ``environment``-scoped schema section
+// into a flat key→def lookup for the edge attributes.
+// fallow-ignore-next-line complexity
+function environmentAttributeDefs(
+  schema?: ProjectSchemaResponse,
+): Record<string, ProjectSchemaSectionProperty> {
+  const defs: Record<string, ProjectSchemaSectionProperty> = {}
+  if (!schema) return defs
+  for (const section of schema.sections) {
+    if (section.scope !== 'environment') continue
+    for (const [key, def] of Object.entries(section.properties)) {
+      defs[key] ??= def
+    }
+  }
+  return defs
+}
+
+function ReleaseBadge({ status }: { status: string }) {
+  const meta = RELEASE_STATUS[status as DeploymentStatus]
+  if (!meta) return null
+  const { Icon, label, spin, variant } = meta
+  return (
+    <Badge className="gap-1" variant={variant}>
+      <Icon className={`size-3${spin ? ' animate-spin' : ''}`} />
+      {label}
+    </Badge>
   )
 }

--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import {
   CheckCircle2,
   Clock,
@@ -107,7 +109,10 @@ export function ProjectEnvironmentsCard({
   projectId,
   projectSchema,
 }: ProjectEnvironmentsCardProps) {
-  const attrDefs = environmentAttributeDefs(projectSchema)
+  const attrDefs = useMemo(
+    () => environmentAttributeDefs(projectSchema),
+    [projectSchema],
+  )
   const { patch, pendingKey } = useEnvironmentEdgePatch(orgSlug, projectId)
   return (
     <Card>
@@ -124,6 +129,9 @@ export function ProjectEnvironmentsCard({
             const displayUrl = url
               ? url.replace(/^https?:\/\//, '').replace(/\/$/, '')
               : null
+            const urlText = (
+              <span className="text-primary text-sm">{displayUrl}</span>
+            )
             const deployment = deploymentStatus[env.slug]
             const version = deployment
               ? (deployment.tag ?? deployment.committish)
@@ -165,19 +173,13 @@ export function ProjectEnvironmentsCard({
                       {isFieldEditable('url', urlDef) ? (
                         <InlineField
                           def={urlDef}
-                          display={
-                            <span className="text-primary text-sm">
-                              {displayUrl}
-                            </span>
-                          }
+                          display={urlText}
                           onCommit={(v) => patch(env.slug, 'url', v)}
                           pending={pendingKey === `${env.slug}/url`}
                           raw={env.url ?? null}
                         />
                       ) : (
-                        <span className="text-primary text-sm">
-                          {displayUrl}
-                        </span>
+                        urlText
                       )}
                       {url ? (
                         <a

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -8,15 +8,10 @@ import { toast } from 'sonner'
 import {
   archiveProject,
   deleteProject,
-  listEnvironments,
   listLinkDefinitions,
   listProjectPlugins,
-  patchProject,
-  rescoreProject,
   unarchiveProject,
 } from '@/api/endpoints'
-import { EditEnvironmentsCard } from '@/components/EditEnvironmentsCard'
-import { EditIdentifiersCard } from '@/components/EditIdentifiersCard'
 import { EditLinksCard } from '@/components/EditLinksCard'
 import { IntegrationsCard } from '@/components/IntegrationsCard'
 import { ProjectPluginsSection } from '@/components/project/ProjectPluginsSection'
@@ -32,25 +27,17 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
-import { useAuth } from '@/hooks/useAuth'
-import { useProjectDeploymentResync } from '@/hooks/useDeploymentResync'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { extractApiErrorDetail } from '@/lib/apiError'
-import { sortEnvironments } from '@/lib/utils'
 import type { Project } from '@/types'
 
+// fallow-ignore-next-line complexity
 export function ProjectSettingsTab({ project }: { project: Project }) {
   const { selectedOrganization } = useOrganization()
   const orgSlug = selectedOrganization?.slug || ''
   const queryClient = useQueryClient()
   const navigate = useNavigate()
-  const { user } = useAuth()
-  const isAdmin = user?.is_admin === true
-  const canRescore =
-    isAdmin || (user?.permissions ?? []).includes('scoring_policy:rescore')
-  const canResyncDeployments =
-    isAdmin || (user?.permissions ?? []).includes('project:deployment:write')
-  const { patch, scheduleScoreRefresh } = useProjectPatch(orgSlug, project.id)
+  const { patch } = useProjectPatch(orgSlug, project.id)
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleteRepository, setDeleteRepository] = useState(true)
@@ -147,15 +134,6 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
     },
   })
 
-  const rescoreMutation = useMutation({
-    mutationFn: () => rescoreProject(project.id),
-    onError: mutationErrorHandler('recompute score'),
-    onSuccess: () => {
-      toast.success('Score recompute enqueued')
-      scheduleScoreRefresh()
-    },
-  })
-
   const { data: projectPlugins = [] } = useQuery({
     enabled: !!orgSlug && !!project.id,
     queryFn: ({ signal }) => listProjectPlugins(orgSlug, project.id, signal),
@@ -175,21 +153,6 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
     [projectPlugins],
   )
 
-  // Pick the project's deployment plugin (project-level or inherited)
-  // and only render the resync card when its manifest opts in. Multiple
-  // deployment assignments are rare; we resync the default one and
-  // expose ``source`` via the existing endpoint flag if needed later.
-  const deploymentPlugin = useMemo(() => {
-    const candidates = projectPlugins.filter(
-      (assignment) =>
-        assignment.plugin_type === 'deployment' &&
-        assignment.supports_deployment_sync === true,
-    )
-    return candidates.find((assignment) => assignment.default) ?? candidates[0]
-  }, [projectPlugins])
-
-  const resyncMutation = useProjectDeploymentResync(orgSlug, project.id)
-
   const {
     data: linkDefs = [],
     isError: linkDefsError,
@@ -198,17 +161,6 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listLinkDefinitions(orgSlug, signal),
     queryKey: ['linkDefinitions', orgSlug],
-  })
-
-  const sortedEnvironments = useMemo(
-    () => sortEnvironments(project.environments || []),
-    [project.environments],
-  )
-
-  const { data: availableEnvironments = [] } = useQuery({
-    enabled: !!orgSlug,
-    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
-    queryKey: ['environments', orgSlug],
   })
 
   return (
@@ -237,60 +189,9 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
         />
       )}
 
-      <EditEnvironmentsCard
-        availableEnvironments={availableEnvironments}
-        environments={sortedEnvironments}
-        onPatch={async (envData) => {
-          try {
-            await patchProject(orgSlug, project.id, [
-              { op: 'replace', path: '/environments', value: envData },
-            ])
-          } catch (error) {
-            toast.error(`Save failed: ${extractApiErrorDetail(error)}`)
-            throw error
-          }
-          invalidateProject()
-        }}
-      />
-
-      <EditIdentifiersCard
-        identifiers={project.identifiers || {}}
-        onPatch={(entries) => patch('/identifiers', entries)}
-      />
-
       <IntegrationsCard orgSlug={orgSlug} projectId={project.id} />
 
       <ProjectPluginsSection orgSlug={orgSlug} projectId={project.id} />
-
-      {(canRescore || (canResyncDeployments && deploymentPlugin)) && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Utility Functions</CardTitle>
-          </CardHeader>
-          <CardContent className="flex gap-2">
-            {canRescore && (
-              <Button
-                disabled={rescoreMutation.isPending}
-                onClick={() => rescoreMutation.mutate()}
-                size="sm"
-                variant="outline"
-              >
-                {rescoreMutation.isPending ? 'Enqueuing...' : 'Recompute Score'}
-              </Button>
-            )}
-            {canResyncDeployments && deploymentPlugin && (
-              <Button
-                disabled={resyncMutation.isPending}
-                onClick={() => resyncMutation.mutate()}
-                size="sm"
-                variant="outline"
-              >
-                {resyncMutation.isPending ? 'Syncing...' : 'Sync Deployments'}
-              </Button>
-            )}
-          </CardContent>
-        </Card>
-      )}
 
       <Card className="border-amber-300">
         <CardHeader>

--- a/src/components/__tests__/ProjectSettingsTab.test.tsx
+++ b/src/components/__tests__/ProjectSettingsTab.test.tsx
@@ -5,7 +5,11 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as endpoints from '@/api/endpoints'
-import type { ArchiveProjectResponse, Project } from '@/types'
+import type {
+  ArchiveProjectResponse,
+  PluginAssignmentResponse,
+  Project,
+} from '@/types'
 
 import { ProjectSettingsTab } from '../ProjectSettingsTab'
 

--- a/src/components/__tests__/ProjectSettingsTab.test.tsx
+++ b/src/components/__tests__/ProjectSettingsTab.test.tsx
@@ -5,11 +5,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as endpoints from '@/api/endpoints'
-import type {
-  ArchiveProjectResponse,
-  PluginAssignmentResponse,
-  Project,
-} from '@/types'
+import type { ArchiveProjectResponse, Project } from '@/types'
 
 import { ProjectSettingsTab } from '../ProjectSettingsTab'
 
@@ -21,7 +17,6 @@ vi.mock('@/api/endpoints', async () => {
     ...actual,
     archiveProject: vi.fn(),
     deleteProject: vi.fn(),
-    listEnvironments: vi.fn(),
     listLinkDefinitions: vi.fn(),
     listProjectPlugins: vi.fn(),
     unarchiveProject: vi.fn(),
@@ -36,14 +31,6 @@ vi.mock('sonner', () => ({
 // data fetching and are irrelevant to the lifecycle-result behaviour.
 // fallow-ignore-next-line unresolved-import
 vi.mock('@/components/EditLinksCard', () => ({ EditLinksCard: () => null }))
-// fallow-ignore-next-line unresolved-import
-vi.mock('@/components/EditEnvironmentsCard', () => ({
-  EditEnvironmentsCard: () => null,
-}))
-// fallow-ignore-next-line unresolved-import
-vi.mock('@/components/EditIdentifiersCard', () => ({
-  EditIdentifiersCard: () => null,
-}))
 // fallow-ignore-next-line unresolved-import
 vi.mock('@/components/project/ProjectPluginsSection', () => ({
   ProjectPluginsSection: () => null,
@@ -79,17 +66,6 @@ const ARCHIVED_PROJECT = {
   team: { name: 'Team', organization: { name: 'Acme', slug: 'acme' } },
 } as Project
 
-const DEPLOYMENT_PLUGIN = {
-  default: true,
-  label: 'Deploy',
-  options: {},
-  plugin_id: 'dep-1',
-  plugin_slug: 'github-deploy',
-  plugin_type: 'deployment',
-  source: 'project',
-  supports_deployment_sync: true,
-} as PluginAssignmentResponse
-
 function renderTab() {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -112,7 +88,6 @@ describe('ProjectSettingsTab archive lifecycle results', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     mockAuthUser = { is_admin: false, permissions: [] }
-    vi.mocked(endpoints.listEnvironments).mockResolvedValue([])
     vi.mocked(endpoints.listLinkDefinitions).mockResolvedValue([])
     vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([])
     toast = (await import('sonner')).toast as unknown as typeof toast
@@ -186,7 +161,6 @@ describe('ProjectSettingsTab delete flow', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     mockAuthUser = { is_admin: false, permissions: [] }
-    vi.mocked(endpoints.listEnvironments).mockResolvedValue([])
     vi.mocked(endpoints.listLinkDefinitions).mockResolvedValue([])
     vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([])
     toast = (await import('sonner')).toast as unknown as typeof toast
@@ -274,58 +248,5 @@ describe('ProjectSettingsTab delete flow', () => {
       expect(toast.warning).toHaveBeenCalledTimes(1)
     })
     expect(toast.warning.mock.calls[0][0]).toContain('1 integration failed')
-  })
-})
-
-describe('ProjectSettingsTab utility functions gating', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockAuthUser = { is_admin: false, permissions: [] }
-    vi.mocked(endpoints.listEnvironments).mockResolvedValue([])
-    vi.mocked(endpoints.listLinkDefinitions).mockResolvedValue([])
-    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([])
-  })
-
-  it('hides the card when the user has neither permission', async () => {
-    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([
-      DEPLOYMENT_PLUGIN,
-    ])
-    const { queryByText } = renderTab()
-    await waitFor(() => expect(endpoints.listProjectPlugins).toHaveBeenCalled())
-    expect(queryByText('Utility Functions')).not.toBeInTheDocument()
-  })
-
-  it('shows the card with only Recompute Score for rescore permission', async () => {
-    mockAuthUser = { is_admin: false, permissions: ['scoring_policy:rescore'] }
-    const { queryByRole, queryByText } = renderTab()
-    await waitFor(() =>
-      expect(queryByText('Utility Functions')).toBeInTheDocument(),
-    )
-    expect(
-      queryByRole('button', { name: 'Recompute Score' }),
-    ).toBeInTheDocument()
-    expect(
-      queryByRole('button', { name: 'Sync Deployments' }),
-    ).not.toBeInTheDocument()
-  })
-
-  it('shows Sync Deployments for project:deployment:write without admin', async () => {
-    mockAuthUser = {
-      is_admin: false,
-      permissions: ['project:deployment:write'],
-    }
-    vi.mocked(endpoints.listProjectPlugins).mockResolvedValue([
-      DEPLOYMENT_PLUGIN,
-    ])
-    const { queryByRole, queryByText } = renderTab()
-    await waitFor(() =>
-      expect(queryByText('Utility Functions')).toBeInTheDocument(),
-    )
-    expect(
-      queryByRole('button', { name: 'Sync Deployments' }),
-    ).toBeInTheDocument()
-    expect(
-      queryByRole('button', { name: 'Recompute Score' }),
-    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/admin/blueprints/BlueprintForm.tsx
+++ b/src/components/admin/blueprints/BlueprintForm.tsx
@@ -385,6 +385,14 @@ export function BlueprintForm({
       if (dupes.length > 0) {
         errors.schema = `Duplicate property name: ${dupes[0]}`
       }
+      // Property names must be lowercase, underscore-delimited (snake_case):
+      // start with a lowercase letter, then lowercase letters/digits/_.
+      const badName = names.find((n) => n && !/^[a-z][a-z0-9_]*$/.test(n))
+      if (badName) {
+        errors.schema =
+          `Property name "${badName}" must be lowercase and ` +
+          'underscore-delimited (e.g. acceptance_test_status)'
+      }
     }
 
     setValidationErrors(errors)

--- a/src/components/admin/blueprints/BlueprintSchemaPropertyRow.tsx
+++ b/src/components/admin/blueprints/BlueprintSchemaPropertyRow.tsx
@@ -21,6 +21,7 @@ import type { SchemaProperty } from '@/types'
 
 import {
   ARRAY_ITEM_TYPES,
+  DISPLAY_FORMATS,
   PROPERTY_TYPES,
   STRING_FORMATS,
 } from './blueprint-schema-utils'
@@ -56,6 +57,10 @@ export function BlueprintSchemaPropertyRow({
   uiMapEntries,
   updateProperty,
 }: BlueprintSchemaPropertyRowProps) {
+  // Property names must be lowercase, underscore-delimited (snake_case).
+  // Save is also blocked in BlueprintForm.validateForm; this is the inline cue.
+  const nameInvalid =
+    prop.name.trim() !== '' && !/^[a-z][a-z0-9_]*$/.test(prop.name)
   return (
     <div className="border-input bg-secondary rounded-lg border">
       {/* Property Row */}
@@ -108,13 +113,21 @@ export function BlueprintSchemaPropertyRow({
         </div>
 
         <Input
-          className="flex-1 font-mono text-sm"
+          aria-invalid={nameInvalid}
+          className={`flex-1 font-mono text-sm${
+            nameInvalid ? ' border-danger focus-visible:ring-danger' : ''
+          }`}
           onChange={(e) =>
             updateProperty(prop.id, {
               name: e.target.value,
             })
           }
           placeholder="Property name"
+          title={
+            nameInvalid
+              ? 'Must be lowercase, underscore-delimited (e.g. acceptance_test_status)'
+              : undefined
+          }
           value={prop.name}
         />
 
@@ -260,7 +273,7 @@ export function BlueprintSchemaPropertyRow({
           </div>
 
           {prop.type === 'string' && (
-            <div className="grid grid-cols-3 gap-3">
+            <div className="grid grid-cols-4 gap-3">
               <div>
                 <Label className="text-secondary mb-1 block text-xs">
                   Format
@@ -321,6 +334,33 @@ export function BlueprintSchemaPropertyRow({
                   type="number"
                   value={prop.maxLength ?? ''}
                 />
+              </div>
+              <div>
+                <Label className="text-secondary mb-1 block text-xs">
+                  Display Format
+                </Label>
+                {/* Optional human-readable transform applied to the rendered
+                    value (serialized as x-display.format). 'none' clears it. */}
+                <Select
+                  onValueChange={(v) =>
+                    updateProperty(prop.id, {
+                      displayFormat: v === 'none' ? undefined : v,
+                    })
+                  }
+                  value={prop.displayFormat || 'none'}
+                >
+                  <SelectTrigger aria-label="Display Format">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">(none)</SelectItem>
+                    {DISPLAY_FORMATS.map((f) => (
+                      <SelectItem key={f.value} value={f.value}>
+                        {f.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
           )}

--- a/src/components/admin/blueprints/blueprint-schema-utils.ts
+++ b/src/components/admin/blueprints/blueprint-schema-utils.ts
@@ -64,6 +64,17 @@ export const STRING_FORMATS = [
   'uuid',
 ]
 
+// Value-display transforms (serialized as `x-display.format`). Applied to the
+// rendered value only; `x-ui` color/icon resolution still keys off the raw
+// value. Mirrors `applyDisplayFormat` in `lib/project-field-formatting`.
+export const DISPLAY_FORMATS: { label: string; value: string }[] = [
+  { label: 'Humanize (Title Case, _ → space)', value: 'humanize' },
+  { label: 'Title Case', value: 'titlecase' },
+  { label: 'UPPERCASE', value: 'uppercase' },
+  { label: 'lowercase', value: 'lowercase' },
+  { label: 'Capitalize first letter', value: 'capitalize' },
+]
+
 export type SchemaEditorMode = 'code' | 'visual'
 
 export function buildJsonSchema(
@@ -130,6 +141,10 @@ export function buildJsonSchema(
       propSchema['x-ui'] = xUiObj
     }
 
+    if (prop.displayFormat) {
+      propSchema['x-display'] = { format: prop.displayFormat }
+    }
+
     props[prop.name] = propSchema
     if (prop.required) required.push(prop.name)
   }
@@ -154,6 +169,9 @@ export function schemaToProperties(
 
   for (const [name, propSchema] of Object.entries(props)) {
     const xUi = propSchema['x-ui'] as Record<string, unknown> | undefined
+    const xDisplay = propSchema['x-display'] as
+      | Record<string, unknown>
+      | undefined
     const items = propSchema.items as Record<string, unknown> | undefined
     result.push({
       colorAge: xUi?.['color-age'] as Record<string, string> | undefined,
@@ -164,6 +182,7 @@ export function schemaToProperties(
           ? String(propSchema.default)
           : undefined,
       description: propSchema.description as string | undefined,
+      displayFormat: xDisplay?.format as string | undefined,
       editable: xUi?.['editable'] === false ? false : undefined,
       enumValues: propSchema.enum as string[] | undefined,
       format: propSchema.format as string | undefined,

--- a/src/components/ui/actor-badge.tsx
+++ b/src/components/ui/actor-badge.tsx
@@ -1,0 +1,45 @@
+import { Bot } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+interface ActorBadgeProps {
+  /** The actor login/name (e.g. a GitHub login like `kevin.vance`). */
+  actor: string
+}
+
+// Service/automation actors get a bot icon instead of initials.
+const BOT_PATTERN =
+  /(\[bot\]|\bbot\b|-bot\b|github-actions|\bactions\b|automation|\bservice\b)/i
+
+/**
+ * Compact actor identity: a circular avatar + the actor name. People show
+ * initials on an amber tint; bot/service actors (e.g. `github-actions`) show a
+ * bot icon on a neutral tint. Used for the per-environment "Deployed by" value
+ * where the actor is a remote login rather than an Imbi user (so it is not the
+ * Gravatar-based `UserDisplay`).
+ */
+export function ActorBadge({ actor }: ActorBadgeProps) {
+  const isBot = BOT_PATTERN.test(actor)
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2">
+      <span
+        className={cn(
+          'flex size-7 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold',
+          isBot ? 'bg-tertiary text-secondary' : 'bg-amber-bg text-amber-text',
+        )}
+      >
+        {isBot ? <Bot className="size-3.5" /> : initialsOf(actor)}
+      </span>
+      <span className="text-primary truncate text-sm">{actor}</span>
+    </span>
+  )
+}
+
+function initialsOf(actor: string): string {
+  const parts = actor.split(/[^a-z0-9]+/i).filter(Boolean)
+  const initials = parts
+    .slice(0, 2)
+    .map((p) => p[0])
+    .join('')
+  return (initials || actor.slice(0, 2)).toUpperCase()
+}

--- a/src/components/ui/attribute-value.tsx
+++ b/src/components/ui/attribute-value.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from 'react'
+
+import type { ProjectSchemaSectionProperty } from '@/api/endpoints'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { getIcon } from '@/lib/icons'
+import {
+  applyDisplayFormat,
+  COLOR_TEXT,
+  formatFieldValue,
+} from '@/lib/project-field-formatting'
+import { resolveColor, resolveIcon, type XUiMaps } from '@/lib/ui-maps'
+
+interface AttributeValueProps {
+  /** Blueprint schema definition driving formatting + x-ui color/icon maps. */
+  def?: ProjectSchemaSectionProperty
+  /** Rendered when the value is empty/unset. Defaults to `null`. */
+  fallback?: ReactNode
+  /** The raw attribute value (string/number/bool/etc.) as stored. */
+  rawValue: unknown
+}
+
+/**
+ * Renders an attribute value with the shared display logic used across the
+ * app: schema-aware formatting (`formatFieldValue`) plus `x-ui` color/icon
+ * resolution (exact map / numeric range / age threshold) and a hover tooltip
+ * with the full timestamp for date fields. Returns `null` when there is no
+ * value so callers can supply their own empty state.
+ *
+ * Used by the project-attributes section and the per-environment edge
+ * attributes on the project overview.
+ */
+// fallow-ignore-next-line complexity
+export function AttributeValue({
+  def,
+  fallback = null,
+  rawValue,
+}: AttributeValueProps) {
+  const value = formatFieldValue(rawValue, def)
+  if (value === null) return fallback
+
+  // Optional human-readable transform (e.g. ``in_progress`` -> ``In
+  // Progress``). Applied to the display string only; color/icon resolution
+  // below still keys off the raw value.
+  const displayValue = applyDisplayFormat(value, def?.['x-display'])
+
+  const uiMaps = toUiMaps(def)
+  const mappedColor = resolveColor(uiMaps, rawValue)
+  const mappedIcon = resolveIcon(uiMaps, rawValue)
+  const Icon = mappedIcon ? getIcon(mappedIcon) : null
+  const colorClass = mappedColor
+    ? (COLOR_TEXT[mappedColor] ?? 'text-primary')
+    : 'text-primary'
+
+  const isDate = def?.format === 'date-time' || def?.format === 'date'
+  const title =
+    isDate && rawValue != null
+      ? new Date(String(rawValue)).toLocaleString()
+      : undefined
+
+  return (
+    <span className="flex items-center gap-1.5">
+      {Icon && <Icon className={`size-3.5 shrink-0 ${colorClass}`} />}
+      {title ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={`text-sm ${colorClass} cursor-help underline decoration-dotted`}
+              >
+                {displayValue}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{title}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        <span className={`text-sm ${colorClass}`}>{displayValue}</span>
+      )}
+    </span>
+  )
+}
+
+function toUiMaps(def?: ProjectSchemaSectionProperty): XUiMaps {
+  const xUi = def?.['x-ui']
+  if (!xUi) return {}
+  return {
+    colorAge: xUi['color-age'],
+    colorMap: xUi['color-map'],
+    colorRange: xUi['color-range'],
+    iconAge: xUi['icon-age'],
+    iconMap: xUi['icon-map'],
+    iconRange: xUi['icon-range'],
+  }
+}

--- a/src/hooks/useBalancedEnvLayout.ts
+++ b/src/hooks/useBalancedEnvLayout.ts
@@ -1,0 +1,123 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+
+// Vertical gap between the two right-column cards (Tailwind `gap-6`).
+const COLUMN_GAP = 24
+// Default cap on the Recent-activity card height in the nested layout, and the
+// activity height the layout decision is computed against.
+const ACTIVITY_MAX = 600
+// Hysteresis band (px) so near-equal heights don't oscillate between layouts.
+const DEADBAND = 8
+
+export interface BalancedEnvLayout {
+  // Recent-activity card header.
+  activityHeaderRef: React.RefObject<HTMLDivElement | null>
+  // Wrapper around the Recent-activity list content; measured at its intrinsic
+  // height regardless of how tall the card is stretched, which keeps the
+  // decision stable (no feedback loop) when the column is bottom-aligned.
+  activityInnerRef: React.RefObject<HTMLDivElement | null>
+  // ``max-height`` (px) to apply to the Recent-activity card. In the nested
+  // layout this is the 600px default; in the full-width layout it is exactly
+  // the height that bottom-aligns the right column with Project details
+  // (details − health − gap), so the card grows to meet details when it has
+  // the content to fill it.
+  activityMaxHeightPx: number
+  // Project details card (left column, top). Its height is the bar the right
+  // column is compared against.
+  detailsRef: React.RefObject<HTMLDivElement | null>
+  // Health & compliance card (right column, top).
+  healthRef: React.RefObject<HTMLDivElement | null>
+  recompute: () => void
+  // When true the right column's *natural* height is shorter than the details
+  // card, so the Environments card should span the full width below both
+  // columns (and the right column should stretch to align its bottom).
+  spanFull: boolean
+}
+
+/**
+ * Decide whether the Environments card nests under Project details (left
+ * column) or spans the full width below both columns.
+ *
+ * Rule: span full width when the right column's *natural* height (Health +
+ * Recent activity, capped) is shorter than the Project details card. In that
+ * case nesting the Environments card under details would leave a tall empty
+ * gap on the right, so we drop it to a full-width row and let the right column
+ * stretch to bottom-align with details. When the right column already extends
+ * past details (e.g. the score breakdown is open, or activity is long), the
+ * Environments card stays nested to balance the columns.
+ *
+ * The decision is computed from intrinsic content heights only, never from the
+ * stretched right-column height, so stretching can't feed back and oscillate.
+ */
+export function useBalancedEnvLayout(): BalancedEnvLayout {
+  const detailsRef = useRef<HTMLDivElement | null>(null)
+  const healthRef = useRef<HTMLDivElement | null>(null)
+  const activityHeaderRef = useRef<HTMLDivElement | null>(null)
+  const activityInnerRef = useRef<HTMLDivElement | null>(null)
+  const [spanFull, setSpanFull] = useState(false)
+  const [detailsHeight, setDetailsHeight] = useState(0)
+  const [healthHeight, setHealthHeight] = useState(0)
+
+  // fallow-ignore-next-line complexity
+  const recompute = useCallback(() => {
+    const details = detailsRef.current
+    const health = healthRef.current
+    const header = activityHeaderRef.current
+    const inner = activityInnerRef.current
+    if (!details || !health || !header || !inner) return
+
+    // Only balance at the `lg` breakpoint, where the two-column grid applies.
+    if (!window.matchMedia('(min-width: 1024px)').matches) {
+      setSpanFull(false)
+      return
+    }
+
+    const detailsH = details.offsetHeight
+    const activityNatural = Math.min(
+      header.offsetHeight + inner.offsetHeight,
+      ACTIVITY_MAX,
+    )
+    const rightNatural = health.offsetHeight + COLUMN_GAP + activityNatural
+
+    setDetailsHeight(detailsH)
+    setHealthHeight(health.offsetHeight)
+    setSpanFull((prev) =>
+      prev
+        ? rightNatural < detailsH + DEADBAND
+        : rightNatural < detailsH - DEADBAND,
+    )
+  }, [])
+
+  // Full-width layout: cap the activity card at the exact height that
+  // bottom-aligns the right column with Project details, so it stretches to
+  // meet details (limited only by available content). Nested: the 600 default.
+  const activityMaxHeightPx = spanFull
+    ? Math.max(0, detailsHeight - healthHeight - COLUMN_GAP)
+    : ACTIVITY_MAX
+
+  useLayoutEffect(() => {
+    recompute()
+    const observed = [
+      detailsRef.current,
+      healthRef.current,
+      activityHeaderRef.current,
+      activityInnerRef.current,
+    ].filter((el): el is HTMLDivElement => el !== null)
+    const observer = new ResizeObserver(recompute)
+    for (const el of observed) observer.observe(el)
+    window.addEventListener('resize', recompute)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', recompute)
+    }
+  }, [recompute])
+
+  return {
+    activityHeaderRef,
+    activityInnerRef,
+    activityMaxHeightPx,
+    detailsRef,
+    healthRef,
+    recompute,
+    spanFull,
+  }
+}

--- a/src/hooks/useEnvironmentEdgePatch.ts
+++ b/src/hooks/useEnvironmentEdgePatch.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'react'
+
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { patchEnvironmentEdge } from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+export interface UseEnvironmentEdgePatchResult {
+  /** Set/clear one edge attribute on a project x environment edge. */
+  patch: (envSlug: string, key: string, value: unknown) => Promise<void>
+  /** `${envSlug}/${key}` of the in-flight save, for per-field pending UI. */
+  pendingKey: null | string
+}
+
+/**
+ * Inline-edit a single DEPLOYED_IN edge attribute for an environment. Hits the
+ * targeted edge endpoint (per-key SET/REMOVE — reliable, touches only that
+ * edge), then invalidates the project + current-releases queries so the card
+ * re-reads canonical values. Empty/undefined values clear the attribute.
+ */
+export function useEnvironmentEdgePatch(
+  orgSlug: string,
+  projectId: string,
+): UseEnvironmentEdgePatchResult {
+  const qc = useQueryClient()
+  const [pendingKey, setPendingKey] = useState<null | string>(null)
+
+  const patch = useCallback(
+    async (envSlug: string, key: string, value: unknown) => {
+      const fieldKey = `${envSlug}/${key}`
+      setPendingKey(fieldKey)
+      try {
+        await patchEnvironmentEdge(orgSlug, projectId, envSlug, {
+          [key]: value === '' || value === undefined ? null : value,
+        })
+        qc.invalidateQueries({ queryKey: ['project', orgSlug, projectId] })
+        qc.invalidateQueries({
+          queryKey: ['currentReleases', orgSlug, projectId],
+        })
+      } catch (error) {
+        toast.error(`Save failed: ${extractApiErrorDetail(error)}`)
+        throw error
+      } finally {
+        setPendingKey(null)
+      }
+    },
+    [qc, orgSlug, projectId],
+  )
+
+  return { patch, pendingKey }
+}

--- a/src/lib/project-field-formatting.ts
+++ b/src/lib/project-field-formatting.ts
@@ -23,6 +23,34 @@ const WORD_OVERRIDES: Record<string, string> = {
   sonarqube: 'SonarQube',
 }
 
+// Blueprint `x-display` value transforms, keyed by `format`:
+//   - `humanize`   — replace `_`/`-` with spaces and Title-Case each word
+//   - `titlecase`  — Title-Case each word (separators left intact)
+//   - `uppercase`  — UPPER CASE
+//   - `lowercase`  — lower case
+//   - `capitalize` — capitalize the first character only
+const DISPLAY_TRANSFORMS: Record<string, (value: string) => string> = {
+  capitalize: (v) => (v ? v[0].toUpperCase() + v.slice(1) : v),
+  humanize: (v) => humanizeValue(v),
+  lowercase: (v) => v.toLowerCase(),
+  titlecase: (v) => v.replace(/\b\w/g, (c) => c.toUpperCase()),
+  uppercase: (v) => v.toUpperCase(),
+}
+
+/**
+ * Apply a blueprint `x-display` transform to an already-formatted value.
+ * Unknown/absent transforms return the value as-is.
+ */
+export function applyDisplayFormat(
+  value: string,
+  xDisplay?: null | { format?: null | string },
+): string {
+  const transform = xDisplay?.format
+    ? DISPLAY_TRANSFORMS[xDisplay.format]
+    : undefined
+  return transform ? transform(value) : value
+}
+
 export function formatFieldKey(key: null | string | undefined): string {
   if (!key) return ''
   return key
@@ -134,4 +162,15 @@ export function resolveFieldValue(
     }
   }
   return undefined
+}
+
+/** Replace `_`/`-` separators with spaces and Title-Case each word. */
+function humanizeValue(value: string): string {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(' ')
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -495,6 +495,9 @@ export interface CurrentReleaseEnvironment {
   environment: { name: string; slug: string }
   external_run_url: null | string
   last_event_at: null | string
+  // Deployer of the latest event when observed from a remote (e.g. the
+  // GitHub actor); null for in-product deploys.
+  performed_by?: null | string
   release: null | Release
 }
 
@@ -1329,6 +1332,9 @@ export interface SchemaProperty {
   colorRange?: Record<string, string>
   defaultValue?: string
   description?: string
+  // Human-readable display transform applied to the rendered value
+  // (serialized as `x-display.format`; see DISPLAY_FORMATS).
+  displayFormat?: string
   editable?: boolean
   enumValues?: string[]
   format?: string


### PR DESCRIPTION
## Summary

Reworks the project overview **Environments** card into enriched, per-environment cards driven by blueprint-defined `DEPLOYED_IN` edge attributes. Backend PR: AWeber-Imbi/imbi-api#435 (merge first — this consumes the new schema + PATCH endpoint).

- **Release status** — per-environment badge keyed to the `DeploymentStatus` enum; version + deployer ("Deployed by", avatar/initials) surfaced from the current release event.
- **Dynamic edge attributes** — rendered via a new shared `AttributeValue` component (same `formatFieldValue` + `x-ui` color/icon logic as project attributes), inline-editable through `useEnvironmentEdgePatch` (per-key PATCH). No hard-coded columns — whatever the relationship blueprint declares flows through.
- **`x-display` value format** — new blueprint transform (`humanize`/`titlecase`/`uppercase`/`lowercase`/`capitalize`) wired through the blueprint editor, plus a snake_case attribute-name constraint.
- **Inline URL** — environment URL is inline-editable and pinned to the header line (no wrap).
- **Balanced overview layout** (`useBalancedEnvLayout`) — the Environments card nests under Project details when the right column is taller; otherwise it spans full width below both columns and Recent activity stretches to bottom-align with Project details (capped, falling back to natural height when sparse).
- **Settings cleanup** — removed the Environments, Identifiers, and Utility Functions cards from the project Settings tab. The utility actions (Recompute Score / Sync Deployments) remain on the Doctor tab, which is correctly permission-gated.

## Testing

- `npm run build`, `npm run lint`, `npm run format:check`, `fallow audit` — clean.
- `npm run test` — 402 passing (updated `ProjectSettingsTab.test.tsx` for the removed cards).
- Verified live against the okteto dev env (nested vs. full-width layouts, bottom-alignment, inline edits, `x-display`).
