### PR TITLE
Add blueprint compliance check to Project Doctor

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -984,7 +984,7 @@ export const applyProjectBlueprintDefaults = (
   orgSlug: string,
   projectId: string,
 ) =>
-  apiClient.post<{ properties_updated: number }>(
+  apiClient.post<{ properties_removed: number; properties_updated: number }>(
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/analysis/apply-blueprint-defaults`,
   )
 

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -980,6 +980,14 @@ export const runProjectAnalysis = (orgSlug: string, projectId: string) =>
     `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/analysis/run`,
   )
 
+export const applyProjectBlueprintDefaults = (
+  orgSlug: string,
+  projectId: string,
+) =>
+  apiClient.post<{ properties_updated: number }>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/analysis/apply-blueprint-defaults`,
+  )
+
 export interface CommitSyncEnqueueResponse {
   enqueued: boolean
 }

--- a/src/components/ProjectDoctorTab.tsx
+++ b/src/components/ProjectDoctorTab.tsx
@@ -119,15 +119,14 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
     onError: (err) =>
       toast.error(`Apply defaults failed: ${extractApiErrorDetail(err)}`),
     onSuccess: (res) => {
-      const n = res.properties_updated
+      const removed = res.properties_removed ?? 0
+      const total = res.properties_updated + removed
       toast.success(
-        n === 0
-          ? 'No defaults to apply — all properties are already set'
-          : `Applied ${n} blueprint default${n === 1 ? '' : 's'}`,
+        total > 0
+          ? `Blueprint sync: applied ${res.properties_updated}, removed ${removed}`
+          : 'All blueprint properties are already in sync',
       )
-      if (n > 0) {
-        void analyzeMutation.mutateAsync()
-      }
+      if (total > 0) void analyzeMutation.mutateAsync()
     },
   })
 
@@ -201,7 +200,7 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
               >
                 {applyDefaultsMutation.isPending
                   ? 'Applying...'
-                  : 'Apply Blueprint Defaults'}
+                  : 'Apply Blueprint Fixes'}
               </Button>
             )}
           </CardContent>

--- a/src/components/ProjectDoctorTab.tsx
+++ b/src/components/ProjectDoctorTab.tsx
@@ -9,6 +9,7 @@ import {
   type AnalysisReport,
   type AnalysisResult,
   type AnalysisResultStatus,
+  applyProjectBlueprintDefaults,
   getProjectAnalysis,
   rescoreProject,
   runProjectAnalysis,
@@ -113,8 +114,33 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
   // deployment plugin (eligibility) plus a connected commit-sync plugin.
   const commitSync = useCommitSync(orgSlug, project.id, canResyncDeployments)
 
+  const applyDefaultsMutation = useMutation({
+    mutationFn: () => applyProjectBlueprintDefaults(orgSlug, project.id),
+    onError: (err) =>
+      toast.error(`Apply defaults failed: ${extractApiErrorDetail(err)}`),
+    onSuccess: (res) => {
+      const n = res.properties_updated
+      toast.success(
+        n === 0
+          ? 'No defaults to apply — all properties are already set'
+          : `Applied ${n} blueprint default${n === 1 ? '' : 's'}`,
+      )
+      if (n > 0) {
+        void analyzeMutation.mutateAsync()
+      }
+    },
+  })
+
   const report = reportQuery.data
   const results = report?.results ?? []
+  const hasBlueprintIssues =
+    report !== null &&
+    report !== undefined &&
+    results.some(
+      (r) =>
+        r.plugin_slug === 'blueprint-compliance' &&
+        (r.status === 'fail' || r.status === 'warn'),
+    )
 
   return (
     <div className="space-y-6">
@@ -162,6 +188,20 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
                 variant="outline"
               >
                 {commitSync.isSyncing ? 'Syncing...' : 'Sync Commits & Tags'}
+              </Button>
+            )}
+            {canAnalyze && hasBlueprintIssues && (
+              <Button
+                disabled={
+                  applyDefaultsMutation.isPending || analyzeMutation.isPending
+                }
+                onClick={() => applyDefaultsMutation.mutate()}
+                size="sm"
+                variant="outline"
+              >
+                {applyDefaultsMutation.isPending
+                  ? 'Applying...'
+                  : 'Apply Blueprint Defaults'}
               </Button>
             )}
           </CardContent>

--- a/src/components/ProjectDoctorTab.tsx
+++ b/src/components/ProjectDoctorTab.tsx
@@ -126,7 +126,7 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
           ? `Blueprint sync: applied ${res.properties_updated}, removed ${removed}`
           : 'All blueprint properties are already in sync',
       )
-      if (total > 0) void analyzeMutation.mutateAsync()
+      void analyzeMutation.mutateAsync()
     },
   })
 


### PR DESCRIPTION
## Summary

- Adds `blueprint-compliance` findings to the Project Doctor panel: surfaces missing required properties, invalid enum values, out-of-range numerics, missing defaults, and stale properties no longer covered by any applicable blueprint
- Adds "Apply Blueprint Fixes" button (visible when the report has blueprint-compliance warn/fail findings): calls `POST /analysis/apply-blueprint-defaults`, which applies defaults and removes stale properties, then auto-re-runs analysis
- Toast reports `"Blueprint sync: applied N, removed M"` on success

## Test plan

- [ ] Open a project with blueprint-configured types in the Doctor tab
- [ ] Verify `blueprint-compliance` findings appear grouped with other results
- [ ] Click "Apply Blueprint Fixes" and confirm toast + analysis re-run
- [ ] Confirm button is hidden when all blueprint checks pass