### PR TITLE
Make each report a shareable, routable link

### DIFF
--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,4 +1,6 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useEffect } from 'react'
+
+import { Link, useNavigate, useParams } from 'react-router-dom'
 
 import {
   BarChart3,
@@ -70,9 +72,12 @@ export function ReportsPage() {
     reportId && VALID_IDS.has(reportId) ? reportId : DEFAULT_REPORT
   const active = REPORTS.find((r) => r.id === activeId) ?? REPORTS[0]
 
-  function selectReport(id: string) {
-    navigate(`/reports/${id}`, { replace: true })
-  }
+  // Canonicalize bare /reports (and unknown ids) to an explicit report URL
+  useEffect(() => {
+    if (reportId !== activeId) {
+      navigate(`/reports/${activeId}`, { replace: true })
+    }
+  }, [reportId, activeId, navigate])
 
   return (
     <div className="bg-tertiary text-primary min-h-screen">
@@ -95,14 +100,14 @@ export function ReportsPage() {
                 {REPORTS.map((r) => {
                   const isActive = r.id === activeId
                   return (
-                    <button
+                    <Link
                       className={`flex w-full items-start gap-3 rounded-lg px-4 py-3 text-left transition-colors ${
                         isActive
                           ? 'bg-warning text-warning'
                           : 'text-secondary hover:bg-secondary hover:text-primary'
                       }`}
                       key={r.id}
-                      onClick={() => selectReport(r.id)}
+                      to={`/reports/${r.id}`}
                     >
                       {r.id === 'team-kpi' ? (
                         <BarChart3 className="mt-0.5 size-3.5 shrink-0" />
@@ -121,7 +126,7 @@ export function ReportsPage() {
                           {r.description}
                         </div>
                       </div>
-                    </button>
+                    </Link>
                   )
                 })}
               </div>


### PR DESCRIPTION
## Summary

Each report in the Reports section now has a genuine, shareable URL. Previously the sidebar entries were `<button>`s that navigated with `replace: true`, so they weren't real links — you couldn't copy a link address, open one in a new tab, and Back didn't move between reports.

## Problem

- Report sidebar items used `onClick` + `navigate(..., { replace: true })`.
- No right-click → "Copy link address", no ⌘/middle-click to open in a new tab.
- `replace: true` clobbered history, so the browser Back button didn't move between reports.
- Bare `/reports` rendered the default report but left the URL non-canonical.

## Solution

- Convert each sidebar entry to a React Router `<Link to="/reports/<id>">`, matching the pattern in `Navigation.tsx` and `Admin.tsx`. Every report now has a copyable/shareable URL and supports open-in-new-tab; Back/Forward work normally.
- Canonicalize bare `/reports` (and unknown ids) to the explicit default `/reports/monthly-improvement` via a `replace` redirect, mirroring the Settings/Admin pattern. This leaves a clean seam for a dedicated report landing view next.

The route `/reports/:reportId?` and param reading already existed; this makes the entries first-class links and canonicalizes the default.

## Testing

- `tsc --noEmit` clean
- `oxlint` 0 errors
- `format:check` clean
- pre-commit fallow audit: no issues