### PR TITLE
Add PagerDuty UI: incidents tab, lifecycle sync, mapping editor

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -44,6 +44,7 @@ import type {
   IdentityConnectionResponse,
   IdentityConnectionStartRequest,
   IdentityConnectionStartResponse,
+  IncidentResult,
   InstalledPlugin,
   Integration,
   IntegrationCreate,
@@ -1994,6 +1995,37 @@ export const resyncServiceDeployments = (
     `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/deployments/resync`,
   )
 
+// Lifecycle push-sync
+
+export interface LifecycleSyncError {
+  detail: string
+  project_id: string
+}
+
+export interface LifecycleSyncSummary {
+  errors: LifecycleSyncError[]
+  failed: number
+  projects: number
+  skipped: number
+  synced: number
+}
+
+export const syncProjectLifecycle = (
+  orgSlug: string,
+  projectId: string,
+): Promise<LifecycleSyncSummary> =>
+  apiClient.post<LifecycleSyncSummary>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/lifecycle/sync`,
+  )
+
+export const syncServiceLifecycle = (
+  orgSlug: string,
+  serviceSlug: string,
+): Promise<LifecycleSyncSummary> =>
+  apiClient.post<LifecycleSyncSummary>(
+    `/organizations/${encodeURIComponent(orgSlug)}/third-party-services/${encodeURIComponent(serviceSlug)}/lifecycle/sync`,
+  )
+
 // Identity Plugins (org-scoped)
 export interface IdentityPluginRef {
   label: string
@@ -2185,6 +2217,37 @@ export const searchProjectLogs = (
   }
   return apiClient.get<LogResultResponse>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/logs/`,
+    query,
+    signal,
+  )
+}
+
+export interface IncidentSearchParams {
+  cursor?: string
+  end_time?: string
+  limit?: number
+  source?: string
+  start_time?: string
+  status?: string[]
+}
+
+export const searchProjectIncidents = (
+  orgSlug: string,
+  projectId: string,
+  params?: IncidentSearchParams,
+  signal?: AbortSignal,
+) => {
+  const query: Record<string, string | string[]> = {}
+  if (params) {
+    if (params.source) query.source = params.source
+    if (params.start_time) query.start_time = params.start_time
+    if (params.end_time) query.end_time = params.end_time
+    if (params.cursor) query.cursor = params.cursor
+    if (params.limit != null) query.limit = String(params.limit)
+    if (params.status?.length) query.status = params.status
+  }
+  return apiClient.get<IncidentResult>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/incidents/`,
     query,
     signal,
   )

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -52,6 +52,7 @@ import { DeploymentRunWatcher } from '@/components/deploy/DeploymentRunWatcher'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
 import { ConfigurationTab } from '@/components/project/ConfigurationTab'
+import { IncidentsTab } from '@/components/project/IncidentsTab'
 import { LogsTab } from '@/components/project/LogsTab'
 import { ProjectPullRequestsTab } from '@/components/project/ProjectPullRequestsTab'
 import { ProjectActivityLog } from '@/components/ProjectActivityLog'
@@ -109,6 +110,7 @@ const VALID_TABS = [
   'dependencies',
   'relationships',
   'logs',
+  'incidents',
   'documents',
   'operations-log',
   'pull-requests',
@@ -468,6 +470,7 @@ export function ProjectDetail({
       hasConfigurationPlugin: plugins.some(
         (a) => a.plugin_type === 'configuration',
       ),
+      hasIncidentsPlugin: plugins.some((a) => a.plugin_type === 'incidents'),
       hasLifecyclePlugin: plugins.some((a) => a.plugin_type === 'lifecycle'),
       hasLogsPlugin: plugins.some((a) => a.plugin_type === 'logs'),
     }),
@@ -478,6 +481,8 @@ export function ProjectDetail({
     (projectPluginsView?.hasConfigurationPlugin ?? false)
   const hasLogsPlugin =
     projectPluginsSuccess && (projectPluginsView?.hasLogsPlugin ?? false)
+  const hasIncidentsPlugin =
+    projectPluginsSuccess && (projectPluginsView?.hasIncidentsPlugin ?? false)
   const hasLifecyclePlugin =
     projectPluginsSuccess && (projectPluginsView?.hasLifecyclePlugin ?? false)
   const deploymentPlugin = projectPluginsSuccess
@@ -618,6 +623,7 @@ export function ProjectDetail({
     if (
       (activeTab === 'configuration' && !hasConfigurationPlugin) ||
       (activeTab === 'logs' && !hasLogsPlugin) ||
+      (activeTab === 'incidents' && !hasIncidentsPlugin) ||
       (activeTab === 'pull-requests' && !hasLifecyclePlugin)
     ) {
       navigate(`/projects/${project.id}`, { replace: true })
@@ -625,6 +631,7 @@ export function ProjectDetail({
   }, [
     activeTab,
     hasConfigurationPlugin,
+    hasIncidentsPlugin,
     hasLifecyclePlugin,
     hasLogsPlugin,
     navigate,
@@ -756,6 +763,9 @@ export function ProjectDetail({
           : 'Documents',
     },
     ...(hasLogsPlugin ? [{ id: 'logs' as const, label: 'Logs' }] : []),
+    ...(hasIncidentsPlugin
+      ? [{ id: 'incidents' as const, label: 'Incidents' }]
+      : []),
     { id: 'operations-log', label: 'Operations Log' },
     ...(hasLifecyclePlugin
       ? [
@@ -1252,6 +1262,11 @@ export function ProjectDetail({
               orgSlug={orgSlug}
               projectId={project.id}
             />
+          </TabsContent>
+        )}
+        {hasIncidentsPlugin && (
+          <TabsContent value="incidents">
+            <IncidentsTab orgSlug={orgSlug} projectId={project.id} />
           </TabsContent>
         )}
         <TabsContent value="documents">

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -27,6 +27,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { useProjectLifecycleSync } from '@/hooks/useLifecycleSync'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import type { Project } from '@/types'
@@ -153,6 +154,8 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
     [projectPlugins],
   )
 
+  const lifecycleSync = useProjectLifecycleSync(orgSlug, project.id)
+
   const {
     data: linkDefs = [],
     isError: linkDefsError,
@@ -192,6 +195,29 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
       <IntegrationsCard orgSlug={orgSlug} projectId={project.id} />
 
       <ProjectPluginsSection orgSlug={orgSlug} projectId={project.id} />
+
+      {hasLifecyclePlugin && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Sync lifecycle</CardTitle>
+            <CardDescription className="text-secondary">
+              Push this project&apos;s current state to its lifecycle remotes
+              (e.g. create or update the PagerDuty service), re-running each
+              lifecycle plugin&apos;s upsert.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button
+              disabled={lifecycleSync.isPending}
+              onClick={() => lifecycleSync.mutate()}
+              size="sm"
+              variant="outline"
+            >
+              {lifecycleSync.isPending ? 'Syncing...' : 'Sync Lifecycle'}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       <Card className="border-amber-300">
         <CardHeader>

--- a/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
+++ b/src/components/admin/third-party-services/ServicePluginConfiguration.tsx
@@ -57,6 +57,7 @@ import {
 } from '@/components/ui/table'
 import { useServiceDeploymentResync } from '@/hooks/useDeploymentResync'
 import { useExpandableRows } from '@/hooks/useExpandableRows'
+import { useServiceLifecycleSync } from '@/hooks/useLifecycleSync'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { queryKeys } from '@/lib/queryKeys'
 import type {
@@ -188,9 +189,58 @@ export function ServicePluginConfiguration({
           {manifest?.supports_deployment_sync === true && (
             <ResyncCard orgSlug={orgSlug} serviceSlug={serviceSlug} />
           )}
+          {manifest?.supports_lifecycle_sync === true && (
+            <LifecycleSyncCard orgSlug={orgSlug} serviceSlug={serviceSlug} />
+          )}
         </>
       )}
     </div>
+  )
+}
+
+// ------------------------- Lifecycle sync ------------------------------
+
+function LifecycleSyncCard({
+  orgSlug,
+  serviceSlug,
+}: {
+  orgSlug: string
+  serviceSlug: string
+}) {
+  const [showConfirm, setShowConfirm] = useState(false)
+  const sync = useServiceLifecycleSync(orgSlug, serviceSlug)
+  const onConfirm = () => {
+    sync.mutate(undefined, { onSettled: () => setShowConfirm(false) })
+  }
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sync lifecycle for all projects</CardTitle>
+        <CardDescription>
+          Push current Imbi state to the remote for every project that uses this
+          plugin -- re-running each project's upsert to create missing remotes
+          and update existing ones, with bounded concurrency.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {showConfirm ? (
+          <ResyncConfirm
+            isPending={sync.isPending}
+            onCancel={() => setShowConfirm(false)}
+            onConfirm={onConfirm}
+          />
+        ) : (
+          <Button
+            disabled={sync.isPending}
+            onClick={() => setShowConfirm(true)}
+            size="sm"
+            variant="outline"
+          >
+            Sync All Projects
+          </Button>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/src/components/plugin-options/OptionRow.tsx
+++ b/src/components/plugin-options/OptionRow.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
+import { KeyValueEditor } from '@/components/ui/key-value-editor'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -112,12 +113,21 @@ function IntegerControl({ id, onChange, placeholder, value }: ControlProps) {
   )
 }
 
+function MappingControl({ onChange, value }: ControlProps) {
+  const record =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, number | string>)
+      : {}
+  return <KeyValueEditor onChange={(next) => onChange(next)} value={record} />
+}
+
 const CONTROLS_BY_TYPE: Record<
   PluginOptionDef['type'],
   (p: ControlProps) => React.ReactNode
 > = {
   boolean: (p) => <BooleanControl {...p} />,
   integer: (p) => <IntegerControl {...p} />,
+  mapping: (p) => <MappingControl {...p} />,
   secret: (p) => <TextControl {...p} />,
   string: (p) => <TextControl {...p} />,
 }

--- a/src/components/project/IncidentsTab.tsx
+++ b/src/components/project/IncidentsTab.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { AlertTriangle, ExternalLink, RefreshCw } from 'lucide-react'
+
+import { searchProjectIncidents } from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
+import type { IncidentView } from '@/types'
+
+interface IncidentsTabProps {
+  orgSlug: string
+  projectId: string
+}
+
+type RelativeRange = '1d' | '7d' | '30d' | '90d'
+
+const RANGES: { key: RelativeRange; label: string; ms: number }[] = [
+  { key: '1d', label: '1d', ms: 24 * 60 * 60_000 },
+  { key: '7d', label: '7d', ms: 7 * 24 * 60 * 60_000 },
+  { key: '30d', label: '30d', ms: 30 * 24 * 60 * 60_000 },
+  { key: '90d', label: '90d', ms: 90 * 24 * 60 * 60_000 },
+]
+
+const STATUSES = ['triggered', 'acknowledged', 'resolved'] as const
+
+const URGENCY_CLASS: Record<string, string> = {
+  high: 'text-red-600 dark:text-red-400',
+  low: 'text-amber-600 dark:text-amber-400',
+}
+
+const STATUS_CLASS: Record<string, string> = {
+  acknowledged: 'text-amber-600 dark:text-amber-400',
+  resolved: 'text-muted-foreground',
+  triggered: 'text-red-600 dark:text-red-400',
+}
+
+// fallow-ignore-next-line complexity
+export function IncidentsTab({ orgSlug, projectId }: IncidentsTabProps) {
+  const [range, setRange] = useState<RelativeRange>('7d')
+  const [statuses, setStatuses] = useState<Set<string>>(() => new Set(STATUSES))
+  // Accumulated rows across "Load more" cursor pages. Reset whenever the
+  // filters change (handled by the effect below keyed on filterKey).
+  const [accumulated, setAccumulated] = useState<IncidentView[]>([])
+  const [cursor, setCursor] = useState<string | undefined>(undefined)
+
+  const filterKey = `${range}|${[...statuses].sort().join(',')}`
+  useEffect(() => {
+    setAccumulated([])
+    setCursor(undefined)
+  }, [filterKey])
+
+  const window = useMemo(() => {
+    const ms = RANGES.find((r) => r.key === range)?.ms ?? RANGES[1].ms
+    const end = new Date()
+    return {
+      end_time: end.toISOString(),
+      start_time: new Date(end.getTime() - ms).toISOString(),
+    }
+  }, [range])
+
+  const statusList = useMemo(() => [...statuses], [statuses])
+
+  const query = useQuery({
+    queryFn: ({ signal }) =>
+      searchProjectIncidents(
+        orgSlug,
+        projectId,
+        {
+          cursor,
+          end_time: window.end_time,
+          start_time: window.start_time,
+          status:
+            statusList.length === STATUSES.length ? undefined : statusList,
+        },
+        signal,
+      ),
+    queryKey: ['projectIncidents', orgSlug, projectId, filterKey, cursor ?? ''],
+  })
+
+  // Append each fetched page to the accumulator. Keyed on the data
+  // object identity so a refetch of the same cursor doesn't double-append.
+  useEffect(() => {
+    if (!query.data) return
+    setAccumulated((prev) =>
+      cursor ? [...prev, ...query.data.incidents] : query.data.incidents,
+    )
+  }, [query.data, cursor])
+
+  const toggleStatus = (status: string) => {
+    setStatuses((prev) => {
+      const next = new Set(prev)
+      if (next.has(status)) next.delete(status)
+      else next.add(status)
+      // Never allow an empty selection -- treat it as "all".
+      return next.size === 0 ? new Set(STATUSES) : next
+    })
+  }
+
+  const nextCursor = query.data?.next_cursor ?? null
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <SegmentedControl
+          onValueChange={(value) => setRange(value as RelativeRange)}
+          value={range}
+        >
+          {RANGES.map((r) => (
+            <SegmentedControlItem key={r.key} value={r.key}>
+              {r.label}
+            </SegmentedControlItem>
+          ))}
+        </SegmentedControl>
+        <div className="flex items-center gap-1">
+          {STATUSES.map((status) => (
+            <Button
+              key={status}
+              onClick={() => toggleStatus(status)}
+              size="sm"
+              variant={statuses.has(status) ? 'secondary' : 'ghost'}
+            >
+              {status}
+            </Button>
+          ))}
+        </div>
+        <Button
+          aria-label="Refresh incidents"
+          className="ml-auto"
+          disabled={query.isFetching}
+          onClick={() => void query.refetch()}
+          size="sm"
+          variant="ghost"
+        >
+          <RefreshCw
+            className={`size-4 ${query.isFetching ? 'animate-spin' : ''}`}
+          />
+        </Button>
+      </div>
+
+      {query.isLoading && accumulated.length === 0 ? (
+        <LoadingState label="Loading incidents…" />
+      ) : query.isError ? (
+        <div className="border-destructive/40 bg-destructive/5 text-destructive flex items-center gap-2 rounded-md border p-4 text-sm">
+          <AlertTriangle className="size-4" />
+          Failed to load incidents.
+        </div>
+      ) : accumulated.length === 0 ? (
+        <div className="text-muted-foreground rounded-md border p-8 text-center text-sm">
+          No incidents in the selected window.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground border-b text-left text-xs uppercase">
+              <tr>
+                <th className="px-3 py-2 font-medium">Incident</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 font-medium">Urgency</th>
+                <th className="px-3 py-2 font-medium">Opened</th>
+                <th className="px-3 py-2 font-medium">Resolved</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {accumulated.map((incident) => (
+                <IncidentRow incident={incident} key={incident.id} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {nextCursor && (
+        <div className="flex justify-center">
+          <Button
+            disabled={query.isFetching}
+            onClick={() => setCursor(nextCursor)}
+            size="sm"
+            variant="outline"
+          >
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function formatTimestamp(value: null | string | undefined): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? '—' : date.toLocaleString()
+}
+
+// fallow-ignore-next-line complexity
+function IncidentRow({ incident }: { incident: IncidentView }) {
+  return (
+    <tr className="hover:bg-muted/40">
+      <td className="px-3 py-2">
+        <a
+          className="text-foreground inline-flex items-center gap-1 hover:text-amber-600 hover:underline hover:dark:text-amber-400"
+          href={incident.url}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {incident.title || incident.id}
+          <ExternalLink className="size-3 opacity-60" />
+        </a>
+      </td>
+      <td className={`px-3 py-2 ${STATUS_CLASS[incident.status] ?? ''}`}>
+        {incident.status}
+      </td>
+      <td
+        className={`px-3 py-2 ${URGENCY_CLASS[incident.urgency ?? ''] ?? 'text-muted-foreground'}`}
+      >
+        {incident.urgency ?? '—'}
+      </td>
+      <td className="text-muted-foreground px-3 py-2">
+        {formatTimestamp(incident.created_at)}
+      </td>
+      <td className="text-muted-foreground px-3 py-2">
+        {formatTimestamp(incident.resolved_at)}
+      </td>
+    </tr>
+  )
+}

--- a/src/hooks/useLifecycleSync.ts
+++ b/src/hooks/useLifecycleSync.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import type { LifecycleSyncSummary } from '@/api/endpoints'
+import { syncProjectLifecycle, syncServiceLifecycle } from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+// Project-level lifecycle sync. Re-dispatches on_project_updated (an
+// upsert) for the one project, then invalidates the project + its plugins
+// so any newly-written links surface.
+export function useProjectLifecycleSync(orgSlug: string, projectId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => syncProjectLifecycle(orgSlug, projectId),
+    onError: onSyncError,
+    onSuccess: (summary: LifecycleSyncSummary) => {
+      toastResult(summary)
+      void queryClient.invalidateQueries({
+        queryKey: ['project', orgSlug, projectId],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: ['project-plugins', orgSlug, projectId],
+      })
+    },
+  })
+}
+
+// TPS-wide lifecycle sync. The fan-out can touch any project, so drop the
+// org/project scope and let TanStack invalidate every matching scope.
+export function useServiceLifecycleSync(orgSlug: string, serviceSlug: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => syncServiceLifecycle(orgSlug, serviceSlug),
+    onError: onSyncError,
+    onSuccess: (summary: LifecycleSyncSummary) => {
+      toastResult(summary)
+      void queryClient.invalidateQueries({ queryKey: ['project'] })
+      void queryClient.invalidateQueries({ queryKey: ['project-plugins'] })
+    },
+  })
+}
+
+function onSyncError(err: unknown): void {
+  toast.error(extractApiErrorDetail(err) ?? 'Failed to sync lifecycle')
+}
+
+function summarize(s: LifecycleSyncSummary): string {
+  const parts: string[] = []
+  if (s.synced > 0) parts.push(`${s.synced} synced`)
+  if (s.skipped > 0) parts.push(`${s.skipped} skipped`)
+  if (s.failed > 0) parts.push(`${s.failed} failed`)
+  return parts.length > 0 ? parts.join(', ') : 'Nothing to sync'
+}
+
+function toastResult(s: LifecycleSyncSummary): void {
+  const headline = summarize(s)
+  if (s.errors.length > 0) {
+    toast.warning(`Lifecycle sync finished with warnings: ${headline}`, {
+      description: s.errors
+        .slice(0, 5)
+        .map((e) => `${e.project_id}: ${e.detail}`)
+        .join(' • '),
+    })
+  } else {
+    toast.success(`Lifecycle sync complete: ${headline}`)
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -841,6 +841,25 @@ export interface IdentityPollingDescriptor {
   verification_uri_complete: null | string
 }
 
+// Mirrors imbi_common.plugins.IncidentResult / IncidentView, returned by
+// GET /organizations/{org}/projects/{id}/incidents/.
+export interface IncidentResult {
+  incidents: IncidentView[]
+  next_cursor: null | string
+  total: null | number
+}
+
+export interface IncidentView {
+  created_at: string
+  id: string
+  resolved_at?: null | string
+  service?: null | string
+  status: string
+  title: string
+  urgency?: null | string
+  url: string
+}
+
 export interface InstalledPlugin {
   api_version: number
   auth_type: 'api_token' | 'aws-iam-ic' | 'oauth2' | 'oidc'
@@ -868,6 +887,7 @@ export interface InstalledPlugin {
   slug: string
   supported_tabs: PluginType[]
   supports_deployment_sync?: boolean
+  supports_lifecycle_sync?: boolean
   vertex_labels?: PluginVertexLabel[]
   // Body copy shown on the dashboard "unconnected integration" widget.
   // Resolved server-side (override > manifest > null).  ``_default`` is
@@ -1111,6 +1131,7 @@ export interface PluginAssignmentResponse {
   source: 'merged' | 'project' | 'project_type'
   supports_deployment_sync?: boolean
   supports_histogram?: boolean
+  supports_lifecycle_sync?: boolean
 }
 export interface PluginAssignmentRow {
   default: boolean
@@ -1183,7 +1204,7 @@ export interface PluginOptionDef {
   label: string
   name: string
   required: boolean
-  type: 'boolean' | 'integer' | 'secret' | 'string'
+  type: 'boolean' | 'integer' | 'mapping' | 'secret' | 'string'
 }
 
 // Plugin types (hand-written until api-generated.ts snapshot is refreshed)
@@ -1204,7 +1225,12 @@ export interface PluginResponse {
 }
 // The subset of plugin types that render a project-detail tab. Not
 // every plugin type is a tab (e.g. webhook, analysis): tabs ⊆ plugins.
-export type PluginTab = 'configuration' | 'deployment' | 'lifecycle' | 'logs'
+export type PluginTab =
+  | 'configuration'
+  | 'deployment'
+  | 'incidents'
+  | 'lifecycle'
+  | 'logs'
 // A plugin assignment is keyed by the plugin's type. Mirrors
 // imbi_common.plugins.PluginType (the full manifest set).
 export type PluginType =
@@ -1212,6 +1238,7 @@ export type PluginType =
   | 'configuration'
   | 'deployment'
   | 'identity'
+  | 'incidents'
   | 'lifecycle'
   | 'logs'
   | 'webhook'


### PR DESCRIPTION
Phase 5 of the PagerDuty plugin effort — surfaces the incidents and lifecycle-sync capabilities added across imbi-common, imbi-api, imbi-gateway, and the new `imbi-plugin-pagerduty` package.

## Changes

- **types** (`src/types/index.ts`): `'incidents'` plugin tab/type, `IncidentResult`/`IncidentView` models, `supports_lifecycle_sync` on the plugin manifest/assignment shapes, and a `'mapping'` plugin-option type.
- **endpoints** (`src/api/endpoints.ts`): `searchProjectIncidents` plus `syncProjectLifecycle`/`syncServiceLifecycle`.
- **IncidentsTab** (new): read-only live-query table with relative-range (1d/7d/30d/90d) and status filters, cursor-based "Load more" paging, and loading/error/empty states. Wired into `ProjectDetail` behind `hasIncidentsPlugin`.
- **useLifecycleSync** hook (new) + "Sync lifecycle" cards:
  - admin third-party-services page, gated on `manifest.supports_lifecycle_sync`
  - per-project `ProjectSettingsTab`, gated on `hasLifecyclePlugin`
- **OptionRow**: renders `type='mapping'` options via the existing `KeyValueEditor` (e.g. `team_escalation_policy_mapping`).

## Verification

- `tsc --noEmit` clean
- `oxlint` 0 errors
- `fallow audit --base origin/main` gate green (the two `IncidentsTab` complexity findings carry sanctioned `// fallow-ignore` suppressions; duplication is warn-only)

Depends on the imbi-common 2.11 release (Phase 6) for the runtime contracts; the UI degrades gracefully (tabs/cards only appear when the corresponding plugin capability is present).