### PR TITLE
Add Releases tab for build-and-release-only projects

### DIFF
--- a/src/api/releases.ts
+++ b/src/api/releases.ts
@@ -33,7 +33,10 @@ export const getReleaseHistory = async (
     undefined,
     signal,
   )
-  return Array.isArray(response) ? response : []
+  if (!Array.isArray(response)) {
+    throw new Error('Unexpected release-history response: expected an array')
+  }
+  return response
 }
 
 export const cutRelease = (

--- a/src/api/releases.ts
+++ b/src/api/releases.ts
@@ -1,0 +1,47 @@
+// Releases-tab API calls (build-and-release-only projects). Kept separate
+// from the large endpoints.ts so this focused surface stays readable.
+import type {
+  CutReleaseRequest,
+  CutReleaseResponse,
+  ReleaseDrift,
+  ReleaseHistoryEntry,
+} from '@/types'
+
+import { apiClient } from './client'
+
+const base = (orgSlug: string, projectId: string): string =>
+  `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/deployments`
+
+export const getReleaseDrift = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<ReleaseDrift> =>
+  apiClient.get<ReleaseDrift>(
+    `${base(orgSlug, projectId)}/release-drift`,
+    undefined,
+    signal,
+  )
+
+export const getReleaseHistory = async (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<ReleaseHistoryEntry[]> => {
+  const response = await apiClient.get<ReleaseHistoryEntry[]>(
+    `${base(orgSlug, projectId)}/release-history`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
+}
+
+export const cutRelease = (
+  orgSlug: string,
+  projectId: string,
+  body: CutReleaseRequest,
+): Promise<CutReleaseResponse> =>
+  apiClient.post<CutReleaseResponse>(
+    `${base(orgSlug, projectId)}/releases/cut`,
+    body,
+  )

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -61,6 +61,7 @@ import { ProjectDoctorTab } from '@/components/ProjectDoctorTab'
 import { ProjectEnvironmentsCard } from '@/components/ProjectEnvironmentsCard'
 import { ProjectRelationshipsTab } from '@/components/ProjectRelationshipsTab'
 import { ProjectSettingsTab } from '@/components/ProjectSettingsTab'
+import { ReleasesTab } from '@/components/releases/ReleasesTab'
 import { RelocatePreviewDialog } from '@/components/RelocatePreviewDialog'
 import { ScoreHistoryTab } from '@/components/ScoreHistoryTab'
 import { Button } from '@/components/ui/button'
@@ -109,6 +110,7 @@ const VALID_TABS = [
   'configuration',
   'dependencies',
   'relationships',
+  'releases',
   'logs',
   'incidents',
   'documents',
@@ -491,6 +493,12 @@ export function ProjectDetail({
   const deploymentIdentityPluginId =
     deploymentPlugin?.identity_plugin_id ?? null
 
+  // Build-and-release-only projects: a deployment plugin is assigned but the
+  // project has no environments to roll out to, so the "Releases" tab shows
+  // instead. (The Deployments tab for env-having projects is a future task;
+  // inverting this condition is the single switch that will gate it.)
+  const isReleaseOnly = !!deploymentPlugin && sortedEnvironments.length === 0
+
   // Per-user identity connections — used to gate deploy/promote on the
   // current user actually having an active connection to the deployment
   // provider. Without this, chips render as buttons that 401 on click.
@@ -624,6 +632,7 @@ export function ProjectDetail({
       (activeTab === 'configuration' && !hasConfigurationPlugin) ||
       (activeTab === 'logs' && !hasLogsPlugin) ||
       (activeTab === 'incidents' && !hasIncidentsPlugin) ||
+      (activeTab === 'releases' && !isReleaseOnly) ||
       (activeTab === 'pull-requests' && !hasLifecyclePlugin)
     ) {
       navigate(`/projects/${project.id}`, { replace: true })
@@ -634,6 +643,7 @@ export function ProjectDetail({
     hasIncidentsPlugin,
     hasLifecyclePlugin,
     hasLogsPlugin,
+    isReleaseOnly,
     navigate,
     project.id,
     projectPluginsFetched,
@@ -767,6 +777,7 @@ export function ProjectDetail({
       ? [{ id: 'incidents' as const, label: 'Incidents' }]
       : []),
     { id: 'operations-log', label: 'Operations Log' },
+    ...(isReleaseOnly ? [{ id: 'releases' as const, label: 'Releases' }] : []),
     ...(hasLifecyclePlugin
       ? [
           {
@@ -1296,6 +1307,11 @@ export function ProjectDetail({
             showSummary={false}
           />
         </TabsContent>
+        {isReleaseOnly && (
+          <TabsContent value="releases">
+            <ReleasesTab orgSlug={orgSlug} project={project} />
+          </TabsContent>
+        )}
         {hasLifecyclePlugin && (
           <TabsContent value="pull-requests">
             <ProjectPullRequestsTab orgSlug={orgSlug} projectId={project.id} />

--- a/src/components/releases/CiStatusDot.tsx
+++ b/src/components/releases/CiStatusDot.tsx
@@ -1,0 +1,55 @@
+import {
+  Check,
+  CircleDashed,
+  type LucideIcon,
+  TriangleAlert,
+  X,
+} from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+import type { DeploymentCommitCiStatus } from '@/types'
+
+interface CiStatusDotProps {
+  className?: string
+  size?: number
+  status: DeploymentCommitCiStatus | null | string
+}
+
+const MAP: Record<string, { color: string; icon: LucideIcon; title: string }> =
+  {
+    fail: { color: 'text-danger', icon: X, title: 'CI failed' },
+    pass: { color: 'text-success', icon: Check, title: 'CI passed' },
+    unknown: {
+      color: 'text-tertiary',
+      icon: CircleDashed,
+      title: 'CI status unknown',
+    },
+    warn: {
+      color: 'text-warning',
+      icon: TriangleAlert,
+      title: 'CI passed with warnings',
+    },
+  }
+
+/** A small, colour-independent CI status indicator (icon carries meaning). */
+export function CiStatusDot({
+  className,
+  size = 14,
+  status,
+}: CiStatusDotProps) {
+  const s = MAP[status ?? 'unknown'] ?? MAP.unknown
+  const Icon = s.icon
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center rounded-full border',
+        s.color,
+        className,
+      )}
+      style={{ height: size + 2, width: size + 2 }}
+      title={s.title}
+    >
+      <Icon size={size - 4} strokeWidth={3} />
+    </span>
+  )
+}

--- a/src/components/releases/CurrentlyReleasedCard.test.tsx
+++ b/src/components/releases/CurrentlyReleasedCard.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { render } from '@/test/utils'
+import type { ReleaseHistoryEntry } from '@/types'
+
+import { deriveArtifact } from './artifact'
+import { CurrentlyReleasedCard } from './CurrentlyReleasedCard'
+
+const RELEASE: ReleaseHistoryEntry = {
+  author: 'Gavin',
+  ci_status: 'pass',
+  notes_markdown: '## Notes',
+  published_at: '2026-01-01T00:00:00Z',
+  release_url: 'https://gh/releases/v1.0.0',
+  sha: 'abc1234def',
+  short_sha: 'abc1234',
+  tag: 'v1.0.0',
+}
+
+describe('CurrentlyReleasedCard', () => {
+  it('renders the tag, sha and author', () => {
+    render(
+      <CurrentlyReleasedCard
+        artifact={deriveArtifact({ links: {}, name: 'lib' })}
+        released={RELEASE}
+      />,
+    )
+    expect(screen.getByText('v1.0.0')).toBeInTheDocument()
+    expect(screen.getByText('abc1234')).toBeInTheDocument()
+    expect(screen.getByText('Gavin')).toBeInTheDocument()
+  })
+
+  it('hides the pull command and index link for an unknown artifact', () => {
+    render(
+      <CurrentlyReleasedCard
+        artifact={deriveArtifact({ links: {}, name: 'lib' })}
+        released={RELEASE}
+      />,
+    )
+    expect(screen.queryByText(/pip install|docker pull/)).toBeNull()
+    expect(screen.queryByText('Package index')).toBeNull()
+  })
+
+  it('shows a pull command for a pypi-linked project', () => {
+    render(
+      <CurrentlyReleasedCard
+        artifact={deriveArtifact({
+          links: { pypi: 'https://pypi.org/project/address-verification' },
+          name: 'address-verification',
+        })}
+        released={RELEASE}
+      />,
+    )
+    expect(
+      screen.getByText('pip install address-verification'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders an empty state when nothing is released', () => {
+    render(
+      <CurrentlyReleasedCard
+        artifact={deriveArtifact({ links: {}, name: 'lib' })}
+        released={null}
+      />,
+    )
+    expect(screen.getByText('No releases published yet.')).toBeInTheDocument()
+  })
+})

--- a/src/components/releases/CurrentlyReleasedCard.tsx
+++ b/src/components/releases/CurrentlyReleasedCard.tsx
@@ -1,0 +1,94 @@
+import { Clock, ExternalLink, User } from 'lucide-react'
+
+import { formatRelativeDate } from '@/lib/formatDate'
+import type { ReleaseHistoryEntry } from '@/types'
+
+import type { ArtifactInfo } from './artifact'
+import { CiStatusDot } from './CiStatusDot'
+
+interface CurrentlyReleasedCardProps {
+  artifact: ArtifactInfo
+  released: null | ReleaseHistoryEntry
+}
+
+export function CurrentlyReleasedCard({
+  artifact,
+  released,
+}: CurrentlyReleasedCardProps) {
+  const ArtifactIcon = artifact.icon
+  return (
+    <div className="border-tertiary bg-primary rounded-lg border px-4 py-4">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <p className="text-tertiary text-xs tracking-wider uppercase">
+          Currently released
+        </p>
+        {artifact.indexUrl ? (
+          <a
+            className="text-tertiary hover:text-primary inline-flex items-center gap-1.5 text-xs"
+            href={artifact.indexUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <ArtifactIcon size={13} />
+            {artifact.indexLabel ?? 'Package index'}
+          </a>
+        ) : null}
+      </div>
+
+      {released ? (
+        <>
+          <div className="flex items-baseline gap-2.5">
+            <span className="font-mono text-xl font-semibold">
+              {released.tag}
+            </span>
+            <span className="text-tertiary font-mono text-xs">
+              {released.short_sha}
+            </span>
+            <CiStatusDot status={released.ci_status} />
+          </div>
+          <div className="mt-2.5 flex flex-wrap items-center gap-4">
+            <StatPill icon={Clock}>
+              Published {formatRelativeDate(released.published_at)}
+            </StatPill>
+            {released.author ? (
+              <StatPill icon={User}>{released.author}</StatPill>
+            ) : null}
+            {artifact.pull ? (
+              <StatPill icon={ArtifactIcon}>
+                <span className="font-mono">{artifact.pull}</span>
+              </StatPill>
+            ) : null}
+            {released.release_url ? (
+              <a
+                className="text-tertiary hover:text-primary inline-flex items-center gap-1 text-xs"
+                href={released.release_url}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <ExternalLink size={12} />
+                Release notes
+              </a>
+            ) : null}
+          </div>
+        </>
+      ) : (
+        <p className="text-tertiary text-sm">No releases published yet.</p>
+      )}
+    </div>
+  )
+}
+
+function StatPill({
+  children,
+  icon: Icon,
+}: {
+  children: React.ReactNode
+  icon: typeof Clock
+}) {
+  return (
+    <span className="text-tertiary inline-flex items-center gap-1.5 text-xs">
+      <Icon size={13} />
+      {children}
+    </span>
+  )
+}

--- a/src/components/releases/ReleaseCommitPicker.tsx
+++ b/src/components/releases/ReleaseCommitPicker.tsx
@@ -1,0 +1,105 @@
+import { Check, ExternalLink } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import type { RecentCommit } from '@/types'
+
+import { CiStatusDot } from './CiStatusDot'
+
+interface CommitRowProps {
+  active: boolean
+  commit: RecentCommit
+  held: boolean
+  idx: number
+  onSelect: (sha: string) => void
+}
+
+interface ReleaseCommitPickerProps {
+  commits: RecentCommit[]
+  onSelect: (sha: string) => void
+  selectedSha: null | string
+}
+
+/**
+ * Selectable commit list for the release form. Newest-first; commits newer
+ * than the selection dim (they'd be held back). The selected row expands to
+ * its full commit message.
+ */
+export function ReleaseCommitPicker({
+  commits,
+  onSelect,
+  selectedSha,
+}: ReleaseCommitPickerProps) {
+  const selIdx = commits.findIndex((c) => c.sha === selectedSha)
+  return (
+    <div className="border-tertiary bg-primary overflow-hidden rounded-md border">
+      {commits.map((c, idx) => (
+        <CommitRow
+          active={c.sha === selectedSha}
+          commit={c}
+          held={selIdx >= 0 && idx < selIdx}
+          idx={idx}
+          key={c.sha}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function CommitRow({ active, commit, held, idx, onSelect }: CommitRowProps) {
+  const lines = commit.message.split('\n')
+  const subject = lines[0] ?? ''
+  const body = lines.slice(1).join('\n').trim()
+  return (
+    <div
+      className={cn(
+        'border-b border-tertiary last:border-b-0',
+        held && 'opacity-50',
+      )}
+    >
+      <button
+        className={cn(
+          'flex w-full min-w-0 items-center gap-3 px-3 py-2 text-left transition-colors',
+          active ? 'bg-action/5' : 'hover:bg-secondary',
+        )}
+        onClick={() => onSelect(commit.sha)}
+        type="button"
+      >
+        <span
+          className={cn(
+            'flex size-4 shrink-0 items-center justify-center rounded-full border',
+            active ? 'border-action bg-action text-white' : 'border-secondary',
+          )}
+        >
+          {active ? <Check size={10} strokeWidth={3} /> : null}
+        </span>
+        <span className="text-secondary shrink-0 font-mono text-xs">
+          {commit.short_sha}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm">{subject}</span>
+        <CiStatusDot status={commit.ci_status} />
+        <Badge variant="neutral">{idx === 0 ? 'tip' : `−${idx}`}</Badge>
+      </button>
+      {active && body ? (
+        <pre className="bg-action/5 text-secondary overflow-x-auto px-3 pt-1 pb-3 pl-13 font-mono text-xs whitespace-pre-wrap">
+          {body}
+        </pre>
+      ) : null}
+      {active && commit.url ? (
+        <div className="bg-action/5 px-3 pb-2 pl-13">
+          <a
+            className="text-tertiary hover:text-primary inline-flex items-center gap-1 text-xs"
+            href={commit.url}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <ExternalLink size={11} />
+            View commit
+          </a>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/releases/ReleaseHistory.test.tsx
+++ b/src/components/releases/ReleaseHistory.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { render } from '@/test/utils'
+import type { ReleaseHistoryEntry } from '@/types'
+
+import { deriveArtifact } from './artifact'
+import { ReleaseHistory } from './ReleaseHistory'
+
+const RELEASES: ReleaseHistoryEntry[] = [
+  {
+    author: 'Gavin',
+    ci_status: 'pass',
+    notes_markdown: '## Added\n- A thing',
+    published_at: '2026-01-02T00:00:00Z',
+    release_url: 'https://gh/releases/v1.1.0',
+    sha: 'aaa1111bbb',
+    short_sha: 'aaa1111',
+    tag: 'v1.1.0',
+  },
+  {
+    author: 'Kevin',
+    ci_status: 'warn',
+    notes_markdown: null,
+    published_at: '2026-01-01T00:00:00Z',
+    release_url: null,
+    sha: 'ccc2222ddd',
+    short_sha: 'ccc2222',
+    tag: 'v1.0.0',
+  },
+]
+
+const ARTIFACT = deriveArtifact({ links: {}, name: 'lib' })
+
+describe('ReleaseHistory', () => {
+  it('renders each release with a Latest badge on the current tag', () => {
+    render(
+      <ReleaseHistory
+        artifact={ARTIFACT}
+        currentTag="v1.1.0"
+        releases={RELEASES}
+      />,
+    )
+    expect(screen.getByText('v1.1.0')).toBeInTheDocument()
+    expect(screen.getByText('v1.0.0')).toBeInTheDocument()
+    expect(screen.getByText('Latest')).toBeInTheDocument()
+  })
+
+  it('expands a row to render its markdown notes', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReleaseHistory
+        artifact={ARTIFACT}
+        currentTag="v1.1.0"
+        releases={RELEASES}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /v1\.1\.0/ }))
+    expect(screen.getByText('A thing')).toBeInTheDocument()
+  })
+
+  it('renders nothing when there are no releases', () => {
+    const { container } = render(
+      <ReleaseHistory artifact={ARTIFACT} currentTag={null} releases={[]} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/releases/ReleaseHistory.tsx
+++ b/src/components/releases/ReleaseHistory.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react'
+
+import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+import { Badge } from '@/components/ui/badge'
+import { formatRelativeDate } from '@/lib/formatDate'
+import { cn } from '@/lib/utils'
+import type { ReleaseHistoryEntry } from '@/types'
+
+import type { ArtifactInfo } from './artifact'
+import { CiStatusDot } from './CiStatusDot'
+
+interface ReleaseHistoryProps {
+  artifact: ArtifactInfo
+  currentTag: null | string
+  releases: ReleaseHistoryEntry[]
+}
+
+interface ReleaseRowProps {
+  artifact: ArtifactInfo
+  isCurrent: boolean
+  isOpen: boolean
+  onToggle: () => void
+  rel: ReleaseHistoryEntry
+}
+
+export function ReleaseHistory({
+  artifact,
+  currentTag,
+  releases,
+}: ReleaseHistoryProps) {
+  const [open, setOpen] = useState<null | string>(null)
+  if (releases.length === 0) return null
+  return (
+    <div className="border-tertiary mt-3 border-t pt-3">
+      <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+        Release history
+      </p>
+      <div>
+        {releases.map((rel) => (
+          <ReleaseRow
+            artifact={artifact}
+            isCurrent={rel.tag === currentTag}
+            isOpen={open === rel.tag}
+            key={rel.tag}
+            onToggle={() => setOpen((o) => (o === rel.tag ? null : rel.tag))}
+            rel={rel}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function ReleaseRow({
+  artifact,
+  isCurrent,
+  isOpen,
+  onToggle,
+  rel,
+}: ReleaseRowProps) {
+  return (
+    <div
+      className={cn(
+        '-mx-2 rounded-md transition-colors',
+        isOpen && 'bg-secondary',
+      )}
+    >
+      <button
+        className="hover:bg-secondary grid w-full grid-cols-[auto_auto_auto_1fr_auto] items-center gap-3 rounded-md px-2 py-1.5 text-left"
+        onClick={onToggle}
+        type="button"
+      >
+        {isOpen ? (
+          <ChevronDown className="text-tertiary size-3.5" />
+        ) : (
+          <ChevronRight className="text-tertiary size-3.5" />
+        )}
+        <span className="flex items-center gap-2">
+          <span className="font-mono text-sm font-semibold">{rel.tag}</span>
+          <CiStatusDot size={13} status={rel.ci_status} />
+        </span>
+        <span className="text-tertiary font-mono text-xs">{rel.short_sha}</span>
+        <span className="text-tertiary text-xs">
+          {formatRelativeDate(rel.published_at)}
+        </span>
+        {isCurrent ? <Badge variant="accent">Latest</Badge> : <span />}
+      </button>
+      {isOpen ? (
+        <div className="px-2 pb-3 pl-[2.1rem]">
+          {rel.notes_markdown ? (
+            <div className="document-markdown max-w-none text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+              <Markdown
+                components={{
+                  a: (props) => (
+                    <a {...props} rel="noopener noreferrer" target="_blank" />
+                  ),
+                }}
+                remarkPlugins={[remarkGfm]}
+              >
+                {rel.notes_markdown}
+              </Markdown>
+            </div>
+          ) : (
+            <p className="text-tertiary text-xs">No release notes.</p>
+          )}
+          <div className="mt-2 flex flex-wrap items-center gap-4">
+            {rel.author ? (
+              <span className="text-tertiary text-xs">
+                released by {rel.author}
+              </span>
+            ) : null}
+            {(rel.release_url ?? rel.tag_url) ? (
+              <a
+                className="text-tertiary hover:text-primary inline-flex items-center gap-1 text-xs"
+                href={(rel.release_url ?? rel.tag_url) as string}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <ExternalLink size={12} />
+                {rel.release_url ? 'Release notes' : 'View tag'}
+              </a>
+            ) : null}
+            {artifact.indexUrl ? (
+              <a
+                className="text-tertiary hover:text-primary inline-flex items-center gap-1 text-xs"
+                href={artifact.indexUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <artifact.icon size={12} />
+                {artifact.indexLabel ?? 'Package index'}
+              </a>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/releases/ReleaseReadyCard.test.tsx
+++ b/src/components/releases/ReleaseReadyCard.test.tsx
@@ -1,0 +1,141 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import * as releases from '@/api/releases'
+import { render } from '@/test/utils'
+import type { ReleaseDrift } from '@/types'
+
+import { ReleaseReadyCard } from './ReleaseReadyCard'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return { ...actual, draftReleaseNotes: vi.fn() }
+})
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/releases', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/releases')>('@/api/releases')
+  return { ...actual, cutRelease: vi.fn() }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    loading: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+const COMMITS = [
+  {
+    author: 'Alice',
+    authored_at: '2026-01-02T00:00:00Z',
+    ci_status: 'pass' as const,
+    message: 'feat: a new thing',
+    sha: 'aaa1111',
+    short_sha: 'aaa1111',
+    url: null,
+  },
+  {
+    author: 'Bob',
+    authored_at: '2026-01-01T00:00:00Z',
+    ci_status: 'pass' as const,
+    message: 'fix: a bug',
+    sha: 'bbb2222',
+    short_sha: 'bbb2222',
+    url: null,
+  },
+]
+
+// First-release drift (no prior tag) -> no AI auto-draft to interfere.
+const FIRST_RELEASE: ReleaseDrift = {
+  commits: COMMITS,
+  commits_since_tag: 2,
+  head_sha: 'aaa1111',
+  latest_tag: null,
+  latest_tag_at: null,
+  latest_tag_sha: null,
+  suggested_bump: 'minor',
+  suggested_tag: 'v0.1.0',
+}
+
+function renderCard(drift: ReleaseDrift) {
+  render(
+    <ReleaseReadyCard
+      drift={drift}
+      onCut={() => {}}
+      orgSlug="acme"
+      projectId="p1"
+    />,
+  )
+}
+
+describe('ReleaseReadyCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(releases.cutRelease).mockResolvedValue({
+      committish: 'aaa1111',
+      recorded: true,
+      release_url: 'https://gh/releases/v0.1.0',
+      tag: 'v0.1.0',
+    })
+  })
+
+  it('renders the up-to-date card when there is no drift', () => {
+    renderCard({ ...FIRST_RELEASE, commits: [], commits_since_tag: 0 })
+    expect(screen.getByText('Up to date')).toBeInTheDocument()
+  })
+
+  it('cuts a release with the tip commit and suggested tag', async () => {
+    const user = userEvent.setup()
+    renderCard(FIRST_RELEASE)
+    await user.click(screen.getByRole('button', { name: /& release/i }))
+    await waitFor(() => {
+      expect(releases.cutRelease).toHaveBeenCalledWith('acme', 'p1', {
+        committish: 'aaa1111',
+        release_name: 'v0.1.0',
+        release_notes_markdown: '',
+        tag: 'v0.1.0',
+      })
+    })
+  })
+
+  it('blocks submission on an invalid semver tag', async () => {
+    const user = userEvent.setup()
+    renderCard(FIRST_RELEASE)
+    const tagInput = screen.getByPlaceholderText('vX.Y.Z')
+    await user.clear(tagInput)
+    await user.type(tagInput, 'main')
+    expect(screen.getByText(/Use a semver tag/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /& release/i })).toBeDisabled()
+  })
+
+  it('auto-drafts release notes when a prior tag exists', async () => {
+    vi.mocked(endpoints.draftReleaseNotes).mockResolvedValue({
+      bump: 'major',
+      commits_considered: 2,
+      degraded: false,
+      notes_markdown: '## AI notes',
+      reasoning: 'big change',
+      version: 'v2.0.0',
+    })
+    renderCard({
+      ...FIRST_RELEASE,
+      latest_tag: 'v1.0.0',
+      latest_tag_sha: 'tagsha',
+      suggested_tag: 'v1.1.0',
+    })
+    await waitFor(() => {
+      expect(endpoints.draftReleaseNotes).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('v2.0.0')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/releases/ReleaseReadyCard.tsx
+++ b/src/components/releases/ReleaseReadyCard.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useState } from 'react'
+
+import { useMutation } from '@tanstack/react-query'
+import { Check, Loader2, RefreshCw, Rocket, Sparkles, Tag } from 'lucide-react'
+
+import { draftReleaseNotes } from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { SEMVER_RE } from '@/lib/semver'
+import type { DraftReleaseNotesResponse, ReleaseDrift } from '@/types'
+
+import { ReleaseCommitPicker } from './ReleaseCommitPicker'
+import { useCutReleaseMutation } from './useCutReleaseMutation'
+
+interface ReleaseReadyCardProps {
+  drift: ReleaseDrift
+  onCut: () => void
+  orgSlug: string
+  projectId: string
+}
+
+interface TagFieldsProps {
+  latestTag: null | string
+  onChange: (value: string) => void
+  tag: string
+  tagValid: boolean
+}
+
+// fallow-ignore-next-line complexity
+export function ReleaseReadyCard({
+  drift,
+  onCut,
+  orgSlug,
+  projectId,
+}: ReleaseReadyCardProps) {
+  const commits = drift.commits
+  const [selectedSha, setSelectedSha] = useState<null | string>(
+    commits[0]?.sha ?? null,
+  )
+  const [tag, setTag] = useState<string>(drift.suggested_tag)
+  const [notes, setNotes] = useState<string>('')
+  const [tagDirty, setTagDirty] = useState(false)
+  const [notesDirty, setNotesDirty] = useState(false)
+
+  // AI drafting needs a base tag to compare against; for the first-ever
+  // release there's nothing to diff, so notes are authored by hand.
+  const canDraft = !!drift.latest_tag_sha && !!selectedSha
+  const draftMutation = useMutation({
+    mutationFn: ({ headSha }: { headSha: string }) =>
+      draftReleaseNotes(orgSlug, projectId, {
+        base_sha: drift.latest_tag_sha ?? '',
+        head_sha: headSha,
+        last_tag: drift.latest_tag,
+      }),
+  })
+  const seedFromDraft = (data: DraftReleaseNotesResponse) => {
+    if (!tagDirty) setTag(data.version)
+    if (!notesDirty) setNotes(data.notes_markdown)
+  }
+
+  // Auto-draft once on mount when a diff against the prior tag exists.
+  useEffect(() => {
+    if (!canDraft || !selectedSha) return
+    draftMutation.mutate({ headSha: selectedSha }, { onSuccess: seedFromDraft })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const { cut, isPending } = useCutReleaseMutation({
+    onSuccess: onCut,
+    orgSlug,
+    projectId,
+  })
+
+  // Up to date — nothing new to cut.
+  if (commits.length === 0) {
+    return (
+      <div className="border-success bg-success/10 flex items-center gap-3 rounded-lg border p-4">
+        <span className="text-success">
+          <Check size={18} strokeWidth={3} />
+        </span>
+        <div>
+          <div className="text-sm font-semibold">Up to date</div>
+          <div className="text-tertiary mt-0.5 text-xs">
+            The latest commit is already released — nothing new to cut.
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const tagValid = SEMVER_RE.test(tag)
+  const canSubmit = tagValid && !!selectedSha && !isPending
+  const reset = () => {
+    setSelectedSha(commits[0]?.sha ?? null)
+    setTag(drift.suggested_tag)
+    setNotes('')
+    setTagDirty(false)
+    setNotesDirty(false)
+  }
+  const submit = () => {
+    if (!selectedSha) return
+    cut({
+      committish: selectedSha,
+      release_name: tag,
+      release_notes_markdown: notes,
+      tag,
+    })
+  }
+
+  return (
+    <div className="border-action overflow-hidden rounded-lg border">
+      <div className="border-action bg-action/10 flex items-center gap-3 border-b px-4 py-3">
+        <span className="border-action bg-primary text-action flex size-8 shrink-0 items-center justify-center rounded-md border">
+          <Tag size={16} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold">
+            {drift.commits_since_tag} commit
+            {drift.commits_since_tag === 1 ? '' : 's'} ready to release
+          </div>
+          <div className="text-action mt-0.5 text-xs">
+            Build at{' '}
+            <span className="font-mono">
+              {drift.head_sha?.slice(0, 7) ?? '—'}
+            </span>{' '}
+            · cutting <span className="font-mono">{drift.suggested_tag}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4 px-4 py-4">
+        <section>
+          <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+            Select the newest commit to include
+          </p>
+          <ReleaseCommitPicker
+            commits={commits}
+            onSelect={setSelectedSha}
+            selectedSha={selectedSha}
+          />
+        </section>
+
+        <section className="border-tertiary flex flex-col gap-2 border-t pt-4">
+          <p className="text-tertiary text-xs tracking-wider uppercase">
+            Tag & release notes
+          </p>
+          <TagFields
+            latestTag={drift.latest_tag}
+            onChange={(v) => {
+              setTag(v)
+              setTagDirty(true)
+            }}
+            tag={tag}
+            tagValid={tagValid}
+          />
+          {!tagValid && tag.length > 0 ? (
+            <span className="text-danger text-xs">
+              Use a semver tag, e.g. v6.5.2
+            </span>
+          ) : null}
+          {canDraft ? (
+            <div className="flex items-center justify-between">
+              <span className="text-tertiary text-xs">
+                {drift.suggested_bump
+                  ? `AI suggests a ${drift.suggested_bump} bump → `
+                  : ''}
+                <span className="font-mono">{drift.suggested_tag}</span>
+              </span>
+              <Button
+                disabled={!selectedSha || draftMutation.isPending}
+                onClick={() => {
+                  if (!selectedSha) return
+                  draftMutation.mutate(
+                    { headSha: selectedSha },
+                    {
+                      onSuccess: (data) => {
+                        setTagDirty(false)
+                        setNotesDirty(false)
+                        setTag(data.version)
+                        setNotes(data.notes_markdown)
+                      },
+                    },
+                  )
+                }}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                {draftMutation.isPending ? (
+                  <RefreshCw className="mr-1 size-3.5 animate-spin" />
+                ) : (
+                  <Sparkles className="mr-1 size-3.5" />
+                )}
+                Regenerate with AI
+              </Button>
+            </div>
+          ) : null}
+          <Textarea
+            className="min-h-40 font-mono text-xs"
+            onChange={(e) => {
+              setNotes(e.target.value)
+              setNotesDirty(true)
+            }}
+            placeholder="## Highlights&#10;- …"
+            value={notes}
+          />
+        </section>
+
+        <div className="border-tertiary flex items-center justify-end gap-2 border-t pt-4">
+          <Button onClick={reset} type="button" variant="ghost">
+            Reset
+          </Button>
+          <Button disabled={!canSubmit} onClick={submit} type="button">
+            {isPending ? (
+              <Loader2 className="mr-1 size-4 animate-spin" />
+            ) : (
+              <Rocket className="mr-1 size-4" />
+            )}
+            {`Tag ${tag || 'vX.Y.Z'} & release`}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// The current/new tag input pair mirrors the deploy PromoteTab's; kept as a
+// small local component rather than shared to avoid coupling the two flows.
+// fallow-ignore-next-line duplication
+function TagFields({ latestTag, onChange, tag, tagValid }: TagFieldsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <Label className="text-tertiary flex flex-col gap-1 text-xs">
+        Current
+        <Input
+          className="bg-tertiary font-mono"
+          disabled
+          value={latestTag ?? '—'}
+        />
+      </Label>
+      <Label className="text-tertiary flex flex-col gap-1 text-xs">
+        New tag
+        <Input
+          aria-invalid={!tagValid && tag.length > 0}
+          className="font-mono"
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="vX.Y.Z"
+          value={tag}
+        />
+      </Label>
+    </div>
+  )
+}

--- a/src/components/releases/ReleasesTab.tsx
+++ b/src/components/releases/ReleasesTab.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { GitBranch } from 'lucide-react'
+
+import { getReleaseDrift, getReleaseHistory } from '@/api/releases'
+import { LoadingState } from '@/components/ui/loading-state'
+import type { Project } from '@/types'
+
+import { deriveArtifact } from './artifact'
+import { CurrentlyReleasedCard } from './CurrentlyReleasedCard'
+import { ReleaseHistory } from './ReleaseHistory'
+import { ReleaseReadyCard } from './ReleaseReadyCard'
+
+interface ReleasesTabProps {
+  orgSlug: string
+  project: Pick<Project, 'id' | 'links' | 'name'>
+}
+
+// fallow-ignore-next-line complexity
+export function ReleasesTab({ orgSlug, project }: ReleasesTabProps) {
+  const enabled = !!orgSlug && !!project.id
+  const {
+    data: drift,
+    error: driftError,
+    isLoading: driftLoading,
+  } = useQuery({
+    enabled,
+    queryFn: ({ signal }) => getReleaseDrift(orgSlug, project.id, signal),
+    queryKey: ['releaseDrift', orgSlug, project.id],
+  })
+  const { data: history = [], isLoading: historyLoading } = useQuery({
+    enabled,
+    queryFn: ({ signal }) => getReleaseHistory(orgSlug, project.id, signal),
+    queryKey: ['releaseHistory', orgSlug, project.id],
+  })
+
+  const artifact = useMemo(() => deriveArtifact(project), [project])
+  const ArtifactIcon = artifact.icon
+
+  if (driftLoading || historyLoading) {
+    return <LoadingState label="Loading releases…" />
+  }
+  if (driftError || !drift) {
+    return (
+      <div className="border-tertiary text-tertiary rounded-lg border p-6 text-center text-sm">
+        Could not load release data for this project.
+      </div>
+    )
+  }
+
+  const released = history[0] ?? null
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="inline-flex items-center gap-2 text-base font-semibold">
+          <ArtifactIcon className="text-tertiary size-4" />
+          Releases
+        </h2>
+        {drift.head_sha ? (
+          <span className="text-tertiary inline-flex items-center gap-1.5 text-xs">
+            <GitBranch size={13} />
+            build{' '}
+            <span className="font-mono">{drift.head_sha.slice(0, 7)}</span>
+          </span>
+        ) : null}
+      </div>
+
+      <ReleaseReadyCard
+        drift={drift}
+        onCut={() => {}}
+        orgSlug={orgSlug}
+        projectId={project.id}
+      />
+      <CurrentlyReleasedCard artifact={artifact} released={released} />
+      <ReleaseHistory
+        artifact={artifact}
+        currentTag={released?.tag ?? null}
+        releases={history}
+      />
+    </div>
+  )
+}

--- a/src/components/releases/ReleasesTab.tsx
+++ b/src/components/releases/ReleasesTab.tsx
@@ -29,7 +29,11 @@ export function ReleasesTab({ orgSlug, project }: ReleasesTabProps) {
     queryFn: ({ signal }) => getReleaseDrift(orgSlug, project.id, signal),
     queryKey: ['releaseDrift', orgSlug, project.id],
   })
-  const { data: history = [], isLoading: historyLoading } = useQuery({
+  const {
+    data: history = [],
+    error: historyError,
+    isLoading: historyLoading,
+  } = useQuery({
     enabled,
     queryFn: ({ signal }) => getReleaseHistory(orgSlug, project.id, signal),
     queryKey: ['releaseHistory', orgSlug, project.id],
@@ -41,7 +45,7 @@ export function ReleasesTab({ orgSlug, project }: ReleasesTabProps) {
   if (driftLoading || historyLoading) {
     return <LoadingState label="Loading releases…" />
   }
-  if (driftError || !drift) {
+  if (driftError || historyError || !drift) {
     return (
       <div className="border-tertiary text-tertiary rounded-lg border p-6 text-center text-sm">
         Could not load release data for this project.

--- a/src/components/releases/artifact.test.ts
+++ b/src/components/releases/artifact.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveArtifact } from './artifact'
+
+describe('deriveArtifact', () => {
+  it('returns unknown with no pull command when no package link exists', () => {
+    const a = deriveArtifact({ links: {}, name: 'lib' })
+    expect(a.kind).toBe('unknown')
+    expect(a.pull).toBeNull()
+    expect(a.indexUrl).toBeNull()
+  })
+
+  it('derives a pip install command for a pypi link', () => {
+    const a = deriveArtifact({
+      links: { pypi: 'https://pypi.org/project/address-verification/' },
+      name: 'address-verification',
+    })
+    expect(a.kind).toBe('library')
+    expect(a.pull).toBe('pip install address-verification')
+    expect(a.indexUrl).toBe('https://pypi.org/project/address-verification/')
+  })
+
+  it('derives a docker pull command for a ghcr link', () => {
+    const a = deriveArtifact({
+      links: { ghcr: 'https://ghcr.io/aweber/address-verification' },
+      name: 'address-verification',
+    })
+    expect(a.kind).toBe('container')
+    expect(a.pull).toBe('docker pull ghcr.io/aweber/address-verification')
+  })
+})

--- a/src/components/releases/artifact.ts
+++ b/src/components/releases/artifact.ts
@@ -1,0 +1,81 @@
+import { Box, Container, type LucideIcon, Package } from 'lucide-react'
+
+import type { Project } from '@/types'
+
+export interface ArtifactInfo {
+  icon: LucideIcon
+  indexLabel: null | string
+  indexUrl: null | string
+  kind: 'container' | 'library' | 'unknown'
+  // A copy-pasteable install/pull command, only when confidently derivable.
+  pull: null | string
+}
+
+// Link-key substrings that identify a published-artifact index. The project
+// has no explicit artifact metadata yet, so we infer from its links and hide
+// artifact-specific affordances (pull command, index link) when we can't.
+const CONTAINER_KEYS = ['ghcr', 'docker', 'container', 'image', 'registry']
+const LIBRARY_KEYS = ['pypi', 'package', 'npm', 'rubygems', 'crates', 'maven']
+
+/**
+ * Best-effort artifact descriptor for the Releases tab.
+ *
+ * Returns ``kind: 'unknown'`` (generic icon, no pull command, no index link)
+ * when the project carries no recognizable package/registry link — we never
+ * fabricate an install command.
+ */
+export function deriveArtifact(
+  project: Pick<Project, 'links' | 'name'>,
+): ArtifactInfo {
+  const container = findLink(project.links, CONTAINER_KEYS)
+  if (container) {
+    const path = stripScheme(container[1])
+    return {
+      icon: Container,
+      indexLabel: 'Container image',
+      indexUrl: container[1],
+      kind: 'container',
+      pull: path ? `docker pull ${path}` : null,
+    }
+  }
+  const library = findLink(project.links, LIBRARY_KEYS)
+  if (library) {
+    const [key, url] = library
+    const name = stripScheme(url).split('/').filter(Boolean).pop() ?? null
+    const isNpm = key.toLowerCase().includes('npm')
+    return {
+      icon: Package,
+      indexLabel: isNpm ? 'npm' : 'Package index',
+      indexUrl: url,
+      kind: 'library',
+      pull: name
+        ? isNpm
+          ? `npm install ${name}`
+          : `pip install ${name}`
+        : null,
+    }
+  }
+  return {
+    icon: Box,
+    indexLabel: null,
+    indexUrl: null,
+    kind: 'unknown',
+    pull: null,
+  }
+}
+
+function findLink(
+  links: Record<string, string> | undefined,
+  keys: string[],
+): [string, string] | null {
+  if (!links) return null
+  for (const [key, url] of Object.entries(links)) {
+    const k = key.toLowerCase()
+    if (keys.some((needle) => k.includes(needle)) && url) return [key, url]
+  }
+  return null
+}
+
+function stripScheme(url: string): string {
+  return url.replace(/^https?:\/\//, '').replace(/\/+$/, '')
+}

--- a/src/components/releases/useCutReleaseMutation.tsx
+++ b/src/components/releases/useCutReleaseMutation.tsx
@@ -1,0 +1,76 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { ApiError } from '@/api/client'
+import { cutRelease } from '@/api/releases'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type { CutReleaseRequest } from '@/types'
+
+interface UseCutReleaseOptions {
+  onSuccess?: () => void
+  orgSlug: string
+  projectId: string
+}
+
+interface UseCutReleaseResult {
+  cut: (body: CutReleaseRequest) => void
+  isPending: boolean
+}
+
+/**
+ * Cut a tag + GitHub release for a library project. Unlike deploy/promote
+ * there is no async workflow run to watch — the cut response is synchronous,
+ * so we go straight to a success toast and invalidate the release queries.
+ */
+export function useCutReleaseMutation({
+  onSuccess,
+  orgSlug,
+  projectId,
+}: UseCutReleaseOptions): UseCutReleaseResult {
+  const queryClient = useQueryClient()
+  const mutation = useMutation({
+    mutationFn: (body: CutReleaseRequest) =>
+      cutRelease(orgSlug, projectId, body),
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError
+          ? (extractApiErrorDetail(err) ?? err.message)
+          : (err as Error).message,
+      )
+    },
+    onSuccess: (data) => {
+      for (const key of [
+        ['releaseDrift', orgSlug, projectId],
+        ['releaseHistory', orgSlug, projectId],
+        ['currentReleases', orgSlug, projectId],
+        ['project-releases', orgSlug, projectId],
+      ]) {
+        void queryClient.invalidateQueries({ queryKey: key })
+      }
+      const url = data.release_url
+      toast.success(
+        `Released ${data.tag}`,
+        url
+          ? {
+              action: {
+                label: 'View release',
+                onClick: () => window.open(url, '_blank', 'noopener'),
+              },
+            }
+          : undefined,
+      )
+      if (data.warning) {
+        toast.warning(`Release ${data.tag} recorded with a warning`, {
+          description: data.warning,
+          duration: 10_000,
+        })
+      }
+      onSuccess?.()
+    },
+  })
+
+  return {
+    cut: (body: CutReleaseRequest) => mutation.mutate(body),
+    isPending: mutation.isPending,
+  }
+}

--- a/src/lib/semver.ts
+++ b/src/lib/semver.ts
@@ -1,3 +1,4 @@
 // Shared semver-tag validation for the deploy/promote/release flows.
 // Accepts an optional leading `v` plus an optional `-pre` / `+build` suffix.
-export const SEMVER_RE = /^v?\d+\.\d+\.\d+(?:[-+].+)?$/
+export const SEMVER_RE =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/

--- a/src/lib/semver.ts
+++ b/src/lib/semver.ts
@@ -1,0 +1,3 @@
+// Shared semver-tag validation for the deploy/promote/release flows.
+// Accepts an optional leading `v` plus an optional `-pre` / `+build` suffix.
+export const SEMVER_RE = /^v?\d+\.\d+\.\d+(?:[-+].+)?$/

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -501,6 +501,22 @@ export interface CurrentReleaseEnvironment {
   release: null | Release
 }
 
+export interface CutReleaseRequest {
+  committish: string
+  prerelease?: boolean
+  release_name?: null | string
+  release_notes_markdown?: null | string
+  tag: string
+}
+
+export interface CutReleaseResponse {
+  committish: string
+  recorded: boolean
+  release_url: null | string
+  tag: string
+  warning?: null | string
+}
+
 // Dashboard types are hand-written: the /admin/dashboard/* endpoints are
 // not in the committed OpenAPI snapshot yet. (DatastoreStatus /
 // ServiceStatus live in their own alphabetical slots for module sort.)
@@ -1133,6 +1149,7 @@ export interface PluginAssignmentResponse {
   supports_histogram?: boolean
   supports_lifecycle_sync?: boolean
 }
+
 export interface PluginAssignmentRow {
   default: boolean
   identity_plugin_id?: null | string
@@ -1141,6 +1158,7 @@ export interface PluginAssignmentRow {
   project_type_name: string
   project_type_slug: string
 }
+
 export interface PluginConfigurationResponse {
   auth_type: 'api_token' | 'oauth2'
   fields: PluginCredentialField[]
@@ -1154,7 +1172,6 @@ export interface PluginCreate {
   plugin_slug: string
   service_application_slug?: null | string
 }
-
 export interface PluginCredentialField {
   description: null | string
   label: string
@@ -1168,6 +1185,7 @@ export interface PluginEdge {
   target: PluginEntity
   target_label: string
 }
+
 export interface PluginEdgeLabel {
   from_labels: string[]
   name: string
@@ -1184,7 +1202,6 @@ export interface PluginEdgePut {
 // vertex_labels manifest entry).  Shape varies per plugin model_ref;
 // the host returns whatever Pydantic.model_dump() produced.
 export type PluginEntity = Record<string, unknown> & { id: string }
-
 export interface PluginEntityCreate {
   [key: string]: unknown
 }
@@ -1196,7 +1213,6 @@ export interface PluginEntitySchema {
   title?: string
   type: 'object'
 }
-
 export interface PluginOptionDef {
   choices?: null | string[]
   default?: boolean | null | number | string
@@ -1223,6 +1239,7 @@ export interface PluginResponse {
   status: 'active' | 'unavailable'
   used_as_login?: boolean
 }
+
 // The subset of plugin types that render a project-detail tab. Not
 // every plugin type is a tab (e.g. webhook, analysis): tabs ⊆ plugins.
 export type PluginTab =
@@ -1231,6 +1248,7 @@ export type PluginTab =
   | 'incidents'
   | 'lifecycle'
   | 'logs'
+
 // A plugin assignment is keyed by the plugin's type. Mirrors
 // imbi_common.plugins.PluginType (the full manifest set).
 export type PluginType =
@@ -1270,9 +1288,20 @@ export interface PluginVertexLabel {
   }
 }
 export type ProjectRelationship = Schemas['ProjectRelationship']
+
 export type ProjectRelationshipsResponse =
   Schemas['ProjectRelationshipsResponse']
-
+// Releases tab (build-and-release-only projects). Commit/tag data is read
+// from ClickHouse; release notes come from the graph Release nodes.
+export interface RecentCommit {
+  author?: null | string
+  authored_at: string
+  ci_status: DeploymentCommitCiStatus
+  message: string
+  sha: string
+  short_sha: string
+  url?: null | string
+}
 export interface Release {
   committish: string
   created_at: string
@@ -1303,13 +1332,37 @@ export interface ReleaseDependencyComponent {
   supplier?: null | string
   version: string
 }
-
 export interface ReleaseDependencyIdentifier {
   kind: string
   value: string
 }
 
 export type ReleaseDependencyScope = 'excluded' | 'optional' | 'required'
+
+export interface ReleaseDrift {
+  commits: RecentCommit[]
+  commits_since_tag: number
+  head_sha: null | string
+  latest_tag: null | string
+  latest_tag_at: null | string
+  latest_tag_sha: null | string
+  suggested_bump: SemverBump
+  suggested_tag: string
+}
+
+export interface ReleaseHistoryEntry {
+  author?: null | string
+  ci_status: DeploymentCommitCiStatus
+  notes_markdown?: null | string
+  package_url?: null | string
+  published_at?: null | string
+  release_url?: null | string
+  sha: string
+  short_sha: string
+  tag: string
+  tag_url?: null | string
+  title?: null | string
+}
 
 export interface ReleaseLink {
   label?: null | string


### PR DESCRIPTION
## Summary

Add a project-detail **Releases** tab for build-and-release-only projects
(libraries, container images) that have a deployment plugin but no environments.
Recreates the single-column Build→Release flow from the design: cut a tag +
GitHub release with no deployment step.

## Problem

The release train and deploy/promote modals assume a project has environments.
Library projects have none, so they have no surface to cut a release from.

## Solution

- `ReleasesTab` orchestrator: drift + history via React Query.
- `ReleaseReadyCard`: the release form — selectable commit picker, semver tag
  inputs, AI-drafted notes (reuses `draftReleaseNotes`), `Tag X & release`;
  an "Up to date" state when there's no drift.
- `CurrentlyReleasedCard` + `ReleaseHistory` (markdown notes via react-markdown).
- `CiStatusDot` shared indicator; `useCutReleaseMutation` (no run-watcher —
  optimistic success + query invalidation).
- `deriveArtifact`: infer pip/docker pull + index link from project links; hide
  artifact affordances when not derivable (never fabricated).
- New release-tab API client in `src/api/releases.ts` + types; `SEMVER_RE` in
  `src/lib/semver`.
- The tab is gated on `!!deploymentPlugin && environments.length === 0`,
  structured so the future Deployments tab (env-having projects) is a one-line
  condition flip. Vitest coverage for the cards, history, form, and artifact
  derivation.

## Merge order

The endpoints it calls are added in AWeber-Imbi/imbi-api#439 (which in turn needs
the `imbi-common` release for `commits.ci_status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
