### PR TITLE
Resolve deploy actor to a consistent identity in projects list

### DIFF
--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -27,6 +27,7 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useAuth } from '@/hooks/useAuth'
 import { useDebouncedValue } from '@/hooks/useDebouncedValue'
+import { useLoginToEmail } from '@/hooks/useLoginToEmail'
 import { useSearchShortcut } from '@/hooks/useSearchShortcut'
 import { deriveChipColors } from '@/lib/chip-colors'
 import { formatRelativeDate } from '@/lib/formatDate'
@@ -726,6 +727,22 @@ export function ProjectsView() {
   )
 }
 
+// Resolve a release's ``performed_by`` to an email when possible so the
+// attribution chip renders a consistent display name + Gravatar:
+// ``performed_by`` may be a raw remote login, an email, or an already
+// resolved display name. Emails pass through; a bare login is mapped to
+// the matching Imbi user's email via the local-part lookup; anything
+// unmatched returns ``undefined`` so the caller falls back to the actor
+// string verbatim.
+export function resolveActorEmail(
+  actor: null | string | undefined,
+  loginToEmail: Map<string, string>,
+): string | undefined {
+  if (!actor) return undefined
+  if (actor.includes('@')) return actor
+  return loginToEmail.get(actor)
+}
+
 function abbreviateEnvName(name: string): string {
   const parts = name.trim().split(/\s+/).filter(Boolean)
   if (parts.length === 0) return ''
@@ -1173,14 +1190,19 @@ function ReleaseStamp({
 }: {
   release?: null | { deployed_at: string; performed_by?: null | string }
 }) {
+  const { displayNames, loginToEmail } = useLoginToEmail()
+  const actor = release?.performed_by ?? null
+  const actorEmail = resolveActorEmail(actor, loginToEmail)
   return (
     <p className="text-tertiary mt-1 flex items-center justify-between text-xs">
       {release ? (
         <>
           <span className="min-w-0">
-            {release.performed_by ? (
+            {actor ? (
               <UserIdentity
-                actor={release.performed_by}
+                actor={actor}
+                displayNames={displayNames}
+                email={actorEmail}
                 linkToProfile={false}
                 size="small"
               />

--- a/src/components/__tests__/resolveActorEmail.test.ts
+++ b/src/components/__tests__/resolveActorEmail.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveActorEmail } from '../ProjectsView'
+
+describe('resolveActorEmail', () => {
+  const loginToEmail = new Map([['edl', 'edl@example.com']])
+
+  it('maps a bare login to the matching Imbi user email', () => {
+    expect(resolveActorEmail('edl', loginToEmail)).toBe('edl@example.com')
+  })
+
+  it('passes an email through unchanged', () => {
+    expect(resolveActorEmail('someone@example.com', loginToEmail)).toBe(
+      'someone@example.com',
+    )
+  })
+
+  it('returns undefined for an unmatched login', () => {
+    expect(resolveActorEmail('Ed Long', loginToEmail)).toBeUndefined()
+    expect(resolveActorEmail('ghost', loginToEmail)).toBeUndefined()
+  })
+
+  it('returns undefined for null/empty actors', () => {
+    expect(resolveActorEmail(null, loginToEmail)).toBeUndefined()
+    expect(resolveActorEmail(undefined, loginToEmail)).toBeUndefined()
+    expect(resolveActorEmail('', loginToEmail)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Make the projects-list deployment cards render the deploy actor consistently, regardless of how the sync stored attribution.

## Problem

The deployment cards passed only the raw `performed_by` string to `UserIdentity`. Because different sync paths store the actor differently, the same person rendered inconsistently — e.g. `"Ed Long"` (a resolved display name, initials `EL`) on one release vs `"edl"` (a raw GitHub login, initial `E`) on another.

## Solution

`ReleaseStamp` now resolves the actor through the shared user maps (`useLoginToEmail`) via a small `resolveActorEmail` helper:

- An **email** passes through.
- A **bare login** is mapped to the matching Imbi user's email (local-part lookup), so `UserIdentity` renders the canonical display name + Gravatar.
- Anything **unmatched** returns `undefined`, so it falls back to the actor string verbatim (unchanged behavior).

This unifies the displayed name across releases at render time and is **independent of any backend re-sync** (complements imbi-api #447 / imbi-ui #429, which fix the stored data).

## Notes

- The resolution helper was extracted (`resolveActorEmail`) to keep `ReleaseStamp` under the complexity gate and to unit-test it directly.
- Profile linking stays off (`linkToProfile={false}`) since the row/card is already clickable.
- A `performed_by` that is itself an unmatched display name (e.g. `"Ed Long"` with no login mapping) still shows that name with initials and no Gravatar — but it now matches the resolved login card's name.

## Tests

- `resolveActorEmail.test.ts` — login→email mapping, email pass-through, unmatched + null/empty cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)