### PR TITLE
Make user-triggered deployment resync a deep backfill

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -2145,9 +2145,13 @@ export interface DeploymentResyncSummary {
 export const resyncProjectDeployments = (
   orgSlug: string,
   projectId: string,
-  source?: string,
+  opts: { limit?: number; source?: string } = {},
 ): Promise<DeploymentResyncSummary> => {
-  const search = source ? `?source=${encodeURIComponent(source)}` : ''
+  const params = new URLSearchParams()
+  if (opts.source) params.set('source', opts.source)
+  if (opts.limit != null) params.set('limit', String(opts.limit))
+  const query = params.toString()
+  const search = query ? `?${query}` : ''
   return apiClient.post<DeploymentResyncSummary>(
     `${deploymentsBase(orgSlug, projectId)}/resync${search}`,
   )

--- a/src/components/deployments/useDeploymentSync.ts
+++ b/src/components/deployments/useDeploymentSync.ts
@@ -8,6 +8,7 @@ import { toast } from 'sonner'
 import { resyncProjectDeployments } from '@/api/endpoints'
 import { useCommitSync } from '@/hooks/useCommitSync'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { DEEP_RESYNC_LIMIT } from '@/lib/resync'
 
 const DATA_KEYS = ['recentCommits', 'releaseHistory', 'currentReleases']
 
@@ -23,7 +24,10 @@ export function useDeploymentSync(orgSlug: string, projectId: string) {
 
   const commitSync = useCommitSync(orgSlug, projectId, true, invalidate)
   const resyncMutation = useMutation({
-    mutationFn: () => resyncProjectDeployments(orgSlug, projectId),
+    mutationFn: () =>
+      resyncProjectDeployments(orgSlug, projectId, {
+        limit: DEEP_RESYNC_LIMIT,
+      }),
     onError: (err) =>
       toast.error(extractApiErrorDetail(err) ?? 'Failed to resync releases'),
     onSuccess: (summary) => {

--- a/src/hooks/__tests__/useDeploymentResync.test.tsx
+++ b/src/hooks/__tests__/useDeploymentResync.test.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from 'react'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import type { DeploymentResyncSummary } from '@/api/endpoints'
+import { DEEP_RESYNC_LIMIT } from '@/lib/resync'
+
+import { useProjectDeploymentResync } from '../useDeploymentResync'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return { ...actual, resyncProjectDeployments: vi.fn() }
+})
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}))
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { gcTime: 0, retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+function summary(): DeploymentResyncSummary {
+  return {
+    errors: [],
+    events_recorded: 0,
+    events_skipped: 0,
+    observed: 0,
+    projects: 1,
+    releases_created: 0,
+    releases_updated: 0,
+  }
+}
+
+describe('useProjectDeploymentResync', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('requests a deep backfill so historical attribution is re-resolved', async () => {
+    vi.mocked(endpoints.resyncProjectDeployments).mockResolvedValue(summary())
+    const { result } = renderHook(
+      () => useProjectDeploymentResync('acme', 'p1'),
+      { wrapper: makeWrapper() },
+    )
+    await act(async () => {
+      result.current.mutate()
+    })
+    await waitFor(() =>
+      expect(endpoints.resyncProjectDeployments).toHaveBeenCalledWith(
+        'acme',
+        'p1',
+        { limit: DEEP_RESYNC_LIMIT },
+      ),
+    )
+  })
+})

--- a/src/hooks/useDeploymentResync.ts
+++ b/src/hooks/useDeploymentResync.ts
@@ -7,14 +7,20 @@ import {
   resyncServiceDeployments,
 } from '@/api/endpoints'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { DEEP_RESYNC_LIMIT } from '@/lib/resync'
 
 // Project-level resync. Invalidates the project + currentReleases +
 // operationsLog query keys so badges and deploy widgets refresh once
-// the backfill completes.
+// the backfill completes. Runs a deep backfill (``DEEP_RESYNC_LIMIT``
+// deployments per env) so a user-triggered resync also re-resolves
+// historical deploy attribution, not just the latest event.
 export function useProjectDeploymentResync(orgSlug: string, projectId: string) {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: () => resyncProjectDeployments(orgSlug, projectId),
+    mutationFn: () =>
+      resyncProjectDeployments(orgSlug, projectId, {
+        limit: DEEP_RESYNC_LIMIT,
+      }),
     onError: onResyncError,
     onSuccess: (summary: DeploymentResyncSummary) => {
       toastResult(summary)

--- a/src/lib/resync.ts
+++ b/src/lib/resync.ts
@@ -1,0 +1,6 @@
+// Deployments per environment requested by a user-triggered project
+// resync. The API caps this at 100 (the GitHub per-page ceiling); a deep
+// resync both backfills missing historical DeploymentEvent rows and
+// re-resolves performed_by on already-stored events (dedup'd by
+// external_run_id), which is how stale deploy attribution gets corrected.
+export const DEEP_RESYNC_LIMIT = 100


### PR DESCRIPTION
## Summary

Make the user-facing project resync request a deep backfill instead of the default latest-only catch-up, so it actually corrects stale deploy attribution.

Depends on imbi-api #447 (adds the `limit` query param to the resync endpoint). Harmless before that merges — the param is simply ignored by an older API.

## Problem

The resync action posted to `/resync` with no `limit`, so the API defaulted to `limit=1` — only the **latest** deployment per environment was re-fetched. Historical deploy attribution therefore stayed stale: a deploy synced before a user linked their identity keeps its raw login (e.g. `edl`) as `performed_by` forever, while a later deploy for the same person resolves to their Imbi user.

## Solution

- `resyncProjectDeployments` now takes an `opts` object (`{ limit, source }`) and builds the query via `URLSearchParams`.
- Both **user-triggered** project resync paths pass `limit=DEEP_RESYNC_LIMIT` (100, the API ceiling):
  - Doctor tab "Sync Deployments" button (`useProjectDeploymentResync`)
  - Deployments tab sync (`useDeploymentSync`)
- The TPS-wide resync is left at default depth — it fans out across every project, so a deep backfill there would be heavy.

A deep resync backfills missing historical `DeploymentEvent` rows and re-resolves `performed_by` on already-stored events (dedup'd by `external_run_id`).

## Tests

- `useDeploymentResync.test.tsx` — asserts the project resync calls the endpoint with `{ limit: DEEP_RESYNC_LIMIT }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)