### PR TITLE
Add Sync PRs button to Project Doctor tab

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1029,6 +1029,41 @@ export const getProjectCommitSyncStatus = (
     signal,
   )
 
+export interface PRSyncEnqueueResponse {
+  enqueued: boolean
+}
+
+export type PRSyncState = CommitSyncState
+
+export interface PRSyncStatus {
+  error: null | string
+  last_synced_at: null | string
+  prs_synced: null | number
+  requested_by: null | string
+  status: PRSyncState
+}
+
+// Enqueue a full pull-request history backfill (background job). 202 +
+// {enqueued} — false when debounced or queueing is unavailable.
+export const syncProjectPullRequests = (
+  orgSlug: string,
+  projectId: string,
+): Promise<PRSyncEnqueueResponse> =>
+  apiClient.post<PRSyncEnqueueResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/pull-requests/sync`,
+  )
+
+export const getProjectPRSyncStatus = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<PRSyncStatus> =>
+  apiClient.get<PRSyncStatus>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/pull-requests/sync-status`,
+    undefined,
+    signal,
+  )
+
 export interface ScoreTrend {
   current: null | number
   delta: null | number

--- a/src/components/ProjectDoctorTab.tsx
+++ b/src/components/ProjectDoctorTab.tsx
@@ -27,6 +27,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { useCommitSync } from '@/hooks/useCommitSync'
 import { useProjectDeploymentResync } from '@/hooks/useDeploymentResync'
 import { useProjectPatch } from '@/hooks/useProjectPatch'
+import { usePRSync } from '@/hooks/usePRSync'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { treatNotFoundAsNull } from '@/lib/queryHelpers'
 import type { Project } from '@/types'
@@ -114,6 +115,10 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
   // deployment plugin (eligibility) plus a connected commit-sync plugin.
   const commitSync = useCommitSync(orgSlug, project.id, canResyncDeployments)
 
+  // Same deployment:write gate: requires the GitHub deployment plugin
+  // plus a connected github-pr-sync plugin for the service credential.
+  const prSync = usePRSync(orgSlug, project.id, canResyncDeployments)
+
   const applyDefaultsMutation = useMutation({
     mutationFn: () => applyProjectBlueprintDefaults(orgSlug, project.id),
     onError: (err) =>
@@ -187,6 +192,16 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
                 variant="outline"
               >
                 {commitSync.isSyncing ? 'Syncing...' : 'Sync Commits & Tags'}
+              </Button>
+            )}
+            {canResyncDeployments && (
+              <Button
+                disabled={prSync.isSyncing}
+                onClick={() => prSync.sync()}
+                size="sm"
+                variant="outline"
+              >
+                {prSync.isSyncing ? 'Syncing...' : 'Sync PRs'}
               </Button>
             )}
             {canAnalyze && hasBlueprintIssues && (

--- a/src/hooks/usePRSync.ts
+++ b/src/hooks/usePRSync.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import type { PRSyncState, PRSyncStatus } from '@/api/endpoints'
+import {
+  getProjectPRSyncStatus,
+  syncProjectPullRequests,
+} from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+const POLL_MS = 3000
+
+// Drives the Project Doctor "Sync PRs" button: enqueues the background
+// job and polls the project's PR sync-status while a run is in flight,
+// toasting the terminal result so the user gets feedback even though the
+// work happens off-request.
+// fallow-ignore-next-line complexity
+export function usePRSync(
+  orgSlug: string,
+  projectId: string,
+  enabled: boolean,
+  /** Invoked when a run completes successfully (e.g. to refresh data). */
+  onComplete?: () => void,
+) {
+  const queryClient = useQueryClient()
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
+
+  const statusQuery = useQuery({
+    enabled: enabled && !!orgSlug && !!projectId,
+    queryFn: ({ signal }): Promise<PRSyncStatus> =>
+      getProjectPRSyncStatus(orgSlug, projectId, signal),
+    queryKey: ['prSyncStatus', orgSlug, projectId],
+    // Poll only while a run is queued/running; settle back to idle.
+    refetchInterval: (query) =>
+      isActive(query.state.data?.status) ? POLL_MS : false,
+  })
+
+  // Toast the terminal result when a poll observes the run leaving the
+  // active state. The ref guards against toasting stale state on mount.
+  const previous = useRef<PRSyncState | undefined>(undefined)
+  // fallow-ignore-next-line complexity
+  useEffect(() => {
+    const data = statusQuery.data
+    if (!data) return
+    if (!isActive(data.status) && data.status !== previous.current) {
+      announceTerminal(data)
+      if (data.status === 'success') onCompleteRef.current?.()
+    }
+    previous.current = data.status
+  }, [statusQuery.data])
+
+  const mutation = useMutation({
+    mutationFn: () => syncProjectPullRequests(orgSlug, projectId),
+    onError: (err) =>
+      toast.error(extractApiErrorDetail(err) ?? 'Failed to start PR sync'),
+    onSuccess: (res) => {
+      if (res.enqueued) {
+        toast.success('PR sync started')
+        void queryClient.invalidateQueries({
+          queryKey: ['prSyncStatus', orgSlug, projectId],
+        })
+      } else {
+        toast.info('A PR sync is already in progress')
+      }
+    },
+  })
+
+  const isSyncing = mutation.isPending || isActive(statusQuery.data?.status)
+  return { isSyncing, sync: mutation.mutate }
+}
+
+// Announce a run's terminal outcome once it leaves the active state.
+// fallow-ignore-next-line complexity
+function announceTerminal(data: PRSyncStatus): void {
+  if (data.status === 'success') {
+    toast.success(`Synced ${data.prs_synced ?? 0} pull request(s)`)
+  } else if (data.status === 'failed') {
+    toast.error(`PR sync failed: ${data.error ?? 'unknown error'}`)
+  }
+}
+
+function isActive(state: PRSyncState | undefined): boolean {
+  return state === 'queued' || state === 'running'
+}


### PR DESCRIPTION
## Summary

Adds a **Sync PRs** button to the Project Doctor tab's Utility Functions card, alongside the existing Analyze / Recompute Score / Sync Deployments / Sync Commits & Tags actions.

## Problem

The backend already exposes on-demand pull-request history backfill endpoints (`POST /…/pull-requests/sync` and `GET /…/pull-requests/sync-status`), but there was no UI to trigger them. Operators had no way to kick off a PR backfill for a project from the Doctor tab.

## Solution

Wires the existing endpoints into the UI, mirroring the established **Sync Commits & Tags** feature:

- **`api/endpoints.ts`** — adds `syncProjectPullRequests()` + `getProjectPRSyncStatus()` and the `PRSync*` types.
- **`hooks/usePRSync.ts`** (new) — enqueues the background job, polls `sync-status` while the run is `queued`/`running`, and toasts the terminal result (`Synced N pull request(s)` / failure detail).
- **`components/ProjectDoctorTab.tsx`** — adds the "Sync PRs" button, gated on the same `project:deployment:write` permission the backend enforces.

The new hook intentionally mirrors `useCommitSync`; `fallow` flags the structural similarity as a duplication **warning** only (non-blocking). Complexity findings on the new hook are suppressed with `fallow-ignore-next-line complexity`, consistent with `useDeploymentResync.ts` and the other sync hooks.

## Verification

- `tsc --noEmit` — clean
- `oxlint` — 0 errors / 0 warnings on changed files
- `fallow audit --base origin/main` — exit 0 (pre-commit gate passes)