### PR TITLE
Add Webhook History admin view

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -608,6 +608,36 @@ export const listPluginOpsLogTemplates = async (
 }
 
 // Events
+
+export interface AdminEventsFilters {
+  attributed_to?: string
+  /** Filters on `metadata.event_type` (e.g. `'pull_request'`) — the
+   *  per-source label the gateway resolved from the webhook's
+   *  configured selector. Used together with `type='webhook'` to
+   *  narrow within the webhook category. */
+  event_type?: string
+  project_id?: string
+  since?: string
+  third_party_service?: string
+  /** Event *category*. `'webhook'` for inbound webhook deliveries.
+   *  Wider categories (e.g. system-generated events) may land in
+   *  the same table later. */
+  type?: string
+  until?: string
+}
+
+/**
+ * Per-handler dispatch outcome attached to webhook events by the
+ * gateway's phase-2 metadata write. `status` may be 'succeeded',
+ * 'failed', or 'skipped'; `error` and `duration_ms` are optional.
+ */
+export interface EventHandlerOutcome {
+  duration_ms?: number
+  error?: string
+  handler: string
+  status: string
+}
+
 export interface EventRecord {
   attributed_to: string
   id: string
@@ -617,6 +647,9 @@ export interface EventRecord {
   recorded_at: string
   third_party_service: string
   type: string
+  /** Increments with each phase of the gateway's two-phase recording.
+   *  0 = phase-1 (initial record), 1 = phase-2 (dispatch outcome). */
+  version?: number
 }
 
 export interface EventsPage {
@@ -627,6 +660,35 @@ export interface EventsPage {
 interface EventsEnvelope {
   data: EventRecord[]
 }
+
+export const listAdminEvents = async (
+  params: { cursor?: string; filters?: AdminEventsFilters; limit?: number },
+  signal?: AbortSignal,
+): Promise<EventsPage> => {
+  const query: Record<string, unknown> = { limit: params.limit ?? 100 }
+  if (params.cursor) query.cursor = params.cursor
+  if (params.filters) {
+    for (const [k, v] of Object.entries(params.filters)) {
+      if (v) query[k] = v
+    }
+  }
+  const { data, headers } = await apiClient.getWithHeaders<EventsEnvelope>(
+    '/events/',
+    query,
+    signal,
+  )
+  return {
+    entries: Array.isArray(data?.data) ? data.data : [],
+    nextCursor: parseNextCursor(headers),
+  }
+}
+
+export const getEvent = (eventId: string, signal?: AbortSignal) =>
+  apiClient.get<EventRecord>(
+    `/events/${encodeURIComponent(eventId)}`,
+    undefined,
+    signal,
+  )
 
 export const listProjectEvents = async (
   params: {

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -11,6 +11,7 @@ import {
   FileJson,
   FolderTree,
   Globe,
+  History,
   KeyRound,
   Layers,
   LayoutDashboard,
@@ -47,6 +48,7 @@ import { ServiceAccountManagement } from './admin/ServiceAccountManagement'
 import { TeamManagement } from './admin/TeamManagement'
 import { ThirdPartyServiceManagement } from './admin/ThirdPartyServiceManagement'
 import { UserManagement } from './admin/UserManagement'
+import { WebhookHistory } from './admin/WebhookHistory'
 import { WebhookManagement } from './admin/WebhookManagement'
 
 type AdminSection =
@@ -67,6 +69,7 @@ type AdminSection =
   | 'teams'
   | 'third-party-services'
   | 'users'
+  | 'webhook-history'
   | 'webhooks'
 
 // The admin section shown when none is specified in the URL.
@@ -90,6 +93,7 @@ const VALID_SECTIONS: AdminSection[] = [
   'teams',
   'third-party-services',
   'users',
+  'webhook-history',
   'webhooks',
 ]
 
@@ -189,6 +193,14 @@ export function Admin() {
       icon: Webhook,
       id: 'webhooks',
       label: 'Webhooks',
+      scope: 'org',
+    },
+    {
+      description:
+        'Browse recent inbound webhook deliveries and dispatch outcomes',
+      icon: History,
+      id: 'webhook-history',
+      label: 'Webhook History',
       scope: 'org',
     },
   ]
@@ -386,6 +398,9 @@ export function Admin() {
               <ThirdPartyServiceManagement />
             )}
             {currentSection === 'webhooks' && <WebhookManagement />}
+            {currentSection === 'webhook-history' && (
+              <WebhookHistory eventId={slug} />
+            )}
             {currentSection === 'link-definitions' && (
               <LinkDefinitionManagement />
             )}

--- a/src/components/admin/WebhookHistory.tsx
+++ b/src/components/admin/WebhookHistory.tsx
@@ -1,0 +1,243 @@
+import { useMemo, useState } from 'react'
+
+import type { AdminEventsFilters, EventRecord } from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import { ErrorBanner } from '@/components/ui/error-banner'
+import { Input } from '@/components/ui/input'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { useInfiniteWebhookEvents } from '@/hooks/useInfiniteWebhookEvents'
+import { useProjectsSlimMap } from '@/hooks/useProjectsSlimMap'
+import { useWebhookEvent } from '@/hooks/useWebhookEvent'
+
+import { WebhookHistoryRow } from './WebhookHistoryRow'
+
+const TIME_RANGES = [
+  { label: 'Last 24 hours', value: '24h' },
+  { label: 'Last 7 days', value: '7d' },
+  { label: 'Last 30 days', value: '30d' },
+  { label: 'All time', value: 'all' },
+] as const
+
+type TimeRange = (typeof TIME_RANGES)[number]['value']
+
+interface WebhookHistoryProps {
+  eventId?: string
+}
+
+// fallow-ignore-next-line complexity
+export function WebhookHistory({ eventId }: WebhookHistoryProps) {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
+  const { projectsById } = useProjectsSlimMap(orgSlug)
+
+  const [tps, setTps] = useState('')
+  const [eventType, setEventType] = useState('')
+  const [projectId, setProjectId] = useState('')
+  const [timeRange, setTimeRange] = useState<TimeRange>('7d')
+
+  // fallow-ignore-next-line complexity
+  const filters: AdminEventsFilters = useMemo(() => {
+    // Always scope to the webhook category. The gateway records every
+    // inbound delivery with `type='webhook'`; the per-source label
+    // (e.g. `pull_request`) sits in `metadata.event_type` and the API
+    // exposes that as the `event_type` query parameter.
+    const f: AdminEventsFilters = { type: 'webhook' }
+    if (tps) f.third_party_service = tps
+    if (eventType) f.event_type = eventType
+    if (projectId) f.project_id = projectId
+    const since = sinceFromRange(timeRange)
+    if (since) f.since = since
+    return f
+  }, [tps, eventType, projectId, timeRange])
+
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isLoading,
+  } = useInfiniteWebhookEvents(filters)
+
+  const pinnedQuery = useWebhookEvent(eventId)
+
+  // fallow-ignore-next-line complexity
+  const tpsOptions = useMemo(() => {
+    const set = new Set<string>()
+    for (const e of data?.entries ?? []) {
+      if (e.third_party_service) set.add(e.third_party_service)
+    }
+    return Array.from(set).sort()
+  }, [data?.entries])
+
+  const projectLabel = (event: EventRecord) =>
+    projectsById.get(event.project_id)?.slug ?? event.project_id
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="min-w-40">
+          <label className="text-secondary mb-1 block text-xs" htmlFor="wh-tps">
+            Third-party service
+          </label>
+          <Select
+            onValueChange={(v) => setTps(v === '__all' ? '' : v)}
+            value={tps || '__all'}
+          >
+            <SelectTrigger className="h-8" id="wh-tps">
+              <SelectValue placeholder="All services" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all">All services</SelectItem>
+              {tpsOptions.map((slug) => (
+                <SelectItem key={slug} value={slug}>
+                  {slug}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="min-w-40">
+          <label
+            className="text-secondary mb-1 block text-xs"
+            htmlFor="wh-type"
+          >
+            Event type
+          </label>
+          <Input
+            className="h-8"
+            id="wh-type"
+            onChange={(e) => setEventType(e.target.value)}
+            placeholder="e.g. pull_request"
+            value={eventType}
+          />
+        </div>
+        <div className="min-w-40">
+          <label
+            className="text-secondary mb-1 block text-xs"
+            htmlFor="wh-project"
+          >
+            Project
+          </label>
+          <Select
+            onValueChange={(v) => setProjectId(v === '__all' ? '' : v)}
+            value={projectId || '__all'}
+          >
+            <SelectTrigger className="h-8" id="wh-project">
+              <SelectValue placeholder="All projects" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all">All projects</SelectItem>
+              {Array.from(projectsById.values())
+                .sort((a, b) => a.slug.localeCompare(b.slug))
+                .map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.slug}
+                  </SelectItem>
+                ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="min-w-35">
+          <label
+            className="text-secondary mb-1 block text-xs"
+            htmlFor="wh-range"
+          >
+            Time range
+          </label>
+          <Select
+            onValueChange={(v) => setTimeRange(v as TimeRange)}
+            value={timeRange}
+          >
+            <SelectTrigger className="h-8" id="wh-range">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_RANGES.map((r) => (
+                <SelectItem key={r.value} value={r.value}>
+                  {r.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {pinnedQuery.data ? (
+        <div className="space-y-2">
+          <div className="text-secondary text-xs font-medium uppercase">
+            Pinned event
+          </div>
+          <WebhookHistoryRow
+            defaultOpen
+            event={pinnedQuery.data}
+            projectLabel={projectLabel(pinnedQuery.data)}
+          />
+        </div>
+      ) : null}
+      {eventId && pinnedQuery.isError ? (
+        <ErrorBanner
+          error={pinnedQuery.error}
+          title={`Could not load event ${eventId}`}
+        />
+      ) : null}
+
+      {isLoading ? (
+        <LoadingState label="Loading webhook history..." />
+      ) : error ? (
+        <ErrorBanner error={error} title="Failed to load webhook events" />
+      ) : (
+        <div className="space-y-2">
+          {(data?.entries ?? []).length === 0 ? (
+            <div className="text-secondary py-12 text-center text-sm">
+              No webhook events match the current filters.
+            </div>
+          ) : (
+            (data?.entries ?? []).map((event) => (
+              <WebhookHistoryRow
+                event={event}
+                key={event.id}
+                projectLabel={projectLabel(event)}
+              />
+            ))
+          )}
+          <div className="flex justify-center pt-2">
+            {hasNextPage ? (
+              <Button
+                disabled={isFetchingNextPage}
+                onClick={() => void fetchNextPage()}
+                size="sm"
+                variant="outline"
+              >
+                {isFetchingNextPage ? 'Loading...' : 'Load more'}
+              </Button>
+            ) : isFetching ? (
+              <span className="text-secondary text-xs">Refreshing...</span>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function sinceFromRange(range: TimeRange): string | undefined {
+  if (range === 'all') return undefined
+  const now = Date.now()
+  const ms =
+    range === '24h'
+      ? 24 * 60 * 60 * 1000
+      : range === '7d'
+        ? 7 * 24 * 60 * 60 * 1000
+        : 30 * 24 * 60 * 60 * 1000
+  return new Date(now - ms).toISOString()
+}

--- a/src/components/admin/WebhookHistoryRow.tsx
+++ b/src/components/admin/WebhookHistoryRow.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+
+import { Link } from 'react-router-dom'
+
+import { CheckCircle2, Clipboard, ClockIcon, XCircle } from 'lucide-react'
+
+import type { EventHandlerOutcome, EventRecord } from '@/api/endpoints'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+
+interface DispositionMeta {
+  label: string
+  tone: 'failure' | 'pending' | 'success'
+}
+
+interface WebhookHistoryRowProps {
+  defaultOpen?: boolean
+  event: EventRecord
+  projectLabel?: string
+}
+
+export function WebhookHistoryRow({
+  defaultOpen = false,
+  event,
+  projectLabel,
+}: WebhookHistoryRowProps) {
+  const [open, setOpen] = useState(defaultOpen)
+  const handlers = getHandlers(event.metadata)
+  const disposition = deriveDisposition(handlers)
+  const webhookId = getWebhookId(event.metadata)
+  const headers = getRedactedHeaders(event.metadata)
+  // The per-source label (e.g. 'pull_request') lives in
+  // `metadata.event_type`. Old rows recorded before the
+  // category/subtype split carried it as the top-level `type`, so
+  // fall back to that for display only.
+  const eventTypeLabel =
+    getMetadataString(event.metadata, 'event_type') ||
+    event.type ||
+    '(unspecified)'
+
+  const dispositionVariant =
+    disposition.tone === 'success'
+      ? 'default'
+      : disposition.tone === 'failure'
+        ? 'destructive'
+        : 'secondary'
+
+  const onCopyLink = () => {
+    const url = `${window.location.origin}/admin/webhook-history/${encodeURIComponent(event.id)}`
+    void navigator.clipboard.writeText(url)
+  }
+
+  return (
+    <div
+      className="rounded-md border border-slate-200 bg-white"
+      data-testid="webhook-history-row"
+    >
+      <button
+        aria-expanded={open}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left"
+        onClick={() => setOpen((v) => !v)}
+        type="button"
+      >
+        <ClockIcon className="text-tertiary size-4" />
+        <span className="text-secondary text-sm tabular-nums">
+          {new Date(event.recorded_at).toLocaleString()}
+        </span>
+        <Badge variant="secondary">{event.third_party_service}</Badge>
+        <span className="text-primary text-sm font-medium">
+          {eventTypeLabel}
+        </span>
+        <span className="text-secondary text-sm">
+          {projectLabel ?? event.project_id}
+        </span>
+        {event.attributed_to ? (
+          <span className="text-secondary text-xs">
+            attributed to {event.attributed_to}
+          </span>
+        ) : null}
+        <span className="ml-auto inline-flex items-center gap-1">
+          <Badge variant={dispositionVariant}>{disposition.label}</Badge>
+        </span>
+      </button>
+      {open ? (
+        <div className="space-y-3 border-t border-slate-200 bg-slate-50 px-4 py-3 text-sm">
+          <div className="flex items-center justify-between">
+            <div className="text-secondary text-xs">
+              project:{' '}
+              <Link
+                className="text-amber-text hover:underline"
+                to={`/projects/${event.project_id}`}
+              >
+                <code>{projectLabel ?? event.project_id}</code>
+              </Link>{' '}
+              · event id: <code>{event.id}</code>
+              {webhookId ? (
+                <>
+                  {' '}
+                  · webhook id: <code>{webhookId}</code>
+                </>
+              ) : null}
+            </div>
+            <Button
+              aria-label="Copy event link"
+              onClick={onCopyLink}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <Clipboard className="mr-1 size-3" />
+              Copy link
+            </Button>
+          </div>
+          <div>
+            <div className="text-secondary mb-1 text-xs font-medium uppercase">
+              Handlers
+            </div>
+            {handlers.length === 0 ? (
+              <div className="text-tertiary text-xs">
+                No handlers fired (filter did not match or no rules).
+              </div>
+            ) : (
+              <ul className="space-y-1">
+                {handlers.map((h, i) => (
+                  <li
+                    className="flex items-center gap-2"
+                    key={`${h.handler}-${i}`}
+                  >
+                    {h.status === 'succeeded' ? (
+                      <CheckCircle2 className="size-3 text-emerald-600" />
+                    ) : (
+                      <XCircle className="size-3 text-rose-600" />
+                    )}
+                    <code className="text-xs">{h.handler}</code>
+                    <span className="text-secondary text-xs">{h.status}</span>
+                    {typeof h.duration_ms === 'number' ? (
+                      <span className="text-tertiary text-xs">
+                        {h.duration_ms}ms
+                      </span>
+                    ) : null}
+                    {h.error ? (
+                      <span className="text-xs text-rose-700">{h.error}</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          {Object.keys(headers).length > 0 ? (
+            <details>
+              <summary className="text-secondary cursor-pointer text-xs font-medium uppercase">
+                Headers
+              </summary>
+              <pre className="mt-1 overflow-x-auto rounded bg-slate-100 p-2 text-xs">
+                {JSON.stringify(headers, null, 2)}
+              </pre>
+            </details>
+          ) : null}
+          <details>
+            <summary className="text-secondary cursor-pointer text-xs font-medium uppercase">
+              Payload
+            </summary>
+            <pre className="mt-1 overflow-x-auto rounded bg-slate-100 p-2 text-xs">
+              {JSON.stringify(event.payload, null, 2)}
+            </pre>
+          </details>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function deriveDisposition(handlers: EventHandlerOutcome[]): DispositionMeta {
+  if (handlers.length === 0) {
+    return { label: 'Recorded · no handlers', tone: 'pending' }
+  }
+  const succeeded = handlers.filter((h) => h.status === 'succeeded').length
+  const failed = handlers.filter((h) => h.status === 'failed').length
+  if (failed === 0) {
+    return { label: `${succeeded} handlers · ok`, tone: 'success' }
+  }
+  return {
+    label: `${succeeded} of ${handlers.length} handlers ok`,
+    tone: 'failure',
+  }
+}
+
+function getHandlers(metadata: Record<string, unknown>): EventHandlerOutcome[] {
+  const raw = metadata.handlers
+  return Array.isArray(raw) ? (raw as EventHandlerOutcome[]) : []
+}
+
+function getMetadataString(
+  metadata: Record<string, unknown>,
+  key: string,
+): string {
+  const raw = metadata[key]
+  return typeof raw === 'string' ? raw : ''
+}
+
+function getRedactedHeaders(
+  metadata: Record<string, unknown>,
+): Record<string, string> {
+  const raw = metadata.headers
+  if (raw && typeof raw === 'object') {
+    return raw as Record<string, string>
+  }
+  return {}
+}
+
+function getWebhookId(metadata: Record<string, unknown>): string {
+  return getMetadataString(metadata, 'webhook_id')
+}

--- a/src/components/admin/__tests__/WebhookHistoryRow.test.tsx
+++ b/src/components/admin/__tests__/WebhookHistoryRow.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import type { EventRecord } from '@/api/endpoints'
+import { fireEvent, render, screen } from '@/test/utils'
+
+import { WebhookHistoryRow } from '../WebhookHistoryRow'
+
+function makeEvent(overrides: Partial<EventRecord> = {}): EventRecord {
+  return {
+    attributed_to: '',
+    id: 'evt-1',
+    metadata: {},
+    payload: {},
+    project_id: 'proj-1',
+    recorded_at: '2026-04-01T12:00:00Z',
+    third_party_service: 'github-enterprise-cloud',
+    type: 'pull_request',
+    ...overrides,
+  }
+}
+
+describe('WebhookHistoryRow disposition', () => {
+  it('renders "Recorded · no handlers" when handlers is empty', () => {
+    render(<WebhookHistoryRow event={makeEvent()} />)
+    expect(screen.getByText(/Recorded.+no handlers/)).toBeInTheDocument()
+  })
+
+  it('renders "N handlers · ok" when every handler succeeded', () => {
+    const event = makeEvent({
+      metadata: {
+        handlers: [
+          { duration_ms: 12, handler: 'gh#open', status: 'succeeded' },
+          { duration_ms: 8, handler: 'gh#notify', status: 'succeeded' },
+        ],
+      },
+    })
+    render(<WebhookHistoryRow event={event} />)
+    expect(screen.getByText('2 handlers · ok')).toBeInTheDocument()
+  })
+
+  it('renders "N of M handlers ok" when any handler failed', () => {
+    const event = makeEvent({
+      metadata: {
+        handlers: [
+          { duration_ms: 12, handler: 'gh#open', status: 'succeeded' },
+          { error: 'boom', handler: 'gh#notify', status: 'failed' },
+        ],
+      },
+    })
+    render(<WebhookHistoryRow event={event} />)
+    expect(screen.getByText('1 of 2 handlers ok')).toBeInTheDocument()
+  })
+
+  it('expands to show handler list with status and duration', () => {
+    const event = makeEvent({
+      metadata: {
+        handlers: [
+          { duration_ms: 42, handler: 'gh#open', status: 'succeeded' },
+        ],
+      },
+    })
+    render(<WebhookHistoryRow event={event} />)
+    fireEvent.click(screen.getByRole('button', { expanded: false }))
+    expect(screen.getByText('gh#open')).toBeInTheDocument()
+    expect(screen.getByText('succeeded')).toBeInTheDocument()
+    expect(screen.getByText('42ms')).toBeInTheDocument()
+  })
+
+  it('honors defaultOpen and shows the copy-link button', () => {
+    render(<WebhookHistoryRow defaultOpen event={makeEvent()} />)
+    expect(
+      screen.getByRole('button', { name: /Copy event link/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('prefers metadata.event_type over the top-level type for the badge', () => {
+    const event = makeEvent({
+      metadata: { event_type: 'pull_request', handlers: [] },
+      // After the type-category refactor the top-level `type` is
+      // `'webhook'`; the per-source label lives in metadata.
+      type: 'webhook',
+    })
+    render(<WebhookHistoryRow event={event} />)
+    expect(screen.getByText('pull_request')).toBeInTheDocument()
+    expect(screen.queryByText('webhook')).not.toBeInTheDocument()
+  })
+
+  it('falls back to top-level type when metadata.event_type is missing', () => {
+    // Defensive against legacy rows recorded before the
+    // category/subtype split.
+    const event = makeEvent({ metadata: {}, type: 'legacy_event' })
+    render(<WebhookHistoryRow event={event} />)
+    expect(screen.getByText('legacy_event')).toBeInTheDocument()
+  })
+
+  it('links the project id to the project page in the detail panel', () => {
+    render(
+      <WebhookHistoryRow
+        defaultOpen
+        event={makeEvent({ project_id: 'proj-42' })}
+        projectLabel="my-service"
+      />,
+    )
+    const link = screen.getByRole('link', { name: /my-service/ })
+    expect(link).toHaveAttribute('href', '/projects/proj-42')
+  })
+})

--- a/src/hooks/useInfiniteWebhookEvents.ts
+++ b/src/hooks/useInfiniteWebhookEvents.ts
@@ -1,0 +1,64 @@
+import { type InfiniteData, useInfiniteQuery } from '@tanstack/react-query'
+
+import {
+  type AdminEventsFilters,
+  type EventRecord,
+  type EventsPage,
+  listAdminEvents,
+} from '@/api/endpoints'
+
+const PAGE_SIZE = 100
+
+interface SelectedWebhookEventsData {
+  entries: EventRecord[]
+  pageParams: Array<string | undefined>
+  pages: EventsPage[]
+}
+
+/**
+ * Paginated webhook-history feed for the admin view. Reads the
+ * coalesced `events_latest` projection on the server side, so each
+ * event id appears at most once (with its highest-version metadata).
+ */
+export function useInfiniteWebhookEvents(filters: AdminEventsFilters) {
+  return useInfiniteQuery<
+    EventsPage,
+    Error,
+    SelectedWebhookEventsData,
+    readonly unknown[],
+    string | undefined
+  >({
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (!lastPage.nextCursor) return undefined
+      if (lastPage.nextCursor === lastPageParam) return undefined
+      return lastPage.nextCursor
+    },
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam, signal }) =>
+      listAdminEvents(
+        {
+          cursor: pageParam as string | undefined,
+          filters,
+          limit: PAGE_SIZE,
+        },
+        signal,
+      ),
+    queryKey: ['webhookEvents', 'infinite', filters],
+    select: (data: InfiniteData<EventsPage, string | undefined>) => {
+      const seen = new Set<string>()
+      const entries: EventRecord[] = []
+      for (const page of data.pages) {
+        for (const entry of page.entries) {
+          if (seen.has(entry.id)) continue
+          seen.add(entry.id)
+          entries.push(entry)
+        }
+      }
+      return {
+        entries,
+        pageParams: data.pageParams,
+        pages: data.pages,
+      }
+    },
+  })
+}

--- a/src/hooks/useWebhookEvent.ts
+++ b/src/hooks/useWebhookEvent.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { type EventRecord, getEvent } from '@/api/endpoints'
+
+/**
+ * Fetch a single webhook event by id. Used by the deep-link landing
+ * in the webhook-history admin view so a shared URL works even when
+ * the target event is past the default cursor page.
+ */
+export function useWebhookEvent(eventId: string | undefined) {
+  return useQuery<EventRecord>({
+    enabled: Boolean(eventId),
+    queryFn: ({ signal }) => {
+      if (!eventId) throw new Error('eventId is required')
+      return getEvent(eventId, signal)
+    },
+    queryKey: ['webhookEvent', eventId],
+    retry: false,
+    staleTime: 60_000,
+  })
+}


### PR DESCRIPTION
## Summary

Adds a Webhook History admin view that lists recorded webhook
deliveries with their handler outcomes, filters, and shareable
per-event deep links.

## Problem

Operators have no way to see what inbound webhooks the gateway
received, whether each matched project's handlers succeeded, or to
share a link to a specific delivery while debugging an integration.

## Solution

- New admin section under `/admin/webhook-history` (and
  `/admin/webhook-history/<event-id>` for deep links) wired into
  `Admin.tsx` alongside the existing Webhooks entry.
- `WebhookHistory.tsx` composes a toolbar (TPS, event-type, project,
  time-range), the paged event list, and a pinned deep-link card when
  an `event-id` is in the path. The baseline filter is `type=webhook`;
  the toolbar event-type input maps to the new `event_type` query
  parameter that narrows on `metadata.event_type`.
- `WebhookHistoryRow.tsx` renders a summary line plus an expandable
  detail panel: handler outcomes (succeeded / failed / skipped with
  `duration_ms`), redacted headers, raw payload, the webhook id, the
  event id, and a link to the project page. A copy-link button writes
  the shareable URL to the clipboard.
- Badge label prefers `metadata.event_type` and falls back to the
  top-level `type` for legacy rows recorded before the category /
  subtype split.
- New TanStack Query hooks: `useInfiniteWebhookEvents` (paged list
  keyed by filters) and `useWebhookEvent` (single fetch for the
  deep-link card).
- New endpoint helpers `listAdminEvents` and `getEvent`;
  `AdminEventsFilters`, `EventHandlerOutcome`, and an optional
  `version` on `EventRecord`.
- RTL tests cover the three disposition states (no handlers / all ok /
  partial fail), the `metadata.event_type`-over-`type` badge
  preference, the legacy fallback, and the project-page deep-link in
  the detail panel.

Consumes the `/events` filters and by-id endpoint from the companion
imbi-api PR.

---

**Companion PRs** (merge in order):
1. imbi-common https://github.com/AWeber-Imbi/imbi-common/pull/159 — schema (`events.version` + `events_latest` view)
2. imbi-api https://github.com/AWeber-Imbi/imbi-api/pull/437 — `/events` filters + by-id endpoint
3. imbi-ui https://github.com/AWeber-Imbi/imbi-ui/pull/415 — Webhook History admin view
