### PR TITLE
Fix UserIdentity rendering on project detail

### DIFF
--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -280,7 +280,7 @@ function EntryRow({
   const email = actor.includes('@') ? actor : undefined
   return (
     <div
-      className={`relative flex gap-3 py-3 ${href ? 'hover:bg-secondary/40 -mx-2 rounded-md px-2' : ''}`}
+      className={`relative flex items-start gap-3 py-3 ${href ? 'hover:bg-secondary/40 -mx-2 rounded-md px-2' : ''}`}
     >
       <div className="relative flex w-4 shrink-0 flex-col items-center">
         <div

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -191,6 +191,7 @@ export function ProjectDetail({
       committish: string
       notes: null | string
       performedBy: null | string
+      performedByEmail: null | string
       runUrl: null | string
       status: string
       tag: null | string
@@ -205,6 +206,7 @@ export function ProjectDetail({
         committish: string
         notes: null | string
         performedBy: null | string
+        performedByEmail: null | string
         runUrl: null | string
         status: string
         tag: null | string
@@ -222,6 +224,7 @@ export function ProjectDetail({
         committish: row.release.committish,
         notes: row.release.description ?? null,
         performedBy: row.performed_by ?? null,
+        performedByEmail: row.performed_by_email ?? null,
         runUrl: row.external_run_url,
         status: row.current_status ?? '',
         tag: row.release.tag ?? null,

--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -31,6 +31,9 @@ interface DeploymentInfo {
   committish: string
   // Deployer of the latest deploy event (remote actor); null for in-product.
   performedBy: null | string
+  // Email of the deployer when resolved to an Imbi user — drives Gravatar +
+  // profile link; null for unresolved remote logins.
+  performedByEmail: null | string
   status: string
   tag: null | string
   updated: string
@@ -213,7 +216,10 @@ export function ProjectEnvironmentsCard({
                         <UserIdentity
                           actor={deployment.performedBy}
                           displayNames={displayNames}
-                          email={loginToEmail.get(deployment.performedBy)}
+                          email={
+                            deployment.performedByEmail ??
+                            loginToEmail.get(deployment.performedBy)
+                          }
                           size="small"
                         />
                       </div>


### PR DESCRIPTION
## Summary

Two fixes to how the canonical `UserIdentity` widget renders on the project detail page.

## Problem

- **Recent activity avatar floats mid-row.** In the project-detail "Recent activity" log (`ProjectActivityLog`), the floating avatar appeared vertically centered across the two-line entry (name + body) instead of aligning to the top.
- **Environments card shows initials, not a Gravatar.** The "Deployed by" identity on the Environments card fell back to initials for deployers whose login didn't equal their email local-part (e.g. Andrew Rabert), instead of rendering the Gravatar + profile link.

## Solution

- **Top-align the activity-log avatar:** add `items-start` to the `EntryRow` flex container so the `UserIdentity` span no longer stretches to the full row height (its inner `items-center` was centering the 24px avatar). The avatar now aligns with the name line.
- **Resolve the deployer email properly:** the API already returns `performed_by_email` on each current-release row (built for Gravatar + profile resolution), but `ProjectDetail`'s `deploymentStatus` was dropping it. Thread it through and prefer it for the `UserIdentity` email, falling back to the existing `loginToEmail` local-part lookup.

## Notes

CSS-only change for the alignment fix. The Gravatar fix only renders a photo when the backend has populated `performed_by_email`; historical deploys without a resolved actor email will still show initials until re-resynced (no backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)