### PR TITLE
Add Documents index page and user profile Documents tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,11 @@ const OperationsLogPage = lazy(() =>
     default: m.OperationsLogPage,
   })),
 )
+const DocumentsIndexPage = lazy(() =>
+  import('./pages/DocumentsIndexPage').then((m) => ({
+    default: m.DocumentsIndexPage,
+  })),
+)
 const AdminPage = lazy(() =>
   import('./pages/AdminPage').then((m) => ({ default: m.AdminPage })),
 )
@@ -121,6 +126,14 @@ function App() {
                 <Route
                   element={
                     <ProtectedRoute>
+                      <DocumentsIndexPage />
+                    </ProtectedRoute>
+                  }
+                  path="/documents/:subId?/:subAction?"
+                />
+                <Route
+                  element={
+                    <ProtectedRoute>
                       <ReportsPage />
                     </ProtectedRoute>
                   }
@@ -148,7 +161,7 @@ function App() {
                       <UserProfilePage />
                     </ProtectedRoute>
                   }
-                  path="/users/:email"
+                  path="/users/:email/:tab?/:subId?/:subAction?"
                 />
                 <Route
                   element={<Navigate replace to="/operations-log" />}

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -458,14 +458,16 @@ export const deleteLinkDefinition = (orgSlug: string, slug: string) =>
     `/organizations/${encodeURIComponent(orgSlug)}/link-definitions/${encodeURIComponent(slug)}`,
   )
 
-// Document Templates (org-scoped)
+// Document Templates (org-scoped). `context` keeps only templates whose
+// type matches the attachment context (or is 'global').
 export const listDocumentTemplates = async (
   orgSlug: string,
   signal?: AbortSignal,
+  context?: 'project' | 'project_type' | 'user',
 ): Promise<DocumentTemplate[]> => {
   const response = await apiClient.get<DocumentTemplate[]>(
     `/organizations/${encodeURIComponent(orgSlug)}/document-templates/`,
-    undefined,
+    context ? { context } : undefined,
     signal,
   )
   return Array.isArray(response) ? response : []
@@ -1708,6 +1710,81 @@ export const deleteProjectDocument = (
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}`,
   )
 
+// Org-wide document index. Rows carry `attached_to` (project,
+// project type, or user), `comment_count`, and the author's display
+// name for the Documents index/feed.
+export const listOrgDocuments = async (
+  orgSlug: string,
+  params?: {
+    cursor?: string
+    limit?: number
+    project_id?: string
+    project_type?: string
+    tag?: string
+    user?: string
+  },
+  signal?: AbortSignal,
+): Promise<Document[]> => {
+  const response = await apiClient.get<DocumentListResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/documents/`,
+    params,
+    signal,
+  )
+  return response?.data ?? []
+}
+
+// Attachment-agnostic single-document operations — work regardless of
+// whether the document hangs off a project, a project type, or a user.
+export const patchOrgDocument = (
+  orgSlug: string,
+  documentId: string,
+  operations: PatchOperation[],
+) =>
+  apiClient.patch<Document>(
+    `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}`,
+    operations,
+  )
+
+export const deleteOrgDocument = (orgSlug: string, documentId: string) =>
+  apiClient.delete<void>(
+    `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}`,
+  )
+
+// Documents attached to a user (org member).
+export const listUserDocuments = async (
+  orgSlug: string,
+  email: string,
+  signal?: AbortSignal,
+): Promise<Document[]> => {
+  const response = await apiClient.get<DocumentListResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/users/${encodeURIComponent(email)}/documents/`,
+    undefined,
+    signal,
+  )
+  return response?.data ?? []
+}
+
+export const createUserDocument = (
+  orgSlug: string,
+  email: string,
+  data: DocumentCreate,
+) =>
+  apiClient.post<Document>(
+    `/organizations/${encodeURIComponent(orgSlug)}/users/${encodeURIComponent(email)}/documents/`,
+    data,
+  )
+
+// Documents attached to a project type.
+export const createProjectTypeDocument = (
+  orgSlug: string,
+  typeSlug: string,
+  data: DocumentCreate,
+) =>
+  apiClient.post<Document>(
+    `/organizations/${encodeURIComponent(orgSlug)}/project-types/${encodeURIComponent(typeSlug)}/documents/`,
+    data,
+  )
+
 // Project integrations (EXISTS_IN edges). One row per third-party
 // service the project exists in; `createProjectService` also persists
 // the optional dashboard URL into the project's links.
@@ -1746,16 +1823,21 @@ export const deleteProjectService = (
 // Document comments. Hand-written like the document endpoints above; the
 // comments API is not yet in the committed openapi snapshot. Base path:
 // /organizations/{orgSlug}/projects/{projectId}/documents/{documentId}/comments
+// for project documents, or the attachment-agnostic
+// /organizations/{orgSlug}/documents/{documentId}/comments when
+// `projectId` is null (user- and project-type-attached documents).
 const documentCommentsPath = (
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
 ) =>
-  `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}/comments`
+  projectId === null
+    ? `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}/comments`
+    : `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/documents/${encodeURIComponent(documentId)}/comments`
 
 export const listDocumentComments = async (
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
   signal?: AbortSignal,
 ): Promise<CommentThread[]> => {
@@ -1769,7 +1851,7 @@ export const listDocumentComments = async (
 
 export const createCommentThread = (
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
   body: CreateThreadBody,
 ) =>
@@ -1780,7 +1862,7 @@ export const createCommentThread = (
 
 export const addCommentReply = (
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
   threadId: string,
   body: AddReplyBody,
@@ -1792,7 +1874,7 @@ export const addCommentReply = (
 
 export const resolveCommentThread = (
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
   threadId: string,
   resolved: boolean,
@@ -1804,7 +1886,7 @@ export const resolveCommentThread = (
 
 export const editComment = (
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
   threadId: string,
   commentId: string,
@@ -1821,7 +1903,7 @@ export const editComment = (
 
 export const acknowledgeComment = (
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
   threadId: string,
   commentId: string,
@@ -1833,7 +1915,7 @@ export const acknowledgeComment = (
 
 export const deleteComment = (
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
   threadId: string,
   commentId: string,

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -7,6 +7,7 @@ import {
   BarChart3,
   Building2,
   ChevronDown,
+  FileText,
   FolderKanban,
   LogOut,
   Moon,
@@ -63,6 +64,12 @@ export function Navigation({ currentView }: NavigationProps) {
         id: 'projects',
         label: 'Projects',
         path: '/projects',
+      },
+      {
+        icon: FileText,
+        id: 'documents',
+        label: 'Documents',
+        path: '/documents',
       },
       {
         icon: Activity,

--- a/src/components/documents/DocumentRowCells.tsx
+++ b/src/components/documents/DocumentRowCells.tsx
@@ -1,0 +1,104 @@
+import { ArrowUpRight, Pin } from 'lucide-react'
+
+import { IconTooltip } from '@/components/ui/tooltip'
+import { UserDisplay } from '@/components/ui/user-display'
+import { cn } from '@/lib/utils'
+import type { Document } from '@/types'
+
+import { formatUpdated } from './documentsHelpers'
+import { DocumentTagChip } from './DocumentTagChip'
+
+/**
+ * The trailing cells shared by every document index row: optional
+ * author, relative updated time, and the pin/open action buttons.
+ * Rendered as a fragment so the cells participate in the caller's
+ * grid directly.
+ */
+// fallow-ignore-next-line complexity
+export function DocumentRowTail({
+  displayNames,
+  document,
+  onOpen,
+  onTogglePin,
+  showAuthor = true,
+}: {
+  displayNames?: Map<string, string>
+  document: Document
+  onOpen: (documentId: string) => void
+  onTogglePin: (document: Document) => void
+  showAuthor?: boolean
+}) {
+  const pinned = document.is_pinned
+  return (
+    <>
+      {showAuthor && (
+        <UserDisplay
+          className="text-secondary text-xs"
+          displayName={document.created_by_name ?? undefined}
+          displayNames={displayNames}
+          email={document.created_by}
+          size={18}
+        />
+      )}
+      <div className="text-tertiary text-right font-mono text-[11.5px] whitespace-nowrap">
+        {formatUpdated(document)}
+      </div>
+      <div className="flex justify-end gap-0.5">
+        <RowIconButton
+          onClick={(e) => {
+            e.stopPropagation()
+            onTogglePin(document)
+          }}
+          title={pinned ? 'Unpin document' : 'Pin document'}
+        >
+          <Pin
+            className={cn('size-3', pinned ? 'text-warning' : 'text-tertiary')}
+          />
+        </RowIconButton>
+        <RowIconButton
+          onClick={(e) => {
+            e.stopPropagation()
+            onOpen(document.id)
+          }}
+          title="Open document"
+        >
+          <ArrowUpRight className="text-tertiary size-3" />
+        </RowIconButton>
+      </div>
+    </>
+  )
+}
+
+/** The first three tag chips of an index row. */
+export function DocumentTagsCell({ document }: { document: Document }) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {document.tags.slice(0, 3).map((t) => (
+        <DocumentTagChip key={t.slug} tag={t} />
+      ))}
+    </div>
+  )
+}
+
+function RowIconButton({
+  children,
+  onClick,
+  title,
+}: {
+  children: React.ReactNode
+  onClick: (e: React.MouseEvent) => void
+  title: string
+}) {
+  return (
+    <IconTooltip label={title}>
+      <button
+        aria-label={title}
+        className="text-tertiary hover:bg-tertiary inline-flex size-[22px] cursor-pointer items-center justify-center rounded border-0 bg-transparent"
+        onClick={onClick}
+        type="button"
+      >
+        {children}
+      </button>
+    </IconTooltip>
+  )
+}

--- a/src/components/documents/DocumentsFeed.tsx
+++ b/src/components/documents/DocumentsFeed.tsx
@@ -1,0 +1,156 @@
+import { FileText, FolderKanban, MessageSquare, Pin } from 'lucide-react'
+
+import { Card } from '@/components/ui/card'
+import { UserDisplay } from '@/components/ui/user-display'
+import type { Document } from '@/types'
+
+import {
+  attachmentDisplay,
+  deriveExcerpt,
+  documentTitle,
+} from './documentsHelpers'
+import { DocumentTagChip } from './DocumentTagChip'
+
+interface Props {
+  displayNames?: Map<string, string>
+  documents: Document[]
+  onOpen: (documentId: string) => void
+}
+
+/**
+ * The "Activity feed" view of the org-wide Documents page — one
+ * Confluence-style card per document, newest first.
+ */
+export function DocumentsFeed({ displayNames, documents, onOpen }: Props) {
+  if (documents.length === 0) {
+    return (
+      <Card className="text-tertiary px-10 py-10 text-center text-sm">
+        No recent activity.
+      </Card>
+    )
+  }
+  return (
+    <div className="flex flex-col gap-4">
+      {documents.map((d) => (
+        <FeedCard
+          displayNames={displayNames}
+          document={d}
+          key={d.id}
+          onOpen={onOpen}
+        />
+      ))}
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function FeedCard({
+  displayNames,
+  document,
+  onOpen,
+}: {
+  displayNames?: Map<string, string>
+  document: Document
+  onOpen: (documentId: string) => void
+}) {
+  const title = documentTitle(document)
+  const excerpt = deriveExcerpt(document.content)
+  const attached = attachmentDisplay(document)
+  const team = document.attached_to?.team
+  return (
+    <Card className="hover:border-secondary px-5 py-4 transition-colors hover:shadow-sm">
+      {/* Byline */}
+      <div className="flex items-center gap-2.5">
+        <UserDisplay
+          className="text-primary text-[13.5px]"
+          displayName={document.created_by_name ?? undefined}
+          displayNames={displayNames}
+          email={document.created_by}
+          size={28}
+          textClassName="font-semibold"
+        />
+        <span className="text-secondary text-[13.5px]">
+          {document.updated_at ? 'updated' : 'created'}
+        </span>
+        <span className="text-tertiary">·</span>
+        <span className="text-secondary text-[13.5px] tabular-nums">
+          {feedDate(document)}
+        </span>
+      </div>
+
+      <div className="bg-tertiary my-3 h-px" />
+
+      {/* Title */}
+      <button
+        className="group flex cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left"
+        onClick={() => onOpen(document.id)}
+        type="button"
+      >
+        <span className="bg-info text-info inline-flex size-6 shrink-0 items-center justify-center rounded-md">
+          <FileText className="size-3.5" />
+        </span>
+        <span className="text-primary text-base font-semibold tracking-[-0.01em] group-hover:underline">
+          {title}
+        </span>
+        {document.is_pinned && (
+          <Pin className="text-warning size-3 shrink-0 rotate-45" />
+        )}
+      </button>
+
+      {/* Ownership */}
+      <div className="text-tertiary mt-2 mb-2 flex flex-wrap items-center gap-1.5 text-[13px]">
+        Owned by
+        <UserDisplay
+          className="text-secondary"
+          displayName={document.created_by_name ?? undefined}
+          displayNames={displayNames}
+          email={document.created_by}
+          hideName={false}
+          size={14}
+        />
+        {team && (
+          <>
+            <span className="text-tertiary">·</span>
+            <span className="text-secondary">{team}</span>
+          </>
+        )}
+        <span className="text-tertiary">·</span>
+        <span className="text-secondary inline-flex items-center gap-1.5 whitespace-nowrap">
+          <FolderKanban className="text-tertiary size-3.5" />
+          {attached.name}
+        </span>
+      </div>
+
+      {/* Preview */}
+      <p className="text-secondary m-0 line-clamp-2 text-sm leading-[1.55]">
+        {excerpt}
+      </p>
+
+      {/* Footer */}
+      <div className="mt-3.5 flex items-center gap-2">
+        <span className="border-secondary bg-primary text-tertiary inline-flex h-7 items-center gap-1.5 rounded-md border px-2 text-xs">
+          <MessageSquare className="size-3.5" />
+          <span className="tabular-nums">{document.comment_count ?? 0}</span>
+        </span>
+        <div className="ml-auto inline-flex items-center gap-1.5">
+          {document.tags.map((t) => (
+            <DocumentTagChip key={t.slug} tag={t} />
+          ))}
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function feedDate(document: Document): string {
+  const iso = document.updated_at ?? document.created_at
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    })
+  } catch {
+    return iso
+  }
+}

--- a/src/components/documents/DocumentsIndexTable.tsx
+++ b/src/components/documents/DocumentsIndexTable.tsx
@@ -1,0 +1,154 @@
+import { FileText, Pin } from 'lucide-react'
+
+import type { Document } from '@/types'
+
+import { DocumentRowTail, DocumentTagsCell } from './DocumentRowCells'
+import { DocumentsFilterRail } from './DocumentsFilterRail'
+import {
+  attachmentDisplay,
+  deriveExcerpt,
+  documentTitle,
+} from './documentsHelpers'
+import { useTagFilter } from './useTagFilter'
+
+const GRID_COLUMNS =
+  'minmax(0, 0.9fr) minmax(0, 1.4fr) minmax(0, 0.8fr) 110px 64px 56px'
+
+interface Props {
+  displayNames?: Map<string, string>
+  documents: Document[]
+  onOpen: (documentId: string) => void
+  onTogglePin: (document: Document) => void
+}
+
+/**
+ * The "Index" view of the org-wide Documents page — a flat table with
+ * the attachment (project, project type, or user) as the first column
+ * and a tag-filter rail alongside.
+ */
+export function DocumentsIndexTable({
+  displayNames,
+  documents,
+  onOpen,
+  onTogglePin,
+}: Props) {
+  const filter = useTagFilter(documents, indexHaystack)
+  const { filtered } = filter
+
+  return (
+    <div className="grid grid-cols-[220px_1fr] items-start gap-5">
+      <DocumentsFilterRail
+        active={filter.active}
+        counts={filter.counts}
+        onClear={filter.clear}
+        onSearchChange={filter.setSearch}
+        onToggle={filter.toggle}
+        search={filter.search}
+        tags={filter.tags}
+        totalFiltered={filtered.length}
+      />
+
+      <div>
+        <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
+          <div
+            className="border-tertiary bg-secondary text-overline text-tertiary grid items-center gap-3.5 border-b px-3.5 py-2 uppercase"
+            style={{ gridTemplateColumns: GRID_COLUMNS }}
+          >
+            <span>Project</span>
+            <span>Document</span>
+            <span>Tags</span>
+            <span>Author</span>
+            <span className="text-right">Updated</span>
+            <span />
+          </div>
+          {filtered.map((n) => (
+            <IndexRow
+              displayNames={displayNames}
+              document={n}
+              key={n.id}
+              onOpen={onOpen}
+              onTogglePin={onTogglePin}
+            />
+          ))}
+          {filtered.length === 0 && (
+            <div className="text-tertiary px-8 py-10 text-center text-sm">
+              No documents match.
+            </div>
+          )}
+        </div>
+        <div className="text-tertiary mt-3 text-xs">
+          {filtered.length} {filtered.length === 1 ? 'document' : 'documents'}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function indexHaystack(document: Document): string {
+  const attached = attachmentDisplay(document)
+  return [
+    documentTitle(document),
+    document.content,
+    attached.name,
+    attached.sub,
+    document.attached_to?.team ?? '',
+    document.created_by,
+    document.created_by_name ?? '',
+  ].join(' ')
+}
+
+function IndexRow({
+  displayNames,
+  document,
+  onOpen,
+  onTogglePin,
+}: {
+  displayNames?: Map<string, string>
+  document: Document
+  onOpen: (documentId: string) => void
+  onTogglePin: (document: Document) => void
+}) {
+  const pinned = document.is_pinned
+  const title = documentTitle(document)
+  const excerpt = deriveExcerpt(document.content)
+  const attached = attachmentDisplay(document)
+  return (
+    <div
+      className="border-tertiary hover:bg-secondary grid cursor-pointer items-center gap-3.5 border-b px-3.5 py-3 last:border-b-0"
+      onClick={() => onOpen(document.id)}
+      style={{ gridTemplateColumns: GRID_COLUMNS }}
+    >
+      <div className="min-w-0">
+        <div className="text-primary truncate text-sm font-semibold">
+          {attached.name}
+        </div>
+        {attached.sub && (
+          <div className="text-tertiary mt-0.5 truncate text-xs">
+            {attached.sub}
+          </div>
+        )}
+      </div>
+      <div className="flex min-w-0 items-start gap-2.5">
+        <span className="bg-info text-info mt-0.5 inline-flex size-5.5 shrink-0 items-center justify-center rounded-md">
+          <FileText className="size-3" />
+        </span>
+        <div className="min-w-0">
+          <div className="text-primary flex items-center gap-1.5 text-[13.5px] font-medium">
+            <span className="truncate">{title}</span>
+            {pinned && (
+              <Pin className="text-warning size-3 shrink-0 rotate-45" />
+            )}
+          </div>
+          <div className="text-tertiary mt-0.5 truncate text-xs">{excerpt}</div>
+        </div>
+      </div>
+      <DocumentTagsCell document={document} />
+      <DocumentRowTail
+        displayNames={displayNames}
+        document={document}
+        onOpen={onOpen}
+        onTogglePin={onTogglePin}
+      />
+    </div>
+  )
+}

--- a/src/components/documents/DocumentsIndexTable.tsx
+++ b/src/components/documents/DocumentsIndexTable.tsx
@@ -54,7 +54,7 @@ export function DocumentsIndexTable({
             className="border-tertiary bg-secondary text-overline text-tertiary grid items-center gap-3.5 border-b px-3.5 py-2 uppercase"
             style={{ gridTemplateColumns: GRID_COLUMNS }}
           >
-            <span>Project</span>
+            <span>Attached to</span>
             <span>Document</span>
             <span>Tags</span>
             <span>Author</span>

--- a/src/components/documents/DocumentsPinboard.tsx
+++ b/src/components/documents/DocumentsPinboard.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
-import { ArrowUpRight, Pin } from 'lucide-react'
+import { Pin } from 'lucide-react'
 
 import {
   Card,
@@ -9,23 +9,19 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { IconTooltip } from '@/components/ui/tooltip'
 import { UserDisplay } from '@/components/ui/user-display'
 import { cn } from '@/lib/utils'
 import type { Document, DocumentTemplate } from '@/types'
 
+import { DocumentRowTail, DocumentTagsCell } from './DocumentRowCells'
 import { DocumentsFilterRail } from './DocumentsFilterRail'
-import {
-  deriveExcerpt,
-  documentTitle,
-  formatUpdated,
-  tagCounts,
-  uniqueTagsFromDocuments,
-} from './documentsHelpers'
+import { deriveExcerpt, documentTitle, formatUpdated } from './documentsHelpers'
 import { DocumentTagChip } from './DocumentTagChip'
 import { NewDocumentMenu } from './NewDocumentMenu'
+import { useTagFilter } from './useTagFilter'
 
 interface Props {
+  context?: 'project' | 'project_type' | 'user'
   displayNames?: Map<string, string>
   documents: Document[]
   onCreate: (template?: DocumentTemplate) => void
@@ -33,9 +29,15 @@ interface Props {
   onTogglePin: (document: Document) => void
   orgSlug: string
   projectTypeSlugs?: string[]
+  /**
+   * Hide the Author column where it is redundant — e.g. the user profile
+   * Documents tab, where every document belongs to the profiled user.
+   */
+  showAuthor?: boolean
 }
 
 export function DocumentsPinboard({
+  context = 'project',
   displayNames,
   documents,
   onCreate,
@@ -43,48 +45,24 @@ export function DocumentsPinboard({
   onTogglePin,
   orgSlug,
   projectTypeSlugs,
+  showAuthor = true,
 }: Props) {
-  const [active, setActive] = useState<Set<string>>(new Set())
-  const [search, setSearch] = useState('')
-
-  const tags = useMemo(() => uniqueTagsFromDocuments(documents), [documents])
-  const counts = useMemo(() => tagCounts(documents), [documents])
-
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase()
-    return documents.filter((n) => {
-      for (const slug of active) {
-        if (!n.tags.some((t) => t.slug === slug)) return false
-      }
-      if (!q) return true
-      const title = documentTitle(n).toLowerCase()
-      const content = n.content.toLowerCase()
-      return title.includes(q) || content.includes(q)
-    })
-  }, [documents, active, search])
+  const filter = useTagFilter(documents, pinboardHaystack)
+  const { filtered } = filter
 
   const pinned = useMemo(() => filtered.filter((n) => n.is_pinned), [filtered])
   const rest = useMemo(() => filtered.filter((n) => !n.is_pinned), [filtered])
 
-  const toggle = useCallback((slug: string) => {
-    setActive((prev) => {
-      const next = new Set(prev)
-      if (next.has(slug)) next.delete(slug)
-      else next.add(slug)
-      return next
-    })
-  }, [])
-
   return (
     <div className="grid grid-cols-[220px_1fr] gap-5">
       <DocumentsFilterRail
-        active={active}
-        counts={counts}
-        onClear={() => setActive(new Set())}
-        onSearchChange={setSearch}
-        onToggle={toggle}
-        search={search}
-        tags={tags}
+        active={filter.active}
+        counts={filter.counts}
+        onClear={filter.clear}
+        onSearchChange={filter.setSearch}
+        onToggle={filter.toggle}
+        search={filter.search}
+        tags={filter.tags}
         totalFiltered={filtered.length}
       />
 
@@ -104,6 +82,7 @@ export function DocumentsPinboard({
           )}
           <NewDocumentMenu
             className={cn(pinned.length === 0 && 'ml-auto')}
+            context={context}
             onCreate={onCreate}
             orgSlug={orgSlug}
             projectTypeSlugs={projectTypeSlugs}
@@ -114,14 +93,11 @@ export function DocumentsPinboard({
           <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
             <div
               className="border-tertiary bg-secondary text-overline text-tertiary grid items-center gap-3.5 border-b px-3.5 py-2 uppercase"
-              style={{
-                gridTemplateColumns:
-                  'minmax(0, 1.6fr) minmax(0, 1fr) 100px 60px 60px',
-              }}
+              style={{ gridTemplateColumns: gridColumns(showAuthor) }}
             >
               <span>Document</span>
               <span>Tags</span>
-              <span>Author</span>
+              {showAuthor && <span>Author</span>}
               <span className="text-right">Updated</span>
               <span />
             </div>
@@ -132,6 +108,7 @@ export function DocumentsPinboard({
                 key={n.id}
                 onOpen={onOpen}
                 onTogglePin={onTogglePin}
+                showAuthor={showAuthor}
               />
             ))}
             {rest.length === 0 && (
@@ -146,6 +123,12 @@ export function DocumentsPinboard({
       </div>
     </div>
   )
+}
+
+function gridColumns(showAuthor: boolean): string {
+  return showAuthor
+    ? 'minmax(0, 1.6fr) minmax(0, 1fr) 100px 60px 60px'
+    : 'minmax(0, 1.6fr) minmax(0, 1fr) 60px 60px'
 }
 
 function HeroCard({
@@ -207,23 +190,21 @@ function IndexRow({
   document,
   onOpen,
   onTogglePin,
+  showAuthor,
 }: {
   displayNames?: Map<string, string>
   document: Document
   onOpen: (documentId: string) => void
   onTogglePin: (document: Document) => void
+  showAuthor: boolean
 }) {
-  const pinned = document.is_pinned
   const title = documentTitle(document)
   const excerpt = deriveExcerpt(document.content)
-  const author = document.created_by
   return (
     <div
       className="border-tertiary hover:bg-secondary grid cursor-pointer items-center gap-3.5 border-b px-3.5 py-2.5 last:border-b-0"
       onClick={() => onOpen(document.id)}
-      style={{
-        gridTemplateColumns: 'minmax(0, 1.6fr) minmax(0, 1fr) 100px 60px 60px',
-      }}
+      style={{ gridTemplateColumns: gridColumns(showAuthor) }}
     >
       <div className="min-w-0">
         <div className="text-primary truncate text-[13.5px] font-medium">
@@ -231,65 +212,18 @@ function IndexRow({
         </div>
         <div className="text-tertiary mt-0.5 truncate text-xs">{excerpt}</div>
       </div>
-      <div className="flex flex-wrap gap-1">
-        {document.tags.slice(0, 3).map((t) => (
-          <DocumentTagChip key={t.slug} tag={t} />
-        ))}
-      </div>
-      <UserDisplay
-        className="text-secondary text-xs"
+      <DocumentTagsCell document={document} />
+      <DocumentRowTail
         displayNames={displayNames}
-        email={author}
-        size={18}
+        document={document}
+        onOpen={onOpen}
+        onTogglePin={onTogglePin}
+        showAuthor={showAuthor}
       />
-      <div className="text-tertiary text-right font-mono text-[11.5px]">
-        {formatUpdated(document)}
-      </div>
-      <div className="flex justify-end gap-0.5">
-        <RowIconButton
-          onClick={(e) => {
-            e.stopPropagation()
-            onTogglePin(document)
-          }}
-          title={pinned ? 'Unpin document' : 'Pin document'}
-        >
-          <Pin
-            className={cn('size-3', pinned ? 'text-warning' : 'text-tertiary')}
-          />
-        </RowIconButton>
-        <RowIconButton
-          onClick={(e) => {
-            e.stopPropagation()
-            onOpen(document.id)
-          }}
-          title="Open document"
-        >
-          <ArrowUpRight className="text-tertiary size-3" />
-        </RowIconButton>
-      </div>
     </div>
   )
 }
 
-function RowIconButton({
-  children,
-  onClick,
-  title,
-}: {
-  children: React.ReactNode
-  onClick: (e: React.MouseEvent) => void
-  title: string
-}) {
-  return (
-    <IconTooltip label={title}>
-      <button
-        aria-label={title}
-        className="text-tertiary hover:bg-tertiary inline-flex size-[22px] cursor-pointer items-center justify-center rounded border-0 bg-transparent"
-        onClick={onClick}
-        type="button"
-      >
-        {children}
-      </button>
-    </IconTooltip>
-  )
+function pinboardHaystack(document: Document): string {
+  return `${documentTitle(document)} ${document.content}`
 }

--- a/src/components/documents/DocumentsPinboardEmpty.tsx
+++ b/src/components/documents/DocumentsPinboardEmpty.tsx
@@ -10,12 +10,16 @@ import { filterTemplatesByProjectType } from './documentsHelpers'
 import { DocumentTagChip } from './DocumentTagChip'
 
 interface Props {
+  context?: 'project' | 'project_type' | 'user'
+  emptyHeading?: string
   onCreate: (template?: DocumentTemplate) => void
   orgSlug: string
   projectTypeSlugs?: string[]
 }
 
 export function DocumentsPinboardEmpty({
+  context = 'project',
+  emptyHeading = 'No documents yet for this project',
   onCreate,
   orgSlug,
   projectTypeSlugs,
@@ -26,14 +30,14 @@ export function DocumentsPinboardEmpty({
     isLoading: templatesLoading,
   } = useQuery<DocumentTemplate[]>({
     enabled: !!orgSlug,
-    queryFn: ({ signal }) => listDocumentTemplates(orgSlug, signal),
-    queryKey: ['documentTemplates', orgSlug],
+    queryFn: ({ signal }) => listDocumentTemplates(orgSlug, signal, context),
+    queryKey: ['documentTemplates', orgSlug, context],
   })
 
-  const visibleTemplates = filterTemplatesByProjectType(
-    templates,
-    projectTypeSlugs,
-  )
+  const visibleTemplates =
+    context === 'project'
+      ? filterTemplatesByProjectType(templates, projectTypeSlugs)
+      : templates
 
   return (
     <div className="border-tertiary bg-primary flex flex-col items-center gap-4 rounded-lg border px-10 py-14 text-center">
@@ -46,7 +50,7 @@ export function DocumentsPinboardEmpty({
       </div>
 
       <h2 className="text-h2 m-0 font-medium tracking-[-0.015em]">
-        No documents yet for this project
+        {emptyHeading}
       </h2>
       <p className="text-secondary m-0 max-w-180 text-sm leading-[1.6]">
         Documents capture decisions, reviews, and patterns that outlive any one

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -82,7 +82,7 @@ interface Props {
   onResolveThread: (threadId: string, resolved: boolean) => void
   onTogglePin: () => void
   orgSlug: string
-  projectId: string
+  projectId: null | string
 }
 
 // fallow-ignore-next-line complexity

--- a/src/components/documents/DocumentsTab.tsx
+++ b/src/components/documents/DocumentsTab.tsx
@@ -1,0 +1,163 @@
+import type { ReactNode } from 'react'
+
+import { ErrorBanner } from '@/components/ui/error-banner'
+import { LoadingState } from '@/components/ui/loading-state'
+import type { Document, DocumentTemplate } from '@/types'
+
+import { DocumentsPinboard } from './DocumentsPinboard'
+import { DocumentsPinboardEmpty } from './DocumentsPinboardEmpty'
+import { DocumentsPinboardNew } from './DocumentsPinboardNew'
+import { DocumentsPinboardReader } from './DocumentsPinboardReader'
+import {
+  type DocumentsScope,
+  useDocumentsController,
+} from './useDocumentsController'
+
+export type { DocumentsScope } from './useDocumentsController'
+
+export interface DocumentsListContext {
+  displayNames?: Map<string, string>
+  documents: Document[]
+  onCreate: (template?: DocumentTemplate) => void
+  onOpen: (documentId: string) => void
+  onTogglePin: (document: Document) => void
+}
+
+interface Props {
+  /** Rendered above the editor while creating (e.g. attachment picker). */
+  creatingPrelude?: ReactNode
+  initialAction?: string
+  initialDocumentId?: string
+  orgSlug: string
+  /** Replace the default pinboard list view (e.g. the org-wide feed). */
+  renderList?: (ctx: DocumentsListContext) => ReactNode
+  scope: DocumentsScope
+}
+
+/**
+ * The full documents experience for one {@link DocumentsScope}: the
+ * pinboard list (or a custom list via `renderList`), the reader with
+ * comments, and the editor — with view state mirrored into the URL.
+ */
+// fallow-ignore-next-line complexity
+export function DocumentsTab({
+  creatingPrelude,
+  initialAction,
+  initialDocumentId,
+  orgSlug,
+  renderList,
+  scope,
+}: Props) {
+  const ctl = useDocumentsController(
+    orgSlug,
+    scope,
+    initialDocumentId,
+    initialAction,
+  )
+
+  if (ctl.isLoading) return <LoadingState label="Loading documents…" />
+  if (ctl.error)
+    return <ErrorBanner error={ctl.error} title="Failed to load documents" />
+
+  if (ctl.view.kind === 'creating') {
+    return (
+      <div className="space-y-3.5">
+        {creatingPrelude}
+        <DocumentsPinboardNew
+          allDocuments={ctl.documents}
+          onDiscard={ctl.handleDiscard}
+          onSave={ctl.handleSave}
+          orgSlug={orgSlug}
+          saving={ctl.createPending}
+          template={ctl.view.template}
+        />
+      </div>
+    )
+  }
+
+  if (ctl.editingDocument) {
+    return (
+      <DocumentsPinboardNew
+        allDocuments={ctl.documents}
+        initialDocument={ctl.editingDocument}
+        key={ctl.editingDocument.id}
+        onDiscard={ctl.handleDiscard}
+        onSave={ctl.handleSave}
+        orgSlug={orgSlug}
+        saving={ctl.updatePending}
+      />
+    )
+  }
+
+  if (ctl.selectedDocument) {
+    const document = ctl.selectedDocument
+    return (
+      <DocumentsPinboardReader
+        allDocuments={ctl.documents}
+        comments={ctl.comments.comments}
+        commentsBusy={ctl.comments.commentsBusy}
+        currentUserEmail={ctl.currentUserEmail}
+        deleting={ctl.deletePending}
+        displayNames={ctl.displayNames}
+        document={document}
+        onAcknowledgeComment={ctl.comments.onAcknowledge}
+        onBack={() => ctl.navigateToView({ kind: 'list' })}
+        onCreateThread={ctl.comments.onCreateThread}
+        onDelete={() => ctl.deleteDocument(document.id)}
+        onDeleteComment={ctl.comments.onDelete}
+        onEdit={() =>
+          ctl.navigateToView({ documentId: document.id, kind: 'editing' })
+        }
+        onEditComment={ctl.comments.onEdit}
+        onOpen={(id) => ctl.navigateToView({ documentId: id, kind: 'reading' })}
+        onReplyComment={ctl.comments.onReply}
+        onResolveThread={ctl.comments.onResolve}
+        onTogglePin={() => ctl.togglePin(document)}
+        orgSlug={orgSlug}
+        projectId={scope.commentsProjectId}
+      />
+    )
+  }
+
+  const listContext: DocumentsListContext = {
+    displayNames: ctl.displayNames,
+    documents: ctl.documents,
+    onCreate: ctl.handleCreate,
+    onOpen: (id) => ctl.navigateToView({ documentId: id, kind: 'reading' }),
+    onTogglePin: ctl.togglePin,
+  }
+
+  if (renderList) return <>{renderList(listContext)}</>
+
+  if (ctl.documents.length === 0) {
+    return (
+      <DocumentsPinboardEmpty
+        context={scopeTemplateContext(scope)}
+        emptyHeading={scope.emptyHeading}
+        onCreate={ctl.handleCreate}
+        orgSlug={orgSlug}
+        projectTypeSlugs={scope.projectTypeSlugs}
+      />
+    )
+  }
+
+  return (
+    <DocumentsPinboard
+      context={scopeTemplateContext(scope)}
+      displayNames={ctl.displayNames}
+      documents={ctl.documents}
+      onCreate={ctl.handleCreate}
+      onOpen={listContext.onOpen}
+      onTogglePin={ctl.togglePin}
+      orgSlug={orgSlug}
+      projectTypeSlugs={scope.projectTypeSlugs}
+      showAuthor={scope.showAuthor ?? true}
+    />
+  )
+}
+
+function scopeTemplateContext(
+  scope: DocumentsScope,
+): 'project' | 'project_type' | 'user' {
+  return scope.templateContext === 'org' ? 'user' : scope.templateContext
+}

--- a/src/components/documents/NewDocumentMenu.tsx
+++ b/src/components/documents/NewDocumentMenu.tsx
@@ -64,7 +64,7 @@ export function NewDocumentMenu({
     context === 'project'
       ? filterTemplatesByProjectType(templates, projectTypeSlugs)
       : context === 'org'
-        ? templates.filter((t) => t.type && t.type !== 'project')
+        ? templates.filter((t) => t.type !== 'project')
         : templates
 
   // Nothing to choose between — keep the fast path as a plain button.

--- a/src/components/documents/NewDocumentMenu.tsx
+++ b/src/components/documents/NewDocumentMenu.tsx
@@ -20,6 +20,13 @@ import { DocumentTagChip } from './DocumentTagChip'
 
 interface Props {
   className?: string
+  /**
+   * Attachment context the new document will be created in. Drives which
+   * templates are offered (matching-type plus 'global' templates).
+   * 'org' is the top-level Documents page, where the attachment is picked
+   * in the editor — every template except project-only ones applies.
+   */
+  context?: 'org' | 'project' | 'project_type' | 'user'
   onCreate: (template?: DocumentTemplate) => void
   orgSlug: string
   projectTypeSlugs?: string[]
@@ -34,22 +41,31 @@ const ITEM_CLASS =
  * available to this project. When there are no templates it degrades to a plain
  * button that creates a blank document directly.
  */
+// fallow-ignore-next-line complexity
 export function NewDocumentMenu({
   className,
+  context = 'project',
   onCreate,
   orgSlug,
   projectTypeSlugs,
 }: Props) {
   const { data: templates = [], isLoading } = useQuery<DocumentTemplate[]>({
     enabled: !!orgSlug,
-    queryFn: ({ signal }) => listDocumentTemplates(orgSlug, signal),
-    queryKey: ['documentTemplates', orgSlug],
+    queryFn: ({ signal }) =>
+      listDocumentTemplates(
+        orgSlug,
+        signal,
+        context === 'org' ? undefined : context,
+      ),
+    queryKey: ['documentTemplates', orgSlug, context],
   })
 
-  const visibleTemplates = filterTemplatesByProjectType(
-    templates,
-    projectTypeSlugs,
-  )
+  const visibleTemplates =
+    context === 'project'
+      ? filterTemplatesByProjectType(templates, projectTypeSlugs)
+      : context === 'org'
+        ? templates.filter((t) => t.type && t.type !== 'project')
+        : templates
 
   // Nothing to choose between — keep the fast path as a plain button.
   // (On error we get no templates, so degrade rather than show an empty menu.)

--- a/src/components/documents/ProjectDocumentsTab.tsx
+++ b/src/components/documents/ProjectDocumentsTab.tsx
@@ -1,9 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-
-import { useNavigate } from 'react-router-dom'
-
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
+import { useMemo } from 'react'
 
 import {
   createProjectDocument,
@@ -11,18 +6,8 @@ import {
   listProjectDocuments,
   patchProjectDocument,
 } from '@/api/endpoints'
-import { ErrorBanner } from '@/components/ui/error-banner'
-import { LoadingState } from '@/components/ui/loading-state'
-import { useAuth } from '@/hooks/useAuth'
-import { useDocumentComments } from '@/hooks/useDocumentComments'
-import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
-import { extractApiErrorDetail } from '@/lib/apiError'
-import type { Document, DocumentTemplate } from '@/types'
 
-import { DocumentsPinboard } from './DocumentsPinboard'
-import { DocumentsPinboardEmpty } from './DocumentsPinboardEmpty'
-import { DocumentsPinboardNew } from './DocumentsPinboardNew'
-import { DocumentsPinboardReader } from './DocumentsPinboardReader'
+import { type DocumentsScope, DocumentsTab } from './DocumentsTab'
 
 interface Props {
   initialAction?: string
@@ -32,12 +17,7 @@ interface Props {
   projectTypeSlugs?: string[]
 }
 
-type View =
-  | { documentId: string; kind: 'editing' }
-  | { documentId: string; kind: 'reading' }
-  | { kind: 'creating'; template?: DocumentTemplate | null }
-  | { kind: 'list' }
-
+/** The project-detail Documents tab — a project-scoped {@link DocumentsTab}. */
 export function ProjectDocumentsTab({
   initialAction,
   initialDocumentId,
@@ -45,333 +25,30 @@ export function ProjectDocumentsTab({
   projectId,
   projectTypeSlugs,
 }: Props) {
-  const navigate = useNavigate()
-  const [view, setView] = useState<View>(() =>
-    viewFromUrl(initialDocumentId, initialAction),
+  const scope = useMemo<DocumentsScope>(
+    () => ({
+      basePath: `/projects/${projectId}/documents`,
+      commentsProjectId: projectId,
+      create: (draft) => createProjectDocument(orgSlug, projectId, draft),
+      list: (signal) =>
+        listProjectDocuments(orgSlug, projectId, undefined, signal),
+      patch: (documentId, operations) =>
+        patchProjectDocument(orgSlug, projectId, documentId, operations),
+      projectTypeSlugs,
+      queryKey: ['projectDocuments', orgSlug, projectId] as const,
+      remove: (documentId) =>
+        deleteProjectDocument(orgSlug, projectId, documentId),
+      templateContext: 'project',
+    }),
+    [orgSlug, projectId, projectTypeSlugs],
   )
-  const qc = useQueryClient()
-
-  const navigateToView = useCallback(
-    (next: View) => {
-      setView(next)
-      const base = `/projects/${projectId}/documents`
-      if (next.kind === 'reading') {
-        navigate(`${base}/${encodeURIComponent(next.documentId)}`, {
-          replace: true,
-        })
-      } else if (next.kind === 'editing') {
-        navigate(`${base}/${encodeURIComponent(next.documentId)}/edit`, {
-          replace: true,
-        })
-      } else if (next.kind === 'creating') {
-        navigate(`${base}/new`, { replace: true })
-      } else {
-        navigate(base, { replace: true })
-      }
-    },
-    [navigate, projectId],
-  )
-
-  // Reflect URL changes (e.g. browser back/forward) into local view state.
-  useEffect(() => {
-    const next = viewFromUrl(initialDocumentId, initialAction)
-    setView((prev) => {
-      if (
-        prev.kind === next.kind &&
-        ('documentId' in prev ? prev.documentId : null) ===
-          ('documentId' in next ? next.documentId : null)
-      ) {
-        return prev
-      }
-      return next
-    })
-  }, [initialDocumentId, initialAction])
-
-  const documentsKey = ['projectDocuments', orgSlug, projectId] as const
-
-  const {
-    data: documents = [],
-    error,
-    isLoading,
-  } = useQuery({
-    enabled: !!orgSlug && !!projectId,
-    queryFn: ({ signal }) =>
-      listProjectDocuments(orgSlug, projectId, undefined, signal),
-    queryKey: documentsKey,
-  })
-
-  const { displayNames, isError: usersError } = useUserDisplayNames()
-  const { user } = useAuth()
-  const currentUserEmail = user?.email ?? ''
-
-  useEffect(() => {
-    if (usersError) {
-      console.warn('Failed to load admin users for document display names')
-    }
-  }, [usersError])
-
-  const pinMutation = useMutation<
-    Document,
-    unknown,
-    { documentId: string; pinned: boolean },
-    { previous?: Document[] }
-  >({
-    mutationFn: ({
-      documentId,
-      pinned,
-    }: {
-      documentId: string
-      pinned: boolean
-    }) =>
-      patchProjectDocument(orgSlug, projectId, documentId, [
-        { op: 'replace', path: '/is_pinned', value: pinned },
-      ]),
-    onError: (err, _vars, ctx) => {
-      if (ctx?.previous) qc.setQueryData(documentsKey, ctx.previous)
-      toast.error(`Pin failed: ${extractApiErrorDetail(err)}`)
-    },
-    onMutate: async ({ documentId, pinned }) => {
-      await qc.cancelQueries({ queryKey: documentsKey })
-      const previous = qc.getQueryData<Document[]>(documentsKey)
-      if (previous) {
-        qc.setQueryData<Document[]>(
-          documentsKey,
-          previous.map((n) =>
-            n.id === documentId ? { ...n, is_pinned: pinned } : n,
-          ),
-        )
-      }
-      return { previous }
-    },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: documentsKey })
-    },
-  })
-
-  const createMutation = useMutation({
-    mutationFn: (draft: { content: string; tags: string[]; title: string }) =>
-      createProjectDocument(orgSlug, projectId, draft),
-    onError: (err) => {
-      toast.error(`Save failed: ${extractApiErrorDetail(err)}`)
-    },
-    onSuccess: (document) => {
-      qc.setQueryData<Document[]>(documentsKey, (prev) =>
-        prev ? [document, ...prev] : [document],
-      )
-      qc.invalidateQueries({ queryKey: documentsKey })
-      toast.success('Document saved')
-      navigateToView({ documentId: document.id, kind: 'reading' })
-    },
-  })
-
-  const updateMutation = useMutation({
-    mutationFn: ({
-      documentId,
-      draft,
-    }: {
-      documentId: string
-      draft: { content: string; tags: string[]; title: string }
-    }) =>
-      patchProjectDocument(orgSlug, projectId, documentId, [
-        { op: 'replace', path: '/title', value: draft.title },
-        { op: 'replace', path: '/content', value: draft.content },
-        { op: 'replace', path: '/tags', value: draft.tags },
-      ]),
-    onError: (err) => {
-      toast.error(`Update failed: ${extractApiErrorDetail(err)}`)
-    },
-    onSuccess: (document) => {
-      qc.setQueryData<Document[]>(documentsKey, (prev) =>
-        prev
-          ? prev.map((n) => (n.id === document.id ? document : n))
-          : [document],
-      )
-      qc.invalidateQueries({ queryKey: documentsKey })
-      toast.success('Document updated')
-      navigateToView({ documentId: document.id, kind: 'reading' })
-    },
-  })
-
-  const deleteMutation = useMutation({
-    mutationFn: (documentId: string) =>
-      deleteProjectDocument(orgSlug, projectId, documentId),
-    onError: (err) => {
-      toast.error(`Delete failed: ${extractApiErrorDetail(err)}`)
-    },
-    onSuccess: (_data, documentId) => {
-      qc.setQueryData<Document[]>(documentsKey, (prev) =>
-        prev ? prev.filter((n) => n.id !== documentId) : [],
-      )
-      qc.invalidateQueries({ queryKey: documentsKey })
-      toast.success('Document deleted')
-      navigateToView({ kind: 'list' })
-    },
-  })
-
-  const togglePin = useCallback(
-    (document: Document) => {
-      pinMutation.mutate({
-        documentId: document.id,
-        pinned: !document.is_pinned,
-      })
-    },
-    [pinMutation],
-  )
-
-  const selectedDocument = useMemo(
-    () =>
-      view.kind === 'reading'
-        ? (documents.find((n) => n.id === view.documentId) ?? null)
-        : null,
-    [documents, view],
-  )
-
-  const comments = useDocumentComments(
-    orgSlug,
-    projectId,
-    selectedDocument?.id ?? '',
-    currentUserEmail,
-  )
-
-  const editingDocument = useMemo(
-    () =>
-      view.kind === 'editing'
-        ? (documents.find((n) => n.id === view.documentId) ?? null)
-        : null,
-    [documents, view],
-  )
-
-  // If a deep-linked document id doesn't exist (deleted, wrong id), surface a
-  // toast and bounce back to the list view rather than silently rendering
-  // the empty list. Skip while the documents query is loading or errored —
-  // the error banner (rendered below) already covers fetch failures and
-  // an empty-on-error documents array shouldn't masquerade as a missing document.
-  useEffect(() => {
-    if (isLoading || error) return
-    if (view.kind !== 'reading' && view.kind !== 'editing') return
-    if (documents.some((n) => n.id === view.documentId)) return
-    toast.error('Document not found')
-    navigateToView({ kind: 'list' })
-  }, [error, isLoading, navigateToView, documents, view])
-
-  const handleCreate = useCallback(
-    (template?: DocumentTemplate) => {
-      navigateToView({ kind: 'creating', template: template ?? null })
-    },
-    [navigateToView],
-  )
-
-  const handleDiscard = useCallback(() => {
-    if (view.kind === 'editing') {
-      navigateToView({ documentId: view.documentId, kind: 'reading' })
-    } else {
-      navigateToView({ kind: 'list' })
-    }
-  }, [navigateToView, view])
-
-  const handleSave = useCallback(
-    (draft: { content: string; tags: string[]; title: string }) => {
-      if (view.kind === 'editing') {
-        updateMutation.mutate({ documentId: view.documentId, draft })
-      } else {
-        createMutation.mutate(draft)
-      }
-    },
-    [createMutation, updateMutation, view],
-  )
-
-  if (isLoading) return <LoadingState label="Loading documents…" />
-  if (error)
-    return <ErrorBanner error={error} title="Failed to load documents" />
-
-  if (view.kind === 'creating') {
-    return (
-      <DocumentsPinboardNew
-        allDocuments={documents}
-        onDiscard={handleDiscard}
-        onSave={handleSave}
-        orgSlug={orgSlug}
-        saving={createMutation.isPending}
-        template={view.template}
-      />
-    )
-  }
-
-  if (editingDocument) {
-    return (
-      <DocumentsPinboardNew
-        allDocuments={documents}
-        initialDocument={editingDocument}
-        key={editingDocument.id}
-        onDiscard={handleDiscard}
-        onSave={handleSave}
-        orgSlug={orgSlug}
-        saving={updateMutation.isPending}
-      />
-    )
-  }
-
-  if (selectedDocument) {
-    return (
-      <DocumentsPinboardReader
-        allDocuments={documents}
-        comments={comments.comments}
-        commentsBusy={comments.commentsBusy}
-        currentUserEmail={currentUserEmail}
-        deleting={deleteMutation.isPending}
-        displayNames={displayNames}
-        document={selectedDocument}
-        onAcknowledgeComment={comments.onAcknowledge}
-        onBack={() => navigateToView({ kind: 'list' })}
-        onCreateThread={comments.onCreateThread}
-        onDelete={() => deleteMutation.mutate(selectedDocument.id)}
-        onDeleteComment={comments.onDelete}
-        onEdit={() =>
-          navigateToView({ documentId: selectedDocument.id, kind: 'editing' })
-        }
-        onEditComment={comments.onEdit}
-        onOpen={(id) => navigateToView({ documentId: id, kind: 'reading' })}
-        onReplyComment={comments.onReply}
-        onResolveThread={comments.onResolve}
-        onTogglePin={() => togglePin(selectedDocument)}
-        orgSlug={orgSlug}
-        projectId={projectId}
-      />
-    )
-  }
-
-  if (documents.length === 0) {
-    return (
-      <DocumentsPinboardEmpty
-        onCreate={handleCreate}
-        orgSlug={orgSlug}
-        projectTypeSlugs={projectTypeSlugs}
-      />
-    )
-  }
 
   return (
-    <DocumentsPinboard
-      displayNames={displayNames}
-      documents={documents}
-      onCreate={handleCreate}
-      onOpen={(id) => navigateToView({ documentId: id, kind: 'reading' })}
-      onTogglePin={togglePin}
+    <DocumentsTab
+      initialAction={initialAction}
+      initialDocumentId={initialDocumentId}
       orgSlug={orgSlug}
-      projectTypeSlugs={projectTypeSlugs}
+      scope={scope}
     />
   )
-}
-
-function viewFromUrl(
-  initialDocumentId: string | undefined,
-  initialAction: string | undefined,
-): View {
-  if (initialDocumentId === 'new') return { kind: 'creating' }
-  if (initialDocumentId && initialAction === 'edit') {
-    return { documentId: initialDocumentId, kind: 'editing' }
-  }
-  if (initialDocumentId)
-    return { documentId: initialDocumentId, kind: 'reading' }
-  return { kind: 'list' }
 }

--- a/src/components/documents/comments/useCommentLastVisit.ts
+++ b/src/components/documents/comments/useCommentLastVisit.ts
@@ -15,17 +15,17 @@ const STORAGE_PREFIX = 'imbi:comment-last-visit:'
  */
 export function useCommentLastVisit(
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
 ): number | undefined {
   const [lastVisit, setLastVisit] = useState<number | undefined>(undefined)
 
   useEffect(() => {
-    if (!orgSlug || !projectId || !documentId) {
+    if (!orgSlug || !documentId) {
       setLastVisit(undefined)
       return
     }
-    const key = `${STORAGE_PREFIX}${orgSlug}:${projectId}:${documentId}`
+    const key = `${STORAGE_PREFIX}${orgSlug}:${projectId ?? 'org'}:${documentId}`
     let previous: number | undefined
     try {
       const raw = window.localStorage.getItem(key)

--- a/src/components/documents/documentsHelpers.ts
+++ b/src/components/documents/documentsHelpers.ts
@@ -112,6 +112,31 @@ function truncate(s: string, max: number): string {
 export const EMPTY_ACTIVE: ReadonlySet<string> = new Set()
 
 /**
+ * Display name + subhead for the vertex a document is attached to —
+ * the "Project" column of the org-wide index. Projects show their
+ * comma-delimited type names; project types and users are labelled
+ * by kind.
+ */
+// fallow-ignore-next-line complexity
+export function attachmentDisplay(document: Document): {
+  name: string
+  sub: string
+} {
+  const attached = document.attached_to
+  if (!attached) return { name: '—', sub: '' }
+  if (attached.kind === 'project') {
+    return {
+      name: attached.name,
+      sub: (attached.project_types ?? []).join(', '),
+    }
+  }
+  if (attached.kind === 'project_type') {
+    return { name: attached.name, sub: 'Project type' }
+  }
+  return { name: attached.name || attached.id, sub: 'Personal' }
+}
+
+/**
  * Templates with no project-type restriction apply everywhere; otherwise a
  * template is only offered when it targets one of this project's types.
  */

--- a/src/components/documents/useDocumentsController.ts
+++ b/src/components/documents/useDocumentsController.ts
@@ -1,0 +1,332 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { useNavigate } from 'react-router-dom'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { useAuth } from '@/hooks/useAuth'
+import { useDocumentComments } from '@/hooks/useDocumentComments'
+import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import type { Document, DocumentTemplate, PatchOperation } from '@/types'
+
+export interface DocumentDraft {
+  content: string
+  tags: string[]
+  title: string
+}
+
+/**
+ * Where a set of documents lives — every API call and route the
+ * documents UI needs, abstracted over the attachment target (project,
+ * user, the whole org) so the exact same pinboard/reader/editor flow
+ * renders in each context.
+ */
+export interface DocumentsScope {
+  /** Route prefix the list/read/edit/new views live under. */
+  basePath: string
+  /** Project id for project-scoped comment routes; null = generic. */
+  commentsProjectId: null | string
+  create: (draft: DocumentDraft) => Promise<Document>
+  /** Heading for the empty state. */
+  emptyHeading?: string
+  list: (signal?: AbortSignal) => Promise<Document[]>
+  patch: (documentId: string, operations: PatchOperation[]) => Promise<Document>
+  projectTypeSlugs?: string[]
+  queryKey: readonly unknown[]
+  remove: (documentId: string) => Promise<void>
+  /** Hide the redundant Author column (e.g. a user's own documents). */
+  showAuthor?: boolean
+  templateContext: 'org' | 'project' | 'project_type' | 'user'
+}
+
+type DocumentsView =
+  | { documentId: string; kind: 'editing' }
+  | { documentId: string; kind: 'reading' }
+  | { kind: 'creating'; template?: DocumentTemplate | null }
+  | { kind: 'list' }
+
+/**
+ * Owns the document list query, the view state machine (list / read /
+ * edit / create, mirrored into the URL under `scope.basePath`), and
+ * the create/update/pin/delete mutations for one {@link DocumentsScope}.
+ * Shared by the project tab, the user profile tab, and the org-wide
+ * Documents page.
+ */
+// fallow-ignore-next-line complexity
+export function useDocumentsController(
+  orgSlug: string,
+  scope: DocumentsScope,
+  initialDocumentId?: string,
+  initialAction?: string,
+) {
+  const navigate = useNavigate()
+  const [view, setView] = useState<DocumentsView>(() =>
+    viewFromUrl(initialDocumentId, initialAction),
+  )
+  const qc = useQueryClient()
+
+  const navigateToView = useCallback(
+    (next: DocumentsView) => {
+      setView(next)
+      const base = scope.basePath
+      if (next.kind === 'reading') {
+        navigate(`${base}/${encodeURIComponent(next.documentId)}`, {
+          replace: true,
+        })
+      } else if (next.kind === 'editing') {
+        navigate(`${base}/${encodeURIComponent(next.documentId)}/edit`, {
+          replace: true,
+        })
+      } else if (next.kind === 'creating') {
+        navigate(`${base}/new`, { replace: true })
+      } else {
+        navigate(base, { replace: true })
+      }
+    },
+    [navigate, scope.basePath],
+  )
+
+  // Reflect URL changes (e.g. browser back/forward) into local view state.
+  useEffect(() => {
+    const next = viewFromUrl(initialDocumentId, initialAction)
+    // fallow-ignore-next-line complexity
+    setView((prev) => {
+      if (
+        prev.kind === next.kind &&
+        ('documentId' in prev ? prev.documentId : null) ===
+          ('documentId' in next ? next.documentId : null)
+      ) {
+        return prev
+      }
+      return next
+    })
+  }, [initialDocumentId, initialAction])
+
+  const documentsKey = scope.queryKey
+
+  const {
+    data: documents = [],
+    error,
+    isLoading,
+  } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => scope.list(signal),
+    queryKey: documentsKey,
+  })
+
+  const { displayNames, isError: usersError } = useUserDisplayNames()
+  const { user } = useAuth()
+  const currentUserEmail = user?.email ?? ''
+
+  useEffect(() => {
+    if (usersError) {
+      console.warn('Failed to load admin users for document display names')
+    }
+  }, [usersError])
+
+  const pinMutation = useMutation<
+    Document,
+    unknown,
+    { documentId: string; pinned: boolean },
+    { previous?: Document[] }
+  >({
+    mutationFn: ({
+      documentId,
+      pinned,
+    }: {
+      documentId: string
+      pinned: boolean
+    }) =>
+      scope.patch(documentId, [
+        { op: 'replace', path: '/is_pinned', value: pinned },
+      ]),
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) qc.setQueryData(documentsKey, ctx.previous)
+      toast.error(`Pin failed: ${extractApiErrorDetail(err)}`)
+    },
+    onMutate: async ({ documentId, pinned }) => {
+      await qc.cancelQueries({ queryKey: documentsKey })
+      const previous = qc.getQueryData<Document[]>(documentsKey)
+      if (previous) {
+        qc.setQueryData<Document[]>(
+          documentsKey,
+          previous.map((n) =>
+            n.id === documentId ? { ...n, is_pinned: pinned } : n,
+          ),
+        )
+      }
+      return { previous }
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: documentsKey })
+    },
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (draft: DocumentDraft) => scope.create(draft),
+    onError: (err) => {
+      toast.error(`Save failed: ${extractApiErrorDetail(err)}`)
+    },
+    onSuccess: (document) => {
+      qc.setQueryData<Document[]>(documentsKey, (prev) =>
+        prev ? [document, ...prev] : [document],
+      )
+      qc.invalidateQueries({ queryKey: documentsKey })
+      toast.success('Document saved')
+      navigateToView({ documentId: document.id, kind: 'reading' })
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({
+      documentId,
+      draft,
+    }: {
+      documentId: string
+      draft: DocumentDraft
+    }) =>
+      scope.patch(documentId, [
+        { op: 'replace', path: '/title', value: draft.title },
+        { op: 'replace', path: '/content', value: draft.content },
+        { op: 'replace', path: '/tags', value: draft.tags },
+      ]),
+    onError: (err) => {
+      toast.error(`Update failed: ${extractApiErrorDetail(err)}`)
+    },
+    onSuccess: (document) => {
+      qc.setQueryData<Document[]>(documentsKey, (prev) =>
+        prev
+          ? prev.map((n) => (n.id === document.id ? document : n))
+          : [document],
+      )
+      qc.invalidateQueries({ queryKey: documentsKey })
+      toast.success('Document updated')
+      navigateToView({ documentId: document.id, kind: 'reading' })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (documentId: string) => scope.remove(documentId),
+    onError: (err) => {
+      toast.error(`Delete failed: ${extractApiErrorDetail(err)}`)
+    },
+    onSuccess: (_data, documentId) => {
+      qc.setQueryData<Document[]>(documentsKey, (prev) =>
+        prev ? prev.filter((n) => n.id !== documentId) : [],
+      )
+      qc.invalidateQueries({ queryKey: documentsKey })
+      toast.success('Document deleted')
+      navigateToView({ kind: 'list' })
+    },
+  })
+
+  const togglePin = useCallback(
+    (document: Document) => {
+      pinMutation.mutate({
+        documentId: document.id,
+        pinned: !document.is_pinned,
+      })
+    },
+    [pinMutation],
+  )
+
+  const selectedDocument = useMemo(
+    () =>
+      view.kind === 'reading'
+        ? (documents.find((n) => n.id === view.documentId) ?? null)
+        : null,
+    [documents, view],
+  )
+
+  const comments = useDocumentComments(
+    orgSlug,
+    scope.commentsProjectId,
+    selectedDocument?.id ?? '',
+    currentUserEmail,
+  )
+
+  const editingDocument = useMemo(
+    () =>
+      view.kind === 'editing'
+        ? (documents.find((n) => n.id === view.documentId) ?? null)
+        : null,
+    [documents, view],
+  )
+
+  // If a deep-linked document id doesn't exist (deleted, wrong id), surface a
+  // toast and bounce back to the list view rather than silently rendering
+  // the empty list. Skip while the documents query is loading or errored —
+  // the error banner already covers fetch failures and an empty-on-error
+  // documents array shouldn't masquerade as a missing document.
+  // fallow-ignore-next-line complexity
+  useEffect(() => {
+    if (isLoading || error) return
+    if (view.kind !== 'reading' && view.kind !== 'editing') return
+    if (documents.some((n) => n.id === view.documentId)) return
+    toast.error('Document not found')
+    navigateToView({ kind: 'list' })
+  }, [error, isLoading, navigateToView, documents, view])
+
+  const handleCreate = useCallback(
+    (template?: DocumentTemplate) => {
+      navigateToView({ kind: 'creating', template: template ?? null })
+    },
+    [navigateToView],
+  )
+
+  const handleDiscard = useCallback(() => {
+    if (view.kind === 'editing') {
+      navigateToView({ documentId: view.documentId, kind: 'reading' })
+    } else {
+      navigateToView({ kind: 'list' })
+    }
+  }, [navigateToView, view])
+
+  const handleSave = useCallback(
+    (draft: DocumentDraft) => {
+      if (view.kind === 'editing') {
+        updateMutation.mutate({ documentId: view.documentId, draft })
+      } else {
+        createMutation.mutate(draft)
+      }
+    },
+    [createMutation, updateMutation, view],
+  )
+
+  return {
+    comments,
+    createPending: createMutation.isPending,
+    currentUserEmail,
+    deleteDocument: deleteMutation.mutate,
+    deletePending: deleteMutation.isPending,
+    displayNames,
+    documents,
+    editingDocument,
+    error,
+    handleCreate,
+    handleDiscard,
+    handleSave,
+    isLoading,
+    navigateToView,
+    selectedDocument,
+    togglePin,
+    updatePending: updateMutation.isPending,
+    view,
+  }
+}
+
+// fallow-ignore-next-line complexity
+function viewFromUrl(
+  initialDocumentId: string | undefined,
+  initialAction: string | undefined,
+): DocumentsView {
+  if (initialDocumentId === 'new') return { kind: 'creating' }
+  if (initialDocumentId && initialAction === 'edit') {
+    return { documentId: initialDocumentId, kind: 'editing' }
+  }
+  if (initialDocumentId)
+    return { documentId: initialDocumentId, kind: 'reading' }
+  return { kind: 'list' }
+}

--- a/src/components/documents/useTagFilter.ts
+++ b/src/components/documents/useTagFilter.ts
@@ -1,0 +1,55 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import type { Document, TagRef } from '@/types'
+
+import { tagCounts, uniqueTagsFromDocuments } from './documentsHelpers'
+
+/**
+ * Tag-rail filter state shared by the document index views: the
+ * active tag set, the rail's search text, and the documents that
+ * survive both, plus the tag list/counts the rail renders.
+ * `searchHaystack` controls which fields the search matches.
+ */
+export function useTagFilter(
+  documents: Document[],
+  searchHaystack: (document: Document) => string,
+): {
+  active: Set<string>
+  clear: () => void
+  counts: Record<string, number>
+  filtered: Document[]
+  search: string
+  setSearch: (value: string) => void
+  tags: TagRef[]
+  toggle: (slug: string) => void
+} {
+  const [active, setActive] = useState<Set<string>>(new Set())
+  const [search, setSearch] = useState('')
+
+  const tags = useMemo(() => uniqueTagsFromDocuments(documents), [documents])
+  const counts = useMemo(() => tagCounts(documents), [documents])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return documents.filter((n) => {
+      for (const slug of active) {
+        if (!n.tags.some((t) => t.slug === slug)) return false
+      }
+      if (!q) return true
+      return searchHaystack(n).toLowerCase().includes(q)
+    })
+  }, [documents, active, search, searchHaystack])
+
+  const toggle = useCallback((slug: string) => {
+    setActive((prev) => {
+      const next = new Set(prev)
+      if (next.has(slug)) next.delete(slug)
+      else next.add(slug)
+      return next
+    })
+  }, [])
+
+  const clear = useCallback(() => setActive(new Set()), [])
+
+  return { active, clear, counts, filtered, search, setSearch, tags, toggle }
+}

--- a/src/hooks/useDocumentComments.ts
+++ b/src/hooks/useDocumentComments.ts
@@ -60,7 +60,7 @@ interface ThreadVars {
  */
 export function useDocumentComments(
   orgSlug: string,
-  projectId: string,
+  projectId: null | string,
   documentId: string,
   currentUserEmail: string,
 ): Result {
@@ -71,7 +71,7 @@ export function useDocumentComments(
   )
 
   const { data: comments = [], isFetching: commentsBusy } = useQuery({
-    enabled: !!orgSlug && !!projectId && !!documentId,
+    enabled: !!orgSlug && !!documentId,
     queryFn: ({ signal }) =>
       listDocumentComments(orgSlug, projectId, documentId, signal),
     queryKey: commentsKey,

--- a/src/pages/DocumentsIndexPage.tsx
+++ b/src/pages/DocumentsIndexPage.tsx
@@ -1,0 +1,322 @@
+import { useMemo, useState } from 'react'
+
+import { useParams } from 'react-router-dom'
+
+import { useQuery } from '@tanstack/react-query'
+import { Rss, Search, Table } from 'lucide-react'
+
+import {
+  createProjectTypeDocument,
+  createUserDocument,
+  deleteOrgDocument,
+  listOrgDocuments,
+  listProjectTypes,
+  patchOrgDocument,
+} from '@/api/endpoints'
+import { CommandBar } from '@/components/CommandBar'
+import { DocumentsFeed } from '@/components/documents/DocumentsFeed'
+import {
+  attachmentDisplay,
+  documentTitle,
+} from '@/components/documents/documentsHelpers'
+import { DocumentsIndexTable } from '@/components/documents/DocumentsIndexTable'
+import {
+  type DocumentsListContext,
+  DocumentsTab,
+} from '@/components/documents/DocumentsTab'
+import { NewDocumentMenu } from '@/components/documents/NewDocumentMenu'
+import type { DocumentsScope } from '@/components/documents/useDocumentsController'
+import { Navigation } from '@/components/Navigation'
+import { Input } from '@/components/ui/input'
+import { LoadingState } from '@/components/ui/loading-state'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { useAuth } from '@/hooks/useAuth'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
+import type { Document, DocumentTemplate, ProjectType } from '@/types'
+
+/** Attachment choice for a document created from the org-wide page. */
+type AttachTarget = 'user' | `pt:${string}`
+
+/**
+ * Top-level Documents page: every document in the organization,
+ * whichever vertex it is attached to, as an activity feed and an
+ * index table with the attachment as the first column.
+ */
+// fallow-ignore-next-line complexity
+export function DocumentsIndexPage() {
+  usePageTitle('Documents')
+  const { subAction, subId } = useParams<{
+    subAction?: string
+    subId?: string
+  }>()
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug || ''
+  const orgName = selectedOrganization?.name || orgSlug
+
+  return (
+    <div className="bg-tertiary text-primary min-h-screen">
+      <Navigation currentView="documents" />
+      <main
+        className="px-6 pt-20 pb-12"
+        style={{ paddingBottom: 'var(--assistant-height, 64px)' }}
+      >
+        <div className="mx-auto max-w-7xl">
+          {!orgSlug && <LoadingState label="Loading organization…" />}
+          {orgSlug && (
+            <DocumentsIndexBody
+              initialAction={subAction}
+              initialDocumentId={subId}
+              orgName={orgName}
+              orgSlug={orgSlug}
+            />
+          )}
+        </div>
+      </main>
+      <CommandBar />
+    </div>
+  )
+}
+
+function AttachToPicker({
+  currentUserName,
+  onChange,
+  projectTypes,
+  value,
+}: {
+  currentUserName: string
+  onChange: (value: AttachTarget) => void
+  projectTypes: ProjectType[]
+  value: AttachTarget
+}) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <span className="text-secondary text-xs font-medium">Attach to</span>
+      <Select onValueChange={(v) => onChange(v as AttachTarget)} value={value}>
+        <SelectTrigger className="h-8 w-72">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="user">Personal — {currentUserName}</SelectItem>
+          {projectTypes.map((pt) => (
+            <SelectItem key={pt.slug} value={`pt:${pt.slug}`}>
+              Project type — {pt.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function DocumentsIndexBody({
+  initialAction,
+  initialDocumentId,
+  orgName,
+  orgSlug,
+}: {
+  initialAction?: string
+  initialDocumentId?: string
+  orgName: string
+  orgSlug: string
+}) {
+  const [tab, setTab] = useState<'feed' | 'index'>('feed')
+  const [search, setSearch] = useState('')
+  const [attachTo, setAttachTo] = useState<AttachTarget>('user')
+
+  const { data: projectTypes = [] } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => listProjectTypes(orgSlug, signal),
+    queryKey: ['projectTypes', orgSlug],
+  })
+
+  const { displayNames } = useUserDisplayNames()
+  const { user } = useAuth()
+  const currentUserEmail = user?.email ?? ''
+
+  const scope = useMemo<DocumentsScope>(
+    () => ({
+      basePath: '/documents',
+      commentsProjectId: null,
+      create: (draft) =>
+        attachTo === 'user'
+          ? createUserDocument(orgSlug, currentUserEmail, draft)
+          : createProjectTypeDocument(orgSlug, attachTo.slice(3), draft),
+      list: (signal) => listOrgDocuments(orgSlug, { limit: 500 }, signal),
+      patch: (documentId, operations) =>
+        patchOrgDocument(orgSlug, documentId, operations),
+      queryKey: ['orgDocuments', orgSlug] as const,
+      remove: (documentId) => deleteOrgDocument(orgSlug, documentId),
+      templateContext: 'org',
+    }),
+    [orgSlug, attachTo, currentUserEmail],
+  )
+
+  // Pre-select the attachment from the template's type where it is
+  // unambiguous; 'global' and blank documents default to personal.
+  const presetAttachment = (template?: DocumentTemplate) => {
+    if (template?.type === 'project_type' && template.project_type_slugs[0]) {
+      setAttachTo(`pt:${template.project_type_slugs[0]}`)
+    } else {
+      setAttachTo('user')
+    }
+  }
+
+  const renderList = (ctx: DocumentsListContext) => (
+    <DocumentsIndexList
+      ctx={ctx}
+      onCreate={(template) => {
+        presetAttachment(template)
+        ctx.onCreate(template)
+      }}
+      orgName={orgName}
+      orgSlug={orgSlug}
+      search={search}
+      setSearch={setSearch}
+      setTab={setTab}
+      tab={tab}
+    />
+  )
+
+  return (
+    <DocumentsTab
+      creatingPrelude={
+        <AttachToPicker
+          currentUserName={displayNames?.get(currentUserEmail) ?? 'you'}
+          onChange={setAttachTo}
+          projectTypes={projectTypes}
+          value={attachTo}
+        />
+      }
+      initialAction={initialAction}
+      initialDocumentId={initialDocumentId}
+      orgSlug={orgSlug}
+      renderList={renderList}
+      scope={scope}
+    />
+  )
+}
+
+function DocumentsIndexList({
+  ctx,
+  onCreate,
+  orgName,
+  orgSlug,
+  search,
+  setSearch,
+  setTab,
+  tab,
+}: {
+  ctx: DocumentsListContext
+  onCreate: (template?: DocumentTemplate) => void
+  orgName: string
+  orgSlug: string
+  search: string
+  setSearch: (value: string) => void
+  setTab: (value: 'feed' | 'index') => void
+  tab: 'feed' | 'index'
+}) {
+  const searched = useMemo(
+    () => filterDocuments(sortByUpdated(ctx.documents), search),
+    [ctx.documents, search],
+  )
+
+  return (
+    <>
+      {/* Header */}
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-primary m-0 text-2xl font-semibold tracking-[-0.02em]">
+            Documents
+          </h1>
+          <div className="text-tertiary mt-1 text-sm">
+            All documents across the {orgName} organization ·{' '}
+            {ctx.documents.length}{' '}
+            {ctx.documents.length === 1 ? 'document' : 'documents'}
+          </div>
+        </div>
+        <div className="flex items-center gap-2.5">
+          <div className="relative w-70">
+            <Search className="text-tertiary absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+            <Input
+              className="h-8 pl-8"
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search all documents…"
+              value={search}
+            />
+          </div>
+          <NewDocumentMenu
+            context="org"
+            onCreate={onCreate}
+            orgSlug={orgSlug}
+          />
+        </div>
+      </div>
+
+      {/* Feed | Index tabs */}
+      <Tabs onValueChange={(v) => setTab(v as 'feed' | 'index')} value={tab}>
+        <TabsList className="mb-5">
+          <TabsTrigger className="gap-1.5" value="feed">
+            <Rss className="size-3.5" />
+            Activity feed
+          </TabsTrigger>
+          <TabsTrigger className="gap-1.5" value="index">
+            <Table className="size-3.5" />
+            Index ({searched.length})
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {tab === 'feed' && (
+        <DocumentsFeed
+          displayNames={ctx.displayNames}
+          documents={searched}
+          onOpen={ctx.onOpen}
+        />
+      )}
+      {tab === 'index' && (
+        <DocumentsIndexTable
+          displayNames={ctx.displayNames}
+          documents={searched}
+          onOpen={ctx.onOpen}
+          onTogglePin={ctx.onTogglePin}
+        />
+      )}
+    </>
+  )
+}
+
+function filterDocuments(documents: Document[], search: string): Document[] {
+  const q = search.trim().toLowerCase()
+  if (!q) return documents
+  return documents.filter((n) => {
+    const attached = attachmentDisplay(n)
+    return [
+      documentTitle(n),
+      n.content,
+      attached.name,
+      attached.sub,
+      n.attached_to?.team ?? '',
+      n.created_by,
+      n.created_by_name ?? '',
+      n.tags.map((t) => t.name).join(' '),
+    ]
+      .join(' ')
+      .toLowerCase()
+      .includes(q)
+  })
+}
+
+function sortByUpdated(documents: Document[]): Document[] {
+  return [...documents].sort((a, b) =>
+    (b.updated_at ?? b.created_at).localeCompare(a.updated_at ?? a.created_at),
+  )
+}

--- a/src/pages/UserProfile/UserDocumentsTab.tsx
+++ b/src/pages/UserProfile/UserDocumentsTab.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+
+import {
+  createUserDocument,
+  deleteOrgDocument,
+  listUserDocuments,
+  patchOrgDocument,
+} from '@/api/endpoints'
+import {
+  type DocumentsScope,
+  DocumentsTab,
+} from '@/components/documents/DocumentsTab'
+
+interface Props {
+  email: string
+  initialAction?: string
+  initialDocumentId?: string
+  orgSlug: string
+}
+
+/**
+ * The profile Documents tab — the exact project documents experience,
+ * scoped to documents attached to this user. The Author column is
+ * omitted (every document here is the profiled user's) and new
+ * documents attach to the user, offering user + global templates.
+ */
+export function UserDocumentsTab({
+  email,
+  initialAction,
+  initialDocumentId,
+  orgSlug,
+}: Props) {
+  const scope = useMemo<DocumentsScope>(
+    () => ({
+      basePath: `/users/${encodeURIComponent(email)}/documents`,
+      commentsProjectId: null,
+      create: (draft) => createUserDocument(orgSlug, email, draft),
+      emptyHeading: 'No documents yet for this user',
+      list: (signal) => listUserDocuments(orgSlug, email, signal),
+      patch: (documentId, operations) =>
+        patchOrgDocument(orgSlug, documentId, operations),
+      queryKey: ['userDocuments', orgSlug, email] as const,
+      remove: (documentId) => deleteOrgDocument(orgSlug, documentId),
+      showAuthor: false,
+      templateContext: 'user',
+    }),
+    [orgSlug, email],
+  )
+
+  return (
+    <DocumentsTab
+      initialAction={initialAction}
+      initialDocumentId={initialDocumentId}
+      orgSlug={orgSlug}
+      scope={scope}
+    />
+  )
+}

--- a/src/pages/UserProfile/UserProfilePage.tsx
+++ b/src/pages/UserProfile/UserProfilePage.tsx
@@ -1,12 +1,14 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
 
-import { getAdminUser } from '@/api/endpoints'
+import { getAdminUser, listUserDocuments } from '@/api/endpoints'
 import { CommandBar } from '@/components/CommandBar'
 import { Navigation } from '@/components/Navigation'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useOrganization } from '@/contexts/OrganizationContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 
 import { fetchContributions, fetchIdentities, fetchStats } from './api'
@@ -15,16 +17,33 @@ import { OrganizationMemberships } from './OrganizationMemberships'
 import { ProfileHeader } from './ProfileHeader'
 import { RecentActivity } from './RecentActivity'
 import { StatisticsCard } from './StatisticsCard'
+import { UserDocumentsTab } from './UserDocumentsTab'
 
+// fallow-ignore-next-line complexity
 export function UserProfilePage() {
-  const { email: rawEmail } = useParams<{ email: string }>()
+  const navigate = useNavigate()
+  const {
+    email: rawEmail,
+    subAction,
+    subId,
+    tab,
+  } = useParams<{
+    email: string
+    subAction?: string
+    subId?: string
+    tab?: string
+  }>()
   const email = useMemo(
     () => (rawEmail ? decodeURIComponent(rawEmail) : ''),
     [rawEmail],
   )
   usePageTitle(email ? `Profile · ${email}` : 'User profile')
 
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug || ''
+
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const activeTab = tab === 'documents' ? 'documents' : 'activity'
 
   const userQuery = useQuery({
     enabled: !!email,
@@ -50,6 +69,25 @@ export function UserProfilePage() {
     queryKey: ['user-identities', email],
   })
 
+  // Shares the UserDocumentsTab query key so the tab-count chip and the
+  // tab content come from the same cache entry.
+  const documentsQuery = useQuery({
+    enabled: !!email && !!orgSlug,
+    queryFn: ({ signal }) => listUserDocuments(orgSlug, email, signal),
+    queryKey: ['userDocuments', orgSlug, email],
+  })
+  const documentCount = documentsQuery.data?.length ?? 0
+
+  const handleTabChange = useCallback(
+    (next: string) => {
+      const base = `/users/${encodeURIComponent(email)}`
+      navigate(next === 'documents' ? `${base}/documents` : base, {
+        replace: true,
+      })
+    },
+    [navigate, email],
+  )
+
   return (
     <div className="bg-tertiary text-primary min-h-screen">
       <Navigation currentView="users" />
@@ -69,19 +107,47 @@ export function UserProfilePage() {
                 identities={identitiesQuery.data}
                 user={userQuery.data}
               />
-              <ContributionHeatmap
-                data={contributionsQuery.data}
-                isLoading={contributionsQuery.isLoading}
-              />
-              <StatisticsCard data={statsQuery.data} />
-              <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-                <div className="lg:col-span-1">
-                  <OrganizationMemberships user={userQuery.data} />
-                </div>
-                <div className="lg:col-span-2">
-                  <RecentActivity email={email} />
-                </div>
-              </div>
+              <Tabs onValueChange={handleTabChange} value={activeTab}>
+                <TabsList className="mb-4">
+                  <TabsTrigger value="activity">Activity</TabsTrigger>
+                  <TabsTrigger value="documents">
+                    {documentCount > 0
+                      ? `Documents (${documentCount})`
+                      : 'Documents'}
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent className="space-y-4" value="activity">
+                  <ContributionHeatmap
+                    data={contributionsQuery.data}
+                    isLoading={contributionsQuery.isLoading}
+                  />
+                  <StatisticsCard data={statsQuery.data} />
+                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+                    <div className="lg:col-span-1">
+                      <OrganizationMemberships user={userQuery.data} />
+                    </div>
+                    <div className="lg:col-span-2">
+                      <RecentActivity email={email} />
+                    </div>
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="documents">
+                  {orgSlug && (
+                    <UserDocumentsTab
+                      email={email}
+                      initialAction={
+                        activeTab === 'documents' ? subAction : undefined
+                      }
+                      initialDocumentId={
+                        activeTab === 'documents' ? subId : undefined
+                      }
+                      orgSlug={orgSlug}
+                    />
+                  )}
+                </TabsContent>
+              </Tabs>
             </>
           )}
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -649,16 +649,30 @@ export interface DeploymentTriggerResponse {
 }
 
 export interface Document {
+  attached_to?: DocumentAttachment | null
+  comment_count?: number
   content: string
   created_at: string
   created_by: string
+  created_by_name?: null | string
   id: string
   is_pinned: boolean
-  project_id: string
+  project_id: null | string
   tags: TagRef[]
   title: string
   updated_at?: null | string
   updated_by?: null | string
+}
+
+// The vertex a document is attached to. `id` is the project id, the
+// project-type slug, or the user email depending on `kind`; `team` and
+// `project_types` are only populated for projects.
+export interface DocumentAttachment {
+  id: string
+  kind: 'project' | 'project_type' | 'user'
+  name: string
+  project_types?: string[]
+  team?: null | string
 }
 
 export interface DocumentCreate {
@@ -669,9 +683,6 @@ export interface DocumentCreate {
 
 export type DocumentListResponse = CollectionResponse<Document>
 
-// Document Templates. Inlined for the same reason as Document/Tag — the
-// committed openapi.json snapshot predates these endpoints. Switch to
-// `Schemas['DocumentTemplateResponse']` etc. once the snapshot is refreshed.
 export interface DocumentTemplate {
   content: string
   created_at: string
@@ -685,6 +696,7 @@ export interface DocumentTemplate {
   sort_order: number
   tags: TagRef[]
   title?: null | string
+  type?: DocumentTemplateType
   updated_at?: null | string
 }
 
@@ -698,7 +710,20 @@ export interface DocumentTemplateCreate {
   sort_order?: number
   tags?: string[]
   title?: null | string
+  type?: DocumentTemplateType
 }
+
+// Document Templates. Inlined for the same reason as Document/Tag — the
+// committed openapi.json snapshot predates these endpoints. Switch to
+// `Schemas['DocumentTemplateResponse']` etc. once the snapshot is refreshed.
+// Which attachment contexts may use a template: 'project', 'user', and
+// 'project_type' restrict the template to documents attached to that
+// vertex kind; 'global' applies everywhere.
+export type DocumentTemplateType =
+  | 'global'
+  | 'project'
+  | 'project_type'
+  | 'user'
 
 export interface DraftReleaseNotesRequest {
   base_sha: string


### PR DESCRIPTION
## Summary

Implements the Claude Design "Imbi – Document Index" handoff (`Documents Index.html` + `User Profile.html`).

- **New top-level Documents nav item and `/documents` page:** every document in the organization, with Activity feed and Index views. The feed renders Confluence-style cards (byline, title, "Owned by author · team · attachment", preview, comment count, tags); the index table puts the **attachment first** (project name with comma-delimited type names, project type, or user) ahead of Document / Tags / Author / Updated, with the tag-filter rail and a global search. Reading/editing/creating reuse the exact document reader and editor components via the new attachment-agnostic endpoints; creating from this page picks the attachment (personal or a project type) in the editor.
- **User profile gains Activity | Documents tabs** at the header rule. The Documents tab is the project documents experience scoped to the profiled user, minus the Project and Author columns; new documents attach to the user and offer user + global templates.
- **Refactor:** the list query, view state machine, and document mutations now live in a shared `useDocumentsController` hook; `DocumentsTab` is scope-parameterized (project tab, profile tab, and the org page all drive it, the org page via `renderList`/`creatingPrelude`). Tag filtering and the shared row cells were likewise extracted.
- Document type carries `attached_to`/`comment_count`/`created_by_name`; `DocumentTemplate` carries `type`; comment endpoints accept a null `projectId` to use the attachment-agnostic comment routes.

**Not implemented from the prototype (deliberately):** the tweaks panel / stacked arrangement (a design-tool affordance) and the reaction button (no backing API).

## Part of a 3-PR stack — merge last

1. imbi-common `feature/document-attachment-types`
2. imbi-api `feature/document-attachments` — provides the endpoints this PR calls
3. **imbi-ui** (this PR)

## Testing

Build, oxlint (0 errors), 435 tests, and the fallow audit gate all pass. Not yet exercised against a running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
