### PR TITLE
Use Gravatar for email-based "Deployed by" in Environments card

### DIFF
--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -21,6 +21,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EnvironmentBadge } from '@/components/ui/environment-badge'
 import { isFieldEditable } from '@/components/ui/inline-edit/field-policy'
 import { InlineField } from '@/components/ui/inline-edit/InlineField'
+import { UserDisplay } from '@/components/ui/user-display'
 import { useEnvironmentEdgePatch } from '@/hooks/useEnvironmentEdgePatch'
 import { formatFieldKey } from '@/lib/project-field-formatting'
 import { sanitizeHttpUrl } from '@/lib/utils'
@@ -208,7 +209,15 @@ export function ProjectEnvironmentsCard({
                     {deployment?.performedBy ? (
                       <div className="min-w-0">
                         <div className={OVERLINE_CLASS}>Deployed by</div>
-                        <ActorBadge actor={deployment.performedBy} />
+                        {deployment.performedBy.includes('@') ? (
+                          <UserDisplay
+                            email={deployment.performedBy}
+                            linkToProfile={false}
+                            size={28}
+                          />
+                        ) : (
+                          <ActorBadge actor={deployment.performedBy} />
+                        )}
                       </div>
                     ) : null}
 


### PR DESCRIPTION
## Summary
Switch the "Deployed by" field in the Project Environments card to use Gravatar (via `UserDisplay`) when the actor is an email address, falling back to `ActorBadge` for GitHub logins and bot actors.

## Problem
The `performed_by` field on a deployment can be either an email address (in-product deploy by an Imbi user) or a GitHub login / bot name (remote/CI deploy). `ActorBadge` was always used regardless, which meant in-product deploys showed amber initials (e.g. `JA` for `jimf@aweber.com`) instead of the user's Gravatar photo.

## Solution
Check whether `performedBy` contains `@` to determine the actor type:
- **Email** → render `UserDisplay` (Gravatar) at `size={28}` to match `ActorBadge`'s circle dimensions
- **Non-email** → render `ActorBadge` as before (initials for humans, bot icon for automation)

## Impact
Users who deploy in-product will now see their Gravatar photo in the Environments card instead of amber initials. No change for CI/remote deploys.