### PR TITLE
Route non-Project search results in the command bar

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -2582,8 +2582,11 @@ export interface SearchResult {
   attribute: string
   chunk_text: string
   distance: number
+  name?: null | string
   node_id: string
   node_label: string
+  project_id?: null | string
+  slug?: null | string
 }
 
 export const searchOrganization = (

--- a/src/components/search/SearchResultsPanel.tsx
+++ b/src/components/search/SearchResultsPanel.tsx
@@ -95,6 +95,13 @@ const ENTITY_STYLES: Record<
     round: true,
     text: 'text-entity-domain',
   },
+  Role: {
+    dot: 'bg-entity-config',
+    hex: '#7A7873',
+    label: 'Role',
+    round: true,
+    text: 'text-entity-config',
+  },
   Tag: {
     dot: 'bg-entity-domain',
     hex: '#C86B5E',
@@ -392,9 +399,32 @@ export function SearchResultsPanel({
   )
 }
 
-function getResultPath(result: SearchResult): null | string {
-  if (result.node_label === 'Project') return `/projects/${result.node_id}`
-  return null
+// Maps a node label to its /admin section. These node types are edited on
+// the admin pages, which route by slug (see Admin.tsx).
+const ADMIN_SECTIONS: Record<string, string> = {
+  Blueprint: 'blueprints',
+  DocumentTemplate: 'document-templates',
+  Environment: 'environments',
+  LinkDefinition: 'link-definitions',
+  Organization: 'organizations',
+  ProjectType: 'project-types',
+  Role: 'roles',
+  Team: 'teams',
+  ThirdPartyService: 'third-party-services',
+}
+
+export function getResultPath(result: SearchResult): null | string {
+  const { node_id, node_label, project_id, slug } = result
+  if (node_label === 'Project') return `/projects/${node_id}`
+  // Documents and Releases live under their parent project; project_id is
+  // supplied by the search API's result enrichment.
+  if (node_label === 'Document')
+    return project_id ? `/projects/${project_id}/documents/${node_id}` : null
+  // ReleasesTab does not yet consume the subId, so this lands on the tab.
+  if (node_label === 'Release')
+    return project_id ? `/projects/${project_id}/releases/${node_id}` : null
+  const section = ADMIN_SECTIONS[node_label]
+  return section && slug ? `/admin/${section}/${slug}` : null
 }
 
 function highlightKeywords(text: string, query: string): React.ReactNode {
@@ -445,7 +475,8 @@ function ResultCard({
 
   const isNameAttr = result.attribute === 'name'
   const enriched = enrichment.get(result.node_id)
-  const entityName = enriched?.name ?? nameByNodeId.get(result.node_id)
+  const entityName =
+    enriched?.name ?? result.name ?? nameByNodeId.get(result.node_id)
   const title =
     entityName ??
     (isNameAttr

--- a/src/components/search/SearchResultsPanel.tsx
+++ b/src/components/search/SearchResultsPanel.tsx
@@ -9,6 +9,7 @@ import {
   getConfidenceLabel,
   type SearchResult,
 } from '@/api/search'
+import { getResultPath } from '@/components/search/getResultPath'
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible'
 import { Label } from '@/components/ui/label'
 import { Slider } from '@/components/ui/slider'
@@ -397,34 +398,6 @@ export function SearchResultsPanel({
       </div>
     </div>
   )
-}
-
-// Maps a node label to its /admin section. These node types are edited on
-// the admin pages, which route by slug (see Admin.tsx).
-const ADMIN_SECTIONS: Record<string, string> = {
-  Blueprint: 'blueprints',
-  DocumentTemplate: 'document-templates',
-  Environment: 'environments',
-  LinkDefinition: 'link-definitions',
-  Organization: 'organizations',
-  ProjectType: 'project-types',
-  Role: 'roles',
-  Team: 'teams',
-  ThirdPartyService: 'third-party-services',
-}
-
-export function getResultPath(result: SearchResult): null | string {
-  const { node_id, node_label, project_id, slug } = result
-  if (node_label === 'Project') return `/projects/${node_id}`
-  // Documents and Releases live under their parent project; project_id is
-  // supplied by the search API's result enrichment.
-  if (node_label === 'Document')
-    return project_id ? `/projects/${project_id}/documents/${node_id}` : null
-  // ReleasesTab does not yet consume the subId, so this lands on the tab.
-  if (node_label === 'Release')
-    return project_id ? `/projects/${project_id}/releases/${node_id}` : null
-  const section = ADMIN_SECTIONS[node_label]
-  return section && slug ? `/admin/${section}/${slug}` : null
 }
 
 function highlightKeywords(text: string, query: string): React.ReactNode {

--- a/src/components/search/__tests__/getResultPath.test.ts
+++ b/src/components/search/__tests__/getResultPath.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SearchResult } from '@/api/endpoints'
 
-import { getResultPath } from '../SearchResultsPanel'
+import { getResultPath } from '../getResultPath'
 
 function result(overrides: Partial<SearchResult>): SearchResult {
   return {
@@ -38,6 +38,10 @@ describe('getResultPath', () => {
 
   it('returns null for a Document with no project_id', () => {
     expect(getResultPath(result({ node_label: 'Document' }))).toBeNull()
+  })
+
+  it('returns null for a Release with no project_id', () => {
+    expect(getResultPath(result({ node_label: 'Release' }))).toBeNull()
   })
 
   it('routes admin node types by slug', () => {

--- a/src/components/search/__tests__/getResultPath.test.ts
+++ b/src/components/search/__tests__/getResultPath.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SearchResult } from '@/api/endpoints'
+
+import { getResultPath } from '../SearchResultsPanel'
+
+function result(overrides: Partial<SearchResult>): SearchResult {
+  return {
+    attribute: 'description',
+    chunk_text: '…',
+    distance: 0.1,
+    node_id: 'node-1',
+    node_label: 'Project',
+    ...overrides,
+  }
+}
+
+describe('getResultPath', () => {
+  it('routes a Project by id', () => {
+    expect(getResultPath(result({ node_label: 'Project' }))).toBe(
+      '/projects/node-1',
+    )
+  })
+
+  it('routes a Document under its parent project', () => {
+    const path = getResultPath(
+      result({ node_label: 'Document', project_id: 'proj-9' }),
+    )
+    expect(path).toBe('/projects/proj-9/documents/node-1')
+  })
+
+  it('routes a Release under its parent project', () => {
+    const path = getResultPath(
+      result({ node_label: 'Release', project_id: 'proj-9' }),
+    )
+    expect(path).toBe('/projects/proj-9/releases/node-1')
+  })
+
+  it('returns null for a Document with no project_id', () => {
+    expect(getResultPath(result({ node_label: 'Document' }))).toBeNull()
+  })
+
+  it('routes admin node types by slug', () => {
+    const cases: Array<[string, string]> = [
+      ['Team', 'teams'],
+      ['Environment', 'environments'],
+      ['ProjectType', 'project-types'],
+      ['ThirdPartyService', 'third-party-services'],
+      ['DocumentTemplate', 'document-templates'],
+      ['LinkDefinition', 'link-definitions'],
+      ['Organization', 'organizations'],
+      ['Blueprint', 'blueprints'],
+      ['Role', 'roles'],
+    ]
+    for (const [nodeLabel, section] of cases) {
+      const path = getResultPath(
+        result({ node_label: nodeLabel, slug: 'the-slug' }),
+      )
+      expect(path).toBe(`/admin/${section}/the-slug`)
+    }
+  })
+
+  it('returns null for an admin node type missing its slug', () => {
+    expect(getResultPath(result({ node_label: 'Team' }))).toBeNull()
+  })
+
+  it('returns null for routeless types (Tag, Comment, Component)', () => {
+    for (const nodeLabel of ['Tag', 'Comment', 'Component']) {
+      expect(
+        getResultPath(result({ node_label: nodeLabel, slug: 'x' })),
+      ).toBeNull()
+    }
+  })
+})

--- a/src/components/search/getResultPath.ts
+++ b/src/components/search/getResultPath.ts
@@ -1,0 +1,29 @@
+import type { SearchResult } from '@/api/search'
+
+// Maps a node label to its /admin section. These node types are edited on
+// the admin pages, which route by slug (see Admin.tsx).
+const ADMIN_SECTIONS: Record<string, string> = {
+  Blueprint: 'blueprints',
+  DocumentTemplate: 'document-templates',
+  Environment: 'environments',
+  LinkDefinition: 'link-definitions',
+  Organization: 'organizations',
+  ProjectType: 'project-types',
+  Role: 'roles',
+  Team: 'teams',
+  ThirdPartyService: 'third-party-services',
+}
+
+export function getResultPath(result: SearchResult): null | string {
+  const { node_id, node_label, project_id, slug } = result
+  if (node_label === 'Project') return `/projects/${node_id}`
+  // Documents and Releases live under their parent project; project_id is
+  // supplied by the search API's result enrichment.
+  if (node_label === 'Document')
+    return project_id ? `/projects/${project_id}/documents/${node_id}` : null
+  // ReleasesTab does not yet consume the subId, so this lands on the tab.
+  if (node_label === 'Release')
+    return project_id ? `/projects/${project_id}/releases/${node_id}` : null
+  const section = ADMIN_SECTIONS[node_label]
+  return section && slug ? `/admin/${section}/${slug}` : null
+}


### PR DESCRIPTION
## Summary

The command bar's `getResultPath` only built a URL for `Project` results, so `navigableResults` filtered out every other node type. Documents, Releases, and the admin-scoped entities never appeared in search — even though the backend already returns and embeds them.

## Problem

`getResultPath` returned `null` for everything except `Project`, and the result list/counts derive from `navigableResults` (results with a non-null path). So non-Project types were dropped before render.

## Solution

- Route **Documents**/**Releases** under their parent project using the new `project_id` from the search API, and the **admin** node types (Team, Environment, ProjectType, ThirdPartyService, DocumentTemplate, LinkDefinition, Organization, Blueprint, Role) via their `slug` and an explicit label → `/admin` section map.
- Use the API-provided `name` as a display-title fallback so the newly surfaced types show a real title instead of a content snippet.
- Add a `Role` entry to `ENTITY_STYLES`.

**Tag/Comment/Component** have no detail route and intentionally stay hidden. Releases land on the project's Releases tab (the tab doesn't yet consume a release `subId`).

## Testing

- New `getResultPath.test.ts` (7 cases): Project, Document/Release with and without `project_id`, all admin types → correct section, missing-slug → null, and routeless types → null.
- `tsc --noEmit`, oxlint (0 errors), and fallow all clean for the changed files.

## Dependency

Requires **AWeber-Imbi/imbi-api#442** (adds `name`/`slug`/`project_id` to `SearchResult`). Without it, Documents/Releases/admin types resolve to `null` and remain hidden — so this is safe to merge independently but only takes effect once the API change ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)