### PR TITLE
Add Deployments tab to the project detail page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ vite.config.js
 
 figma/
 .worktrees/
+
+# Large local design-spec export (exceeds the repo file-size gate);
+# the UserIdentity component is implemented against it but it is not tracked.
+docs/useridentity.html

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -89,8 +89,8 @@ import type {
   ProjectRelationshipsResponse,
   ProjectType,
   ProjectTypeCreate,
-  PromotionOption,
   PullRequestListResponse,
+  RecentCommit,
   Release,
   ReleaseDependenciesResponse,
   Role,
@@ -1888,17 +1888,26 @@ export const listRefCommits = async (
   return Array.isArray(response) ? response : []
 }
 
-export const resolveDeploymentCommit = (
+// Synced commit history from ClickHouse (newest first) — the Deployments
+// tab reads this instead of the live source host so it reflects imbi's
+// own data; the commit/tag sync keeps it fresh.
+export const listRecentCommits = async (
   orgSlug: string,
   projectId: string,
-  committish: string,
+  params: { limit?: number; ref?: string } = {},
   signal?: AbortSignal,
-): Promise<DeploymentCommit> =>
-  apiClient.get<DeploymentCommit>(
-    `${deploymentsBase(orgSlug, projectId)}/commits/${encodeURIComponent(committish)}`,
+): Promise<RecentCommit[]> => {
+  const search = new URLSearchParams()
+  if (params.limit != null) search.set('limit', String(params.limit))
+  if (params.ref) search.set('ref', params.ref)
+  const query = search.toString()
+  const response = await apiClient.get<RecentCommit[]>(
+    `${deploymentsBase(orgSlug, projectId)}/recent-commits${query ? `?${query}` : ''}`,
     undefined,
     signal,
   )
+  return Array.isArray(response) ? response : []
+}
 
 export const compareDeploymentRefs = (
   orgSlug: string,
@@ -1915,19 +1924,6 @@ export const compareDeploymentRefs = (
     undefined,
     signal,
   )
-}
-
-export const listPromotionOptions = async (
-  orgSlug: string,
-  projectId: string,
-  signal?: AbortSignal,
-): Promise<PromotionOption[]> => {
-  const response = await apiClient.get<PromotionOption[]>(
-    `${deploymentsBase(orgSlug, projectId)}/promotion-options`,
-    undefined,
-    signal,
-  )
-  return Array.isArray(response) ? response : []
 }
 
 export const triggerDeployment = (

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -89,6 +89,7 @@ import type {
   ProjectRelationshipsResponse,
   ProjectType,
   ProjectTypeCreate,
+  PromotionOption,
   PullRequestListResponse,
   Release,
   ReleaseDependenciesResponse,
@@ -1902,6 +1903,19 @@ export const compareDeploymentRefs = (
     undefined,
     signal,
   )
+}
+
+export const listPromotionOptions = async (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<PromotionOption[]> => {
+  const response = await apiClient.get<PromotionOption[]>(
+    `${deploymentsBase(orgSlug, projectId)}/promotion-options`,
+    undefined,
+    signal,
+  )
+  return Array.isArray(response) ? response : []
 }
 
 export const triggerDeployment = (

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1888,6 +1888,18 @@ export const listRefCommits = async (
   return Array.isArray(response) ? response : []
 }
 
+export const resolveDeploymentCommit = (
+  orgSlug: string,
+  projectId: string,
+  committish: string,
+  signal?: AbortSignal,
+): Promise<DeploymentCommit> =>
+  apiClient.get<DeploymentCommit>(
+    `${deploymentsBase(orgSlug, projectId)}/commits/${encodeURIComponent(committish)}`,
+    undefined,
+    signal,
+  )
+
 export const compareDeploymentRefs = (
   orgSlug: string,
   projectId: string,

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1204,6 +1204,8 @@ export function ProjectDetail({
               orgSlug={orgSlug}
               projectId={project.id}
               readiness={deploymentReadiness}
+              serviceIcon={deploymentPlugin?.service_icon ?? null}
+              serviceLabel={deploymentPlugin?.service_name ?? null}
             />
           </TabsContent>
         )}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -49,6 +49,7 @@ import {
   ReleaseModal,
 } from '@/components/deploy/DeploymentModal'
 import { DeploymentRunWatcher } from '@/components/deploy/DeploymentRunWatcher'
+import { DeploymentsTab } from '@/components/deployments/DeploymentsTab'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
 import { ConfigurationTab } from '@/components/project/ConfigurationTab'
@@ -109,6 +110,7 @@ const VALID_TABS = [
   'overview',
   'configuration',
   'dependencies',
+  'deployments',
   'relationships',
   'releases',
   'logs',
@@ -187,7 +189,6 @@ export function ProjectDetail({
   // placeholder for the version slot so versions don't pop in.
   const releasesLoading = releasesPending && !!orgSlug && !!project.id
 
-  // fallow-ignore-next-line complexity
   const deploymentStatus: Record<
     string,
     {
@@ -200,6 +201,7 @@ export function ProjectDetail({
       tag: null | string
       updated: string
     }
+    // fallow-ignore-next-line complexity
   > = useMemo(() => {
     const out: Record<
       string,
@@ -595,6 +597,10 @@ export function ProjectDetail({
   )
   const canTriggerDeployments =
     isDeployable && !!deploymentPlugin && deploymentReadiness === 'connected'
+  // Deployable projects with a pipeline get the Deployments tab — the
+  // counterpart of the release-only "Releases" tab above.
+  const hasDeploymentsTab =
+    isDeployable && !!deploymentPlugin && sortedEnvironments.length > 0
 
   // fallow-ignore-next-line complexity
   const deploymentConnectLabel = (() => {
@@ -637,6 +643,7 @@ export function ProjectDetail({
       (activeTab === 'logs' && !hasLogsPlugin) ||
       (activeTab === 'incidents' && !hasIncidentsPlugin) ||
       (activeTab === 'releases' && !isReleaseOnly) ||
+      (activeTab === 'deployments' && !hasDeploymentsTab) ||
       (activeTab === 'pull-requests' && !hasLifecyclePlugin)
     ) {
       navigate(`/projects/${project.id}`, { replace: true })
@@ -644,6 +651,7 @@ export function ProjectDetail({
   }, [
     activeTab,
     hasConfigurationPlugin,
+    hasDeploymentsTab,
     hasIncidentsPlugin,
     hasLifecyclePlugin,
     hasLogsPlugin,
@@ -769,6 +777,9 @@ export function ProjectDetail({
       ? [{ id: 'configuration' as const, label: 'Configuration' }]
       : []),
     { id: 'dependencies', label: 'Dependencies' },
+    ...(hasDeploymentsTab
+      ? [{ id: 'deployments' as const, label: 'Deployments' }]
+      : []),
     {
       id: 'documents',
       label:
@@ -1314,6 +1325,19 @@ export function ProjectDetail({
         {isReleaseOnly && (
           <TabsContent value="releases">
             <ReleasesTab orgSlug={orgSlug} project={project} />
+          </TabsContent>
+        )}
+        {hasDeploymentsTab && (
+          <TabsContent value="deployments">
+            <DeploymentsTab
+              canTrigger={canTriggerDeployments}
+              connectLabel={deploymentConnectLabel}
+              environments={sortedEnvironments}
+              onRunStarted={handleRunStarted}
+              orgSlug={orgSlug}
+              projectId={project.id}
+              readiness={deploymentReadiness}
+            />
           </TabsContent>
         )}
         {hasLifecyclePlugin && (

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -12,13 +12,11 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
-  ArrowRight,
   Check,
   ChevronDown,
   Copy,
   Stethoscope as DoctorIcon,
   Filter,
-  Info,
   RefreshCw,
   Settings2 as SettingsIcon,
   TrendingDown,
@@ -77,7 +75,6 @@ import { InlineMultiSelect } from '@/components/ui/inline-edit/InlineMultiSelect
 import { InlineSelect } from '@/components/ui/inline-edit/InlineSelect'
 import { InlineText } from '@/components/ui/inline-edit/InlineText'
 import { InlineTextarea } from '@/components/ui/inline-edit/InlineTextarea'
-import { LabelChip } from '@/components/ui/label-chip'
 import { ScoreBadge } from '@/components/ui/score-badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
@@ -185,9 +182,6 @@ export function ProjectDetail({
     queryFn: ({ signal }) => listCurrentReleases(orgSlug, project.id, signal),
     queryKey: ['currentReleases', orgSlug, project.id],
   })
-  // While the releases query is in-flight, chips render a fuzzy
-  // placeholder for the version slot so versions don't pop in.
-  const releasesLoading = releasesPending && !!orgSlug && !!project.id
 
   const deploymentStatus: Record<
     string,
@@ -369,21 +363,6 @@ export function ProjectDetail({
     () => navigate(`/projects/${project.id}`, { replace: true }),
     [navigate, project.id],
   )
-  const openDeploy = useCallback(
-    (envSlug?: string) => {
-      // The bare "Deploy" button doesn't carry an env, so default to
-      // the entry-point env (idx 0) for first-time deployments.
-      const slug = envSlug ?? sortedEnvironments[0]?.slug
-      if (slug) navigate(`/projects/${project.id}/deploy/${slug}`)
-    },
-    [navigate, project.id, sortedEnvironments],
-  )
-  const openPromote = useCallback(
-    (_fromEnvironment: string, toEnvironment: string) =>
-      navigate(`/projects/${project.id}/promote/${toEnvironment}`),
-    [navigate, project.id],
-  )
-
   // Active deployment runs (one watcher per entry).  Pushed by the
   // DeployTab/PromoteTab onRunStarted callback; the watcher itself
   // calls back to remove its entry once the run reaches a terminal
@@ -852,118 +831,6 @@ export function ProjectDetail({
                 </span>
               )}
             </div>
-          </div>
-
-          {/* Deployment Pipeline — chips are the only entry points
-               for Deploy/Promote, routed by position in the train. */}
-          <div className="flex flex-col items-end gap-2">
-            <div className="flex items-center gap-2">
-              {sortedEnvironments.length > 0 &&
-                // fallow-ignore-next-line complexity
-                sortedEnvironments.map((env, idx) => {
-                  const deployment = deploymentStatus[env.slug]
-                  const color = env.label_color
-                  // Release-train action selection is driven by per-env
-                  // flags (``can_deploy`` / ``can_promote``).  Defaults
-                  // match the backend model: deployable, opt-in promote.
-                  // When both flags are true, deploy wins (re-rolling an
-                  // env is the more common interactive op).  When both
-                  // are false, the chip renders without a click target.
-                  const canDeploy = env.can_deploy ?? true
-                  const canPromote = env.can_promote ?? false
-                  const isPromoteSlot = canPromote && !canDeploy
-                  // Promote needs an upstream env to source the build
-                  // from; fall back to the immediately preceding env in
-                  // the sorted train (mirrors the old idx-based UX).
-                  const previousSlug = isPromoteSlot
-                    ? sortedEnvironments[idx - 1]?.slug
-                    : undefined
-                  const isInteractive =
-                    canDeploy || (isPromoteSlot && previousSlug)
-                  const handleClick = !isInteractive
-                    ? undefined
-                    : isPromoteSlot
-                      ? () => openPromote(previousSlug as string, env.slug)
-                      : () => openDeploy(env.slug)
-                  const tooltipText = isPromoteSlot
-                    ? 'Promote'
-                    : canPromote
-                      ? 'Deploy / Promote'
-                      : 'Deploy'
-                  const versionSlot = deployment ? (
-                    <span className="font-mono">
-                      {deployment.tag ?? deployment.committish}
-                    </span>
-                  ) : releasesLoading ? (
-                    <span
-                      aria-hidden
-                      className="inline-block h-3 w-14 animate-pulse rounded bg-current/25 align-middle blur-[2px]"
-                    />
-                  ) : null
-                  const chipBody = color ? (
-                    <LabelChip
-                      className="rounded-md px-3 py-1.5 text-sm"
-                      hex={color}
-                    >
-                      <span className="inline-flex items-center gap-1.5">
-                        {env.name}
-                        {versionSlot}
-                      </span>
-                    </LabelChip>
-                  ) : (
-                    <span className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium">
-                      {env.name}
-                      {versionSlot}
-                    </span>
-                  )
-                  return (
-                    <span className="contents" key={env.slug}>
-                      {idx > 0 && (
-                        <ArrowRight className="text-tertiary size-4" />
-                      )}
-                      {canTriggerDeployments && isInteractive ? (
-                        <TooltipProvider delayDuration={200}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                aria-label={
-                                  isPromoteSlot
-                                    ? `Promote ${previousSlug} to ${env.name}`
-                                    : `Deploy to ${env.name}`
-                                }
-                                className="hover:ring-ring focus-visible:ring-ring cursor-pointer rounded-md transition hover:shadow-md hover:ring-1 hover:ring-offset-1 focus:outline-none focus-visible:ring-2"
-                                onClick={handleClick}
-                                type="button"
-                              >
-                                {chipBody}
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>{tooltipText}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      ) : (
-                        chipBody
-                      )}
-                    </span>
-                  )
-                })}
-            </div>
-            {isDeployable && deploymentPlugin && (
-              <div className="text-tertiary flex items-center gap-1.5 text-xs italic">
-                <Info className="size-3.5" />
-                <span>
-                  {deploymentReadiness === 'connected'
-                    ? 'Click on an environment to deploy to it'
-                    : deploymentReadiness === 'loading'
-                      ? 'Checking deployment access…'
-                      : deploymentReadiness === 'error'
-                        ? 'Could not check deployment access — retry shortly'
-                        : `Connect to ${deploymentConnectLabel} to enable deployments`}
-                </span>
-              </div>
-            )}
           </div>
         </div>
 

--- a/src/components/deploy/lists.tsx
+++ b/src/components/deploy/lists.tsx
@@ -165,7 +165,7 @@ export function CommitList({
             </button>
             {c.url ? (
               <a
-                aria-label="View commit on GitHub"
+                aria-label="View commit"
                 className="text-tertiary hover:text-primary"
                 href={c.url}
                 rel="noopener"

--- a/src/components/deployments/CommitDeployCard.test.tsx
+++ b/src/components/deployments/CommitDeployCard.test.tsx
@@ -1,0 +1,134 @@
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import { render } from '@/test/utils'
+import type {
+  CurrentReleaseEnvironment,
+  DeploymentCommit,
+  Environment,
+} from '@/types'
+
+import { CommitDeployCard } from './CommitDeployCard'
+import type { PipelineStage } from './pipeline'
+import type { DeploymentActions } from './useDeploymentActions'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return {
+    ...actual,
+    listDeploymentRefs: vi.fn(),
+    listRefCommits: vi.fn(),
+    resolveDeploymentCommit: vi.fn(),
+  }
+})
+
+const ENV = {
+  id: 'testing',
+  label_color: '#6B9A3F',
+  name: 'Testing',
+  slug: 'testing',
+  sort_order: 1,
+} as unknown as Environment
+
+const commit = (sha: string, message: string): DeploymentCommit => ({
+  author: 'kevin',
+  ci_status: 'pass',
+  is_head: false,
+  message,
+  sha,
+  short_sha: sha.slice(0, 7),
+})
+
+const currentFor = (committish: string): CurrentReleaseEnvironment => ({
+  ci_status: 'pass',
+  current_status: 'success',
+  environment: { name: 'testing', slug: 'testing' },
+  external_run_url: null,
+  last_event_at: '2026-06-01T00:00:00Z',
+  release: {
+    committish,
+    created_at: '2026-06-01T00:00:00Z',
+    created_by: 'gavin',
+    id: 'rel-1',
+    links: [],
+    project_id: 'p1',
+    tag: null,
+    title: committish,
+  },
+})
+
+const makeStage = (committish: string): PipelineStage => ({
+  current: currentFor(committish),
+  env: ENV,
+  kind: 'commit',
+  pendingReleases: [],
+  rollbackTargets: [],
+  upstream: null,
+  upstreamCurrent: null,
+})
+
+const makeActions = (): DeploymentActions => ({
+  deploy: vi.fn(),
+  deployPending: false,
+  deployPendingSha: null,
+  promote: vi.fn(),
+  promotePending: false,
+})
+
+const RECENT = [
+  commit('aaa1111aaa1111', 'newest change'),
+  commit('bbb2222bbb2222', 'middle change'),
+  commit('ccc3333ccc3333', 'older change'),
+]
+
+const setup = (committish: string) => {
+  vi.mocked(endpoints.listDeploymentRefs).mockResolvedValue([
+    {
+      is_default: true,
+      kind: 'default',
+      name: 'main',
+      sha: 'aaa1111aaa1111',
+    },
+  ])
+  vi.mocked(endpoints.listRefCommits).mockResolvedValue(RECENT)
+  render(
+    <CommitDeployCard
+      accent={null}
+      actions={makeActions()}
+      canTrigger
+      orgSlug="org"
+      projectId="p1"
+      stage={makeStage(committish)}
+    />,
+  )
+}
+
+describe('CommitDeployCard', () => {
+  it('marks the deployed commit and splits Deploy/Roll back around it', async () => {
+    setup('bbb2222bbb2222')
+    await waitFor(() =>
+      expect(screen.getByText('deployed')).toBeInTheDocument(),
+    )
+    expect(screen.getAllByRole('button', { name: /Deploy/ })).toHaveLength(1)
+    expect(screen.getAllByRole('button', { name: /Roll back/ })).toHaveLength(1)
+    expect(endpoints.resolveDeploymentCommit).not.toHaveBeenCalled()
+  })
+
+  it('pins the deployed commit when it falls outside the recent window', async () => {
+    vi.mocked(endpoints.resolveDeploymentCommit).mockResolvedValue(
+      commit('ddd4444ddd4444', 'the running commit'),
+    )
+    setup('ddd4444ddd4444')
+    await waitFor(() =>
+      expect(screen.getByText('deployed')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('the running commit')).toBeInTheDocument()
+    expect(screen.getByText('… older commits not shown')).toBeInTheDocument()
+    // Everything in the window is newer than the pinned current commit.
+    expect(screen.getAllByRole('button', { name: /Deploy/ })).toHaveLength(3)
+    expect(screen.queryByRole('button', { name: /Roll back/ })).toBeNull()
+  })
+})

--- a/src/components/deployments/CommitDeployCard.test.tsx
+++ b/src/components/deployments/CommitDeployCard.test.tsx
@@ -1,29 +1,16 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import * as endpoints from '@/api/endpoints'
 import { render } from '@/test/utils'
 import type {
   CurrentReleaseEnvironment,
-  DeploymentCommit,
   Environment,
+  RecentCommit,
 } from '@/types'
 
 import { CommitDeployCard } from './CommitDeployCard'
 import type { PipelineStage } from './pipeline'
 import type { DeploymentActions } from './useDeploymentActions'
-
-// fallow-ignore-next-line unresolved-import
-vi.mock('@/api/endpoints', async () => {
-  const actual =
-    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
-  return {
-    ...actual,
-    listDeploymentRefs: vi.fn(),
-    listRefCommits: vi.fn(),
-    resolveDeploymentCommit: vi.fn(),
-  }
-})
 
 const ENV = {
   id: 'testing',
@@ -33,10 +20,10 @@ const ENV = {
   sort_order: 1,
 } as unknown as Environment
 
-const commit = (sha: string, message: string): DeploymentCommit => ({
+const commit = (sha: string, message: string): RecentCommit => ({
   author: 'kevin',
+  authored_at: '2026-06-01T00:00:00Z',
   ci_status: 'pass',
-  is_head: false,
   message,
   sha,
   short_sha: sha.slice(0, 7),
@@ -64,6 +51,7 @@ const makeStage = (committish: string): PipelineStage => ({
   current: currentFor(committish),
   env: ENV,
   kind: 'commit',
+  pendingCommits: [],
   pendingReleases: [],
   rollbackTargets: [],
   upstream: null,
@@ -84,51 +72,53 @@ const RECENT = [
   commit('ccc3333ccc3333', 'older change'),
 ]
 
-const setup = (committish: string) => {
-  vi.mocked(endpoints.listDeploymentRefs).mockResolvedValue([
-    {
-      is_default: true,
-      kind: 'default',
-      name: 'main',
-      sha: 'aaa1111aaa1111',
-    },
-  ])
-  vi.mocked(endpoints.listRefCommits).mockResolvedValue(RECENT)
+const setup = (committish: string, recentCommits: RecentCommit[] = RECENT) =>
   render(
     <CommitDeployCard
       accent={null}
       actions={makeActions()}
       canTrigger
-      orgSlug="org"
-      projectId="p1"
+      recentCommits={recentCommits}
       stage={makeStage(committish)}
     />,
   )
-}
 
 describe('CommitDeployCard', () => {
-  it('marks the deployed commit and splits Deploy/Roll back around it', async () => {
+  it('marks the deployed commit and splits Deploy/Roll back around it', () => {
     setup('bbb2222bbb2222')
-    await waitFor(() =>
-      expect(screen.getByText('deployed')).toBeInTheDocument(),
-    )
+    expect(screen.getByText('deployed')).toBeInTheDocument()
+    expect(screen.getByText('HEAD')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /Deploy/ })).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /Roll back/ })).toHaveLength(1)
-    expect(endpoints.resolveDeploymentCommit).not.toHaveBeenCalled()
   })
 
-  it('pins the deployed commit when it falls outside the recent window', async () => {
-    vi.mocked(endpoints.resolveDeploymentCommit).mockResolvedValue(
-      commit('ddd4444ddd4444', 'the running commit'),
+  it('pulls the deployed commit forward when it is outside the display window', () => {
+    // 30 commits in the synced history; the deployed one is the 28th —
+    // beyond the 25-row display window, so it pins below a gap row.
+    const many = Array.from({ length: 30 }, (_, i) =>
+      commit(`sha${String(i).padStart(4, '0')}aaaa`, `commit ${i}`),
     )
-    setup('ddd4444ddd4444')
-    await waitFor(() =>
-      expect(screen.getByText('deployed')).toBeInTheDocument(),
-    )
-    expect(screen.getByText('the running commit')).toBeInTheDocument()
+    setup('sha0027aaaa', many)
+    expect(screen.getByText('deployed')).toBeInTheDocument()
+    expect(screen.getByText('commit 27')).toBeInTheDocument()
     expect(screen.getByText('… older commits not shown')).toBeInTheDocument()
-    // Everything in the window is newer than the pinned current commit.
-    expect(screen.getAllByRole('button', { name: /Deploy/ })).toHaveLength(3)
     expect(screen.queryByRole('button', { name: /Roll back/ })).toBeNull()
+  })
+
+  it('pins a bare-SHA row when the deployed commit is not synced at all', () => {
+    setup('fff9999fff9999')
+    expect(screen.getByText('deployed')).toBeInTheDocument()
+    expect(
+      screen.getByText('Not in the synced commit history — try a sync'),
+    ).toBeInTheDocument()
+  })
+
+  it('prompts for a sync when no commits are synced', () => {
+    setup('bbb2222bbb2222', [])
+    expect(
+      screen.getByText(
+        'No synced commits yet — run a sync from the pipeline sidebar.',
+      ),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/deployments/CommitDeployCard.tsx
+++ b/src/components/deployments/CommitDeployCard.tsx
@@ -1,6 +1,5 @@
-import { Fragment, useMemo, useState } from 'react'
+import { Fragment, useState } from 'react'
 
-import { useQuery } from '@tanstack/react-query'
 import {
   ExternalLink,
   GitCommitHorizontal,
@@ -9,20 +8,15 @@ import {
   Upload,
 } from 'lucide-react'
 
-import {
-  listDeploymentRefs,
-  listRefCommits,
-  resolveDeploymentCommit,
-} from '@/api/endpoints'
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { LoadingState } from '@/components/ui/loading-state'
 import type { ChipColors } from '@/lib/chip-colors'
-import type { DeploymentCommit, DeploymentRef } from '@/types'
+import type { RecentCommit } from '@/types'
 
 import { ConfirmActionDialog } from './ConfirmActionDialog'
 import type { PipelineStage } from './pipeline'
+import { shaMatch } from './pipeline'
 import { StageCardShell } from './StageCardShell'
 import type { DeploymentActions } from './useDeploymentActions'
 
@@ -30,87 +24,52 @@ interface CommitDeployCardProps {
   accent: ChipColors | null
   actions: DeploymentActions
   canTrigger: boolean
-  orgSlug: string
-  projectId: string
+  /** Synced default-branch commit history, newest first. */
+  recentCommits: RecentCommit[]
   stage: PipelineStage
 }
 
-const COMMIT_LIMIT = 25
+const DISPLAY_LIMIT = 25
 
 /**
- * The entry environment: tracks raw commits off the default branch.
- * Deploy a newer commit forward, or roll back to an older one — no
- * promotion happens here.
+ * The entry environment: tracks raw commits off the default branch
+ * (from imbi's synced history). Deploy a newer commit forward, or roll
+ * back to an older one — no promotion happens here.
  */
 // fallow-ignore-next-line complexity
 export function CommitDeployCard({
   accent,
   actions,
   canTrigger,
-  orgSlug,
-  projectId,
+  recentCommits,
   stage,
 }: CommitDeployCardProps) {
   const [confirming, setConfirming] = useState<null | {
-    commit: DeploymentCommit
+    commit: RecentCommit
     rollback: boolean
   }>(null)
 
-  const { data: refs = [] } = useQuery<DeploymentRef[]>({
-    queryFn: ({ signal }) =>
-      listDeploymentRefs(orgSlug, projectId, { kind: 'default' }, signal),
-    queryKey: ['deploymentRefs', orgSlug, projectId, 'branch'],
-  })
-  const defaultBranchName = useMemo(() => {
-    const def = refs.find((r) => r.is_default)
-    return def?.name ?? 'main'
-  }, [refs])
-
-  const {
-    data: commits = [],
-    isError,
-    isLoading,
-  } = useQuery<DeploymentCommit[]>({
-    queryFn: ({ signal }) =>
-      listRefCommits(
-        orgSlug,
-        projectId,
-        defaultBranchName,
-        { limit: COMMIT_LIMIT },
-        signal,
-      ),
-    queryKey: ['refCommits', orgSlug, projectId, defaultBranchName],
-  })
-
   const currentSha = stage.current?.release?.committish ?? null
-  const matchesCurrent = (c: DeploymentCommit) =>
-    !!currentSha &&
-    (c.sha.startsWith(currentSha) || currentSha.startsWith(c.sha))
+  const matchesCurrent = (c: RecentCommit) =>
+    !!currentSha && shaMatch(c.sha, currentSha)
 
-  // The deployed commit can be older than the recent-commits window (the
-  // branch has moved on). Resolve it so the list still anchors on what's
-  // actually running, pinned below a gap marker.
-  const currentMissing =
-    !!currentSha &&
-    !isLoading &&
-    !isError &&
-    commits.length > 0 &&
-    !commits.some(matchesCurrent)
-  const { data: resolvedCurrent } = useQuery<DeploymentCommit>({
-    enabled: currentMissing,
-    queryFn: ({ signal }) =>
-      resolveDeploymentCommit(orgSlug, projectId, currentSha ?? '', signal),
-    queryKey: ['resolveCommit', orgSlug, projectId, currentSha],
-  })
-  const rows = useMemo(
-    () =>
-      currentMissing && resolvedCurrent
-        ? [...commits, resolvedCurrent]
-        : commits,
-    [commits, currentMissing, resolvedCurrent],
-  )
+  // Show the most recent window; when the deployed commit is older than
+  // it, pull it forward from the rest of the synced history (or pin a
+  // bare-SHA row) so the list always anchors on what's running.
+  const windowRows = recentCommits.slice(0, DISPLAY_LIMIT)
+  const currentInWindow = windowRows.some(matchesCurrent)
+  const pinnedCurrent =
+    !currentInWindow && currentSha && windowRows.length > 0
+      ? (recentCommits.find(matchesCurrent) ?? {
+          authored_at: '',
+          ci_status: 'unknown' as const,
+          message: 'Not in the synced commit history — try a sync',
+          sha: currentSha,
+          short_sha: currentSha.slice(0, 7),
+        })
+      : null
+  const rows = pinnedCurrent ? [...windowRows, pinnedCurrent] : windowRows
   const deployedIdx = rows.findIndex(matchesCurrent)
-  const pinnedCurrent = currentMissing && !!resolvedCurrent
 
   return (
     <StageCardShell
@@ -130,17 +89,11 @@ export function CommitDeployCard({
     >
       <div className="px-4 py-4">
         <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
-          Recent commits on {defaultBranchName}
+          Recent commits
         </p>
-        {isLoading ? (
-          <LoadingState label="Loading commits…" />
-        ) : isError ? (
-          <p className="border-danger bg-danger/10 text-danger rounded-md border px-3 py-2 text-sm">
-            Failed to load commits.
-          </p>
-        ) : commits.length === 0 ? (
+        {rows.length === 0 ? (
           <p className="border-secondary text-tertiary rounded-md border p-3 text-sm">
-            No commits available.
+            No synced commits yet — run a sync from the pipeline sidebar.
           </p>
         ) : (
           <ul className="border-tertiary max-h-120 overflow-y-auto rounded-md border">
@@ -157,6 +110,7 @@ export function CommitDeployCard({
                   canTrigger={canTrigger && !actions.deployPending}
                   commit={c}
                   isCurrent={idx === deployedIdx}
+                  isHead={idx === 0}
                   onAction={(rollback) =>
                     setConfirming({ commit: c, rollback })
                   }
@@ -192,7 +146,7 @@ export function CommitDeployCard({
             action: 'deploy',
             envName: stage.env.name,
             envSlug: stage.env.slug,
-            refLabel: defaultBranchName,
+            refLabel: null,
             rollback: confirming.rollback,
             sha: confirming.commit.sha,
           })
@@ -216,14 +170,16 @@ function CommitRow({
   canTrigger,
   commit,
   isCurrent,
+  isHead,
   onAction,
   rollback,
 }: {
   accent: ChipColors | null
   actionPending: boolean
   canTrigger: boolean
-  commit: DeploymentCommit
+  commit: RecentCommit
   isCurrent: boolean
+  isHead: boolean
   onAction: (rollback: boolean) => void
   rollback: boolean
 }) {
@@ -233,11 +189,13 @@ function CommitRow({
       style={isCurrent && accent ? { backgroundColor: accent.bg } : undefined}
     >
       <span className="shrink-0 font-mono text-xs">{commit.short_sha}</span>
-      {commit.is_head ? <Badge variant="outline">HEAD</Badge> : null}
+      {isHead ? <Badge variant="outline">HEAD</Badge> : null}
       <span className="min-w-0 flex-1 truncate text-sm">
         {commit.message.split('\n')[0]}
       </span>
-      <CiStatusDot status={commit.ci_status} />
+      {commit.ci_status !== 'unknown' ? (
+        <CiStatusDot status={commit.ci_status} />
+      ) : null}
       {commit.author ? (
         <span className="text-tertiary hidden shrink-0 text-xs sm:inline">
           {commit.author}

--- a/src/components/deployments/CommitDeployCard.tsx
+++ b/src/components/deployments/CommitDeployCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -9,7 +9,11 @@ import {
   Upload,
 } from 'lucide-react'
 
-import { listDeploymentRefs, listRefCommits } from '@/api/endpoints'
+import {
+  listDeploymentRefs,
+  listRefCommits,
+  resolveDeploymentCommit,
+} from '@/api/endpoints'
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -31,7 +35,7 @@ interface CommitDeployCardProps {
   stage: PipelineStage
 }
 
-const COMMIT_LIMIT = 10
+const COMMIT_LIMIT = 25
 
 /**
  * The entry environment: tracks raw commits off the default branch.
@@ -79,11 +83,34 @@ export function CommitDeployCard({
   })
 
   const currentSha = stage.current?.release?.committish ?? null
-  const deployedIdx = currentSha
-    ? commits.findIndex(
-        (c) => c.sha.startsWith(currentSha) || currentSha.startsWith(c.sha),
-      )
-    : -1
+  const matchesCurrent = (c: DeploymentCommit) =>
+    !!currentSha &&
+    (c.sha.startsWith(currentSha) || currentSha.startsWith(c.sha))
+
+  // The deployed commit can be older than the recent-commits window (the
+  // branch has moved on). Resolve it so the list still anchors on what's
+  // actually running, pinned below a gap marker.
+  const currentMissing =
+    !!currentSha &&
+    !isLoading &&
+    !isError &&
+    commits.length > 0 &&
+    !commits.some(matchesCurrent)
+  const { data: resolvedCurrent } = useQuery<DeploymentCommit>({
+    enabled: currentMissing,
+    queryFn: ({ signal }) =>
+      resolveDeploymentCommit(orgSlug, projectId, currentSha ?? '', signal),
+    queryKey: ['resolveCommit', orgSlug, projectId, currentSha],
+  })
+  const rows = useMemo(
+    () =>
+      currentMissing && resolvedCurrent
+        ? [...commits, resolvedCurrent]
+        : commits,
+    [commits, currentMissing, resolvedCurrent],
+  )
+  const deployedIdx = rows.findIndex(matchesCurrent)
+  const pinnedCurrent = currentMissing && !!resolvedCurrent
 
   return (
     <StageCardShell
@@ -116,18 +143,26 @@ export function CommitDeployCard({
             No commits available.
           </p>
         ) : (
-          <ul className="border-tertiary rounded-md border">
-            {commits.map((c, idx) => (
-              <CommitRow
-                accent={accent}
-                actionPending={actions.deployPendingSha === c.sha}
-                canTrigger={canTrigger && !actions.deployPending}
-                commit={c}
-                isCurrent={idx === deployedIdx}
-                key={c.sha}
-                onAction={(rollback) => setConfirming({ commit: c, rollback })}
-                rollback={deployedIdx >= 0 && idx > deployedIdx}
-              />
+          <ul className="border-tertiary max-h-120 overflow-y-auto rounded-md border">
+            {rows.map((c, idx) => (
+              <Fragment key={c.sha}>
+                {pinnedCurrent && idx === rows.length - 1 ? (
+                  <li className="border-tertiary text-tertiary border-b px-3 py-1 text-center text-xs italic last:border-b-0">
+                    … older commits not shown
+                  </li>
+                ) : null}
+                <CommitRow
+                  accent={accent}
+                  actionPending={actions.deployPendingSha === c.sha}
+                  canTrigger={canTrigger && !actions.deployPending}
+                  commit={c}
+                  isCurrent={idx === deployedIdx}
+                  onAction={(rollback) =>
+                    setConfirming({ commit: c, rollback })
+                  }
+                  rollback={deployedIdx >= 0 && idx > deployedIdx}
+                />
+              </Fragment>
             ))}
           </ul>
         )}

--- a/src/components/deployments/CommitDeployCard.tsx
+++ b/src/components/deployments/CommitDeployCard.tsx
@@ -1,0 +1,244 @@
+import { useMemo, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import {
+  ExternalLink,
+  GitCommitHorizontal,
+  Loader2,
+  RotateCcw,
+  Upload,
+} from 'lucide-react'
+
+import { listDeploymentRefs, listRefCommits } from '@/api/endpoints'
+import { CiStatusDot } from '@/components/releases/CiStatusDot'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { LoadingState } from '@/components/ui/loading-state'
+import type { ChipColors } from '@/lib/chip-colors'
+import type { DeploymentCommit, DeploymentRef } from '@/types'
+
+import { ConfirmActionDialog } from './ConfirmActionDialog'
+import type { PipelineStage } from './pipeline'
+import { StageCardShell } from './StageCardShell'
+import type { DeploymentActions } from './useDeploymentActions'
+
+interface CommitDeployCardProps {
+  accent: ChipColors | null
+  actions: DeploymentActions
+  canTrigger: boolean
+  orgSlug: string
+  projectId: string
+  stage: PipelineStage
+}
+
+const COMMIT_LIMIT = 10
+
+/**
+ * The entry environment: tracks raw commits off the default branch.
+ * Deploy a newer commit forward, or roll back to an older one — no
+ * promotion happens here.
+ */
+// fallow-ignore-next-line complexity
+export function CommitDeployCard({
+  accent,
+  actions,
+  canTrigger,
+  orgSlug,
+  projectId,
+  stage,
+}: CommitDeployCardProps) {
+  const [confirming, setConfirming] = useState<null | {
+    commit: DeploymentCommit
+    rollback: boolean
+  }>(null)
+
+  const { data: refs = [] } = useQuery<DeploymentRef[]>({
+    queryFn: ({ signal }) =>
+      listDeploymentRefs(orgSlug, projectId, { kind: 'default' }, signal),
+    queryKey: ['deploymentRefs', orgSlug, projectId, 'branch'],
+  })
+  const defaultBranchName = useMemo(() => {
+    const def = refs.find((r) => r.is_default)
+    return def?.name ?? 'main'
+  }, [refs])
+
+  const {
+    data: commits = [],
+    isError,
+    isLoading,
+  } = useQuery<DeploymentCommit[]>({
+    queryFn: ({ signal }) =>
+      listRefCommits(
+        orgSlug,
+        projectId,
+        defaultBranchName,
+        { limit: COMMIT_LIMIT },
+        signal,
+      ),
+    queryKey: ['refCommits', orgSlug, projectId, defaultBranchName],
+  })
+
+  const currentSha = stage.current?.release?.committish ?? null
+  const deployedIdx = currentSha
+    ? commits.findIndex(
+        (c) => c.sha.startsWith(currentSha) || currentSha.startsWith(c.sha),
+      )
+    : -1
+
+  return (
+    <StageCardShell
+      accent={accent}
+      icon={GitCommitHorizontal}
+      subtitle={
+        currentSha ? (
+          <>
+            On <span className="font-mono">{currentSha.slice(0, 7)}</span> ·
+            deploy a newer commit or roll back
+          </>
+        ) : (
+          'Nothing deployed yet — deploy a commit to get started'
+        )
+      }
+      title={stage.env.name}
+    >
+      <div className="px-4 py-4">
+        <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+          Recent commits on {defaultBranchName}
+        </p>
+        {isLoading ? (
+          <LoadingState label="Loading commits…" />
+        ) : isError ? (
+          <p className="border-danger bg-danger/10 text-danger rounded-md border px-3 py-2 text-sm">
+            Failed to load commits.
+          </p>
+        ) : commits.length === 0 ? (
+          <p className="border-secondary text-tertiary rounded-md border p-3 text-sm">
+            No commits available.
+          </p>
+        ) : (
+          <ul className="border-tertiary rounded-md border">
+            {commits.map((c, idx) => (
+              <CommitRow
+                accent={accent}
+                actionPending={actions.deployPendingSha === c.sha}
+                canTrigger={canTrigger && !actions.deployPending}
+                commit={c}
+                isCurrent={idx === deployedIdx}
+                key={c.sha}
+                onAction={(rollback) => setConfirming({ commit: c, rollback })}
+                rollback={deployedIdx >= 0 && idx > deployedIdx}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ConfirmActionDialog
+        confirmLabel={
+          confirming
+            ? `${confirming.rollback ? 'Roll back to' : 'Deploy'} ${confirming.commit.short_sha}`
+            : 'Deploy'
+        }
+        description={
+          confirming ? (
+            <>
+              {confirming.rollback ? 'Redeploys' : 'Deploys'}{' '}
+              <span className="font-mono">{confirming.commit.short_sha}</span> (
+              {confirming.commit.message.split('\n')[0]}) to {stage.env.name}.
+            </>
+          ) : (
+            ''
+          )
+        }
+        onCancel={() => setConfirming(null)}
+        onConfirm={() => {
+          if (!confirming) return
+          actions.deploy({
+            action: 'deploy',
+            envName: stage.env.name,
+            envSlug: stage.env.slug,
+            refLabel: defaultBranchName,
+            rollback: confirming.rollback,
+            sha: confirming.commit.sha,
+          })
+          setConfirming(null)
+        }}
+        open={confirming !== null}
+        title={
+          confirming?.rollback
+            ? `Roll back ${stage.env.name}?`
+            : `Deploy to ${stage.env.name}?`
+        }
+      />
+    </StageCardShell>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function CommitRow({
+  accent,
+  actionPending,
+  canTrigger,
+  commit,
+  isCurrent,
+  onAction,
+  rollback,
+}: {
+  accent: ChipColors | null
+  actionPending: boolean
+  canTrigger: boolean
+  commit: DeploymentCommit
+  isCurrent: boolean
+  onAction: (rollback: boolean) => void
+  rollback: boolean
+}) {
+  return (
+    <li
+      className="border-tertiary flex min-w-0 items-center gap-3 border-b px-3 py-1.5 last:border-b-0"
+      style={isCurrent && accent ? { backgroundColor: accent.bg } : undefined}
+    >
+      <span className="shrink-0 font-mono text-xs">{commit.short_sha}</span>
+      {commit.is_head ? <Badge variant="outline">HEAD</Badge> : null}
+      <span className="min-w-0 flex-1 truncate text-sm">
+        {commit.message.split('\n')[0]}
+      </span>
+      <CiStatusDot status={commit.ci_status} />
+      {commit.author ? (
+        <span className="text-tertiary hidden shrink-0 text-xs sm:inline">
+          {commit.author}
+        </span>
+      ) : null}
+      {commit.url ? (
+        <a
+          aria-label="View commit"
+          className="text-tertiary hover:text-primary"
+          href={commit.url}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <ExternalLink className="size-3.5" />
+        </a>
+      ) : null}
+      {isCurrent ? (
+        <Badge variant="neutral">deployed</Badge>
+      ) : (
+        <Button
+          disabled={!canTrigger}
+          onClick={() => onAction(rollback)}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {actionPending ? (
+            <Loader2 className="mr-1 size-3.5 animate-spin" />
+          ) : rollback ? (
+            <RotateCcw className="mr-1 size-3.5" />
+          ) : (
+            <Upload className="mr-1 size-3.5" />
+          )}
+          {rollback ? 'Roll back' : 'Deploy'}
+        </Button>
+      )}
+    </li>
+  )
+}

--- a/src/components/deployments/CommitDeployCard.tsx
+++ b/src/components/deployments/CommitDeployCard.tsx
@@ -11,6 +11,7 @@ import {
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { isBotActor, UserIdentity } from '@/components/ui/user-identity'
 import type { ChipColors } from '@/lib/chip-colors'
 import type { RecentCommit } from '@/types'
 
@@ -197,8 +198,13 @@ function CommitRow({
         <CiStatusDot status={commit.ci_status} />
       ) : null}
       {commit.author ? (
-        <span className="text-tertiary hidden shrink-0 text-xs sm:inline">
-          {commit.author}
+        <span className="hidden shrink-0 sm:inline">
+          <UserIdentity
+            email={commit.author_email}
+            kind={isBotActor(commit.author) ? 'bot' : 'user'}
+            name={commit.author}
+            size="small"
+          />
         </span>
       ) : null}
       {commit.url ? (

--- a/src/components/deployments/ConfirmActionDialog.tsx
+++ b/src/components/deployments/ConfirmActionDialog.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface ConfirmActionDialogProps {
+  confirmLabel: string
+  description: ReactNode
+  onCancel: () => void
+  onConfirm: () => void
+  open: boolean
+  title: string
+}
+
+/**
+ * Non-destructive confirm for one-click dispatch rows (deploy / roll
+ * back). The shared ConfirmDialog hard-codes destructive styling, so the
+ * deployments tab keeps its own default-styled variant.
+ */
+export function ConfirmActionDialog({
+  confirmLabel,
+  description,
+  onCancel,
+  onConfirm,
+  open,
+  title,
+}: ConfirmActionDialogProps) {
+  return (
+    <AlertDialog
+      onOpenChange={(next) => {
+        if (!next) onCancel()
+      }}
+      open={open}
+    >
+      <AlertDialogContent className="sm:max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/deployments/CurrentlyRunningCard.test.tsx
+++ b/src/components/deployments/CurrentlyRunningCard.test.tsx
@@ -73,7 +73,12 @@ const makeActions = (): DeploymentActions => ({
 describe('CurrentlyRunningCard', () => {
   it('shows the running version, deployer, and environment URL', () => {
     render(
-      <CurrentlyRunningCard actions={makeActions()} canTrigger stage={STAGE} />,
+      <CurrentlyRunningCard
+        accent={null}
+        actions={makeActions()}
+        canTrigger
+        stage={STAGE}
+      />,
     )
     expect(screen.getByText('v6.5.0')).toBeInTheDocument()
     expect(screen.getByText('gavin')).toBeInTheDocument()
@@ -83,7 +88,12 @@ describe('CurrentlyRunningCard', () => {
   it('expands a recent release into its notes', async () => {
     const user = userEvent.setup()
     render(
-      <CurrentlyRunningCard actions={makeActions()} canTrigger stage={STAGE} />,
+      <CurrentlyRunningCard
+        accent={null}
+        actions={makeActions()}
+        canTrigger
+        stage={STAGE}
+      />,
     )
     await user.click(screen.getByRole('button', { name: /v6\.4\.0/ }))
     expect(screen.getByText('old fix')).toBeInTheDocument()
@@ -92,7 +102,14 @@ describe('CurrentlyRunningCard', () => {
   it('rolls back through the confirm dialog', async () => {
     const actions = makeActions()
     const user = userEvent.setup()
-    render(<CurrentlyRunningCard actions={actions} canTrigger stage={STAGE} />)
+    render(
+      <CurrentlyRunningCard
+        accent={null}
+        actions={actions}
+        canTrigger
+        stage={STAGE}
+      />,
+    )
     await user.click(screen.getByRole('button', { name: 'Roll back' }))
     await user.click(
       screen.getByRole('button', { name: 'Roll back to v6.4.0' }),

--- a/src/components/deployments/CurrentlyRunningCard.test.tsx
+++ b/src/components/deployments/CurrentlyRunningCard.test.tsx
@@ -1,0 +1,108 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { render } from '@/test/utils'
+import type {
+  CurrentReleaseEnvironment,
+  Environment,
+  ReleaseHistoryEntry,
+} from '@/types'
+
+import { CurrentlyRunningCard } from './CurrentlyRunningCard'
+import type { PipelineStage } from './pipeline'
+import type { DeploymentActions } from './useDeploymentActions'
+
+const ENV = {
+  id: 'production',
+  label_color: '#C86B5E',
+  name: 'Production',
+  slug: 'production',
+  sort_order: 3,
+  url: 'https://service.example.com',
+} as unknown as Environment
+
+const CURRENT: CurrentReleaseEnvironment = {
+  ci_status: 'pass',
+  current_status: 'success',
+  environment: { name: 'production', slug: 'production' },
+  external_run_url: null,
+  last_event_at: '2026-06-01T00:00:00Z',
+  performed_by: 'gavin',
+  release: {
+    committish: 'aaa111aaa111',
+    created_at: '2026-06-01T00:00:00Z',
+    created_by: 'gavin',
+    id: 'rel-1',
+    links: [],
+    project_id: 'p1',
+    tag: 'v6.5.0',
+    title: 'v6.5.0',
+  },
+}
+
+const ROLLBACK: ReleaseHistoryEntry = {
+  author: 'gavin',
+  ci_status: 'pass',
+  notes_markdown: '### Fixed\n- old fix',
+  published_at: '2026-05-01T00:00:00Z',
+  sha: '000999000999',
+  short_sha: '0009990',
+  tag: 'v6.4.0',
+}
+
+const STAGE: PipelineStage = {
+  current: CURRENT,
+  env: ENV,
+  kind: 'release',
+  pendingReleases: [],
+  rollbackTargets: [ROLLBACK],
+  upstream: null,
+  upstreamCurrent: null,
+}
+
+const makeActions = (): DeploymentActions => ({
+  deploy: vi.fn(),
+  deployPending: false,
+  deployPendingSha: null,
+  promote: vi.fn(),
+  promotePending: false,
+})
+
+describe('CurrentlyRunningCard', () => {
+  it('shows the running version, deployer, and environment URL', () => {
+    render(
+      <CurrentlyRunningCard actions={makeActions()} canTrigger stage={STAGE} />,
+    )
+    expect(screen.getByText('v6.5.0')).toBeInTheDocument()
+    expect(screen.getByText('gavin')).toBeInTheDocument()
+    expect(screen.getByText('service.example.com')).toBeInTheDocument()
+  })
+
+  it('expands a recent release into its notes', async () => {
+    const user = userEvent.setup()
+    render(
+      <CurrentlyRunningCard actions={makeActions()} canTrigger stage={STAGE} />,
+    )
+    await user.click(screen.getByRole('button', { name: /v6\.4\.0/ }))
+    expect(screen.getByText('old fix')).toBeInTheDocument()
+  })
+
+  it('rolls back through the confirm dialog', async () => {
+    const actions = makeActions()
+    const user = userEvent.setup()
+    render(<CurrentlyRunningCard actions={actions} canTrigger stage={STAGE} />)
+    await user.click(screen.getByRole('button', { name: 'Roll back' }))
+    await user.click(
+      screen.getByRole('button', { name: 'Roll back to v6.4.0' }),
+    )
+    expect(actions.deploy).toHaveBeenCalledWith({
+      action: 'deploy',
+      envName: 'Production',
+      envSlug: 'production',
+      refLabel: 'v6.4.0',
+      rollback: true,
+      sha: '000999000999',
+    })
+  })
+})

--- a/src/components/deployments/CurrentlyRunningCard.test.tsx
+++ b/src/components/deployments/CurrentlyRunningCard.test.tsx
@@ -55,6 +55,7 @@ const STAGE: PipelineStage = {
   current: CURRENT,
   env: ENV,
   kind: 'release',
+  pendingCommits: [],
   pendingReleases: [],
   rollbackTargets: [ROLLBACK],
   upstream: null,

--- a/src/components/deployments/CurrentlyRunningCard.tsx
+++ b/src/components/deployments/CurrentlyRunningCard.tsx
@@ -4,15 +4,16 @@ import { formatDistanceToNow } from 'date-fns'
 import {
   ChevronDown,
   ChevronRight,
+  CircleDot,
   Clock,
-  ExternalLink,
   Globe,
   RotateCcw,
-  User,
 } from 'lucide-react'
 
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Button } from '@/components/ui/button'
+import { isBotActor, UserIdentity } from '@/components/ui/user-identity'
+import type { ChipColors } from '@/lib/chip-colors'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { cn } from '@/lib/utils'
 import type { ReleaseHistoryEntry } from '@/types'
@@ -20,9 +21,11 @@ import type { ReleaseHistoryEntry } from '@/types'
 import { ConfirmActionDialog } from './ConfirmActionDialog'
 import type { PipelineStage } from './pipeline'
 import { ReleaseNotesMarkdown } from './ReleaseNotesMarkdown'
+import { StageCardShell } from './StageCardShell'
 import type { DeploymentActions } from './useDeploymentActions'
 
 interface CurrentlyRunningCardProps {
+  accent: ChipColors | null
   actions: DeploymentActions
   canTrigger: boolean
   stage: PipelineStage
@@ -34,6 +37,7 @@ interface CurrentlyRunningCardProps {
  */
 // fallow-ignore-next-line complexity
 export function CurrentlyRunningCard({
+  accent,
   actions,
   canTrigger,
   stage,
@@ -44,41 +48,25 @@ export function CurrentlyRunningCard({
   const envUrl = stage.env.url ?? null
 
   return (
-    <div className="border-tertiary rounded-lg border px-4 py-3.5">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-tertiary text-xs tracking-wider uppercase">
-          Currently running
-        </p>
-        {envUrl ? (
+    <StageCardShell
+      accent={accent}
+      aside={
+        envUrl ? (
           <a
-            className="text-tertiary hover:text-primary inline-flex items-center gap-1.5 text-xs"
+            className="inline-flex items-center gap-1.5 text-xs hover:underline"
             href={envUrl}
             rel="noopener noreferrer"
             target="_blank"
           >
-            <Globe size={13} />
+            <Globe size={12} />
             {envUrl.replace(/^https?:\/\//, '')}
           </a>
-        ) : null}
-      </div>
-
-      {release ? (
-        <>
-          <div className="mt-2 flex items-baseline gap-2.5">
-            <span className="font-mono text-xl font-semibold">
-              {release.tag ?? release.committish.slice(0, 7)}
-            </span>
-            {release.tag ? (
-              <span className="text-tertiary font-mono text-xs">
-                {release.committish.slice(0, 7)}
-              </span>
-            ) : null}
-            {stage.current?.ci_status &&
-            stage.current.ci_status !== 'unknown' ? (
-              <CiStatusDot status={stage.current.ci_status} />
-            ) : null}
-          </div>
-          <div className="text-tertiary mt-2 flex flex-wrap items-center gap-4 text-xs">
+        ) : undefined
+      }
+      icon={CircleDot}
+      subtitle={
+        release ? (
+          <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
             {stage.current?.last_event_at ? (
               <span className="inline-flex items-center gap-1.5">
                 <Clock size={13} />
@@ -89,38 +77,66 @@ export function CurrentlyRunningCard({
               </span>
             ) : null}
             {stage.current?.performed_by ? (
-              <span className="inline-flex items-center gap-1.5">
-                <User size={13} />
-                {stage.current.performed_by}
-              </span>
+              <>
+                <span aria-hidden="true">·</span>
+                <UserIdentity
+                  email={stage.current.performed_by_email}
+                  kind={isBotActor(stage.current.performed_by) ? 'bot' : 'user'}
+                  name={stage.current.performed_by}
+                  size="small"
+                />
+              </>
             ) : null}
-          </div>
-        </>
-      ) : (
-        <p className="text-tertiary mt-2 text-sm italic">
-          Nothing deployed yet.
-        </p>
-      )}
+          </span>
+        ) : undefined
+      }
+      title={
+        <span className="flex items-baseline gap-2.5">
+          Currently running
+          {release ? (
+            <>
+              <span className="font-mono text-base">
+                {release.tag ?? release.committish.slice(0, 7)}
+              </span>
+              {release.tag ? (
+                <span className="text-tertiary font-mono text-xs font-normal">
+                  {release.committish.slice(0, 7)}
+                </span>
+              ) : null}
+              {stage.current?.ci_status &&
+              stage.current.ci_status !== 'unknown' ? (
+                <CiStatusDot status={stage.current.ci_status} />
+              ) : null}
+            </>
+          ) : null}
+        </span>
+      }
+    >
+      <div className="px-4 py-4">
+        {release ? null : (
+          <p className="text-tertiary text-sm italic">Nothing deployed yet.</p>
+        )}
 
-      {stage.rollbackTargets.length > 0 ? (
-        <div className="border-tertiary mt-3 border-t pt-3">
-          <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
-            Recent releases
-          </p>
-          {stage.rollbackTargets.map((rel) => (
-            <RollbackRow
-              canTrigger={canTrigger}
-              isOpen={openTag === rel.tag}
-              key={rel.tag}
-              onRollback={() => setConfirming(rel)}
-              onToggle={() =>
-                setOpenTag((o) => (o === rel.tag ? null : rel.tag))
-              }
-              rel={rel}
-            />
-          ))}
-        </div>
-      ) : null}
+        {stage.rollbackTargets.length > 0 ? (
+          <div>
+            <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+              Recent releases
+            </p>
+            {stage.rollbackTargets.map((rel) => (
+              <RollbackRow
+                canTrigger={canTrigger}
+                isOpen={openTag === rel.tag}
+                key={rel.tag}
+                onRollback={() => setConfirming(rel)}
+                onToggle={() =>
+                  setOpenTag((o) => (o === rel.tag ? null : rel.tag))
+                }
+                rel={rel}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
 
       <ConfirmActionDialog
         confirmLabel={
@@ -153,7 +169,7 @@ export function CurrentlyRunningCard({
         open={confirming !== null}
         title={`Roll back ${stage.env.name}?`}
       />
-    </div>
+    </StageCardShell>
   )
 }
 
@@ -179,7 +195,7 @@ function RollbackRow({
     >
       <div className="hover:bg-secondary flex items-center gap-3 rounded-md px-2 py-1">
         <button
-          className="grid flex-1 cursor-pointer grid-cols-[auto_auto_auto_1fr] items-center gap-3 text-left"
+          className="grid flex-1 cursor-pointer grid-cols-[0.8rem_8rem_1rem_4.5rem_1fr] items-center gap-3 text-left"
           onClick={onToggle}
           type="button"
         >
@@ -188,10 +204,8 @@ function RollbackRow({
           ) : (
             <ChevronRight className="text-tertiary size-3.5" />
           )}
-          <span className="flex items-center gap-2">
-            <span className="font-mono text-sm font-semibold">{rel.tag}</span>
-            <CiStatusDot size={13} status={rel.ci_status} />
-          </span>
+          <span className="font-mono text-sm font-semibold">{rel.tag}</span>
+          <CiStatusDot size={13} status={rel.ci_status} />
           <span className="text-tertiary font-mono text-xs">
             {rel.short_sha}
           </span>
@@ -200,37 +214,31 @@ function RollbackRow({
           </span>
         </button>
         <Button
+          className="h-7 px-2.5 text-xs"
           disabled={!canTrigger}
           onClick={onRollback}
           size="sm"
           type="button"
-          variant="ghost"
+          variant="outline"
         >
           <RotateCcw className="mr-1 size-3.5" />
           Roll back
         </Button>
       </div>
       {isOpen ? (
-        <div className="px-2 pb-3 pl-[2.1rem]">
+        <div className="px-2 pb-3 pl-8">
           <ReleaseNotesMarkdown notes={rel.notes_markdown} />
-          <div className="mt-2 flex flex-wrap items-center gap-4">
-            {rel.author ? (
-              <span className="text-tertiary text-xs">
-                released by {rel.author}
-              </span>
-            ) : null}
-            {(rel.release_url ?? rel.tag_url) ? (
-              <a
-                className="text-tertiary hover:text-primary inline-flex items-center gap-1 text-xs"
-                href={(rel.release_url ?? rel.tag_url) as string}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <ExternalLink size={12} />
-                {rel.release_url ? 'Release notes' : 'View tag'}
-              </a>
-            ) : null}
-          </div>
+          {rel.author ? (
+            <div className="text-tertiary mt-2 inline-flex items-center gap-1.5 text-xs">
+              released by
+              <UserIdentity
+                email={rel.author_email}
+                kind={isBotActor(rel.author) ? 'bot' : 'user'}
+                name={rel.author}
+                size="small"
+              />
+            </div>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/components/deployments/CurrentlyRunningCard.tsx
+++ b/src/components/deployments/CurrentlyRunningCard.tsx
@@ -1,0 +1,238 @@
+import { useState } from 'react'
+
+import { formatDistanceToNow } from 'date-fns'
+import {
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  ExternalLink,
+  Globe,
+  RotateCcw,
+  User,
+} from 'lucide-react'
+
+import { CiStatusDot } from '@/components/releases/CiStatusDot'
+import { Button } from '@/components/ui/button'
+import { formatRelativeDate } from '@/lib/formatDate'
+import { cn } from '@/lib/utils'
+import type { ReleaseHistoryEntry } from '@/types'
+
+import { ConfirmActionDialog } from './ConfirmActionDialog'
+import type { PipelineStage } from './pipeline'
+import { ReleaseNotesMarkdown } from './ReleaseNotesMarkdown'
+import type { DeploymentActions } from './useDeploymentActions'
+
+interface CurrentlyRunningCardProps {
+  actions: DeploymentActions
+  canTrigger: boolean
+  stage: PipelineStage
+}
+
+/**
+ * What the environment runs now, plus the recent releases it can roll
+ * back to (each expandable into its release notes).
+ */
+// fallow-ignore-next-line complexity
+export function CurrentlyRunningCard({
+  actions,
+  canTrigger,
+  stage,
+}: CurrentlyRunningCardProps) {
+  const [openTag, setOpenTag] = useState<null | string>(null)
+  const [confirming, setConfirming] = useState<null | ReleaseHistoryEntry>(null)
+  const release = stage.current?.release ?? null
+  const envUrl = stage.env.url ?? null
+
+  return (
+    <div className="border-tertiary rounded-lg border px-4 py-3.5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-tertiary text-xs tracking-wider uppercase">
+          Currently running
+        </p>
+        {envUrl ? (
+          <a
+            className="text-tertiary hover:text-primary inline-flex items-center gap-1.5 text-xs"
+            href={envUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <Globe size={13} />
+            {envUrl.replace(/^https?:\/\//, '')}
+          </a>
+        ) : null}
+      </div>
+
+      {release ? (
+        <>
+          <div className="mt-2 flex items-baseline gap-2.5">
+            <span className="font-mono text-xl font-semibold">
+              {release.tag ?? release.committish.slice(0, 7)}
+            </span>
+            {release.tag ? (
+              <span className="text-tertiary font-mono text-xs">
+                {release.committish.slice(0, 7)}
+              </span>
+            ) : null}
+            {stage.current?.ci_status &&
+            stage.current.ci_status !== 'unknown' ? (
+              <CiStatusDot status={stage.current.ci_status} />
+            ) : null}
+          </div>
+          <div className="text-tertiary mt-2 flex flex-wrap items-center gap-4 text-xs">
+            {stage.current?.last_event_at ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Clock size={13} />
+                Deployed{' '}
+                {formatDistanceToNow(new Date(stage.current.last_event_at), {
+                  addSuffix: true,
+                })}
+              </span>
+            ) : null}
+            {stage.current?.performed_by ? (
+              <span className="inline-flex items-center gap-1.5">
+                <User size={13} />
+                {stage.current.performed_by}
+              </span>
+            ) : null}
+          </div>
+        </>
+      ) : (
+        <p className="text-tertiary mt-2 text-sm italic">
+          Nothing deployed yet.
+        </p>
+      )}
+
+      {stage.rollbackTargets.length > 0 ? (
+        <div className="border-tertiary mt-3 border-t pt-3">
+          <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+            Recent releases
+          </p>
+          {stage.rollbackTargets.map((rel) => (
+            <RollbackRow
+              canTrigger={canTrigger}
+              isOpen={openTag === rel.tag}
+              key={rel.tag}
+              onRollback={() => setConfirming(rel)}
+              onToggle={() =>
+                setOpenTag((o) => (o === rel.tag ? null : rel.tag))
+              }
+              rel={rel}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <ConfirmActionDialog
+        confirmLabel={
+          confirming ? `Roll back to ${confirming.tag}` : 'Roll back'
+        }
+        description={
+          confirming ? (
+            <>
+              Redeploys <span className="font-mono">{confirming.tag}</span> to{' '}
+              {stage.env.name}. {stage.env.name} will show as behind until you
+              move forward again; no new tag is cut.
+            </>
+          ) : (
+            ''
+          )
+        }
+        onCancel={() => setConfirming(null)}
+        onConfirm={() => {
+          if (!confirming) return
+          actions.deploy({
+            action: 'deploy',
+            envName: stage.env.name,
+            envSlug: stage.env.slug,
+            refLabel: confirming.tag,
+            rollback: true,
+            sha: confirming.sha,
+          })
+          setConfirming(null)
+        }}
+        open={confirming !== null}
+        title={`Roll back ${stage.env.name}?`}
+      />
+    </div>
+  )
+}
+
+function RollbackRow({
+  canTrigger,
+  isOpen,
+  onRollback,
+  onToggle,
+  rel,
+}: {
+  canTrigger: boolean
+  isOpen: boolean
+  onRollback: () => void
+  onToggle: () => void
+  rel: ReleaseHistoryEntry
+}) {
+  return (
+    <div
+      className={cn(
+        '-mx-2 rounded-md transition-colors',
+        isOpen && 'bg-secondary',
+      )}
+    >
+      <div className="hover:bg-secondary flex items-center gap-3 rounded-md px-2 py-1">
+        <button
+          className="grid flex-1 cursor-pointer grid-cols-[auto_auto_auto_1fr] items-center gap-3 text-left"
+          onClick={onToggle}
+          type="button"
+        >
+          {isOpen ? (
+            <ChevronDown className="text-tertiary size-3.5" />
+          ) : (
+            <ChevronRight className="text-tertiary size-3.5" />
+          )}
+          <span className="flex items-center gap-2">
+            <span className="font-mono text-sm font-semibold">{rel.tag}</span>
+            <CiStatusDot size={13} status={rel.ci_status} />
+          </span>
+          <span className="text-tertiary font-mono text-xs">
+            {rel.short_sha}
+          </span>
+          <span className="text-tertiary text-xs">
+            {formatRelativeDate(rel.published_at)}
+          </span>
+        </button>
+        <Button
+          disabled={!canTrigger}
+          onClick={onRollback}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <RotateCcw className="mr-1 size-3.5" />
+          Roll back
+        </Button>
+      </div>
+      {isOpen ? (
+        <div className="px-2 pb-3 pl-[2.1rem]">
+          <ReleaseNotesMarkdown notes={rel.notes_markdown} />
+          <div className="mt-2 flex flex-wrap items-center gap-4">
+            {rel.author ? (
+              <span className="text-tertiary text-xs">
+                released by {rel.author}
+              </span>
+            ) : null}
+            {(rel.release_url ?? rel.tag_url) ? (
+              <a
+                className="text-tertiary hover:text-primary inline-flex items-center gap-1 text-xs"
+                href={(rel.release_url ?? rel.tag_url) as string}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <ExternalLink size={12} />
+                {rel.release_url ? 'Release notes' : 'View tag'}
+              </a>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/deployments/CurrentlyRunningCard.tsx
+++ b/src/components/deployments/CurrentlyRunningCard.tsx
@@ -15,7 +15,7 @@ import { Button } from '@/components/ui/button'
 import { isBotActor, UserIdentity } from '@/components/ui/user-identity'
 import type { ChipColors } from '@/lib/chip-colors'
 import { formatRelativeDate } from '@/lib/formatDate'
-import { cn } from '@/lib/utils'
+import { cn, sanitizeHttpUrl } from '@/lib/utils'
 import type { ReleaseHistoryEntry } from '@/types'
 
 import { ConfirmActionDialog } from './ConfirmActionDialog'
@@ -45,7 +45,7 @@ export function CurrentlyRunningCard({
   const [openTag, setOpenTag] = useState<null | string>(null)
   const [confirming, setConfirming] = useState<null | ReleaseHistoryEntry>(null)
   const release = stage.current?.release ?? null
-  const envUrl = stage.env.url ?? null
+  const envUrl = sanitizeHttpUrl(stage.env.url ?? null)
 
   return (
     <StageCardShell
@@ -59,7 +59,7 @@ export function CurrentlyRunningCard({
             target="_blank"
           >
             <Globe size={12} />
-            {envUrl.replace(/^https?:\/\//, '')}
+            {envUrl.replace(/^https?:\/\//, '').replace(/\/$/, '')}
           </a>
         ) : undefined
       }

--- a/src/components/deployments/DeploymentsTab.tsx
+++ b/src/components/deployments/DeploymentsTab.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
-import { Rocket } from 'lucide-react'
 
 import { listCurrentReleases, listPromotionOptions } from '@/api/endpoints'
 import { getReleaseHistory } from '@/api/releases'
@@ -112,36 +111,30 @@ export function DeploymentsTab({
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <h2 className="inline-flex items-center gap-2 text-base font-semibold">
-        <Rocket className="text-tertiary size-4" />
-        Deployments
-      </h2>
-      <div className="grid items-start gap-5 md:grid-cols-[240px_minmax(0,1fr)]">
-        <EnvironmentNav
-          connectLabel={connectLabel}
-          isDarkMode={isDarkMode}
-          onSelect={setSelectedSlug}
-          pendingCommitsBySlug={pendingCommitsBySlug}
-          readiness={readiness}
-          selectedSlug={effectiveSlug}
-          stages={stages}
+    <div className="grid items-start gap-5 md:grid-cols-[240px_minmax(0,1fr)]">
+      <EnvironmentNav
+        connectLabel={connectLabel}
+        isDarkMode={isDarkMode}
+        onSelect={setSelectedSlug}
+        pendingCommitsBySlug={pendingCommitsBySlug}
+        readiness={readiness}
+        selectedSlug={effectiveSlug}
+        stages={stages}
+      />
+      {selectedStage ? (
+        <EnvironmentDetail
+          accent={
+            selectedStage.env.label_color
+              ? deriveChipColors(selectedStage.env.label_color, isDarkMode)
+              : null
+          }
+          actions={actions}
+          canTrigger={canTrigger}
+          orgSlug={orgSlug}
+          projectId={projectId}
+          stage={selectedStage}
         />
-        {selectedStage ? (
-          <EnvironmentDetail
-            accent={
-              selectedStage.env.label_color
-                ? deriveChipColors(selectedStage.env.label_color, isDarkMode)
-                : null
-            }
-            actions={actions}
-            canTrigger={canTrigger}
-            orgSlug={orgSlug}
-            projectId={projectId}
-            stage={selectedStage}
-          />
-        ) : null}
-      </div>
+      ) : null}
     </div>
   )
 }

--- a/src/components/deployments/DeploymentsTab.tsx
+++ b/src/components/deployments/DeploymentsTab.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 
-import { listCurrentReleases, listPromotionOptions } from '@/api/endpoints'
+import { listCurrentReleases, listRecentCommits } from '@/api/endpoints'
 import { getReleaseHistory } from '@/api/releases'
 import type { DeploymentRunStarted } from '@/components/deploy/DeploymentModal'
 import { LoadingState } from '@/components/ui/loading-state'
@@ -14,6 +14,7 @@ import { EnvironmentDetail } from './EnvironmentDetail'
 import { EnvironmentNav } from './EnvironmentNav'
 import { buildPipeline, defaultStageSlug } from './pipeline'
 import { useDeploymentActions } from './useDeploymentActions'
+import { useDeploymentSync } from './useDeploymentSync'
 
 interface DeploymentsTabProps {
   canTrigger: boolean
@@ -26,10 +27,18 @@ interface DeploymentsTabProps {
   readiness: 'connected' | 'disconnected' | 'error' | 'loading'
 }
 
+// Synced default-branch commits to consider; covers the realistic gap
+// between the oldest deployed environment and the branch tip.
+const COMMIT_WINDOW = 200
+
 /**
  * Project-detail Deployments tab: an environment sidebar (descending
  * sort order) and a per-environment detail pane for deploying,
  * promoting, and rolling back.
+ *
+ * Reads exclusively from imbi's synced data (graph releases + the
+ * ClickHouse commit/tag history) — never the live source host. The
+ * sidebar's sync action refreshes commits, tags, and releases.
  */
 // fallow-ignore-next-line complexity
 export function DeploymentsTab({
@@ -62,40 +71,36 @@ export function DeploymentsTab({
     queryFn: ({ signal }) => getReleaseHistory(orgSlug, projectId, signal),
     queryKey: ['releaseHistory', orgSlug, projectId],
   })
-  // Adjacent-env commit counts for the sidebar badges; tolerated as
-  // best-effort (the endpoint already degrades per-pair on plugin
-  // failures).
-  const { data: promotionOptions = [] } = useQuery({
+  const {
+    data: recentCommits = [],
+    error: commitsError,
+    isLoading: commitsLoading,
+  } = useQuery({
     enabled,
-    queryFn: ({ signal }) => listPromotionOptions(orgSlug, projectId, signal),
-    queryKey: ['promotionOptions', orgSlug, projectId],
+    queryFn: ({ signal }) =>
+      listRecentCommits(orgSlug, projectId, { limit: COMMIT_WINDOW }, signal),
+    queryKey: ['recentCommits', orgSlug, projectId],
   })
 
   const stages = useMemo(
-    () => buildPipeline(environments, currentReleases, history),
-    [environments, currentReleases, history],
+    () => buildPipeline(environments, currentReleases, history, recentCommits),
+    [environments, currentReleases, history, recentCommits],
   )
-  const pendingCommitsBySlug = useMemo(() => {
-    const out: Record<string, null | number | undefined> = {}
-    for (const option of promotionOptions) {
-      out[option.to_environment] = option.commits_pending
-    }
-    return out
-  }, [promotionOptions])
 
   const [selectedSlug, setSelectedSlug] = useState<null | string>(null)
   const effectiveSlug =
     selectedSlug && stages.some((s) => s.env.slug === selectedSlug)
       ? selectedSlug
-      : defaultStageSlug(stages, pendingCommitsBySlug)
+      : defaultStageSlug(stages)
   const selectedStage = stages.find((s) => s.env.slug === effectiveSlug) ?? null
 
   const actions = useDeploymentActions({ onRunStarted, orgSlug, projectId })
+  const { isSyncing, sync } = useDeploymentSync(orgSlug, projectId)
 
-  if (currentLoading || historyLoading) {
+  if (currentLoading || historyLoading || commitsLoading) {
     return <LoadingState label="Loading deployments…" />
   }
-  if (currentError || historyError) {
+  if (currentError || historyError || commitsError) {
     return (
       <div className="border-tertiary text-tertiary rounded-lg border p-6 text-center text-sm">
         Could not load deployment data for this project.
@@ -115,8 +120,9 @@ export function DeploymentsTab({
       <EnvironmentNav
         connectLabel={connectLabel}
         isDarkMode={isDarkMode}
+        isSyncing={isSyncing}
         onSelect={setSelectedSlug}
-        pendingCommitsBySlug={pendingCommitsBySlug}
+        onSync={sync}
         readiness={readiness}
         selectedSlug={effectiveSlug}
         stages={stages}
@@ -132,6 +138,7 @@ export function DeploymentsTab({
           canTrigger={canTrigger}
           orgSlug={orgSlug}
           projectId={projectId}
+          recentCommits={recentCommits}
           stage={selectedStage}
         />
       ) : null}

--- a/src/components/deployments/DeploymentsTab.tsx
+++ b/src/components/deployments/DeploymentsTab.tsx
@@ -25,6 +25,9 @@ interface DeploymentsTabProps {
   orgSlug: string
   projectId: string
   readiness: 'connected' | 'disconnected' | 'error' | 'loading'
+  /** Third-party service powering the deployment plugin. */
+  serviceIcon: null | string
+  serviceLabel: null | string
 }
 
 // Synced default-branch commits to consider; covers the realistic gap
@@ -49,6 +52,8 @@ export function DeploymentsTab({
   orgSlug,
   projectId,
   readiness,
+  serviceIcon,
+  serviceLabel,
 }: DeploymentsTabProps) {
   const { isDarkMode } = useTheme()
   const enabled = !!orgSlug && !!projectId
@@ -125,6 +130,8 @@ export function DeploymentsTab({
         onSync={sync}
         readiness={readiness}
         selectedSlug={effectiveSlug}
+        serviceIcon={serviceIcon}
+        serviceLabel={serviceLabel}
         stages={stages}
       />
       {selectedStage ? (

--- a/src/components/deployments/DeploymentsTab.tsx
+++ b/src/components/deployments/DeploymentsTab.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { Rocket } from 'lucide-react'
+
+import { listCurrentReleases, listPromotionOptions } from '@/api/endpoints'
+import { getReleaseHistory } from '@/api/releases'
+import type { DeploymentRunStarted } from '@/components/deploy/DeploymentModal'
+import { LoadingState } from '@/components/ui/loading-state'
+import { useTheme } from '@/contexts/ThemeContext'
+import { deriveChipColors } from '@/lib/chip-colors'
+import type { Environment } from '@/types'
+
+import { EnvironmentDetail } from './EnvironmentDetail'
+import { EnvironmentNav } from './EnvironmentNav'
+import { buildPipeline, defaultStageSlug } from './pipeline'
+import { useDeploymentActions } from './useDeploymentActions'
+
+interface DeploymentsTabProps {
+  canTrigger: boolean
+  connectLabel: string
+  /** Pipeline environments, already sorted ascending by sort_order. */
+  environments: Environment[]
+  onRunStarted?: (run: DeploymentRunStarted) => void
+  orgSlug: string
+  projectId: string
+  readiness: 'connected' | 'disconnected' | 'error' | 'loading'
+}
+
+/**
+ * Project-detail Deployments tab: an environment sidebar (descending
+ * sort order) and a per-environment detail pane for deploying,
+ * promoting, and rolling back.
+ */
+// fallow-ignore-next-line complexity
+export function DeploymentsTab({
+  canTrigger,
+  connectLabel,
+  environments,
+  onRunStarted,
+  orgSlug,
+  projectId,
+  readiness,
+}: DeploymentsTabProps) {
+  const { isDarkMode } = useTheme()
+  const enabled = !!orgSlug && !!projectId
+
+  const {
+    data: currentReleases = [],
+    error: currentError,
+    isLoading: currentLoading,
+  } = useQuery({
+    enabled,
+    queryFn: ({ signal }) => listCurrentReleases(orgSlug, projectId, signal),
+    queryKey: ['currentReleases', orgSlug, projectId],
+  })
+  const {
+    data: history = [],
+    error: historyError,
+    isLoading: historyLoading,
+  } = useQuery({
+    enabled,
+    queryFn: ({ signal }) => getReleaseHistory(orgSlug, projectId, signal),
+    queryKey: ['releaseHistory', orgSlug, projectId],
+  })
+  // Adjacent-env commit counts for the sidebar badges; tolerated as
+  // best-effort (the endpoint already degrades per-pair on plugin
+  // failures).
+  const { data: promotionOptions = [] } = useQuery({
+    enabled,
+    queryFn: ({ signal }) => listPromotionOptions(orgSlug, projectId, signal),
+    queryKey: ['promotionOptions', orgSlug, projectId],
+  })
+
+  const stages = useMemo(
+    () => buildPipeline(environments, currentReleases, history),
+    [environments, currentReleases, history],
+  )
+  const pendingCommitsBySlug = useMemo(() => {
+    const out: Record<string, null | number | undefined> = {}
+    for (const option of promotionOptions) {
+      out[option.to_environment] = option.commits_pending
+    }
+    return out
+  }, [promotionOptions])
+
+  const [selectedSlug, setSelectedSlug] = useState<null | string>(null)
+  const effectiveSlug =
+    selectedSlug && stages.some((s) => s.env.slug === selectedSlug)
+      ? selectedSlug
+      : defaultStageSlug(stages, pendingCommitsBySlug)
+  const selectedStage = stages.find((s) => s.env.slug === effectiveSlug) ?? null
+
+  const actions = useDeploymentActions({ onRunStarted, orgSlug, projectId })
+
+  if (currentLoading || historyLoading) {
+    return <LoadingState label="Loading deployments…" />
+  }
+  if (currentError || historyError) {
+    return (
+      <div className="border-tertiary text-tertiary rounded-lg border p-6 text-center text-sm">
+        Could not load deployment data for this project.
+      </div>
+    )
+  }
+  if (stages.length === 0) {
+    return (
+      <div className="border-tertiary text-tertiary rounded-lg border p-6 text-center text-sm">
+        No environments are configured for this project.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="inline-flex items-center gap-2 text-base font-semibold">
+        <Rocket className="text-tertiary size-4" />
+        Deployments
+      </h2>
+      <div className="grid items-start gap-5 md:grid-cols-[240px_minmax(0,1fr)]">
+        <EnvironmentNav
+          connectLabel={connectLabel}
+          isDarkMode={isDarkMode}
+          onSelect={setSelectedSlug}
+          pendingCommitsBySlug={pendingCommitsBySlug}
+          readiness={readiness}
+          selectedSlug={effectiveSlug}
+          stages={stages}
+        />
+        {selectedStage ? (
+          <EnvironmentDetail
+            accent={
+              selectedStage.env.label_color
+                ? deriveChipColors(selectedStage.env.label_color, isDarkMode)
+                : null
+            }
+            actions={actions}
+            canTrigger={canTrigger}
+            orgSlug={orgSlug}
+            projectId={projectId}
+            stage={selectedStage}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/components/deployments/EnvironmentDetail.tsx
+++ b/src/components/deployments/EnvironmentDetail.tsx
@@ -66,6 +66,7 @@ export function EnvironmentDetail({
         />
       )}
       <CurrentlyRunningCard
+        accent={accent}
         actions={actions}
         canTrigger={canTrigger}
         stage={stage}

--- a/src/components/deployments/EnvironmentDetail.tsx
+++ b/src/components/deployments/EnvironmentDetail.tsx
@@ -1,0 +1,73 @@
+import type { ChipColors } from '@/lib/chip-colors'
+
+import { CommitDeployCard } from './CommitDeployCard'
+import { CurrentlyRunningCard } from './CurrentlyRunningCard'
+import { PendingPromoteCard } from './PendingPromoteCard'
+import { PendingReleasesCard } from './PendingReleasesCard'
+import type { PipelineStage } from './pipeline'
+import type { DeploymentActions } from './useDeploymentActions'
+
+interface EnvironmentDetailProps {
+  accent: ChipColors | null
+  actions: DeploymentActions
+  canTrigger: boolean
+  orgSlug: string
+  projectId: string
+  stage: PipelineStage
+}
+
+/**
+ * Detail pane for the selected environment. The stage kind picks the
+ * hero card: commit-based deploys for the entry env, an inline promote
+ * form when the upstream runs untagged commits, or the pending-release
+ * stack when the upstream already runs tags.
+ */
+export function EnvironmentDetail({
+  accent,
+  actions,
+  canTrigger,
+  orgSlug,
+  projectId,
+  stage,
+}: EnvironmentDetailProps) {
+  if (stage.kind === 'commit') {
+    return (
+      <CommitDeployCard
+        accent={accent}
+        actions={actions}
+        canTrigger={canTrigger}
+        orgSlug={orgSlug}
+        projectId={projectId}
+        stage={stage}
+      />
+    )
+  }
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      {stage.kind === 'promote' ? (
+        <PendingPromoteCard
+          accent={accent}
+          actions={actions}
+          canTrigger={canTrigger}
+          orgSlug={orgSlug}
+          projectId={projectId}
+          stage={stage}
+        />
+      ) : (
+        <PendingReleasesCard
+          accent={accent}
+          actions={actions}
+          canTrigger={canTrigger}
+          orgSlug={orgSlug}
+          projectId={projectId}
+          stage={stage}
+        />
+      )}
+      <CurrentlyRunningCard
+        actions={actions}
+        canTrigger={canTrigger}
+        stage={stage}
+      />
+    </div>
+  )
+}

--- a/src/components/deployments/EnvironmentDetail.tsx
+++ b/src/components/deployments/EnvironmentDetail.tsx
@@ -1,4 +1,5 @@
 import type { ChipColors } from '@/lib/chip-colors'
+import type { RecentCommit } from '@/types'
 
 import { CommitDeployCard } from './CommitDeployCard'
 import { CurrentlyRunningCard } from './CurrentlyRunningCard'
@@ -13,6 +14,8 @@ interface EnvironmentDetailProps {
   canTrigger: boolean
   orgSlug: string
   projectId: string
+  /** Synced default-branch commit history, newest first. */
+  recentCommits: RecentCommit[]
   stage: PipelineStage
 }
 
@@ -28,6 +31,7 @@ export function EnvironmentDetail({
   canTrigger,
   orgSlug,
   projectId,
+  recentCommits,
   stage,
 }: EnvironmentDetailProps) {
   if (stage.kind === 'commit') {
@@ -36,8 +40,7 @@ export function EnvironmentDetail({
         accent={accent}
         actions={actions}
         canTrigger={canTrigger}
-        orgSlug={orgSlug}
-        projectId={projectId}
+        recentCommits={recentCommits}
         stage={stage}
       />
     )
@@ -58,8 +61,7 @@ export function EnvironmentDetail({
           accent={accent}
           actions={actions}
           canTrigger={canTrigger}
-          orgSlug={orgSlug}
-          projectId={projectId}
+          recentCommits={recentCommits}
           stage={stage}
         />
       )}

--- a/src/components/deployments/EnvironmentNav.test.tsx
+++ b/src/components/deployments/EnvironmentNav.test.tsx
@@ -6,6 +6,7 @@ import { render } from '@/test/utils'
 import type {
   CurrentReleaseEnvironment,
   Environment,
+  RecentCommit,
   ReleaseHistoryEntry,
 } from '@/types'
 
@@ -47,11 +48,20 @@ const release = (tag: string): ReleaseHistoryEntry => ({
   tag,
 })
 
+const commit = (sha: string): RecentCommit => ({
+  authored_at: '2026-06-01T00:00:00Z',
+  ci_status: 'pass',
+  message: `change ${sha}`,
+  sha,
+  short_sha: sha.slice(0, 7),
+})
+
 const STAGES: PipelineStage[] = [
   {
     current: current('testing', null, 'ddd444ddd444'),
     env: env('testing', 'Testing', 1),
     kind: 'commit',
+    pendingCommits: [],
     pendingReleases: [],
     rollbackTargets: [],
     upstream: null,
@@ -61,6 +71,7 @@ const STAGES: PipelineStage[] = [
     current: current('staging', 'v6.5.2', 'ccc333ccc333'),
     env: env('staging', 'Staging', 2),
     kind: 'promote',
+    pendingCommits: Array.from({ length: 8 }, (_, i) => commit(`sha${i}aaaa`)),
     pendingReleases: [],
     rollbackTargets: [],
     upstream: env('testing', 'Testing', 1),
@@ -70,6 +81,7 @@ const STAGES: PipelineStage[] = [
     current: current('production', 'v6.5.0', 'aaa111aaa111'),
     env: env('production', 'Production', 3),
     kind: 'release',
+    pendingCommits: [],
     pendingReleases: [release('v6.5.2'), release('v6.5.1')],
     rollbackTargets: [],
     upstream: env('staging', 'Staging', 2),
@@ -77,20 +89,29 @@ const STAGES: PipelineStage[] = [
   },
 ]
 
+const renderNav = (
+  overrides: Partial<Parameters<typeof EnvironmentNav>[0]> = {},
+) =>
+  render(
+    <EnvironmentNav
+      connectLabel="GitHub"
+      isDarkMode={false}
+      isSyncing={false}
+      onSelect={() => {}}
+      onSync={() => {}}
+      readiness="connected"
+      selectedSlug="staging"
+      stages={STAGES}
+      {...overrides}
+    />,
+  )
+
 describe('EnvironmentNav', () => {
   it('renders environments in descending sort order', () => {
-    render(
-      <EnvironmentNav
-        connectLabel="GitHub"
-        isDarkMode={false}
-        onSelect={() => {}}
-        pendingCommitsBySlug={{}}
-        readiness="connected"
-        selectedSlug="staging"
-        stages={STAGES}
-      />,
-    )
-    const buttons = screen.getAllByRole('button')
+    renderNav()
+    const buttons = screen
+      .getAllByRole('button')
+      .filter((b) => /Testing|Staging|Production/.test(b.textContent ?? ''))
     expect(buttons.map((b) => b.textContent)).toEqual([
       expect.stringContaining('Production'),
       expect.stringContaining('Staging'),
@@ -99,17 +120,7 @@ describe('EnvironmentNav', () => {
   })
 
   it('badges pending releases and pending commits', () => {
-    render(
-      <EnvironmentNav
-        connectLabel="GitHub"
-        isDarkMode={false}
-        onSelect={() => {}}
-        pendingCommitsBySlug={{ staging: 8 }}
-        readiness="connected"
-        selectedSlug="staging"
-        stages={STAGES}
-      />,
-    )
+    renderNav()
     // Production shows the newest pending release tag.
     expect(
       screen.getByTitle('Release v6.5.2 is waiting to deploy here'),
@@ -124,33 +135,30 @@ describe('EnvironmentNav', () => {
   it('invokes onSelect with the clicked environment slug', async () => {
     const onSelect = vi.fn()
     const user = userEvent.setup()
-    render(
-      <EnvironmentNav
-        connectLabel="GitHub"
-        isDarkMode={false}
-        onSelect={onSelect}
-        pendingCommitsBySlug={{}}
-        readiness="connected"
-        selectedSlug="staging"
-        stages={STAGES}
-      />,
-    )
+    renderNav({ onSelect })
     await user.click(screen.getByRole('button', { name: /Production/ }))
     expect(onSelect).toHaveBeenCalledWith('production')
   })
 
-  it('shows the connect hint when disconnected', () => {
-    render(
-      <EnvironmentNav
-        connectLabel="GitHub"
-        isDarkMode={false}
-        onSelect={() => {}}
-        pendingCommitsBySlug={{}}
-        readiness="disconnected"
-        selectedSlug={null}
-        stages={STAGES}
-      />,
+  it('triggers the sync action and disables while syncing', async () => {
+    const onSync = vi.fn()
+    const user = userEvent.setup()
+    renderNav({ onSync })
+    await user.click(
+      screen.getByRole('button', { name: 'Sync commits, tags & releases' }),
     )
+    expect(onSync).toHaveBeenCalled()
+  })
+
+  it('disables the sync button while a sync is running', () => {
+    renderNav({ isSyncing: true })
+    expect(
+      screen.getByRole('button', { name: 'Sync commits, tags & releases' }),
+    ).toBeDisabled()
+  })
+
+  it('shows the connect hint when disconnected', () => {
+    renderNav({ readiness: 'disconnected', selectedSlug: null })
     expect(
       screen.getByText('Connect to GitHub to enable deployments'),
     ).toBeInTheDocument()

--- a/src/components/deployments/EnvironmentNav.test.tsx
+++ b/src/components/deployments/EnvironmentNav.test.tsx
@@ -94,13 +94,15 @@ const renderNav = (
 ) =>
   render(
     <EnvironmentNav
-      connectLabel="GitHub"
+      connectLabel="Example Identity"
       isDarkMode={false}
       isSyncing={false}
       onSelect={() => {}}
       onSync={() => {}}
       readiness="connected"
       selectedSlug="staging"
+      serviceIcon={null}
+      serviceLabel="Example Service"
       stages={STAGES}
       {...overrides}
     />,
@@ -129,7 +131,8 @@ describe('EnvironmentNav', () => {
     expect(
       screen.getByTitle('8 commits waiting to promote here'),
     ).toBeInTheDocument()
-    expect(screen.getByText('GitHub connected')).toBeInTheDocument()
+    // Connected state names the service powering the deployment plugin.
+    expect(screen.getByText('Example Service')).toBeInTheDocument()
   })
 
   it('invokes onSelect with the clicked environment slug', async () => {
@@ -160,7 +163,7 @@ describe('EnvironmentNav', () => {
   it('shows the connect hint when disconnected', () => {
     renderNav({ readiness: 'disconnected', selectedSlug: null })
     expect(
-      screen.getByText('Connect to GitHub to enable deployments'),
+      screen.getByText('Connect to Example Identity to enable deployments'),
     ).toBeInTheDocument()
   })
 })

--- a/src/components/deployments/EnvironmentNav.test.tsx
+++ b/src/components/deployments/EnvironmentNav.test.tsx
@@ -1,0 +1,158 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { render } from '@/test/utils'
+import type {
+  CurrentReleaseEnvironment,
+  Environment,
+  ReleaseHistoryEntry,
+} from '@/types'
+
+import { EnvironmentNav } from './EnvironmentNav'
+import type { PipelineStage } from './pipeline'
+
+const env = (slug: string, name: string, sortOrder: number): Environment =>
+  ({
+    id: slug,
+    label_color: '#5A89C9',
+    name,
+    slug,
+    sort_order: sortOrder,
+  }) as unknown as Environment
+
+const current = (slug: string, tag: null | string, committish: string) =>
+  ({
+    ci_status: 'pass',
+    current_status: 'success',
+    environment: { name: slug, slug },
+    external_run_url: null,
+    last_event_at: '2026-06-01T00:00:00Z',
+    release: {
+      committish,
+      created_at: '2026-06-01T00:00:00Z',
+      created_by: 'gavin',
+      id: `${slug}-rel`,
+      links: [],
+      project_id: 'p1',
+      tag,
+      title: tag ?? committish,
+    },
+  }) as CurrentReleaseEnvironment
+
+const release = (tag: string): ReleaseHistoryEntry => ({
+  ci_status: 'pass',
+  sha: 'ccc333ccc333',
+  short_sha: 'ccc333c',
+  tag,
+})
+
+const STAGES: PipelineStage[] = [
+  {
+    current: current('testing', null, 'ddd444ddd444'),
+    env: env('testing', 'Testing', 1),
+    kind: 'commit',
+    pendingReleases: [],
+    rollbackTargets: [],
+    upstream: null,
+    upstreamCurrent: null,
+  },
+  {
+    current: current('staging', 'v6.5.2', 'ccc333ccc333'),
+    env: env('staging', 'Staging', 2),
+    kind: 'promote',
+    pendingReleases: [],
+    rollbackTargets: [],
+    upstream: env('testing', 'Testing', 1),
+    upstreamCurrent: current('testing', null, 'ddd444ddd444'),
+  },
+  {
+    current: current('production', 'v6.5.0', 'aaa111aaa111'),
+    env: env('production', 'Production', 3),
+    kind: 'release',
+    pendingReleases: [release('v6.5.2'), release('v6.5.1')],
+    rollbackTargets: [],
+    upstream: env('staging', 'Staging', 2),
+    upstreamCurrent: current('staging', 'v6.5.2', 'ccc333ccc333'),
+  },
+]
+
+describe('EnvironmentNav', () => {
+  it('renders environments in descending sort order', () => {
+    render(
+      <EnvironmentNav
+        connectLabel="GitHub"
+        isDarkMode={false}
+        onSelect={() => {}}
+        pendingCommitsBySlug={{}}
+        readiness="connected"
+        selectedSlug="staging"
+        stages={STAGES}
+      />,
+    )
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.map((b) => b.textContent)).toEqual([
+      expect.stringContaining('Production'),
+      expect.stringContaining('Staging'),
+      expect.stringContaining('Testing'),
+    ])
+  })
+
+  it('badges pending releases and pending commits', () => {
+    render(
+      <EnvironmentNav
+        connectLabel="GitHub"
+        isDarkMode={false}
+        onSelect={() => {}}
+        pendingCommitsBySlug={{ staging: 8 }}
+        readiness="connected"
+        selectedSlug="staging"
+        stages={STAGES}
+      />,
+    )
+    // Production shows the newest pending release tag.
+    expect(
+      screen.getByTitle('Release v6.5.2 is waiting to deploy here'),
+    ).toBeInTheDocument()
+    // Staging shows the count of commits waiting to promote.
+    expect(
+      screen.getByTitle('8 commits waiting to promote here'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('GitHub connected')).toBeInTheDocument()
+  })
+
+  it('invokes onSelect with the clicked environment slug', async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <EnvironmentNav
+        connectLabel="GitHub"
+        isDarkMode={false}
+        onSelect={onSelect}
+        pendingCommitsBySlug={{}}
+        readiness="connected"
+        selectedSlug="staging"
+        stages={STAGES}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /Production/ }))
+    expect(onSelect).toHaveBeenCalledWith('production')
+  })
+
+  it('shows the connect hint when disconnected', () => {
+    render(
+      <EnvironmentNav
+        connectLabel="GitHub"
+        isDarkMode={false}
+        onSelect={() => {}}
+        pendingCommitsBySlug={{}}
+        readiness="disconnected"
+        selectedSlug={null}
+        stages={STAGES}
+      />,
+    )
+    expect(
+      screen.getByText('Connect to GitHub to enable deployments'),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/deployments/EnvironmentNav.tsx
+++ b/src/components/deployments/EnvironmentNav.tsx
@@ -1,0 +1,170 @@
+import { ArrowUp, Check, GitMerge, Loader2, Plug, PlugZap } from 'lucide-react'
+
+import { deriveChipColors } from '@/lib/chip-colors'
+import { cn } from '@/lib/utils'
+
+import type { PipelineStage } from './pipeline'
+
+interface EnvironmentNavProps {
+  connectLabel: string
+  isDarkMode: boolean
+  onSelect: (slug: string) => void
+  /** Commits pending per target env slug (promote-kind badge counts). */
+  pendingCommitsBySlug: Record<string, null | number | undefined>
+  readiness: Readiness
+  selectedSlug: null | string
+  /** Stages in ascending sort order; rendered descending (last env first). */
+  stages: PipelineStage[]
+}
+
+type Readiness = 'connected' | 'disconnected' | 'error' | 'loading'
+
+// fallow-ignore-next-line complexity
+export function EnvironmentNav({
+  connectLabel,
+  isDarkMode,
+  onSelect,
+  pendingCommitsBySlug,
+  readiness,
+  selectedSlug,
+  stages,
+}: EnvironmentNavProps) {
+  return (
+    <nav className="border-tertiary sticky top-4 self-start rounded-lg border p-2.5">
+      <p className="text-tertiary px-2 pt-1 pb-2 text-xs tracking-wider uppercase">
+        Pipeline
+      </p>
+      {[...stages].reverse().map((stage) => {
+        const accent = stage.env.label_color
+          ? deriveChipColors(stage.env.label_color, isDarkMode)
+          : null
+        const active = stage.env.slug === selectedSlug
+        const version =
+          stage.current?.release?.tag ??
+          stage.current?.release?.committish.slice(0, 7) ??
+          'not deployed'
+        return (
+          <button
+            className={cn(
+              'mb-0.5 flex w-full items-center gap-3 rounded-md border border-transparent px-2.5 py-2 text-left transition-colors',
+              !active && 'hover:bg-secondary',
+            )}
+            key={stage.env.slug}
+            onClick={() => onSelect(stage.env.slug)}
+            style={
+              active && accent
+                ? { backgroundColor: accent.bg, borderColor: accent.border }
+                : undefined
+            }
+            type="button"
+          >
+            <span className="min-w-0 flex-1">
+              <span
+                className={cn(
+                  'block text-sm',
+                  active ? 'font-semibold' : 'font-medium',
+                )}
+              >
+                {stage.env.name}
+              </span>
+              <span className="text-tertiary block font-mono text-[11px]">
+                {version}
+              </span>
+            </span>
+            <StageBadge
+              accent={accent}
+              pendingCommits={pendingCommitsBySlug[stage.env.slug]}
+              stage={stage}
+            />
+          </button>
+        )
+      })}
+      <div className="border-tertiary mt-2 border-t px-2 pt-2.5 pb-1">
+        <ConnectionStatus connectLabel={connectLabel} readiness={readiness} />
+      </div>
+    </nav>
+  )
+}
+
+function ConnectionStatus({
+  connectLabel,
+  readiness,
+}: {
+  connectLabel: string
+  readiness: Readiness
+}) {
+  if (readiness === 'connected') {
+    return (
+      <span className="text-success inline-flex items-center gap-1.5 text-xs">
+        <PlugZap size={13} />
+        {connectLabel} connected
+      </span>
+    )
+  }
+  if (readiness === 'loading') {
+    return (
+      <span className="text-tertiary inline-flex items-center gap-1.5 text-xs">
+        <Loader2 className="animate-spin" size={13} />
+        Checking deployment access…
+      </span>
+    )
+  }
+  return (
+    <span className="text-tertiary inline-flex items-center gap-1.5 text-xs">
+      <Plug size={13} />
+      {readiness === 'error'
+        ? 'Could not check deployment access'
+        : `Connect to ${connectLabel} to enable deployments`}
+    </span>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function StageBadge({
+  accent,
+  pendingCommits,
+  stage,
+}: {
+  accent: null | ReturnType<typeof deriveChipColors>
+  pendingCommits: null | number | undefined
+  stage: PipelineStage
+}) {
+  if (stage.kind === 'release' && stage.pendingReleases.length > 0) {
+    const newest = stage.pendingReleases[0]
+    return (
+      <span
+        className="bg-secondary inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[11px] font-semibold"
+        style={
+          accent ? { backgroundColor: accent.bg, color: accent.fg } : undefined
+        }
+        title={`Release ${newest.tag} is waiting to deploy here`}
+      >
+        <GitMerge size={11} />
+        {newest.tag}
+      </span>
+    )
+  }
+  if (stage.kind === 'promote' && (pendingCommits ?? 0) > 0) {
+    return (
+      <span
+        className="bg-secondary inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold"
+        style={
+          accent ? { backgroundColor: accent.bg, color: accent.fg } : undefined
+        }
+        title={`${pendingCommits} commits waiting to promote here`}
+      >
+        <ArrowUp size={11} />
+        {pendingCommits}
+      </span>
+    )
+  }
+  if (stage.kind === 'commit') return null
+  return (
+    <span
+      className="border-success text-success flex size-4.5 shrink-0 items-center justify-center rounded-full border"
+      title="In sync"
+    >
+      <Check size={11} strokeWidth={3} />
+    </span>
+  )
+}

--- a/src/components/deployments/EnvironmentNav.tsx
+++ b/src/components/deployments/EnvironmentNav.tsx
@@ -1,5 +1,19 @@
-import { ArrowUp, Check, GitMerge, Loader2, Plug, PlugZap } from 'lucide-react'
+import {
+  ArrowUp,
+  Check,
+  GitMerge,
+  Loader2,
+  Plug,
+  PlugZap,
+  RefreshCw,
+} from 'lucide-react'
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { deriveChipColors } from '@/lib/chip-colors'
 import { cn } from '@/lib/utils'
 
@@ -8,9 +22,9 @@ import type { PipelineStage } from './pipeline'
 interface EnvironmentNavProps {
   connectLabel: string
   isDarkMode: boolean
+  isSyncing: boolean
   onSelect: (slug: string) => void
-  /** Commits pending per target env slug (promote-kind badge counts). */
-  pendingCommitsBySlug: Record<string, null | number | undefined>
+  onSync: () => void
   readiness: Readiness
   selectedSlug: null | string
   /** Stages in ascending sort order; rendered descending (last env first). */
@@ -23,8 +37,9 @@ type Readiness = 'connected' | 'disconnected' | 'error' | 'loading'
 export function EnvironmentNav({
   connectLabel,
   isDarkMode,
+  isSyncing,
   onSelect,
-  pendingCommitsBySlug,
+  onSync,
   readiness,
   selectedSlug,
   stages,
@@ -71,16 +86,33 @@ export function EnvironmentNav({
                 {version}
               </span>
             </span>
-            <StageBadge
-              accent={accent}
-              pendingCommits={pendingCommitsBySlug[stage.env.slug]}
-              stage={stage}
-            />
+            <StageBadge accent={accent} stage={stage} />
           </button>
         )
       })}
-      <div className="border-tertiary mt-2 border-t px-2 pt-2.5 pb-1">
+      <div className="border-tertiary mt-2 flex items-center justify-between gap-2 border-t px-2 pt-2.5 pb-1">
         <ConnectionStatus connectLabel={connectLabel} readiness={readiness} />
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                aria-label="Sync commits, tags & releases"
+                className="text-tertiary hover:text-primary shrink-0 cursor-pointer rounded p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={isSyncing}
+                onClick={onSync}
+                type="button"
+              >
+                <RefreshCw
+                  className={cn(isSyncing && 'animate-spin')}
+                  size={14}
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Sync commits, tags & releases</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
     </nav>
   )
@@ -122,11 +154,9 @@ function ConnectionStatus({
 // fallow-ignore-next-line complexity
 function StageBadge({
   accent,
-  pendingCommits,
   stage,
 }: {
   accent: null | ReturnType<typeof deriveChipColors>
-  pendingCommits: null | number | undefined
   stage: PipelineStage
 }) {
   if (stage.kind === 'release' && stage.pendingReleases.length > 0) {
@@ -144,17 +174,17 @@ function StageBadge({
       </span>
     )
   }
-  if (stage.kind === 'promote' && (pendingCommits ?? 0) > 0) {
+  if (stage.kind === 'promote' && stage.pendingCommits.length > 0) {
     return (
       <span
         className="bg-secondary inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold"
         style={
           accent ? { backgroundColor: accent.bg, color: accent.fg } : undefined
         }
-        title={`${pendingCommits} commits waiting to promote here`}
+        title={`${stage.pendingCommits.length} commits waiting to promote here`}
       >
         <ArrowUp size={11} />
-        {pendingCommits}
+        {stage.pendingCommits.length}
       </span>
     )
   }

--- a/src/components/deployments/EnvironmentNav.tsx
+++ b/src/components/deployments/EnvironmentNav.tsx
@@ -8,6 +8,7 @@ import {
   RefreshCw,
 } from 'lucide-react'
 
+import { EntityIcon } from '@/components/ui/entity-icon'
 import {
   Tooltip,
   TooltipContent,
@@ -27,6 +28,9 @@ interface EnvironmentNavProps {
   onSync: () => void
   readiness: Readiness
   selectedSlug: null | string
+  /** Third-party service powering the deployment plugin. */
+  serviceIcon: null | string
+  serviceLabel: null | string
   /** Stages in ascending sort order; rendered descending (last env first). */
   stages: PipelineStage[]
 }
@@ -42,6 +46,8 @@ export function EnvironmentNav({
   onSync,
   readiness,
   selectedSlug,
+  serviceIcon,
+  serviceLabel,
   stages,
 }: EnvironmentNavProps) {
   return (
@@ -91,7 +97,12 @@ export function EnvironmentNav({
         )
       })}
       <div className="border-tertiary mt-2 flex items-center justify-between gap-2 border-t px-2 pt-2.5 pb-1">
-        <ConnectionStatus connectLabel={connectLabel} readiness={readiness} />
+        <ConnectionStatus
+          connectLabel={connectLabel}
+          readiness={readiness}
+          serviceIcon={serviceIcon}
+          serviceLabel={serviceLabel}
+        />
         <TooltipProvider delayDuration={200}>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -121,15 +132,23 @@ export function EnvironmentNav({
 function ConnectionStatus({
   connectLabel,
   readiness,
+  serviceIcon,
+  serviceLabel,
 }: {
   connectLabel: string
   readiness: Readiness
+  serviceIcon: null | string
+  serviceLabel: null | string
 }) {
   if (readiness === 'connected') {
     return (
       <span className="text-success inline-flex items-center gap-1.5 text-xs">
-        <PlugZap size={13} />
-        {connectLabel} connected
+        {serviceIcon ? (
+          <EntityIcon className="size-3.5" icon={serviceIcon} />
+        ) : (
+          <PlugZap size={13} />
+        )}
+        {serviceLabel ?? connectLabel}
       </span>
     )
   }

--- a/src/components/deployments/PendingPromoteCard.tsx
+++ b/src/components/deployments/PendingPromoteCard.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { useMutation, useQuery } from '@tanstack/react-query'
+import {
+  ArrowUp,
+  Check,
+  Loader2,
+  RefreshCw,
+  Rocket,
+  Sparkles,
+} from 'lucide-react'
+
+import { compareDeploymentRefs, draftReleaseNotes } from '@/api/endpoints'
+import { ReleaseCommitPicker } from '@/components/releases/ReleaseCommitPicker'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { LoadingState } from '@/components/ui/loading-state'
+import { Textarea } from '@/components/ui/textarea'
+import type { ChipColors } from '@/lib/chip-colors'
+import { SEMVER_RE } from '@/lib/semver'
+import type { DraftReleaseNotesResponse } from '@/types'
+
+import type { PipelineStage } from './pipeline'
+import { StageCardShell } from './StageCardShell'
+import type { DeploymentActions } from './useDeploymentActions'
+
+interface PendingPromoteCardProps {
+  accent: ChipColors | null
+  actions: DeploymentActions
+  canTrigger: boolean
+  orgSlug: string
+  projectId: string
+  stage: PipelineStage
+}
+
+/**
+ * Always-on inline promote form: the upstream environment runs untagged
+ * commits, so moving them here cuts a new tag and rolls it out. Pick the
+ * newest commit to include, set the tag + notes (AI-drafted), promote.
+ */
+// fallow-ignore-next-line complexity
+export function PendingPromoteCard({
+  accent,
+  actions,
+  canTrigger,
+  orgSlug,
+  projectId,
+  stage,
+}: PendingPromoteCardProps) {
+  const upstreamName = stage.upstream?.name ?? 'upstream'
+  const lastTag = stage.current?.release?.tag ?? null
+  const fromTipSha = stage.upstreamCurrent?.release?.committish ?? null
+
+  const compareEnabled = !!lastTag && !!fromTipSha && lastTag !== fromTipSha
+  const { data: compare, isLoading: compareLoading } = useQuery({
+    enabled: compareEnabled,
+    queryFn: ({ signal }) =>
+      compareDeploymentRefs(
+        orgSlug,
+        projectId,
+        lastTag ?? '',
+        fromTipSha ?? '',
+        undefined,
+        signal,
+      ),
+    queryKey: ['compare', orgSlug, projectId, lastTag, fromTipSha],
+  })
+  // Newest-first for the picker (the API returns oldest-first).
+  const commits = useMemo(
+    () => [...(compare?.commits ?? [])].reverse(),
+    [compare],
+  )
+
+  const [selectedSha, setSelectedSha] = useState<null | string>(null)
+  useEffect(() => {
+    setSelectedSha(commits.length > 0 ? commits[0].sha : fromTipSha)
+  }, [commits, fromTipSha])
+
+  const [tag, setTag] = useState('')
+  const [notes, setNotes] = useState('')
+  const [tagDirty, setTagDirty] = useState(false)
+  const [notesDirty, setNotesDirty] = useState(false)
+  const [draft, setDraft] = useState<DraftReleaseNotesResponse | null>(null)
+
+  const draftMutation = useMutation({
+    mutationFn: ({ headSha }: { headSha: string }) =>
+      draftReleaseNotes(orgSlug, projectId, {
+        base_sha: lastTag ?? '',
+        head_sha: headSha,
+        last_tag: lastTag,
+      }),
+  })
+
+  // Auto-draft once when there is a non-empty diff to summarize.
+  const hasDiff = !!lastTag && !!selectedSha && commits.length > 0
+  useEffect(() => {
+    if (draft || !hasDiff) return
+    draftMutation.mutate(
+      { headSha: selectedSha as string },
+      { onSuccess: setDraft },
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasDiff, selectedSha])
+
+  useEffect(() => {
+    if (!draft) return
+    if (!tagDirty) setTag(draft.version)
+    if (!notesDirty) setNotes(draft.notes_markdown)
+  }, [draft, tagDirty, notesDirty])
+
+  if (!fromTipSha) {
+    return (
+      <div className="border-tertiary text-tertiary rounded-lg border p-4 text-sm">
+        Nothing is deployed in {upstreamName} yet — deploy upstream first.
+      </div>
+    )
+  }
+
+  // Synced: the diff between this env's tag and the upstream tip is empty.
+  if (compareEnabled && !compareLoading && compare && commits.length === 0) {
+    return <UpToDateCard upstreamName={upstreamName} />
+  }
+
+  const tagValid = SEMVER_RE.test(tag)
+  const canSubmit =
+    tagValid && !!selectedSha && canTrigger && !actions.promotePending
+  const selIdx = commits.findIndex((c) => c.sha === selectedSha)
+  const heldCount = selIdx > 0 ? selIdx : 0
+  const reset = () => {
+    setSelectedSha(commits.length > 0 ? commits[0].sha : fromTipSha)
+    setTag(draft?.version ?? '')
+    setNotes(draft?.notes_markdown ?? '')
+    setTagDirty(false)
+    setNotesDirty(false)
+  }
+
+  return (
+    <StageCardShell
+      accent={accent}
+      icon={ArrowUp}
+      subtitle={
+        <>
+          Promoting cuts a new tag from {upstreamName} and deploys it to{' '}
+          {stage.env.name.toLowerCase()}
+        </>
+      }
+      title={
+        commits.length > 0
+          ? `${commits.length} commit${commits.length === 1 ? '' : 's'} waiting to promote from ${upstreamName}`
+          : `Promote from ${upstreamName}`
+      }
+    >
+      <div className="flex flex-col gap-4 px-4 py-4">
+        {compare ? (
+          <div className="text-tertiary flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs">
+            <span>{compare.commits.length} commits</span>
+            <span>{compare.files_changed} files</span>
+            <span className="text-success">+{compare.additions}</span>
+            <span className="text-danger">−{compare.deletions}</span>
+            <span className="ml-auto">
+              {lastTag} … {fromTipSha.slice(0, 7)}
+            </span>
+          </div>
+        ) : null}
+
+        <section>
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <p className="text-tertiary text-xs tracking-wider uppercase">
+              Select the newest commit to include
+            </p>
+            {heldCount > 0 ? (
+              <span className="text-tertiary text-xs">
+                {heldCount} newer held back
+              </span>
+            ) : null}
+          </div>
+          {compareEnabled && compareLoading ? (
+            <LoadingState label="Loading commits…" />
+          ) : !compareEnabled ? (
+            <p className="border-secondary text-tertiary rounded-md border p-3 text-sm">
+              {lastTag
+                ? 'No commit delta to compare for this selection.'
+                : `No prior release to compare against — promoting tags ${upstreamName}'s current commit.`}
+            </p>
+          ) : (
+            <ReleaseCommitPicker
+              accent={accent}
+              commits={commits}
+              onSelect={setSelectedSha}
+              selectedSha={selectedSha}
+            />
+          )}
+        </section>
+
+        <section className="border-tertiary flex flex-col gap-2 border-t pt-4">
+          <p className="text-tertiary text-xs tracking-wider uppercase">
+            Tag & release notes
+          </p>
+          <div className="grid grid-cols-2 gap-3">
+            <Label className="text-tertiary flex flex-col gap-1 text-xs">
+              Current
+              <Input
+                className="bg-tertiary font-mono"
+                disabled
+                value={lastTag ?? '—'}
+              />
+            </Label>
+            <Label className="text-tertiary flex flex-col gap-1 text-xs">
+              New tag
+              <Input
+                aria-invalid={!tagValid && tag.length > 0}
+                className="font-mono"
+                onChange={(e) => {
+                  setTag(e.target.value)
+                  setTagDirty(true)
+                }}
+                placeholder="vX.Y.Z"
+                value={tag}
+              />
+            </Label>
+          </div>
+          {!tagValid && tag.length > 0 ? (
+            <span className="text-danger text-xs">
+              Use a semver tag, e.g. v6.5.2
+            </span>
+          ) : null}
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-tertiary min-w-0 truncate text-xs">
+              {draftMutation.isPending && !draft ? (
+                'AI drafting…'
+              ) : draft ? (
+                <>
+                  AI suggests a {draft.bump} bump →{' '}
+                  <span className="font-mono">{draft.version}</span>
+                  {draft.degraded ? ' (AI unavailable)' : ''}
+                </>
+              ) : (
+                `${compare?.commits.length ?? 0} commits considered`
+              )}
+            </span>
+            <Button
+              disabled={!hasDiff || draftMutation.isPending}
+              onClick={() => {
+                if (!hasDiff) return
+                draftMutation.mutate(
+                  { headSha: selectedSha as string },
+                  {
+                    onSuccess: (data) => {
+                      setDraft(data)
+                      setTagDirty(false)
+                      setNotesDirty(false)
+                      setTag(data.version)
+                      setNotes(data.notes_markdown)
+                    },
+                  },
+                )
+              }}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              {draftMutation.isPending ? (
+                <RefreshCw className="mr-1 size-3.5 animate-spin" />
+              ) : (
+                <Sparkles className="mr-1 size-3.5" />
+              )}
+              Regenerate with AI
+            </Button>
+          </div>
+          <Textarea
+            className="min-h-32 font-mono text-xs"
+            onChange={(e) => {
+              setNotes(e.target.value)
+              setNotesDirty(true)
+            }}
+            placeholder="## Highlights&#10;- …"
+            value={notes}
+          />
+        </section>
+
+        <div className="border-tertiary flex items-center justify-end gap-2 border-t pt-4">
+          <Button onClick={reset} type="button" variant="ghost">
+            Reset
+          </Button>
+          <Button
+            disabled={!canSubmit}
+            onClick={() => {
+              if (!selectedSha) return
+              actions.promote({
+                fromEnvironment: stage.upstream?.slug ?? '',
+                notes,
+                sha: selectedSha,
+                tag,
+                toEnvironment: stage.env.slug,
+                toEnvName: stage.env.name,
+              })
+            }}
+            type="button"
+          >
+            {actions.promotePending ? (
+              <Loader2 className="mr-1 size-4 animate-spin" />
+            ) : (
+              <Rocket className="mr-1 size-4" />
+            )}
+            {`Tag ${tag || 'vX.Y.Z'} & deploy to ${stage.env.name.toLowerCase()}`}
+          </Button>
+        </div>
+      </div>
+    </StageCardShell>
+  )
+}
+
+export function UpToDateCard({ upstreamName }: { upstreamName: string }) {
+  return (
+    <div className="border-success bg-success/10 flex items-center gap-3 rounded-lg border p-4">
+      <span className="text-success">
+        <Check size={18} strokeWidth={3} />
+      </span>
+      <div>
+        <div className="text-sm font-semibold">
+          Up to date with {upstreamName}
+        </div>
+        <div className="text-tertiary mt-0.5 text-xs">
+          Nothing is waiting to move into this environment.
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/deployments/PendingPromoteCard.tsx
+++ b/src/components/deployments/PendingPromoteCard.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import {
   ArrowUp,
   Check,
@@ -10,12 +10,11 @@ import {
   Sparkles,
 } from 'lucide-react'
 
-import { compareDeploymentRefs, draftReleaseNotes } from '@/api/endpoints'
+import { draftReleaseNotes } from '@/api/endpoints'
 import { ReleaseCommitPicker } from '@/components/releases/ReleaseCommitPicker'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { LoadingState } from '@/components/ui/loading-state'
 import { Textarea } from '@/components/ui/textarea'
 import type { ChipColors } from '@/lib/chip-colors'
 import { SEMVER_RE } from '@/lib/semver'
@@ -38,6 +37,7 @@ interface PendingPromoteCardProps {
  * Always-on inline promote form: the upstream environment runs untagged
  * commits, so moving them here cuts a new tag and rolls it out. Pick the
  * newest commit to include, set the tag + notes (AI-drafted), promote.
+ * The commit range comes from imbi's synced history (stage.pendingCommits).
  */
 // fallow-ignore-next-line complexity
 export function PendingPromoteCard({
@@ -51,26 +51,8 @@ export function PendingPromoteCard({
   const upstreamName = stage.upstream?.name ?? 'upstream'
   const lastTag = stage.current?.release?.tag ?? null
   const fromTipSha = stage.upstreamCurrent?.release?.committish ?? null
-
-  const compareEnabled = !!lastTag && !!fromTipSha && lastTag !== fromTipSha
-  const { data: compare, isLoading: compareLoading } = useQuery({
-    enabled: compareEnabled,
-    queryFn: ({ signal }) =>
-      compareDeploymentRefs(
-        orgSlug,
-        projectId,
-        lastTag ?? '',
-        fromTipSha ?? '',
-        undefined,
-        signal,
-      ),
-    queryKey: ['compare', orgSlug, projectId, lastTag, fromTipSha],
-  })
-  // Newest-first for the picker (the API returns oldest-first).
-  const commits = useMemo(
-    () => [...(compare?.commits ?? [])].reverse(),
-    [compare],
-  )
+  // Already newest-first from the synced ClickHouse history.
+  const commits = stage.pendingCommits
 
   const [selectedSha, setSelectedSha] = useState<null | string>(null)
   useEffect(() => {
@@ -117,8 +99,8 @@ export function PendingPromoteCard({
     )
   }
 
-  // Synced: the diff between this env's tag and the upstream tip is empty.
-  if (compareEnabled && !compareLoading && compare && commits.length === 0) {
+  // Synced: nothing newer than this env's release is deployed upstream.
+  if (lastTag && commits.length === 0) {
     return <UpToDateCard upstreamName={upstreamName} />
   }
 
@@ -152,14 +134,11 @@ export function PendingPromoteCard({
       }
     >
       <div className="flex flex-col gap-4 px-4 py-4">
-        {compare ? (
+        {commits.length > 0 ? (
           <div className="text-tertiary flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs">
-            <span>{compare.commits.length} commits</span>
-            <span>{compare.files_changed} files</span>
-            <span className="text-success">+{compare.additions}</span>
-            <span className="text-danger">−{compare.deletions}</span>
+            <span>{commits.length} commits</span>
             <span className="ml-auto">
-              {lastTag} … {fromTipSha.slice(0, 7)}
+              {lastTag ?? '—'} … {fromTipSha.slice(0, 7)}
             </span>
           </div>
         ) : null}
@@ -175,13 +154,9 @@ export function PendingPromoteCard({
               </span>
             ) : null}
           </div>
-          {compareEnabled && compareLoading ? (
-            <LoadingState label="Loading commits…" />
-          ) : !compareEnabled ? (
+          {commits.length === 0 ? (
             <p className="border-secondary text-tertiary rounded-md border p-3 text-sm">
-              {lastTag
-                ? 'No commit delta to compare for this selection.'
-                : `No prior release to compare against — promoting tags ${upstreamName}'s current commit.`}
+              {`No prior release to compare against — promoting tags ${upstreamName}'s current commit.`}
             </p>
           ) : (
             <ReleaseCommitPicker
@@ -236,7 +211,7 @@ export function PendingPromoteCard({
                   {draft.degraded ? ' (AI unavailable)' : ''}
                 </>
               ) : (
-                `${compare?.commits.length ?? 0} commits considered`
+                `${commits.length} commits considered`
               )}
             </span>
             <Button

--- a/src/components/deployments/PendingReleasesCard.test.tsx
+++ b/src/components/deployments/PendingReleasesCard.test.tsx
@@ -1,0 +1,177 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import { render } from '@/test/utils'
+import type {
+  CurrentReleaseEnvironment,
+  Environment,
+  ReleaseHistoryEntry,
+} from '@/types'
+
+import { PendingReleasesCard } from './PendingReleasesCard'
+import type { PipelineStage } from './pipeline'
+import type { DeploymentActions } from './useDeploymentActions'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return { ...actual, compareDeploymentRefs: vi.fn() }
+})
+
+const ENV = {
+  can_deploy: true,
+  can_promote: false,
+  id: 'production',
+  label_color: '#C86B5E',
+  name: 'Production',
+  slug: 'production',
+  sort_order: 3,
+} as unknown as Environment
+
+const UPSTREAM = {
+  id: 'staging',
+  label_color: '#5A89C9',
+  name: 'Staging',
+  slug: 'staging',
+  sort_order: 2,
+} as unknown as Environment
+
+const entry = (
+  tag: string,
+  sha: string,
+  title: string,
+): ReleaseHistoryEntry => ({
+  ci_status: 'pass',
+  notes_markdown: `### Fixed\n- notes for ${tag}`,
+  published_at: '2026-06-01T00:00:00Z',
+  sha,
+  short_sha: sha.slice(0, 7),
+  tag,
+  title,
+})
+
+const current = (
+  slug: string,
+  tag: string,
+  committish: string,
+): CurrentReleaseEnvironment => ({
+  ci_status: 'pass',
+  current_status: 'success',
+  environment: { name: slug, slug },
+  external_run_url: null,
+  last_event_at: '2026-05-20T00:00:00Z',
+  release: {
+    committish,
+    created_at: '2026-05-20T00:00:00Z',
+    created_by: 'gavin',
+    id: `${slug}-rel`,
+    links: [],
+    project_id: 'p1',
+    tag,
+    title: tag,
+  },
+})
+
+const makeActions = (): DeploymentActions => ({
+  deploy: vi.fn(),
+  deployPending: false,
+  deployPendingSha: null,
+  promote: vi.fn(),
+  promotePending: false,
+})
+
+const makeStage = (pending: ReleaseHistoryEntry[]): PipelineStage => ({
+  current: current('production', 'v6.5.0', 'aaa111aaa111'),
+  env: ENV,
+  kind: 'release',
+  pendingReleases: pending,
+  rollbackTargets: [],
+  upstream: UPSTREAM,
+  upstreamCurrent: current('staging', 'v6.5.2', 'ccc333ccc333'),
+})
+
+const renderCard = (pending: ReleaseHistoryEntry[], actions = makeActions()) =>
+  render(
+    <PendingReleasesCard
+      accent={null}
+      actions={actions}
+      canTrigger
+      orgSlug="org"
+      projectId="p1"
+      stage={makeStage(pending)}
+    />,
+  )
+
+describe('PendingReleasesCard', () => {
+  it('shows the up-to-date state when nothing is pending', () => {
+    renderCard([])
+    expect(screen.getByText('Up to date with Staging')).toBeInTheDocument()
+  })
+
+  it('renders the single-release confirm with its notes', () => {
+    vi.mocked(endpoints.compareDeploymentRefs).mockResolvedValue({
+      additions: 1,
+      ahead: 1,
+      base_sha: 'aaa',
+      behind: 0,
+      commits: [],
+      deletions: 0,
+      files_changed: 1,
+      head_sha: 'bbb',
+      pr_numbers: [],
+    })
+    renderCard([entry('v6.5.1', 'bbb222bbb222', 'Cache TTL fix')])
+    expect(screen.getByText(/is waiting to go live/)).toBeInTheDocument()
+    expect(screen.getByText('notes for v6.5.1')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Deploy v6\.5\.1 to production/ }),
+    ).toBeInTheDocument()
+  })
+
+  it('dispatches a deploy for the selected release', async () => {
+    const actions = makeActions()
+    const user = userEvent.setup()
+    renderCard(
+      [
+        entry('v6.5.2', 'ccc333ccc333', 'Net-zero patch'),
+        entry('v6.5.1', 'bbb222bbb222', 'Cache TTL fix'),
+      ],
+      actions,
+    )
+    expect(
+      screen.getByText('2 releases waiting to go live'),
+    ).toBeInTheDocument()
+    // Defaults to the newest release; the older one rolls up.
+    expect(screen.getByText(/v6\.5\.1 is rolled up/)).toBeInTheDocument()
+    await user.click(
+      screen.getByRole('button', { name: /Deploy v6\.5\.2 to production/ }),
+    )
+    expect(actions.deploy).toHaveBeenCalledWith({
+      action: 'deploy',
+      envName: 'Production',
+      envSlug: 'production',
+      refLabel: 'v6.5.2',
+      sha: 'ccc333ccc333',
+    })
+  })
+
+  it('selecting an older release updates the button, note, and notes accordion', async () => {
+    const user = userEvent.setup()
+    renderCard([
+      entry('v6.5.2', 'ccc333ccc333', 'Net-zero patch'),
+      entry('v6.5.1', 'bbb222bbb222', 'Cache TTL fix'),
+    ])
+    await user.click(screen.getByRole('button', { name: /v6\.5\.1/ }))
+    expect(
+      screen.getByRole('button', { name: /Deploy v6\.5\.1 to production/ }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/v6\.5\.2 stays pending above it/),
+    ).toBeInTheDocument()
+    // Row click also expands the release notes accordion.
+    expect(screen.getByText('notes for v6.5.1')).toBeInTheDocument()
+  })
+})

--- a/src/components/deployments/PendingReleasesCard.test.tsx
+++ b/src/components/deployments/PendingReleasesCard.test.tsx
@@ -2,24 +2,17 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
-import * as endpoints from '@/api/endpoints'
 import { render } from '@/test/utils'
 import type {
   CurrentReleaseEnvironment,
   Environment,
+  RecentCommit,
   ReleaseHistoryEntry,
 } from '@/types'
 
 import { PendingReleasesCard } from './PendingReleasesCard'
 import type { PipelineStage } from './pipeline'
 import type { DeploymentActions } from './useDeploymentActions'
-
-// fallow-ignore-next-line unresolved-import
-vi.mock('@/api/endpoints', async () => {
-  const actual =
-    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
-  return { ...actual, compareDeploymentRefs: vi.fn() }
-})
 
 const ENV = {
   can_deploy: true,
@@ -75,6 +68,23 @@ const current = (
   },
 })
 
+const RECENT_COMMITS: RecentCommit[] = [
+  {
+    authored_at: '2026-06-01T00:00:00Z',
+    ci_status: 'pass',
+    message: 'the pending change',
+    sha: 'bbb222bbb222',
+    short_sha: 'bbb222b',
+  },
+  {
+    authored_at: '2026-05-20T00:00:00Z',
+    ci_status: 'pass',
+    message: 'the released change',
+    sha: 'aaa111aaa111',
+    short_sha: 'aaa111a',
+  },
+]
+
 const makeActions = (): DeploymentActions => ({
   deploy: vi.fn(),
   deployPending: false,
@@ -83,25 +93,32 @@ const makeActions = (): DeploymentActions => ({
   promotePending: false,
 })
 
-const makeStage = (pending: ReleaseHistoryEntry[]): PipelineStage => ({
-  current: current('production', 'v6.5.0', 'aaa111aaa111'),
+const makeStage = (
+  pending: ReleaseHistoryEntry[],
+  envTag = 'v6.5.0',
+): PipelineStage => ({
+  current: current('production', envTag, 'aaa111aaa111'),
   env: ENV,
   kind: 'release',
+  pendingCommits: [],
   pendingReleases: pending,
   rollbackTargets: [],
   upstream: UPSTREAM,
   upstreamCurrent: current('staging', 'v6.5.2', 'ccc333ccc333'),
 })
 
-const renderCard = (pending: ReleaseHistoryEntry[], actions = makeActions()) =>
+const renderCard = (
+  pending: ReleaseHistoryEntry[],
+  actions = makeActions(),
+  envTag = 'v6.5.0',
+) =>
   render(
     <PendingReleasesCard
       accent={null}
       actions={actions}
       canTrigger
-      orgSlug="org"
-      projectId="p1"
-      stage={makeStage(pending)}
+      recentCommits={RECENT_COMMITS}
+      stage={makeStage(pending, envTag)}
     />,
   )
 
@@ -111,21 +128,12 @@ describe('PendingReleasesCard', () => {
     expect(screen.getByText('Up to date with Staging')).toBeInTheDocument()
   })
 
-  it('renders the single-release confirm with its notes', () => {
-    vi.mocked(endpoints.compareDeploymentRefs).mockResolvedValue({
-      additions: 1,
-      ahead: 1,
-      base_sha: 'aaa',
-      behind: 0,
-      commits: [],
-      deletions: 0,
-      files_changed: 1,
-      head_sha: 'bbb',
-      pr_numbers: [],
-    })
+  it('renders the single-release confirm with notes and synced changes', () => {
     renderCard([entry('v6.5.1', 'bbb222bbb222', 'Cache TTL fix')])
     expect(screen.getByText(/is waiting to go live/)).toBeInTheDocument()
     expect(screen.getByText('notes for v6.5.1')).toBeInTheDocument()
+    // Changes section sliced from the synced commit history.
+    expect(screen.getByText('the pending change')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /Deploy v6\.5\.1 to production/ }),
     ).toBeInTheDocument()
@@ -173,5 +181,21 @@ describe('PendingReleasesCard', () => {
     ).toBeInTheDocument()
     // Row click also expands the release notes accordion.
     expect(screen.getByText('notes for v6.5.1')).toBeInTheDocument()
+  })
+
+  it('warns when the pending release ranks below the running one', () => {
+    // Production runs 2.101.0; staging's 1.102.3 is still deployable but
+    // flagged as a roll back to the older line.
+    renderCard(
+      [entry('1.102.3', 'bbb222bbb222', 'Older line hotfix')],
+      makeActions(),
+      '2.101.0',
+    )
+    expect(
+      screen.getByText(/rolls this environment to the older release line/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Deploy 1\.102\.3 to production/ }),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/deployments/PendingReleasesCard.tsx
+++ b/src/components/deployments/PendingReleasesCard.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 
-import { useQuery } from '@tanstack/react-query'
 import {
   Check,
   ChevronDown,
@@ -11,16 +10,16 @@ import {
   Rocket,
 } from 'lucide-react'
 
-import { compareDeploymentRefs } from '@/api/endpoints'
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Button } from '@/components/ui/button'
 import type { ChipColors } from '@/lib/chip-colors'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { cn } from '@/lib/utils'
-import type { ReleaseHistoryEntry } from '@/types'
+import type { RecentCommit, ReleaseHistoryEntry } from '@/types'
 
 import { UpToDateCard } from './PendingPromoteCard'
 import type { PipelineStage } from './pipeline'
+import { commitRange, compareTags } from './pipeline'
 import { ReleaseNotesMarkdown } from './ReleaseNotesMarkdown'
 import { StageCardShell } from './StageCardShell'
 import type { DeploymentActions } from './useDeploymentActions'
@@ -29,8 +28,8 @@ interface PendingReleasesCardProps {
   accent: ChipColors | null
   actions: DeploymentActions
   canTrigger: boolean
-  orgSlug: string
-  projectId: string
+  /** Synced default-branch commit history, newest first. */
+  recentCommits: RecentCommit[]
   stage: PipelineStage
 }
 
@@ -45,8 +44,7 @@ export function PendingReleasesCard({
   accent,
   actions,
   canTrigger,
-  orgSlug,
-  projectId,
+  recentCommits,
   stage,
 }: PendingReleasesCardProps) {
   const pending = stage.pendingReleases
@@ -63,6 +61,12 @@ export function PendingReleasesCard({
   const rolledUp = pending.slice(activeIdx + 1).map((rel) => rel.tag)
   const stillPending = pending.slice(0, activeIdx).map((rel) => rel.tag)
   const canSubmit = canTrigger && !actions.deployPending
+  // The upstream can legitimately run a release that semver-ranks below
+  // this env's current one (divergent lines / roll-forward of an older
+  // line) — deployable, but worth calling out.
+  const currentTag = stage.current?.release?.tag ?? null
+  const cmp = compareTags(active.tag, currentTag)
+  const isDowngrade = cmp != null && cmp < 0
 
   return (
     <StageCardShell
@@ -133,8 +137,7 @@ export function PendingReleasesCard({
           <>
             <SingleReleaseChanges
               entry={active}
-              orgSlug={orgSlug}
-              projectId={projectId}
+              recentCommits={recentCommits}
               stage={stage}
             />
             <section>
@@ -148,6 +151,18 @@ export function PendingReleasesCard({
             </section>
           </>
         )}
+
+        {isDowngrade ? (
+          <div className="border-warning bg-warning text-warning flex gap-2 rounded-md border px-3 py-2.5">
+            <Info className="mt-0.5 size-3.5 shrink-0" />
+            <span className="text-xs leading-relaxed">
+              <span className="font-mono">{active.tag}</span> ranks below the{' '}
+              <span className="font-mono">{currentTag}</span> currently running
+              in {stage.env.name.toLowerCase()} — deploying it rolls this
+              environment to the older release line.
+            </span>
+          </div>
+        ) : null}
 
         <div className="border-tertiary flex items-center justify-end gap-2 border-t pt-4">
           <Button
@@ -266,70 +281,51 @@ function ReleaseStack({
   )
 }
 
-/** Diff summary + commit list for the single-pending-release case. */
+/**
+ * Commit list for the single-pending-release case, sliced from the
+ * synced history between the env's current release and the pending one.
+ */
 function SingleReleaseChanges({
   entry,
-  orgSlug,
-  projectId,
+  recentCommits,
   stage,
 }: {
   entry: ReleaseHistoryEntry
-  orgSlug: string
-  projectId: string
+  recentCommits: RecentCommit[]
   stage: PipelineStage
 }) {
-  const base = stage.current?.release?.tag ?? null
-  const { data: compare } = useQuery({
-    enabled: !!base && base !== entry.tag,
-    queryFn: ({ signal }) =>
-      compareDeploymentRefs(
-        orgSlug,
-        projectId,
-        base ?? '',
-        entry.sha,
-        undefined,
-        signal,
-      ),
-    queryKey: ['compare', orgSlug, projectId, base, entry.sha],
-  })
-  if (!compare) return null
+  const baseSha = stage.current?.release?.committish ?? null
+  const commits = commitRange(recentCommits, entry.sha, baseSha)
+  if (commits.length === 0) return null
   return (
     <div className="flex flex-col gap-3">
       <div className="text-tertiary flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs">
-        <span>{compare.commits.length} commits</span>
-        <span>{compare.files_changed} files</span>
-        <span className="text-success">+{compare.additions}</span>
-        <span className="text-danger">−{compare.deletions}</span>
+        <span>{commits.length} commits</span>
         <span className="ml-auto">
-          {base} … {entry.tag}
+          {stage.current?.release?.tag ?? '—'} … {entry.tag}
         </span>
       </div>
-      {compare.commits.length > 0 ? (
-        <section>
-          <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
-            Changes in{' '}
-            <span className="font-mono normal-case">{entry.tag}</span>
-          </p>
-          <ul className="border-tertiary max-h-60 overflow-y-auto rounded-md border">
-            {[...compare.commits].reverse().map((c) => (
-              <li
-                className="border-tertiary flex min-w-0 items-center gap-3 border-b px-3 py-1.5 last:border-b-0"
-                key={c.sha}
-              >
-                <span className="shrink-0 font-mono text-xs">
-                  {c.short_sha}
-                </span>
-                <span className="min-w-0 flex-1 truncate text-sm">
-                  {c.message.split('\n')[0]}
-                </span>
-                {c.ci_status !== 'unknown' ? (
-                  <CiStatusDot status={c.ci_status} />
-                ) : null}
-              </li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
+      <section>
+        <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+          Changes in <span className="font-mono normal-case">{entry.tag}</span>
+        </p>
+        <ul className="border-tertiary max-h-60 overflow-y-auto rounded-md border">
+          {commits.map((c) => (
+            <li
+              className="border-tertiary flex min-w-0 items-center gap-3 border-b px-3 py-1.5 last:border-b-0"
+              key={c.sha}
+            >
+              <span className="shrink-0 font-mono text-xs">{c.short_sha}</span>
+              <span className="min-w-0 flex-1 truncate text-sm">
+                {c.message.split('\n')[0]}
+              </span>
+              {c.ci_status !== 'unknown' ? (
+                <CiStatusDot status={c.ci_status} />
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   )
 }

--- a/src/components/deployments/PendingReleasesCard.tsx
+++ b/src/components/deployments/PendingReleasesCard.tsx
@@ -322,7 +322,9 @@ function SingleReleaseChanges({
                 <span className="min-w-0 flex-1 truncate text-sm">
                   {c.message.split('\n')[0]}
                 </span>
-                <CiStatusDot status={c.ci_status} />
+                {c.ci_status !== 'unknown' ? (
+                  <CiStatusDot status={c.ci_status} />
+                ) : null}
               </li>
             ))}
           </ul>

--- a/src/components/deployments/PendingReleasesCard.tsx
+++ b/src/components/deployments/PendingReleasesCard.tsx
@@ -1,0 +1,333 @@
+import { useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  GitMerge,
+  Info,
+  Loader2,
+  Rocket,
+} from 'lucide-react'
+
+import { compareDeploymentRefs } from '@/api/endpoints'
+import { CiStatusDot } from '@/components/releases/CiStatusDot'
+import { Button } from '@/components/ui/button'
+import type { ChipColors } from '@/lib/chip-colors'
+import { formatRelativeDate } from '@/lib/formatDate'
+import { cn } from '@/lib/utils'
+import type { ReleaseHistoryEntry } from '@/types'
+
+import { UpToDateCard } from './PendingPromoteCard'
+import type { PipelineStage } from './pipeline'
+import { ReleaseNotesMarkdown } from './ReleaseNotesMarkdown'
+import { StageCardShell } from './StageCardShell'
+import type { DeploymentActions } from './useDeploymentActions'
+
+interface PendingReleasesCardProps {
+  accent: ChipColors | null
+  actions: DeploymentActions
+  canTrigger: boolean
+  orgSlug: string
+  projectId: string
+  stage: PipelineStage
+}
+
+/**
+ * Releases already cut upstream that haven't reached this environment.
+ * One pending release renders as a confirm card with its notes; several
+ * render as a selectable stack — deploying the newest rolls the
+ * intermediate ones up. No new tag is cut either way.
+ */
+// fallow-ignore-next-line complexity
+export function PendingReleasesCard({
+  accent,
+  actions,
+  canTrigger,
+  orgSlug,
+  projectId,
+  stage,
+}: PendingReleasesCardProps) {
+  const pending = stage.pendingReleases
+  const [selectedTag, setSelectedTag] = useState<null | string>(null)
+  const upstreamName = stage.upstream?.name ?? 'upstream'
+
+  if (pending.length === 0) {
+    return <UpToDateCard upstreamName={upstreamName} />
+  }
+
+  const multi = pending.length > 1
+  const active = pending.find((rel) => rel.tag === selectedTag) ?? pending[0]
+  const activeIdx = pending.findIndex((rel) => rel.tag === active.tag)
+  const rolledUp = pending.slice(activeIdx + 1).map((rel) => rel.tag)
+  const stillPending = pending.slice(0, activeIdx).map((rel) => rel.tag)
+  const canSubmit = canTrigger && !actions.deployPending
+
+  return (
+    <StageCardShell
+      accent={accent}
+      icon={GitMerge}
+      subtitle={
+        multi ? (
+          <>
+            {pending.length} releases live in {upstreamName.toLowerCase()} ·
+            choose which to deploy
+          </>
+        ) : (
+          <>
+            {active.title ? `${active.title} · ` : ''}live in{' '}
+            {upstreamName.toLowerCase()}
+            {active.published_at
+              ? ` since ${formatRelativeDate(active.published_at)}`
+              : ''}
+          </>
+        )
+      }
+      title={
+        multi ? (
+          `${pending.length} releases waiting to go live`
+        ) : (
+          <>
+            Release <span className="font-mono">{active.tag}</span> is waiting
+            to go live
+          </>
+        )
+      }
+    >
+      <div className="flex flex-col gap-4 px-4 py-4">
+        {multi ? (
+          <>
+            <section>
+              <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+                Select a release to deploy
+              </p>
+              <ReleaseStack
+                accent={accent}
+                onSelect={setSelectedTag}
+                releases={pending}
+                selectedTag={active.tag}
+              />
+            </section>
+            <div className="border-info bg-info text-info flex gap-2 rounded-md border px-3 py-2.5">
+              <Info className="mt-0.5 size-3.5 shrink-0" />
+              <span className="text-xs leading-relaxed">
+                Deploys release <span className="font-mono">{active.tag}</span>{' '}
+                into {stage.env.name.toLowerCase()}.
+                {rolledUp.length > 0 ? (
+                  <>
+                    {' '}
+                    {rolledUp.join(', ')} {rolledUp.length > 1 ? 'are' : 'is'}{' '}
+                    rolled up — {stage.env.name.toLowerCase()} skips straight to{' '}
+                    {active.tag}.
+                  </>
+                ) : null}
+                {stillPending.length > 0 ? (
+                  <> {stillPending.join(', ')} stays pending above it.</>
+                ) : null}{' '}
+                No new tag is cut.
+              </span>
+            </div>
+          </>
+        ) : (
+          <>
+            <SingleReleaseChanges
+              entry={active}
+              orgSlug={orgSlug}
+              projectId={projectId}
+              stage={stage}
+            />
+            <section>
+              <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+                Release notes ·{' '}
+                <span className="font-mono normal-case">{active.tag}</span>
+              </p>
+              <div className="border-tertiary rounded-md border px-3.5 py-3">
+                <ReleaseNotesMarkdown notes={active.notes_markdown} />
+              </div>
+            </section>
+          </>
+        )}
+
+        <div className="border-tertiary flex items-center justify-end gap-2 border-t pt-4">
+          <Button
+            disabled={!canSubmit}
+            onClick={() =>
+              actions.deploy({
+                action: 'deploy',
+                envName: stage.env.name,
+                envSlug: stage.env.slug,
+                refLabel: active.tag,
+                sha: active.sha,
+              })
+            }
+            type="button"
+          >
+            {actions.deployPending ? (
+              <Loader2 className="mr-1 size-4 animate-spin" />
+            ) : (
+              <Rocket className="mr-1 size-4" />
+            )}
+            {`Deploy ${active.tag} to ${stage.env.name.toLowerCase()}`}
+          </Button>
+        </div>
+      </div>
+    </StageCardShell>
+  )
+}
+
+/**
+ * Radio + accordion stack of the pending releases. Clicking a row selects
+ * it for deploy and toggles its release notes; only one row is open at a
+ * time.
+ */
+function ReleaseStack({
+  accent,
+  onSelect,
+  releases,
+  selectedTag,
+}: {
+  accent: ChipColors | null
+  onSelect: (tag: string) => void
+  releases: ReleaseHistoryEntry[]
+  selectedTag: string
+}) {
+  const [openTag, setOpenTag] = useState<null | string>(null)
+  return (
+    <div className="border-tertiary rounded-md border">
+      {/* fallow-ignore-next-line complexity */}
+      {releases.map((rel) => {
+        const selected = rel.tag === selectedTag
+        const isOpen = rel.tag === openTag
+        return (
+          <div
+            className="border-tertiary border-b last:border-b-0"
+            key={rel.tag}
+          >
+            <button
+              className={cn(
+                'flex w-full min-w-0 items-center gap-3 px-3 py-2.5 text-left transition-colors',
+                !selected && 'hover:bg-secondary',
+              )}
+              onClick={() => {
+                onSelect(rel.tag)
+                setOpenTag((o) => (o === rel.tag ? null : rel.tag))
+              }}
+              style={
+                selected && accent ? { backgroundColor: accent.bg } : undefined
+              }
+              type="button"
+            >
+              <span
+                className={cn(
+                  'flex size-4 shrink-0 items-center justify-center rounded-full border',
+                  !accent && selected && 'border-action bg-action text-white',
+                  !selected && 'border-secondary',
+                )}
+                style={
+                  selected && accent
+                    ? {
+                        backgroundColor: accent.fg,
+                        borderColor: accent.fg,
+                        color: '#fff',
+                      }
+                    : undefined
+                }
+              >
+                {selected ? <Check size={10} strokeWidth={3} /> : null}
+              </span>
+              <span className="shrink-0 font-mono text-sm font-semibold">
+                {rel.tag}
+              </span>
+              <CiStatusDot size={13} status={rel.ci_status} />
+              <span className="text-secondary min-w-0 flex-1 truncate text-xs">
+                {rel.title ?? ''}
+              </span>
+              {rel.published_at ? (
+                <span className="text-tertiary shrink-0 text-xs whitespace-nowrap">
+                  {formatRelativeDate(rel.published_at)}
+                </span>
+              ) : null}
+              {isOpen ? (
+                <ChevronUp className="text-tertiary size-3.5 shrink-0" />
+              ) : (
+                <ChevronDown className="text-tertiary size-3.5 shrink-0" />
+              )}
+            </button>
+            {isOpen ? (
+              <div className="border-tertiary border-t px-3.5 py-3 pl-10">
+                <ReleaseNotesMarkdown notes={rel.notes_markdown} />
+              </div>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Diff summary + commit list for the single-pending-release case. */
+function SingleReleaseChanges({
+  entry,
+  orgSlug,
+  projectId,
+  stage,
+}: {
+  entry: ReleaseHistoryEntry
+  orgSlug: string
+  projectId: string
+  stage: PipelineStage
+}) {
+  const base = stage.current?.release?.tag ?? null
+  const { data: compare } = useQuery({
+    enabled: !!base && base !== entry.tag,
+    queryFn: ({ signal }) =>
+      compareDeploymentRefs(
+        orgSlug,
+        projectId,
+        base ?? '',
+        entry.sha,
+        undefined,
+        signal,
+      ),
+    queryKey: ['compare', orgSlug, projectId, base, entry.sha],
+  })
+  if (!compare) return null
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="text-tertiary flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs">
+        <span>{compare.commits.length} commits</span>
+        <span>{compare.files_changed} files</span>
+        <span className="text-success">+{compare.additions}</span>
+        <span className="text-danger">−{compare.deletions}</span>
+        <span className="ml-auto">
+          {base} … {entry.tag}
+        </span>
+      </div>
+      {compare.commits.length > 0 ? (
+        <section>
+          <p className="text-tertiary mb-2 text-xs tracking-wider uppercase">
+            Changes in{' '}
+            <span className="font-mono normal-case">{entry.tag}</span>
+          </p>
+          <ul className="border-tertiary max-h-60 overflow-y-auto rounded-md border">
+            {[...compare.commits].reverse().map((c) => (
+              <li
+                className="border-tertiary flex min-w-0 items-center gap-3 border-b px-3 py-1.5 last:border-b-0"
+                key={c.sha}
+              >
+                <span className="shrink-0 font-mono text-xs">
+                  {c.short_sha}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm">
+                  {c.message.split('\n')[0]}
+                </span>
+                <CiStatusDot status={c.ci_status} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/deployments/ReleaseNotesMarkdown.tsx
+++ b/src/components/deployments/ReleaseNotesMarkdown.tsx
@@ -1,0 +1,27 @@
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+interface ReleaseNotesMarkdownProps {
+  notes: null | string | undefined
+}
+
+/** Markdown release-notes block shared by the deployment cards. */
+export function ReleaseNotesMarkdown({ notes }: ReleaseNotesMarkdownProps) {
+  if (!notes) {
+    return <p className="text-tertiary text-xs italic">No release notes.</p>
+  }
+  return (
+    <div className="document-markdown max-w-none text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+      <Markdown
+        components={{
+          a: (props) => (
+            <a {...props} rel="noopener noreferrer" target="_blank" />
+          ),
+        }}
+        remarkPlugins={[remarkGfm]}
+      >
+        {notes}
+      </Markdown>
+    </div>
+  )
+}

--- a/src/components/deployments/StageCardShell.tsx
+++ b/src/components/deployments/StageCardShell.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react'
+
+import type { LucideIcon } from 'lucide-react'
+
+import type { ChipColors } from '@/lib/chip-colors'
+
+interface StageCardShellProps {
+  accent: ChipColors | null
+  children: ReactNode
+  icon: LucideIcon
+  subtitle?: ReactNode
+  title: ReactNode
+}
+
+/**
+ * Card with a header strip tinted in the environment's derived color —
+ * the shared frame for the per-environment deployment cards.
+ */
+export function StageCardShell({
+  accent,
+  children,
+  icon: Icon,
+  subtitle,
+  title,
+}: StageCardShellProps) {
+  return (
+    <div
+      className="border-tertiary overflow-hidden rounded-lg border"
+      style={accent ? { borderColor: accent.border } : undefined}
+    >
+      <div
+        className="border-tertiary flex items-center gap-3 border-b px-4 py-3"
+        style={
+          accent
+            ? { backgroundColor: accent.bg, borderColor: accent.border }
+            : undefined
+        }
+      >
+        <span
+          className="bg-primary flex size-8 shrink-0 items-center justify-center rounded-md border"
+          style={
+            accent
+              ? { borderColor: accent.border, color: accent.fg }
+              : undefined
+          }
+        >
+          <Icon size={16} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold">{title}</div>
+          {subtitle ? (
+            <div
+              className="mt-0.5 text-xs"
+              style={accent ? { color: accent.fg } : undefined}
+            >
+              {subtitle}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/src/components/deployments/StageCardShell.tsx
+++ b/src/components/deployments/StageCardShell.tsx
@@ -6,6 +6,8 @@ import type { ChipColors } from '@/lib/chip-colors'
 
 interface StageCardShellProps {
   accent: ChipColors | null
+  /** Right-aligned element in the header strip (e.g. an environment URL). */
+  aside?: ReactNode
   children: ReactNode
   icon: LucideIcon
   subtitle?: ReactNode
@@ -18,6 +20,7 @@ interface StageCardShellProps {
  */
 export function StageCardShell({
   accent,
+  aside,
   children,
   icon: Icon,
   subtitle,
@@ -25,7 +28,7 @@ export function StageCardShell({
 }: StageCardShellProps) {
   return (
     <div
-      className="border-tertiary overflow-hidden rounded-lg border"
+      className="border-tertiary bg-primary overflow-hidden rounded-lg border"
       style={accent ? { borderColor: accent.border } : undefined}
     >
       <div
@@ -57,6 +60,7 @@ export function StageCardShell({
             </div>
           ) : null}
         </div>
+        {aside ? <div className="shrink-0">{aside}</div> : null}
       </div>
       {children}
     </div>

--- a/src/components/deployments/pipeline.test.ts
+++ b/src/components/deployments/pipeline.test.ts
@@ -3,10 +3,16 @@ import { describe, expect, it } from 'vitest'
 import type {
   CurrentReleaseEnvironment,
   Environment,
+  RecentCommit,
   ReleaseHistoryEntry,
 } from '@/types'
 
-import { buildPipeline, defaultStageSlug } from './pipeline'
+import {
+  buildPipeline,
+  commitRange,
+  compareTags,
+  defaultStageSlug,
+} from './pipeline'
 
 const env = (slug: string, sortOrder: number): Environment =>
   ({
@@ -50,6 +56,14 @@ const entry = (tag: string, sha: string): ReleaseHistoryEntry => ({
   tag,
 })
 
+const commit = (sha: string, message: string): RecentCommit => ({
+  authored_at: '2026-06-01T00:00:00Z',
+  ci_status: 'pass',
+  message,
+  sha,
+  short_sha: sha.slice(0, 7),
+})
+
 const ENVS = [env('testing', 1), env('staging', 2), env('production', 3)]
 
 // Newest (highest semver) first, mirroring /deployments/release-history.
@@ -60,6 +74,16 @@ const HISTORY = [
   entry('v6.4.0', '000999000999'),
 ]
 
+// Newest-first synced default-branch history.
+const COMMITS = [
+  commit('fff666fff666', 'newest unreleased'),
+  commit('eee555eee555', 'also unreleased'),
+  commit('ddd444ddd444', 'deployed to testing'),
+  commit('ccc333ccc333', 'release v6.5.2'),
+  commit('bbb222bbb222', 'release v6.5.1'),
+  commit('aaa111aaa111', 'release v6.5.0'),
+]
+
 const CURRENT = [
   currentRelease('testing', 'ddd444ddd444', null),
   currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
@@ -67,10 +91,18 @@ const CURRENT = [
 ]
 
 describe('buildPipeline', () => {
-  const stages = buildPipeline(ENVS, CURRENT, HISTORY)
+  const stages = buildPipeline(ENVS, CURRENT, HISTORY, COMMITS)
 
   it('derives stage kinds from upstream data, not position names', () => {
     expect(stages.map((s) => s.kind)).toEqual(['commit', 'promote', 'release'])
+  })
+
+  it('computes pending commits for promote stages from the synced history', () => {
+    const staging = stages[1]
+    // Testing runs ddd444; staging's release was cut at ccc333 — one
+    // commit is waiting, and the unreleased commits beyond testing are
+    // not offered.
+    expect(staging.pendingCommits.map((c) => c.sha)).toEqual(['ddd444ddd444'])
   })
 
   it('computes pending releases between the env and its upstream', () => {
@@ -83,7 +115,7 @@ describe('buildPipeline', () => {
 
   it('treats an env with no release as pending everything up to upstream', () => {
     const noProd = CURRENT.filter((c) => c.environment.slug !== 'production')
-    const result = buildPipeline(ENVS, noProd, HISTORY)
+    const result = buildPipeline(ENVS, noProd, HISTORY, COMMITS)
     expect(result[2].pendingReleases.map((r) => r.tag)).toEqual([
       'v6.5.2',
       'v6.5.1',
@@ -98,18 +130,32 @@ describe('buildPipeline', () => {
       currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
       currentRelease('production', 'ccc333ccc333', 'v6.5.2'),
     ]
-    const result = buildPipeline(ENVS, synced, HISTORY)
+    const result = buildPipeline(ENVS, synced, HISTORY, COMMITS)
     expect(result[2].pendingReleases).toEqual([])
   })
 
-  it('returns no pending releases when the env is ahead of its upstream', () => {
-    const ahead = [
+  it('offers a divergent upstream release even when the env ranks ahead', () => {
+    // Production runs 2.101.0 while staging runs 1.102.3 — different
+    // releases, so staging's stays deployable (the composer case).
+    const history = [entry('2.101.0', 'ccc333ccc333'), ...HISTORY]
+    const divergent = [
       currentRelease('testing', 'ddd444ddd444', null),
       currentRelease('staging', 'aaa111aaa111', 'v6.5.0'),
+      currentRelease('production', 'ccc333ccc333', '2.101.0'),
+    ]
+    const result = buildPipeline(ENVS, divergent, history, COMMITS)
+    expect(result[2].pendingReleases.map((r) => r.tag)).toEqual(['v6.5.0'])
+  })
+
+  it('offers the upstream release when its tag is missing from history', () => {
+    const divergent = [
+      currentRelease('testing', 'ddd444ddd444', null),
+      currentRelease('staging', '123abc123abc', 'v7.0.0'),
       currentRelease('production', 'ccc333ccc333', 'v6.5.2'),
     ]
-    const result = buildPipeline(ENVS, ahead, HISTORY)
-    expect(result[2].pendingReleases).toEqual([])
+    const result = buildPipeline(ENVS, divergent, HISTORY, COMMITS)
+    expect(result[2].pendingReleases.map((r) => r.tag)).toEqual(['v7.0.0'])
+    expect(result[2].pendingReleases[0].sha).toBe('123abc123abc')
   })
 
   it('collects rollback targets older than the current tag', () => {
@@ -123,22 +169,79 @@ describe('buildPipeline', () => {
     ])
   })
 
+  it('falls back to semver ranking when the current tag is unsynced', () => {
+    // 2.101.0 is not in HISTORY; everything older still ranks below it.
+    const unsynced = [currentRelease('production', '999000999000', '2.101.0')]
+    const result = buildPipeline(ENVS, unsynced, HISTORY, COMMITS)
+    expect(result[2].rollbackTargets.map((r) => r.tag)).toEqual([])
+    const olderLine = [currentRelease('production', '999000999000', 'v6.5.3')]
+    const result2 = buildPipeline(ENVS, olderLine, HISTORY, COMMITS)
+    expect(result2[2].rollbackTargets.map((r) => r.tag)).toEqual([
+      'v6.5.2',
+      'v6.5.1',
+      'v6.5.0',
+      'v6.4.0',
+    ])
+  })
+
   it('treats a tagged upstream as release-kind even mid-train', () => {
-    // Four-stage train: the third and fourth envs both sit below tagged
-    // upstreams, so both are release-kind.
     const envs = [...ENVS, env('dr', 4)]
     const current = [...CURRENT, currentRelease('dr', '000999000999', 'v6.4.0')]
-    const result = buildPipeline(envs, current, HISTORY)
+    const result = buildPipeline(envs, current, HISTORY, COMMITS)
     expect(result[3].kind).toBe('release')
     expect(result[3].pendingReleases.map((r) => r.tag)).toEqual(['v6.5.0'])
   })
 })
 
+describe('commitRange', () => {
+  it('slices from head (inclusive) down to base (exclusive)', () => {
+    expect(
+      commitRange(COMMITS, 'ddd444ddd444', 'bbb222bbb222').map((c) => c.sha),
+    ).toEqual(['ddd444ddd444', 'ccc333ccc333'])
+  })
+
+  it('matches sha prefixes in either direction', () => {
+    expect(
+      commitRange(COMMITS, 'ddd444d', 'ccc333c').map((c) => c.sha),
+    ).toEqual(['ddd444ddd444'])
+  })
+
+  it('returns the window remainder when the base is older than it', () => {
+    expect(
+      commitRange(COMMITS, 'bbb222bbb222', '777zzz777zzz').map((c) => c.sha),
+    ).toEqual(['bbb222bbb222', 'aaa111aaa111'])
+  })
+
+  it('returns nothing when the head is unknown or not ahead', () => {
+    expect(commitRange(COMMITS, '777zzz777zzz', 'aaa111aaa111')).toEqual([])
+    expect(commitRange(COMMITS, 'aaa111aaa111', 'aaa111aaa111')).toEqual([])
+    expect(commitRange(COMMITS, 'aaa111aaa111', 'ccc333ccc333')).toEqual([])
+  })
+})
+
+describe('compareTags', () => {
+  it('orders semver tags and tolerates a leading v', () => {
+    expect(compareTags('1.102.3', '2.101.0')).toBeLessThan(0)
+    expect(compareTags('v6.5.2', '6.5.2')).toBe(0)
+    expect(compareTags('not-semver', '1.0.0')).toBeNull()
+  })
+})
+
 describe('defaultStageSlug', () => {
   it('selects the earliest stage with pending work', () => {
-    const stages = buildPipeline(ENVS, CURRENT, HISTORY)
-    expect(defaultStageSlug(stages, { staging: 3 })).toBe('staging')
-    expect(defaultStageSlug(stages, { staging: 0 })).toBe('production')
+    const stages = buildPipeline(ENVS, CURRENT, HISTORY, COMMITS)
+    expect(defaultStageSlug(stages)).toBe('staging')
+    const noStagingGap = buildPipeline(
+      ENVS,
+      [
+        currentRelease('testing', 'ccc333ccc333', null),
+        currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
+        currentRelease('production', 'aaa111aaa111', 'v6.5.0'),
+      ],
+      HISTORY,
+      COMMITS,
+    )
+    expect(defaultStageSlug(noStagingGap)).toBe('production')
   })
 
   it('falls back to the first environment when nothing is pending', () => {
@@ -147,7 +250,7 @@ describe('defaultStageSlug', () => {
       currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
       currentRelease('production', 'ccc333ccc333', 'v6.5.2'),
     ]
-    const stages = buildPipeline(ENVS, synced, HISTORY)
-    expect(defaultStageSlug(stages, { staging: 0 })).toBe('testing')
+    const stages = buildPipeline(ENVS, synced, HISTORY, COMMITS)
+    expect(defaultStageSlug(stages)).toBe('testing')
   })
 })

--- a/src/components/deployments/pipeline.test.ts
+++ b/src/components/deployments/pipeline.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  CurrentReleaseEnvironment,
+  Environment,
+  ReleaseHistoryEntry,
+} from '@/types'
+
+import { buildPipeline, defaultStageSlug } from './pipeline'
+
+const env = (slug: string, sortOrder: number): Environment =>
+  ({
+    can_deploy: true,
+    can_promote: false,
+    id: slug,
+    label_color: '#5A89C9',
+    name: slug[0].toUpperCase() + slug.slice(1),
+    slug,
+    sort_order: sortOrder,
+  }) as unknown as Environment
+
+const currentRelease = (
+  slug: string,
+  committish: string,
+  tag: null | string,
+): CurrentReleaseEnvironment => ({
+  ci_status: 'pass',
+  current_status: 'success',
+  environment: { name: slug, slug },
+  external_run_url: null,
+  last_event_at: '2026-06-01T00:00:00Z',
+  release: {
+    committish,
+    created_at: '2026-06-01T00:00:00Z',
+    created_by: 'gavin',
+    id: `${slug}-release`,
+    links: [],
+    project_id: 'p1',
+    tag,
+    title: tag ?? committish,
+  },
+})
+
+const entry = (tag: string, sha: string): ReleaseHistoryEntry => ({
+  ci_status: 'pass',
+  notes_markdown: `notes for ${tag}`,
+  published_at: '2026-06-01T00:00:00Z',
+  sha,
+  short_sha: sha.slice(0, 7),
+  tag,
+})
+
+const ENVS = [env('testing', 1), env('staging', 2), env('production', 3)]
+
+// Newest (highest semver) first, mirroring /deployments/release-history.
+const HISTORY = [
+  entry('v6.5.2', 'ccc333ccc333'),
+  entry('v6.5.1', 'bbb222bbb222'),
+  entry('v6.5.0', 'aaa111aaa111'),
+  entry('v6.4.0', '000999000999'),
+]
+
+const CURRENT = [
+  currentRelease('testing', 'ddd444ddd444', null),
+  currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
+  currentRelease('production', 'aaa111aaa111', 'v6.5.0'),
+]
+
+describe('buildPipeline', () => {
+  const stages = buildPipeline(ENVS, CURRENT, HISTORY)
+
+  it('derives stage kinds from upstream data, not position names', () => {
+    expect(stages.map((s) => s.kind)).toEqual(['commit', 'promote', 'release'])
+  })
+
+  it('computes pending releases between the env and its upstream', () => {
+    const production = stages[2]
+    expect(production.pendingReleases.map((r) => r.tag)).toEqual([
+      'v6.5.2',
+      'v6.5.1',
+    ])
+  })
+
+  it('treats an env with no release as pending everything up to upstream', () => {
+    const noProd = CURRENT.filter((c) => c.environment.slug !== 'production')
+    const result = buildPipeline(ENVS, noProd, HISTORY)
+    expect(result[2].pendingReleases.map((r) => r.tag)).toEqual([
+      'v6.5.2',
+      'v6.5.1',
+      'v6.5.0',
+      'v6.4.0',
+    ])
+  })
+
+  it('returns no pending releases when the env matches its upstream', () => {
+    const synced = [
+      currentRelease('testing', 'ddd444ddd444', null),
+      currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
+      currentRelease('production', 'ccc333ccc333', 'v6.5.2'),
+    ]
+    const result = buildPipeline(ENVS, synced, HISTORY)
+    expect(result[2].pendingReleases).toEqual([])
+  })
+
+  it('returns no pending releases when the env is ahead of its upstream', () => {
+    const ahead = [
+      currentRelease('testing', 'ddd444ddd444', null),
+      currentRelease('staging', 'aaa111aaa111', 'v6.5.0'),
+      currentRelease('production', 'ccc333ccc333', 'v6.5.2'),
+    ]
+    const result = buildPipeline(ENVS, ahead, HISTORY)
+    expect(result[2].pendingReleases).toEqual([])
+  })
+
+  it('collects rollback targets older than the current tag', () => {
+    const production = stages[2]
+    expect(production.rollbackTargets.map((r) => r.tag)).toEqual(['v6.4.0'])
+    const staging = stages[1]
+    expect(staging.rollbackTargets.map((r) => r.tag)).toEqual([
+      'v6.5.1',
+      'v6.5.0',
+      'v6.4.0',
+    ])
+  })
+
+  it('treats a tagged upstream as release-kind even mid-train', () => {
+    // Four-stage train: the third and fourth envs both sit below tagged
+    // upstreams, so both are release-kind.
+    const envs = [...ENVS, env('dr', 4)]
+    const current = [...CURRENT, currentRelease('dr', '000999000999', 'v6.4.0')]
+    const result = buildPipeline(envs, current, HISTORY)
+    expect(result[3].kind).toBe('release')
+    expect(result[3].pendingReleases.map((r) => r.tag)).toEqual(['v6.5.0'])
+  })
+})
+
+describe('defaultStageSlug', () => {
+  it('selects the earliest stage with pending work', () => {
+    const stages = buildPipeline(ENVS, CURRENT, HISTORY)
+    expect(defaultStageSlug(stages, { staging: 3 })).toBe('staging')
+    expect(defaultStageSlug(stages, { staging: 0 })).toBe('production')
+  })
+
+  it('falls back to the first environment when nothing is pending', () => {
+    const synced = [
+      currentRelease('testing', 'ccc333ccc333', null),
+      currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
+      currentRelease('production', 'ccc333ccc333', 'v6.5.2'),
+    ]
+    const stages = buildPipeline(ENVS, synced, HISTORY)
+    expect(defaultStageSlug(stages, { staging: 0 })).toBe('testing')
+  })
+})

--- a/src/components/deployments/pipeline.test.ts
+++ b/src/components/deployments/pipeline.test.ts
@@ -228,29 +228,9 @@ describe('compareTags', () => {
 })
 
 describe('defaultStageSlug', () => {
-  it('selects the earliest stage with pending work', () => {
+  it('selects the first rendered environment (highest sort order)', () => {
     const stages = buildPipeline(ENVS, CURRENT, HISTORY, COMMITS)
-    expect(defaultStageSlug(stages)).toBe('staging')
-    const noStagingGap = buildPipeline(
-      ENVS,
-      [
-        currentRelease('testing', 'ccc333ccc333', null),
-        currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
-        currentRelease('production', 'aaa111aaa111', 'v6.5.0'),
-      ],
-      HISTORY,
-      COMMITS,
-    )
-    expect(defaultStageSlug(noStagingGap)).toBe('production')
-  })
-
-  it('falls back to the first environment when nothing is pending', () => {
-    const synced = [
-      currentRelease('testing', 'ccc333ccc333', null),
-      currentRelease('staging', 'ccc333ccc333', 'v6.5.2'),
-      currentRelease('production', 'ccc333ccc333', 'v6.5.2'),
-    ]
-    const stages = buildPipeline(ENVS, synced, HISTORY, COMMITS)
-    expect(defaultStageSlug(stages)).toBe('testing')
+    expect(defaultStageSlug(stages)).toBe('production')
+    expect(defaultStageSlug([])).toBeNull()
   })
 })

--- a/src/components/deployments/pipeline.ts
+++ b/src/components/deployments/pipeline.ts
@@ -43,6 +43,7 @@ export interface PipelineStage {
 
 export type StageKind = 'commit' | 'promote' | 'release'
 
+// Most recent releases offered as rollback targets, regardless of age.
 const ROLLBACK_LIMIT = 10
 
 /**
@@ -136,18 +137,12 @@ export function compareTags(
 }
 
 /**
- * Default selection: the earliest stage with something actionable (the
- * first gap in the train), falling back to the first environment.
+ * Default selection: the first environment as rendered — the sidebar is
+ * descending sort order, so the last stage in pipeline order (e.g.
+ * Production).
  */
 export function defaultStageSlug(stages: PipelineStage[]): null | string {
-  const firstGap = stages.find((stage) =>
-    stage.kind === 'release'
-      ? stage.pendingReleases.length > 0
-      : stage.kind === 'promote'
-        ? stage.pendingCommits.length > 0
-        : false,
-  )
-  return firstGap?.env.slug ?? stages[0]?.env.slug ?? null
+  return stages[stages.length - 1]?.env.slug ?? null
 }
 
 /** SHA-prefix match in either direction (events may record short SHAs). */

--- a/src/components/deployments/pipeline.ts
+++ b/src/components/deployments/pipeline.ts
@@ -1,0 +1,130 @@
+// Pure view-model helpers for the Deployments tab. The tab renders one
+// detail pane per environment ("stage"); the stage *kind* decides which
+// card the pane shows:
+//
+//   'commit'  — the entry environment (no upstream). Deploys raw commits
+//               off the default branch; rolling back redeploys an older
+//               commit. Never promotes.
+//   'promote' — the upstream environment runs an untagged commit, so
+//               moving it forward means cutting a new tag (promote).
+//   'release' — the upstream environment already runs a tagged release,
+//               so moving forward is deploying an existing tag; nothing
+//               new is cut.
+//
+// The kind is derived from the *data* (does the upstream run a tag?), not
+// from the environment's position or name, per the release-train spec.
+import type {
+  CurrentReleaseEnvironment,
+  Environment,
+  ReleaseHistoryEntry,
+} from '@/types'
+
+export interface PipelineStage {
+  current: CurrentReleaseEnvironment | null
+  env: Environment
+  kind: StageKind
+  /** Tagged releases live upstream but not here (newest first). */
+  pendingReleases: ReleaseHistoryEntry[]
+  /** Releases this env could roll back to (newest first, excludes current). */
+  rollbackTargets: ReleaseHistoryEntry[]
+  upstream: Environment | null
+  upstreamCurrent: CurrentReleaseEnvironment | null
+}
+
+export type StageKind = 'commit' | 'promote' | 'release'
+
+const ROLLBACK_LIMIT = 10
+
+/**
+ * Build the per-environment stage models. ``environments`` must already be
+ * sorted ascending by sort_order; ``history`` is the project's release
+ * history, newest (highest semver) first.
+ */
+export function buildPipeline(
+  environments: Environment[],
+  currentReleases: CurrentReleaseEnvironment[],
+  history: ReleaseHistoryEntry[],
+): PipelineStage[] {
+  const currentBySlug = new Map(
+    currentReleases.map((row) => [row.environment.slug, row]),
+  )
+  return environments.map((env, idx) => {
+    const upstream = idx > 0 ? environments[idx - 1] : null
+    const current = currentBySlug.get(env.slug) ?? null
+    const upstreamCurrent = upstream
+      ? (currentBySlug.get(upstream.slug) ?? null)
+      : null
+    const kind: StageKind = !upstream
+      ? 'commit'
+      : upstreamCurrent?.release?.tag
+        ? 'release'
+        : 'promote'
+    return {
+      current,
+      env,
+      kind,
+      pendingReleases:
+        kind === 'release'
+          ? pendingReleases(history, upstreamCurrent, current)
+          : [],
+      rollbackTargets: rollbackTargets(history, current),
+      upstream,
+      upstreamCurrent,
+    }
+  })
+}
+
+/**
+ * Default selection: the earliest stage with something actionable (the
+ * first gap in the train), falling back to the first environment.
+ */
+export function defaultStageSlug(
+  stages: PipelineStage[],
+  pendingCommitsBySlug: Record<string, null | number | undefined>,
+): null | string {
+  const firstGap = stages.find((stage) =>
+    stage.kind === 'release'
+      ? stage.pendingReleases.length > 0
+      : stage.kind === 'promote'
+        ? (pendingCommitsBySlug[stage.env.slug] ?? 0) > 0
+        : false,
+  )
+  return firstGap?.env.slug ?? stages[0]?.env.slug ?? null
+}
+
+/**
+ * Releases the env can deploy: everything at or below the upstream's
+ * current tag (it has been validated upstream) but above this env's own
+ * current tag. ``history`` is newest-first, so this is the slice between
+ * the two tags. Empty when the upstream tag is unknown or the env is
+ * already at (or ahead of) the upstream.
+ */
+// fallow-ignore-next-line complexity
+function pendingReleases(
+  history: ReleaseHistoryEntry[],
+  upstreamCurrent: CurrentReleaseEnvironment | null,
+  current: CurrentReleaseEnvironment | null,
+): ReleaseHistoryEntry[] {
+  const upstreamTag = upstreamCurrent?.release?.tag
+  if (!upstreamTag) return []
+  const fromIdx = history.findIndex((entry) => entry.tag === upstreamTag)
+  if (fromIdx < 0) return []
+  const envTag = current?.release?.tag ?? null
+  const toIdx = envTag
+    ? history.findIndex((entry) => entry.tag === envTag)
+    : history.length
+  if (toIdx >= 0 && toIdx <= fromIdx) return []
+  return history.slice(fromIdx, toIdx < 0 ? history.length : toIdx)
+}
+
+/** Releases older than the env's current tag (what it can roll back to). */
+function rollbackTargets(
+  history: ReleaseHistoryEntry[],
+  current: CurrentReleaseEnvironment | null,
+): ReleaseHistoryEntry[] {
+  const envTag = current?.release?.tag
+  if (!envTag) return []
+  const idx = history.findIndex((entry) => entry.tag === envTag)
+  if (idx < 0) return []
+  return history.slice(idx + 1, idx + 1 + ROLLBACK_LIMIT)
+}

--- a/src/components/deployments/pipeline.ts
+++ b/src/components/deployments/pipeline.ts
@@ -13,9 +13,14 @@
 //
 // The kind is derived from the *data* (does the upstream run a tag?), not
 // from the environment's position or name, per the release-train spec.
+//
+// All commit/tag data comes from imbi's synced ClickHouse history
+// (``/deployments/recent-commits`` + ``/deployments/release-history``),
+// never the live source host — the sidebar's sync action refreshes it.
 import type {
   CurrentReleaseEnvironment,
   Environment,
+  RecentCommit,
   ReleaseHistoryEntry,
 } from '@/types'
 
@@ -23,6 +28,11 @@ export interface PipelineStage {
   current: CurrentReleaseEnvironment | null
   env: Environment
   kind: StageKind
+  /**
+   * Commits deployed upstream but not here (newest first) — what a
+   * promotion would tag. Only populated for promote stages.
+   */
+  pendingCommits: RecentCommit[]
   /** Tagged releases live upstream but not here (newest first). */
   pendingReleases: ReleaseHistoryEntry[]
   /** Releases this env could roll back to (newest first, excludes current). */
@@ -38,16 +48,19 @@ const ROLLBACK_LIMIT = 10
 /**
  * Build the per-environment stage models. ``environments`` must already be
  * sorted ascending by sort_order; ``history`` is the project's release
- * history, newest (highest semver) first.
+ * history, newest (highest semver) first; ``commits`` is the synced
+ * commit history, newest first.
  */
 export function buildPipeline(
   environments: Environment[],
   currentReleases: CurrentReleaseEnvironment[],
   history: ReleaseHistoryEntry[],
+  commits: RecentCommit[],
 ): PipelineStage[] {
   const currentBySlug = new Map(
     currentReleases.map((row) => [row.environment.slug, row]),
   )
+  // fallow-ignore-next-line complexity
   return environments.map((env, idx) => {
     const upstream = idx > 0 ? environments[idx - 1] : null
     const current = currentBySlug.get(env.slug) ?? null
@@ -63,6 +76,14 @@ export function buildPipeline(
       current,
       env,
       kind,
+      pendingCommits:
+        kind === 'promote' && current?.release
+          ? commitRange(
+              commits,
+              upstreamCurrent?.release?.committish ?? null,
+              current.release.committish,
+            )
+          : [],
       pendingReleases:
         kind === 'release'
           ? pendingReleases(history, upstreamCurrent, current)
@@ -75,21 +96,82 @@ export function buildPipeline(
 }
 
 /**
+ * Slice the synced commit history (newest first) from ``headSha``
+ * (inclusive) down to ``baseSha`` (exclusive) — the commits that moving
+ * ``baseSha`` forward to ``headSha`` would pick up. Falls back to the
+ * remainder of the window when the base is older than the synced window,
+ * and to ``[]`` when the head isn't in the history (or is not ahead).
+ */
+// fallow-ignore-next-line complexity
+export function commitRange(
+  commits: RecentCommit[],
+  headSha: null | string,
+  baseSha: null | string,
+): RecentCommit[] {
+  if (!headSha) return []
+  const headIdx = commits.findIndex((c) => shaMatch(c.sha, headSha))
+  if (headIdx < 0) return []
+  if (!baseSha) return commits.slice(headIdx)
+  const baseIdx = commits.findIndex((c) => shaMatch(c.sha, baseSha))
+  if (baseIdx < 0) return commits.slice(headIdx)
+  if (baseIdx <= headIdx) return []
+  return commits.slice(headIdx, baseIdx)
+}
+
+/**
+ * Semver-order two tags: negative when ``a`` ranks below ``b``, zero when
+ * equal, ``null`` when either doesn't parse.
+ */
+export function compareTags(
+  a: null | string | undefined,
+  b: null | string | undefined,
+): null | number {
+  const keyA = semverKey(a)
+  const keyB = semverKey(b)
+  if (!keyA || !keyB) return null
+  for (let i = 0; i < 3; i += 1) {
+    if (keyA[i] !== keyB[i]) return keyA[i] - keyB[i]
+  }
+  return 0
+}
+
+/**
  * Default selection: the earliest stage with something actionable (the
  * first gap in the train), falling back to the first environment.
  */
-export function defaultStageSlug(
-  stages: PipelineStage[],
-  pendingCommitsBySlug: Record<string, null | number | undefined>,
-): null | string {
+export function defaultStageSlug(stages: PipelineStage[]): null | string {
   const firstGap = stages.find((stage) =>
     stage.kind === 'release'
       ? stage.pendingReleases.length > 0
       : stage.kind === 'promote'
-        ? (pendingCommitsBySlug[stage.env.slug] ?? 0) > 0
+        ? stage.pendingCommits.length > 0
         : false,
   )
   return firstGap?.env.slug ?? stages[0]?.env.slug ?? null
+}
+
+/** SHA-prefix match in either direction (events may record short SHAs). */
+export function shaMatch(a: string, b: string): boolean {
+  return !!a && !!b && (a.startsWith(b) || b.startsWith(a))
+}
+
+/** Minimal history entry for a release the tag sync hasn't recorded yet. */
+function entryFromRelease(release: {
+  committish: string
+  created_at: string
+  description?: null | string
+  tag?: null | string
+  title: string
+}): ReleaseHistoryEntry {
+  return {
+    ci_status: 'unknown',
+    notes_markdown: release.description ?? null,
+    published_at: release.created_at,
+    sha: release.committish,
+    short_sha: release.committish.slice(0, 7),
+    tag: release.tag ?? '',
+    title: release.title,
+  }
 }
 
 /**
@@ -105,16 +187,38 @@ function pendingReleases(
   upstreamCurrent: CurrentReleaseEnvironment | null,
   current: CurrentReleaseEnvironment | null,
 ): ReleaseHistoryEntry[] {
-  const upstreamTag = upstreamCurrent?.release?.tag
+  const upstreamRelease = upstreamCurrent?.release
+  const upstreamTag = upstreamRelease?.tag
   if (!upstreamTag) return []
-  const fromIdx = history.findIndex((entry) => entry.tag === upstreamTag)
-  if (fromIdx < 0) return []
   const envTag = current?.release?.tag ?? null
+  // Truly in sync only when both run the same release.
+  if (tagEq(upstreamTag, envTag)) return []
+  const fromIdx = history.findIndex((entry) => tagEq(entry.tag, upstreamTag))
+  if (fromIdx < 0) {
+    // The upstream's tag hasn't reached the synced history yet — still
+    // offer it (it is what's validated upstream).
+    return [entryFromRelease(upstreamRelease)]
+  }
   const toIdx = envTag
-    ? history.findIndex((entry) => entry.tag === envTag)
+    ? history.findIndex((entry) => tagEq(entry.tag, envTag))
     : history.length
-  if (toIdx >= 0 && toIdx <= fromIdx) return []
-  return history.slice(fromIdx, toIdx < 0 ? history.length : toIdx)
+  if (toIdx >= 0 && toIdx <= fromIdx) {
+    // The env ranks at or ahead of its upstream by semver but runs a
+    // *different* release (divergent lines, or a roll-forward of an
+    // older line). What's validated upstream stays deployable.
+    return [history[fromIdx]]
+  }
+  const slice = history.slice(fromIdx, toIdx < 0 ? history.length : toIdx)
+  if (toIdx >= 0 || !envTag) return slice
+  // The env's tag isn't in the synced history — keep only entries that
+  // semver-rank above it rather than treating all older releases as
+  // pending.
+  const envKey = semverKey(envTag)
+  if (!envKey) return slice
+  return slice.filter((entry) => {
+    const key = semverKey(entry.tag)
+    return !!key && semverLess(envKey, key)
+  })
 }
 
 /** Releases older than the env's current tag (what it can roll back to). */
@@ -124,7 +228,40 @@ function rollbackTargets(
 ): ReleaseHistoryEntry[] {
   const envTag = current?.release?.tag
   if (!envTag) return []
-  const idx = history.findIndex((entry) => entry.tag === envTag)
-  if (idx < 0) return []
-  return history.slice(idx + 1, idx + 1 + ROLLBACK_LIMIT)
+  const idx = history.findIndex((entry) => tagEq(entry.tag, envTag))
+  if (idx >= 0) return history.slice(idx + 1, idx + 1 + ROLLBACK_LIMIT)
+  // The env's tag isn't in the synced history (e.g. the tag sync hasn't
+  // caught up) — fall back to semver ranking so the rollback list still
+  // renders with everything strictly older.
+  const envKey = semverKey(envTag)
+  if (!envKey) return []
+  return history
+    .filter((entry) => {
+      const key = semverKey(entry.tag)
+      return !!key && semverLess(key, envKey)
+    })
+    .slice(0, ROLLBACK_LIMIT)
+}
+
+/**
+ * Best-effort semver ordering key — ``null`` when the tag doesn't parse.
+ * Pre-release/build suffixes are ignored; this only backstops list
+ * placement when a tag is missing from the synced history.
+ */
+function semverKey(tag: null | string | undefined): null | number[] {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(tag ?? '')
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null
+}
+
+function semverLess(a: number[], b: number[]): boolean {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) return a[i] < b[i]
+  }
+  return false
+}
+
+/** Tag equality tolerant of an optional leading ``v``. */
+function tagEq(a: null | string | undefined, b: null | string): boolean {
+  if (!a || !b) return false
+  return a.replace(/^v/, '') === b.replace(/^v/, '')
 }

--- a/src/components/deployments/pipeline.ts
+++ b/src/components/deployments/pipeline.ts
@@ -78,11 +78,11 @@ export function buildPipeline(
       env,
       kind,
       pendingCommits:
-        kind === 'promote' && current?.release
+        kind === 'promote' && upstreamCurrent?.release
           ? commitRange(
               commits,
-              upstreamCurrent?.release?.committish ?? null,
-              current.release.committish,
+              upstreamCurrent.release.committish,
+              current?.release?.committish ?? null,
             )
           : [],
       pendingReleases:

--- a/src/components/deployments/useDeploymentActions.tsx
+++ b/src/components/deployments/useDeploymentActions.tsx
@@ -1,0 +1,221 @@
+// Dispatch mutations for the Deployments tab. Mirrors the toast + run
+// watcher wiring of the deploy/promote modal hooks, decoupled from the
+// modal lifecycle so inline cards can dispatch directly.
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { ApiError } from '@/api/client'
+import { promoteDeployment, triggerDeployment } from '@/api/endpoints'
+import type { DeploymentRunStarted } from '@/components/deploy/DeploymentModal'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+export interface DeploymentActions {
+  deploy: (req: DeployRequest) => void
+  deployPending: boolean
+  /** SHA of the deploy currently in flight (drives per-row spinners). */
+  deployPendingSha: null | string
+  promote: (req: PromoteRequest) => void
+  promotePending: boolean
+}
+
+export interface DeployRequest {
+  action: 'deploy' | 'redeploy'
+  envName: string
+  envSlug: string
+  refLabel: null | string
+  /** Changes the loading-toast verb; the request is still a deploy. */
+  rollback?: boolean
+  sha: string
+}
+
+export interface PromoteRequest {
+  fromEnvironment: string
+  notes: string
+  sha: string
+  tag: string
+  toEnvironment: string
+  toEnvName: string
+}
+
+interface UseDeploymentActionsOptions {
+  onRunStarted?: (run: DeploymentRunStarted) => void
+  orgSlug: string
+  projectId: string
+}
+
+export function useDeploymentActions({
+  onRunStarted,
+  orgSlug,
+  projectId,
+}: UseDeploymentActionsOptions): DeploymentActions {
+  const queryClient = useQueryClient()
+  const invalidate = () => {
+    for (const key of [
+      'currentReleases',
+      'promotionOptions',
+      'releaseHistory',
+    ]) {
+      void queryClient.invalidateQueries({
+        queryKey: [key, orgSlug, projectId],
+      })
+    }
+  }
+  const onError = (err: unknown) => {
+    toast.error(
+      err instanceof ApiError
+        ? (extractApiErrorDetail(err) ?? err.message)
+        : (err as Error).message,
+    )
+  }
+
+  const deployMutation = useMutation({
+    mutationFn: (req: DeployRequest) =>
+      triggerDeployment(orgSlug, projectId, {
+        action: req.action,
+        committish: req.sha,
+        environment: req.envSlug,
+        ref_label: req.refLabel,
+      }),
+    onError,
+    // fallow-ignore-next-line complexity
+    onSuccess: (data, req) => {
+      invalidate()
+      const url = data.run.run_url
+      const label = req.refLabel ?? req.sha.slice(0, 7)
+      const verb = req.rollback ? 'Rolling back' : 'Deploying'
+      if (onRunStarted && data.run.run_id) {
+        const toastId = toast.loading(
+          req.rollback
+            ? `${verb} ${req.envName} to ${label}…`
+            : `${verb} ${label} to ${req.envName}…`,
+          {
+            action: url
+              ? {
+                  label: 'View run',
+                  onClick: () => window.open(url, '_blank', 'noopener'),
+                }
+              : undefined,
+            description: data.run.status
+              ? `status: ${data.run.status}`
+              : undefined,
+            icon: <Loader2 className="size-4 animate-spin" />,
+          },
+        )
+        onRunStarted({
+          actionLabel: url ? 'View run' : undefined,
+          actionUrl: url,
+          envName: req.envName,
+          initialStatus: data.run.status,
+          originOrgSlug: orgSlug,
+          originProjectId: projectId,
+          runId: data.run.run_id,
+          runUrl: url,
+          toastId,
+        })
+      } else {
+        toast.success(
+          `Workflow dispatched to ${req.envName}`,
+          url
+            ? {
+                action: {
+                  label: 'View run',
+                  onClick: () => window.open(url, '_blank', 'noopener'),
+                },
+              }
+            : undefined,
+        )
+      }
+    },
+  })
+
+  const promoteMutation = useMutation({
+    mutationFn: (req: PromoteRequest) =>
+      promoteDeployment(orgSlug, projectId, {
+        action: 'promote',
+        from_committish: req.sha,
+        from_environment: req.fromEnvironment,
+        prerelease: false,
+        release_name: req.tag,
+        release_notes_markdown: req.notes,
+        tag: req.tag,
+        to_environment: req.toEnvironment,
+      }),
+    onError,
+    // fallow-ignore-next-line complexity
+    onSuccess: (data, req) => {
+      invalidate()
+      const releaseUrl = data.release_url
+      const runUrl = data.run.run_url
+      const tagLabel = data.tag ?? req.tag
+      // Prefer the run URL when present; fall back to the release URL so
+      // the watcher's recreated toast still has a useful action.
+      const actionUrl = runUrl ?? releaseUrl
+      const actionLabel = runUrl
+        ? 'View run'
+        : releaseUrl
+          ? 'View release'
+          : undefined
+      if (onRunStarted && data.run.run_id) {
+        const toastId = toast.loading(
+          `Promoting ${tagLabel} to ${req.toEnvName}…`,
+          {
+            action:
+              actionUrl && actionLabel
+                ? {
+                    label: actionLabel,
+                    onClick: () => window.open(actionUrl, '_blank', 'noopener'),
+                  }
+                : undefined,
+            description: data.run.status
+              ? `status: ${data.run.status}`
+              : undefined,
+            icon: <Loader2 className="size-4 animate-spin" />,
+          },
+        )
+        onRunStarted({
+          actionLabel,
+          actionUrl,
+          envName: req.toEnvName,
+          initialStatus: data.run.status,
+          originOrgSlug: orgSlug,
+          originProjectId: projectId,
+          runId: data.run.run_id,
+          runUrl,
+          toastId,
+        })
+      } else {
+        const url = releaseUrl ?? runUrl
+        toast.success(
+          `Promoted ${tagLabel} to ${req.toEnvName}`,
+          url
+            ? {
+                action: {
+                  label: 'View',
+                  onClick: () => window.open(url, '_blank', 'noopener'),
+                },
+              }
+            : undefined,
+        )
+      }
+      // Non-fatal partial success (e.g. the tag + release cut but the
+      // GitHub Deployments POST failed) surfaces as an amber toast.
+      if (data.warning) {
+        toast.warning(`Promote to ${req.toEnvName} recorded with a warning`, {
+          description: data.warning,
+          duration: 10_000,
+        })
+      }
+    },
+  })
+
+  return {
+    deploy: (req) => deployMutation.mutate(req),
+    deployPending: deployMutation.isPending,
+    deployPendingSha: deployMutation.isPending
+      ? (deployMutation.variables?.sha ?? null)
+      : null,
+    promote: (req) => promoteMutation.mutate(req),
+    promotePending: promoteMutation.isPending,
+  }
+}

--- a/src/components/deployments/useDeploymentSync.ts
+++ b/src/components/deployments/useDeploymentSync.ts
@@ -1,0 +1,52 @@
+// Sidebar "sync" action: refreshes everything the Deployments tab reads
+// from imbi's own stores — the ClickHouse commit/tag history (background
+// job + poll, via useCommitSync) and the release/deployment state
+// resynced from the remote's deployment records.
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { resyncProjectDeployments } from '@/api/endpoints'
+import { useCommitSync } from '@/hooks/useCommitSync'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+const DATA_KEYS = ['recentCommits', 'releaseHistory', 'currentReleases']
+
+export function useDeploymentSync(orgSlug: string, projectId: string) {
+  const queryClient = useQueryClient()
+  const invalidate = () => {
+    for (const key of DATA_KEYS) {
+      void queryClient.invalidateQueries({
+        queryKey: [key, orgSlug, projectId],
+      })
+    }
+  }
+
+  const commitSync = useCommitSync(orgSlug, projectId, true, invalidate)
+  const resyncMutation = useMutation({
+    mutationFn: () => resyncProjectDeployments(orgSlug, projectId),
+    onError: (err) =>
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to resync releases'),
+    onSuccess: (summary) => {
+      invalidate()
+      const releases = summary.releases_created + summary.releases_updated
+      toast.success(
+        `Releases resynced — ${releases} release(s) and ` +
+          `${summary.events_recorded} event(s) updated`,
+      )
+      if (summary.errors.length > 0) {
+        toast.warning(
+          `Release resync finished with ${summary.errors.length} error(s)`,
+          { description: summary.errors[0]?.detail },
+        )
+      }
+    },
+  })
+
+  return {
+    isSyncing: commitSync.isSyncing || resyncMutation.isPending,
+    sync: () => {
+      commitSync.sync()
+      resyncMutation.mutate()
+    },
+  }
+}

--- a/src/components/releases/ReleaseCommitPicker.tsx
+++ b/src/components/releases/ReleaseCommitPicker.tsx
@@ -124,7 +124,11 @@ function CommitRow({
           {commit.short_sha}
         </span>
         <span className="min-w-0 flex-1 truncate text-sm">{subject}</span>
-        <CiStatusDot status={commit.ci_status} />
+        {/* ``unknown`` is the API's null-equivalent (e.g. compare results
+            carry no check status) — skip the useless gray dot. */}
+        {commit.ci_status !== 'unknown' ? (
+          <CiStatusDot status={commit.ci_status} />
+        ) : null}
         <Badge variant="neutral">{idx === 0 ? 'tip' : `−${idx}`}</Badge>
       </button>
       {active && body ? (

--- a/src/components/releases/ReleaseCommitPicker.tsx
+++ b/src/components/releases/ReleaseCommitPicker.tsx
@@ -1,21 +1,40 @@
 import { Check, ExternalLink } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
+import type { ChipColors } from '@/lib/chip-colors'
 import { cn } from '@/lib/utils'
-import type { RecentCommit } from '@/types'
+import type { DeploymentCommitCiStatus } from '@/types'
 
 import { CiStatusDot } from './CiStatusDot'
 
 interface CommitRowProps {
+  accent?: ChipColors | null
   active: boolean
-  commit: RecentCommit
+  commit: PickerCommit
   held: boolean
   idx: number
   onSelect: (sha: string) => void
 }
 
+/**
+ * Structural subset of a commit the picker needs — satisfied by both
+ * `RecentCommit` (releases tab) and `DeploymentCommit` (deployments tab).
+ */
+interface PickerCommit {
+  ci_status: DeploymentCommitCiStatus
+  message: string
+  sha: string
+  short_sha: string
+  url?: null | string
+}
+
 interface ReleaseCommitPickerProps {
-  commits: RecentCommit[]
+  /**
+   * Optional selection color (e.g. the target environment's derived
+   * palette). Defaults to the amber action color.
+   */
+  accent?: ChipColors | null
+  commits: PickerCommit[]
   onSelect: (sha: string) => void
   selectedSha: null | string
 }
@@ -26,6 +45,7 @@ interface ReleaseCommitPickerProps {
  * its full commit message.
  */
 export function ReleaseCommitPicker({
+  accent,
   commits,
   onSelect,
   selectedSha,
@@ -35,6 +55,7 @@ export function ReleaseCommitPicker({
     <div className="border-tertiary bg-primary max-h-120 overflow-y-auto rounded-md border">
       {commits.map((c, idx) => (
         <CommitRow
+          accent={accent}
           active={c.sha === selectedSha}
           commit={c}
           held={selIdx >= 0 && idx < selIdx}
@@ -48,10 +69,22 @@ export function ReleaseCommitPicker({
 }
 
 // fallow-ignore-next-line complexity
-function CommitRow({ active, commit, held, idx, onSelect }: CommitRowProps) {
+function CommitRow({
+  accent,
+  active,
+  commit,
+  held,
+  idx,
+  onSelect,
+}: CommitRowProps) {
   const lines = commit.message.split('\n')
   const subject = lines[0] ?? ''
   const body = lines.slice(1).join('\n').trim()
+  const activeBg = active
+    ? accent
+      ? { backgroundColor: accent.bg }
+      : undefined
+    : undefined
   return (
     <div
       className={cn(
@@ -62,16 +95,28 @@ function CommitRow({ active, commit, held, idx, onSelect }: CommitRowProps) {
       <button
         className={cn(
           'flex w-full min-w-0 items-center gap-3 px-3 py-2 text-left transition-colors',
-          active ? 'bg-action/5' : 'hover:bg-secondary',
+          active ? !accent && 'bg-action/5' : 'hover:bg-secondary',
         )}
         onClick={() => onSelect(commit.sha)}
+        style={activeBg}
         type="button"
       >
         <span
           className={cn(
             'flex size-4 shrink-0 items-center justify-center rounded-full border',
-            active ? 'border-action bg-action text-white' : 'border-secondary',
+            active
+              ? !accent && 'border-action bg-action text-white'
+              : 'border-secondary',
           )}
+          style={
+            active && accent
+              ? {
+                  backgroundColor: accent.fg,
+                  borderColor: accent.fg,
+                  color: '#fff',
+                }
+              : undefined
+          }
         >
           {active ? <Check size={10} strokeWidth={3} /> : null}
         </span>
@@ -83,12 +128,21 @@ function CommitRow({ active, commit, held, idx, onSelect }: CommitRowProps) {
         <Badge variant="neutral">{idx === 0 ? 'tip' : `−${idx}`}</Badge>
       </button>
       {active && body ? (
-        <pre className="bg-action/5 text-secondary max-h-40 overflow-auto px-3 pt-1 pb-3 pl-13 font-mono text-xs whitespace-pre-wrap">
+        <pre
+          className={cn(
+            'max-h-40 overflow-auto px-3 pt-1 pb-3 pl-13 font-mono text-xs whitespace-pre-wrap text-secondary',
+            !accent && 'bg-action/5',
+          )}
+          style={activeBg}
+        >
           {body}
         </pre>
       ) : null}
       {active && commit.url ? (
-        <div className="bg-action/5 px-3 pb-2 pl-13">
+        <div
+          className={cn('px-3 pb-2 pl-13', !accent && 'bg-action/5')}
+          style={activeBg}
+        >
           <a
             className="text-tertiary hover:text-primary inline-flex items-center gap-1 text-xs"
             href={commit.url}

--- a/src/components/ui/user-identity.tsx
+++ b/src/components/ui/user-identity.tsx
@@ -70,8 +70,7 @@ export function isBotActor(name: null | string): boolean {
  * Canonical identity widget — a person or actor anywhere they appear in Imbi
  * (deploy attribution, ops-log rows, currently-running footers, activity
  * feeds). Avatar resolution: a photo when one loads, a bot glyph for
- * automation actors, otherwise initials on a name-hashed tint. See
- * `docs/useridentity.html`.
+ * automation actors, otherwise initials on a name-hashed tint.
  */
 export function UserIdentity({
   className,

--- a/src/components/ui/user-identity.tsx
+++ b/src/components/ui/user-identity.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Link } from 'react-router-dom'
 
@@ -163,6 +163,9 @@ function IdentityAvatar({
   name: null | string
 }) {
   const [imgFailed, setImgFailed] = useState(false)
+  useEffect(() => {
+    setImgFailed(false)
+  }, [candidateImage, isBot])
   const tint = colorFor(name)
   const showImage = !isBot && candidateImage != null && !imgFailed
   const style: React.CSSProperties = { height: av, width: av }

--- a/src/components/ui/user-identity.tsx
+++ b/src/components/ui/user-identity.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react'
+
+import { Link } from 'react-router-dom'
+
+import { Bot } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+import { useGravatarUrl } from './gravatar'
+
+type Size = 'floating' | 'large' | 'medium' | 'small'
+
+interface SizeSpec {
+  av: number
+  font: number
+  gap: number
+  sub: boolean
+  weight: number
+}
+
+interface UserIdentityProps {
+  className?: string
+  /** Shown as a subtitle at medium/large sizes (mono when it looks like an email). */
+  email?: null | string
+  /**
+   * Explicit avatar photo. When omitted, a Gravatar is derived from `email`.
+   * Either way, a missing or broken image falls back to initials.
+   */
+  image?: null | string
+  kind?: 'bot' | 'user'
+  /**
+   * Link the chip to the user's profile (`/users/:email`) when an email is
+   * known and the actor is a person. Defaults to true.
+   */
+  linkToProfile?: boolean
+  /** Display name; drives the initials and the hashed fallback color. */
+  name: null | string
+  size?: Size
+}
+
+const BOT_PATTERN =
+  /(\[bot\]|\bbot\b|-bot\b|github-actions|\bactions\b|automation|\bservice\b)/i
+
+// The eight Imbi label-palette hues; an actor's initials avatar gets a stable
+// one picked by hashing the name.
+const PALETTE = [
+  '#C86B5E',
+  '#D98847',
+  '#C9A227',
+  '#6B9A3F',
+  '#5A89C9',
+  '#8C82D4',
+  '#C96B97',
+  '#7A7873',
+]
+
+const SIZES: Record<Size, SizeSpec> = {
+  floating: { av: 24, font: 14, gap: 8, sub: false, weight: 600 },
+  large: { av: 44, font: 17, gap: 12, sub: true, weight: 600 },
+  medium: { av: 28, font: 14, gap: 9, sub: true, weight: 500 },
+  small: { av: 20, font: 13.5, gap: 7, sub: false, weight: 500 },
+}
+
+/** Whether an actor login/name reads as a bot or automation account. */
+export function isBotActor(name: null | string): boolean {
+  return name != null && BOT_PATTERN.test(name)
+}
+
+/**
+ * Canonical identity widget — a person or actor anywhere they appear in Imbi
+ * (deploy attribution, ops-log rows, currently-running footers, activity
+ * feeds). Avatar resolution: a photo when one loads, a bot glyph for
+ * automation actors, otherwise initials on a name-hashed tint. See
+ * `docs/useridentity.html`.
+ */
+export function UserIdentity({
+  className,
+  email,
+  image,
+  kind = 'user',
+  linkToProfile = true,
+  name,
+  size = 'medium',
+}: UserIdentityProps) {
+  const s = SIZES[size]
+  const isBot = kind === 'bot'
+  const profileEmail = !isBot && linkToProfile && email ? email : null
+  // Request at 2× for retina; `d=404` makes a missing Gravatar error out so
+  // the <img> onError handler falls back to the initials chip.
+  const gravatarUrl = useGravatarUrl(email ?? '', s.av * 2, '404')
+  const explicitImage = image != null && image !== '' ? image : null
+  const candidateImage = explicitImage ?? (!isBot && email ? gravatarUrl : null)
+
+  const body = (
+    <>
+      <IdentityAvatar
+        av={s.av}
+        candidateImage={candidateImage}
+        isBot={isBot}
+        name={name}
+      />
+      <IdentityText email={email} name={name} size={size} spec={s} />
+    </>
+  )
+
+  if (profileEmail) {
+    return (
+      <Link
+        className={cn(
+          'inline-flex min-w-0 items-center hover:underline',
+          className,
+        )}
+        onClick={(event) => event.stopPropagation()}
+        style={{ gap: s.gap }}
+        title={name ?? profileEmail}
+        to={`/users/${encodeURIComponent(profileEmail)}`}
+      >
+        {body}
+      </Link>
+    )
+  }
+
+  return (
+    <span
+      className={cn('inline-flex min-w-0 items-center', className)}
+      style={{ gap: s.gap }}
+    >
+      {body}
+    </span>
+  )
+}
+
+function colorFor(name: null | string): string {
+  return PALETTE[hashStr(name || '?') % PALETTE.length]
+}
+
+function darken(hex: string, f: number): string {
+  const n = parseInt(hex.slice(1), 16)
+  const r = (n >> 16) & 255
+  const g = (n >> 8) & 255
+  const b = n & 255
+  return `rgb(${Math.round(r * f)}, ${Math.round(g * f)}, ${Math.round(b * f)})`
+}
+
+function hashStr(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (h << 5) - h + s.charCodeAt(i)
+    h |= 0
+  }
+  return Math.abs(h)
+}
+
+function IdentityAvatar({
+  av,
+  candidateImage,
+  isBot,
+  name,
+}: {
+  av: number
+  candidateImage: null | string
+  isBot: boolean
+  name: null | string
+}) {
+  const [imgFailed, setImgFailed] = useState(false)
+  const tint = colorFor(name)
+  const showImage = !isBot && candidateImage != null && !imgFailed
+  const style: React.CSSProperties = { height: av, width: av }
+  if (isBot) {
+    style.boxShadow = 'inset 0 0 0 1px var(--color-border)'
+  } else if (!showImage) {
+    style.backgroundColor = `${tint}33`
+  }
+  return (
+    <span
+      className={cn(
+        'relative inline-flex flex-none items-center justify-center overflow-hidden rounded-full',
+        isBot ? 'bg-secondary text-secondary' : 'bg-secondary',
+      )}
+      style={style}
+    >
+      {isBot ? (
+        <Bot size={Math.round(av * 0.58)} />
+      ) : showImage ? (
+        <img
+          alt={name ?? ''}
+          className="block size-full object-cover"
+          onError={() => setImgFailed(true)}
+          referrerPolicy="no-referrer"
+          src={candidateImage as string}
+        />
+      ) : (
+        <span
+          className="leading-none font-semibold tracking-tight uppercase"
+          style={{ color: darken(tint, 0.55), fontSize: Math.round(av * 0.42) }}
+        >
+          {initialsOf(name)}
+        </span>
+      )}
+    </span>
+  )
+}
+
+function IdentityText({
+  email,
+  name,
+  size,
+  spec,
+}: {
+  email?: null | string
+  name: null | string
+  size: Size
+  spec: SizeSpec
+}) {
+  return (
+    <span className="flex min-w-0 flex-col">
+      <span
+        className="text-primary truncate"
+        style={{
+          fontSize: spec.font,
+          fontWeight: spec.weight,
+          lineHeight: spec.sub ? 1.25 : 1,
+        }}
+      >
+        {name || 'Unknown'}
+      </span>
+      {spec.sub && email ? (
+        <span
+          className={cn(
+            'mt-0.5 truncate text-tertiary',
+            email.includes('@') ? 'font-mono' : 'font-sans',
+          )}
+          style={{ fontSize: size === 'large' ? 13 : 12 }}
+        >
+          {email}
+        </span>
+      ) : null}
+    </span>
+  )
+}
+
+function initialsOf(name: null | string): string {
+  if (!name) return '?'
+  const parts = name
+    .trim()
+    .split(/[\s._-]+/)
+    .filter(Boolean)
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+  }
+  return (parts[0]?.[0] ?? '?').toUpperCase()
+}

--- a/src/hooks/useCommitSync.ts
+++ b/src/hooks/useCommitSync.ts
@@ -43,7 +43,7 @@ export function useCommitSync(
   useEffect(() => {
     const data = statusQuery.data
     if (!data) return
-    if (isActive(previous.current) && !isActive(data.status)) {
+    if (!isActive(data.status) && data.status !== previous.current) {
       announceTerminal(data)
       if (data.status === 'success') onCompleteRef.current?.()
     }

--- a/src/hooks/useCommitSync.ts
+++ b/src/hooks/useCommitSync.ts
@@ -20,8 +20,12 @@ export function useCommitSync(
   orgSlug: string,
   projectId: string,
   enabled: boolean,
+  /** Invoked when a run completes successfully (e.g. to refresh data). */
+  onComplete?: () => void,
 ) {
   const queryClient = useQueryClient()
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
 
   const statusQuery = useQuery({
     enabled: enabled && !!orgSlug && !!projectId,
@@ -41,6 +45,7 @@ export function useCommitSync(
     if (!data) return
     if (isActive(previous.current) && !isActive(data.status)) {
       announceTerminal(data)
+      if (data.status === 'success') onCompleteRef.current?.()
     }
     previous.current = data.status
   }, [statusQuery.data])

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -298,6 +298,19 @@ export interface ProjectTypeCreate {
   slug: string
 }
 
+// One adjacent-env promotion gap from /deployments/promotion-options.
+// ``commits_pending`` is the size of the from..to compare; null means the
+// plugin couldn't be asked (e.g. no current release on either side).
+export interface PromotionOption {
+  commits_pending?: null | number
+  from_environment: string
+  from_sha?: null | string
+  from_version?: null | string
+  to_environment: string
+  to_sha?: null | string
+  to_version?: null | string
+}
+
 export interface PullRequest {
   additions: number
   author: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -496,9 +496,13 @@ export interface CurrentReleaseEnvironment {
   environment: { name: string; slug: string }
   external_run_url: null | string
   last_event_at: null | string
-  // Deployer of the latest event when observed from a remote (e.g. the
-  // GitHub actor); null for in-product deploys.
+  // Deployer of the latest event, for display: an Imbi user's display
+  // name when resolved, else the raw remote login; null for in-product
+  // deploys with no recorded actor.
   performed_by?: null | string
+  // Email of the deployer when they resolve to an Imbi user (profile
+  // link + Gravatar); null for unresolved remote logins.
+  performed_by_email?: null | string
   release: null | Release
 }
 
@@ -1145,6 +1149,10 @@ export interface PluginAssignmentResponse {
   plugin_id: string
   plugin_slug: string
   plugin_type: PluginType
+  // Parent third-party service so the UI can show which service
+  // powers the tab.
+  service_icon?: null | string
+  service_name?: null | string
   source: 'merged' | 'project' | 'project_type'
   supports_deployment_sync?: boolean
   supports_histogram?: boolean
@@ -1296,6 +1304,8 @@ export type ProjectRelationshipsResponse =
 // from ClickHouse; release notes come from the graph Release nodes.
 export interface RecentCommit {
   author?: null | string
+  /** Imbi user email the author resolves to via identity attribution. */
+  author_email?: null | string
   authored_at: string
   ci_status: DeploymentCommitCiStatus
   message: string
@@ -1353,6 +1363,8 @@ export interface ReleaseDrift {
 
 export interface ReleaseHistoryEntry {
   author?: null | string
+  /** Imbi user email of the release author (the resolved `created_by`). */
+  author_email?: null | string
   ci_status: DeploymentCommitCiStatus
   notes_markdown?: null | string
   package_url?: null | string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -298,19 +298,6 @@ export interface ProjectTypeCreate {
   slug: string
 }
 
-// One adjacent-env promotion gap from /deployments/promotion-options.
-// ``commits_pending`` is the size of the from..to compare; null means the
-// plugin couldn't be asked (e.g. no current release on either side).
-export interface PromotionOption {
-  commits_pending?: null | number
-  from_environment: string
-  from_sha?: null | string
-  from_version?: null | string
-  to_environment: string
-  to_sha?: null | string
-  to_version?: null | string
-}
-
 export interface PullRequest {
   additions: number
   author: string


### PR DESCRIPTION
## Summary
Adds a **Deployments** tab to the project detail page for deployable projects, modeled on the recently added Releases tab and implemented from the `imbi-project-deployment-tab` Claude Design handoff (Deployment Tab v2 + Single Release variants).

## Problem
Deploy, promote, and rollback currently live behind URL-driven modals reached from the header release-train chips. There is no single surface that shows, per environment, what is running, what is waiting to move forward, and where you can roll back — the context the design mockups establish (pending commits, pending releases, release notes, history) has nowhere to live.

## Solution
- **Environment sidebar** rendered in *descending* `sort_order` (production first), themed from each environment's `label_color` via `deriveChipColors`. Badges show the pending commit count (promote stages, from `/deployments/promotion-options`) or the newest waiting release tag (release stages), plus the deployment-identity connection status.
- **Stage kind is derived from data, not position** (per the release-train spec invariant):
  - *Entry environment* (no upstream): recent default-branch commits with per-row **Deploy** / **Roll back** behind a confirm dialog. No promotion.
  - *Upstream runs untagged commits*: an always-on inline **promote form** — env-tinted commit picker with held-back dimming, current/new tag fields, AI-drafted notes with regenerate, and a `Tag X & deploy` action.
  - *Upstream runs tagged releases*: a **pending-releases card** — a single release renders its notes + change summary; multiple render as a radio + accordion stack where row click selects and expands notes, deploying the newest rolls intermediates up, and no new tag is cut.
- **Currently running card** with the live version, deployer, environment URL, and recent releases as expandable rollback targets.
- Reuses the Releases tab's `ReleaseCommitPicker` (extended with an optional accent color + structural commit type) and mirrors the deploy modal's dispatch/toast/run-watcher wiring so in-flight runs update the same sonner toasts.
- Tab gates on a deployable project type + deployment plugin assignment + at least one environment; deep links redirect like the other gated tabs. Existing header chips and modals are untouched.

## Impact
New tab only — no changes to existing deploy/promote modal behavior or APIs. Uses existing backend endpoints (`promotion-options`, `release-history`, `compare`, `refs`, deploy/promote dispatch).

## Testing
- 20 new tests (pipeline view-model, EnvironmentNav, PendingReleasesCard, CurrentlyRunningCard); full suite passes (447 tests, 62 files)
- `tsc --noEmit`, oxlint, oxfmt, and the fallow audit gate all pass
- Production build succeeds