### PR TITLE
Gate the Releases tab on the project type's releasable flag

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -493,11 +493,15 @@ export function ProjectDetail({
   const deploymentIdentityPluginId =
     deploymentPlugin?.identity_plugin_id ?? null
 
-  // Build-and-release-only projects: a deployment plugin is assigned but the
-  // project has no environments to roll out to, so the "Releases" tab shows
-  // instead. (The Deployments tab for env-having projects is a future task;
-  // inverting this condition is the single switch that will gate it.)
-  const isReleaseOnly = !!deploymentPlugin && sortedEnvironments.length === 0
+  // Build-and-release-only projects: a deployment plugin is assigned and the
+  // project's type is marked ``releasable`` (library / image — published via
+  // tag + GitHub release with no deploy step), so the "Releases" tab shows.
+  // ``releasable`` and ``deployable`` are mutually exclusive on the project
+  // type; the future Deployments tab gates on the latter (see isDeployable).
+  const isReleasable = (project.project_types ?? []).some(
+    (pt) => (pt as { releasable?: boolean }).releasable === true,
+  )
+  const isReleaseOnly = !!deploymentPlugin && isReleasable
 
   // Per-user identity connections — used to gate deploy/promote on the
   // current user actually having an active connection to the deployment

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -56,6 +56,20 @@ export function ProjectTypeForm({
   const [deployable, setDeployable] = useState<boolean>(
     (projectType as null | { deployable?: boolean })?.deployable ?? false,
   )
+  const [releasable, setReleasable] = useState<boolean>(
+    (projectType as null | { releasable?: boolean })?.releasable ?? false,
+  )
+  // Deployable and releasable are mutually exclusive (the backend rejects
+  // both); turning one on clears the other so the form can't submit an
+  // invalid pair.
+  const handleDeployableChange = (checked: boolean) => {
+    setDeployable(checked)
+    if (checked) setReleasable(false)
+  }
+  const handleReleasableChange = (checked: boolean) => {
+    setReleasable(checked)
+    if (checked) setDeployable(false)
+  }
   const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [orgSlug, setOrgSlug] = useState(
     projectType?.organization.slug || selectedOrganization?.slug || '',
@@ -104,6 +118,7 @@ export function ProjectTypeForm({
       description: description.trim() || null,
       icon: icon.trim() || null,
       name: name.trim(),
+      releasable,
       slug: slug.trim(),
       ...dynamicFormData,
     })
@@ -287,14 +302,38 @@ export function ProjectTypeForm({
                   </Label>
                   <p className="text-tertiary text-xs">
                     Enable deployment tracking and release-train features for
-                    projects of this type.
+                    projects of this type. Mutually exclusive with releasable.
                   </p>
                 </div>
                 <Switch
                   checked={deployable}
                   disabled={isLoading}
                   id="project-type-deployable"
-                  onCheckedChange={setDeployable}
+                  onCheckedChange={handleDeployableChange}
+                />
+              </div>
+            </div>
+
+            <div>
+              <div className="border-input flex items-start justify-between gap-3 rounded-lg border p-3">
+                <div>
+                  <Label
+                    className="text-foreground text-sm font-medium"
+                    htmlFor="project-type-releasable"
+                  >
+                    Releasable
+                  </Label>
+                  <p className="text-tertiary text-xs">
+                    Enable the Releases tab for projects of this type — cut a
+                    tag and GitHub release with no deploy step. Mutually
+                    exclusive with deployable.
+                  </p>
+                </div>
+                <Switch
+                  checked={releasable}
+                  disabled={isLoading}
+                  id="project-type-releasable"
+                  onCheckedChange={handleReleasableChange}
                 />
               </div>
             </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -294,6 +294,7 @@ export interface ProjectTypeCreate {
   description?: null | string
   icon?: null | string
   name: string
+  releasable?: boolean
   slug: string
 }
 


### PR DESCRIPTION
## What
Replaces the environment-count heuristic (`no envs ⇒ release-only`) with the explicit `ProjectType.releasable` flag. The Releases tab shows when a deployment plugin is assigned **and** the project's type is `releasable` — mirroring how `isDeployable` gates deploy actions on `deployable`.

Adds a **Releasable** toggle to the project-type admin form, mutually exclusive with **Deployable** (the toggles clear each other; the backend rejects both as a backstop).

## Why
The old heuristic mis-fired for library project types that carry stray environment edges (migration artifacts): such a project would never show the tab despite being a library. Gating on the flag makes intent explicit and decouples it from environment data.

## Depends on
imbi-common #168 (adds `ProjectType.releasable`). The gate reads the flag via a cast, so this is safe to merge before the common release; the tab simply stays hidden until a type is marked `releasable` (which requires the persisted field).

## Testing
oxlint (0 errors) / oxfmt / tsc clean; fallow audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)