### PR TITLE
Default the search command bar to Project results

### DIFF
--- a/src/components/search/SearchResultsPanel.tsx
+++ b/src/components/search/SearchResultsPanel.tsx
@@ -175,7 +175,7 @@ export function SearchResultsPanel({
 }: SearchResultsPanelProps) {
   const navigate = useNavigate()
   const { selectedOrganization } = useOrganization()
-  const [labelFilter, setLabelFilter] = useState<null | string>(null)
+  const [labelFilter, setLabelFilter] = useState<null | string>('Project')
   const [refineOpen, setRefineOpen] = useState(false)
   const queryStartRef = useRef<null | number>(null)
   const [elapsedMs, setElapsedMs] = useState<null | number>(null)
@@ -183,6 +183,8 @@ export function SearchResultsPanel({
   useEffect(() => {
     queryStartRef.current = Date.now()
     setElapsedMs(null)
+    // Every new search starts on the Project pill, not "All".
+    setLabelFilter('Project')
   }, [query])
 
   useEffect(() => {
@@ -216,10 +218,6 @@ export function SearchResultsPanel({
     [visibleResults],
   )
 
-  const filteredResults = labelFilter
-    ? navigableResults.filter((r) => r.node_label === labelFilter)
-    : navigableResults
-
   const countsByLabel = useMemo(
     () =>
       navigableResults.reduce<Record<string, number>>((acc, r) => {
@@ -228,6 +226,16 @@ export function SearchResultsPanel({
       }, {}),
     [navigableResults],
   )
+
+  // Search defaults to the Project pill; fall back to showing all results
+  // when the current query returned no rows for the selected label, so the
+  // list is never empty while other results exist.
+  const effectiveFilter =
+    labelFilter && countsByLabel[labelFilter] ? labelFilter : null
+
+  const filteredResults = effectiveFilter
+    ? navigableResults.filter((r) => r.node_label === effectiveFilter)
+    : navigableResults
 
   const topResult = navigableResults[0]
   const topLabel = topResult ? getConfidenceLabel(topResult.distance) : null
@@ -268,7 +276,7 @@ export function SearchResultsPanel({
     return (
       <button
         className={`flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-0.5 font-mono text-xs transition-colors ${
-          labelFilter === nodeLabel
+          effectiveFilter === nodeLabel
             ? 'bg-foreground text-background dark:bg-action dark:text-black'
             : 'text-muted-foreground hover:text-foreground'
         }`}
@@ -370,7 +378,7 @@ export function SearchResultsPanel({
       <div className="border-border flex items-center gap-1 overflow-x-auto border-b px-3 py-2">
         <button
           className={`flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 font-mono text-xs font-medium transition-colors ${
-            labelFilter === null
+            effectiveFilter === null
               ? 'bg-foreground text-background dark:bg-action dark:text-black'
               : 'text-muted-foreground hover:text-foreground'
           }`}

--- a/src/components/search/__tests__/SearchResultsPanel.test.tsx
+++ b/src/components/search/__tests__/SearchResultsPanel.test.tsx
@@ -1,0 +1,108 @@
+import { MemoryRouter } from 'react-router-dom'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SearchResult } from '@/api/endpoints'
+
+import { SearchResultsPanel } from '../SearchResultsPanel'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/contexts/OrganizationContext', () => ({
+  useOrganization: () => ({ selectedOrganization: { slug: 'org' } }),
+}))
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ isDarkMode: false }),
+}))
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/hooks/useSearchEnrichment', () => ({
+  useSearchEnrichment: () => new Map(),
+}))
+
+function makeResult(overrides: Partial<SearchResult>): SearchResult {
+  return {
+    attribute: 'description',
+    chunk_text: 'a snippet',
+    distance: 0.1,
+    name: 'Untitled',
+    node_id: 'n',
+    node_label: 'Project',
+    ...overrides,
+  }
+}
+
+// A mixed result set: two Projects plus a Document and a Team that are both
+// navigable (Document via project_id, Team via slug). Titles avoid the query
+// string so highlightKeywords does not split them across spans.
+const MIXED: SearchResult[] = [
+  makeResult({ name: 'Alpha Project', node_id: 'p1', node_label: 'Project' }),
+  makeResult({ name: 'Beta Project', node_id: 'p2', node_label: 'Project' }),
+  makeResult({
+    name: 'Gamma Doc',
+    node_id: 'd1',
+    node_label: 'Document',
+    project_id: 'p1',
+  }),
+  makeResult({
+    name: 'Delta Team',
+    node_id: 't1',
+    node_label: 'Team',
+    slug: 'delta',
+  }),
+]
+
+function renderPanel(results: SearchResult[]) {
+  return render(
+    <SearchResultsPanel
+      isLoading={false}
+      limit={20}
+      onLimitChange={vi.fn()}
+      onThresholdChange={vi.fn()}
+      query="zzz"
+      results={results}
+      threshold={0.75}
+    />,
+    { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> },
+  )
+}
+
+describe('SearchResultsPanel default filter', () => {
+  it('defaults to Project results, hiding other types', () => {
+    renderPanel(MIXED)
+    expect(screen.getByText('Alpha Project')).toBeInTheDocument()
+    expect(screen.getByText('Beta Project')).toBeInTheDocument()
+    expect(screen.queryByText('Gamma Doc')).not.toBeInTheDocument()
+    expect(screen.queryByText('Delta Team')).not.toBeInTheDocument()
+  })
+
+  it('reveals other types when the All pill is clicked', async () => {
+    const user = userEvent.setup()
+    renderPanel(MIXED)
+    await user.click(screen.getByText('All 4'))
+    expect(screen.getByText('Gamma Doc')).toBeInTheDocument()
+    expect(screen.getByText('Delta Team')).toBeInTheDocument()
+  })
+
+  it('falls back to all results when the query returns no Projects', () => {
+    renderPanel([
+      makeResult({
+        name: 'Gamma Doc',
+        node_id: 'd1',
+        node_label: 'Document',
+        project_id: 'p1',
+      }),
+      makeResult({
+        name: 'Delta Team',
+        node_id: 't1',
+        node_label: 'Team',
+        slug: 'delta',
+      }),
+    ])
+    // No Project results exist, so the Project default must not blank the
+    // list — both non-project results stay visible.
+    expect(screen.getByText('Gamma Doc')).toBeInTheDocument()
+    expect(screen.getByText('Delta Team')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Now that search surfaces all node types, every search opened on the **All** pill — burying the common case (finding a project) among documents, releases, and admin entities.

## Changes

- Initialize the label filter to **Project** and reset it to Project on each new query, so a search always starts scoped to projects rather than All. The All pill (and every other type) is still one click away.
- Add a no-Projects fallback: when the current query returns no rows for the selected label, show all results instead of an empty list. This is derived via `effectiveFilter`, which also drives the pill highlight so the active pill always matches what's shown.

## Testing

- New `SearchResultsPanel.test.tsx`: defaults to Project-only, reveals other types on All click, and falls back to showing everything when a query has no Projects.
- `tsc --noEmit`, oxlint (0 errors), and the fallow audit are clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)