### PR TITLE
Fix Releases tab: scrollable lists + accurate cutting tag/suggestion

### DIFF
--- a/src/components/releases/ReleaseCommitPicker.tsx
+++ b/src/components/releases/ReleaseCommitPicker.tsx
@@ -32,7 +32,7 @@ export function ReleaseCommitPicker({
 }: ReleaseCommitPickerProps) {
   const selIdx = commits.findIndex((c) => c.sha === selectedSha)
   return (
-    <div className="border-tertiary bg-primary overflow-hidden rounded-md border">
+    <div className="border-tertiary bg-primary max-h-120 overflow-y-auto rounded-md border">
       {commits.map((c, idx) => (
         <CommitRow
           active={c.sha === selectedSha}
@@ -83,7 +83,7 @@ function CommitRow({ active, commit, held, idx, onSelect }: CommitRowProps) {
         <Badge variant="neutral">{idx === 0 ? 'tip' : `−${idx}`}</Badge>
       </button>
       {active && body ? (
-        <pre className="bg-action/5 text-secondary overflow-x-auto px-3 pt-1 pb-3 pl-13 font-mono text-xs whitespace-pre-wrap">
+        <pre className="bg-action/5 text-secondary max-h-40 overflow-auto px-3 pt-1 pb-3 pl-13 font-mono text-xs whitespace-pre-wrap">
           {body}
         </pre>
       ) : null}

--- a/src/components/releases/ReleaseReadyCard.tsx
+++ b/src/components/releases/ReleaseReadyCard.tsx
@@ -9,7 +9,11 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { SEMVER_RE } from '@/lib/semver'
-import type { DraftReleaseNotesResponse, ReleaseDrift } from '@/types'
+import type {
+  DraftReleaseNotesResponse,
+  ReleaseDrift,
+  SemverBump,
+} from '@/types'
 
 import { ReleaseCommitPicker } from './ReleaseCommitPicker'
 import { useCutReleaseMutation } from './useCutReleaseMutation'
@@ -43,6 +47,13 @@ export function ReleaseReadyCard({
   const [notes, setNotes] = useState<string>('')
   const [tagDirty, setTagDirty] = useState(false)
   const [notesDirty, setNotesDirty] = useState(false)
+  // What the AI draft actually proposed, once it has run. Drives the hint
+  // line so it reflects the real draft rather than the server's keyword
+  // heuristic (drift.suggested_*), which can disagree.
+  const [aiSuggestion, setAiSuggestion] = useState<null | {
+    bump: SemverBump
+    version: string
+  }>(null)
 
   // AI drafting needs a base tag to compare against; for the first-ever
   // release there's nothing to diff, so notes are authored by hand.
@@ -56,6 +67,7 @@ export function ReleaseReadyCard({
       }),
   })
   const seedFromDraft = (data: DraftReleaseNotesResponse) => {
+    setAiSuggestion({ bump: data.bump, version: data.version })
     if (!tagDirty) setTag(data.version)
     if (!notesDirty) setNotes(data.notes_markdown)
   }
@@ -98,6 +110,7 @@ export function ReleaseReadyCard({
     setNotes('')
     setTagDirty(false)
     setNotesDirty(false)
+    setAiSuggestion(null)
   }
   const submit = () => {
     if (!selectedSha) return
@@ -125,7 +138,8 @@ export function ReleaseReadyCard({
             <span className="font-mono">
               {drift.head_sha?.slice(0, 7) ?? '—'}
             </span>{' '}
-            · cutting <span className="font-mono">{drift.suggested_tag}</span>
+            · cutting{' '}
+            <span className="font-mono">{tag || drift.suggested_tag}</span>
           </div>
         </div>
       </div>
@@ -163,10 +177,14 @@ export function ReleaseReadyCard({
           {canDraft ? (
             <div className="flex items-center justify-between">
               <span className="text-tertiary text-xs">
-                {drift.suggested_bump
-                  ? `AI suggests a ${drift.suggested_bump} bump → `
-                  : ''}
-                <span className="font-mono">{drift.suggested_tag}</span>
+                {aiSuggestion
+                  ? `AI suggests a ${aiSuggestion.bump} bump → `
+                  : drift.suggested_bump
+                    ? `Suggested ${drift.suggested_bump} bump → `
+                    : ''}
+                <span className="font-mono">
+                  {aiSuggestion?.version ?? drift.suggested_tag}
+                </span>
               </span>
               <Button
                 disabled={!selectedSha || draftMutation.isPending}
@@ -176,6 +194,10 @@ export function ReleaseReadyCard({
                     { headSha: selectedSha },
                     {
                       onSuccess: (data) => {
+                        setAiSuggestion({
+                          bump: data.bump,
+                          version: data.version,
+                        })
                         setTagDirty(false)
                         setNotesDirty(false)
                         setTag(data.version)


### PR DESCRIPTION
UI fixes for the Releases tab, found while testing a library project.

## Changes
- **Scrollable lists** — the selected commit's notes get `max-h-40` (10rem) and the commit list `max-h-120` (30rem), both `overflow` scroll, so a long history or large commit message no longer blows out the page.
- **Accurate "cutting `<tag>`" header** — it was bound to `drift.suggested_tag` (the server keyword heuristic) while the New-tag field and button used the AI draft's version, so they disagreed (header `v3.0.0`, field `2.2.0`). The header now tracks the live `tag`, falling back to the suggestion only when blank.
- **Honest suggestion hint** — the "AI suggests …" line also showed the heuristic (mislabeled as AI) and conflicted with the real draft. It now tracks the actual draft's bump/version; the heuristic remains only as a pre-draft fallback, relabeled "Suggested".

## Testing
- `vitest run src/components/releases/` — 14 passed
- oxlint (0 errors), oxfmt, tsc clean; fallow audit clean

Pairs with imbi-api `fix/release-drift-latest-tag-semver`, which fixes the drift base that caused the wrong commit count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)