### PR TITLE
Add PR Activity report to the Reports section

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -2863,3 +2863,29 @@ export const getOrgPullRequests = (
     params,
     signal,
   )
+
+export interface PRActivityResponse {
+  members: number
+  rows: PRActivityRow[]
+  since: string
+}
+
+export interface PRActivityRow {
+  avatar_url: null | string
+  created: number
+  display_name: null | string
+  email: null | string
+  login: string
+  merged: number
+}
+
+export const getPRActivity = (
+  orgSlug: string,
+  since: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<PRActivityResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/pull-requests/activity`,
+    { since },
+    signal,
+  )

--- a/src/components/reports/PRActivityReport.tsx
+++ b/src/components/reports/PRActivityReport.tsx
@@ -1,176 +1,47 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import { Download, RefreshCw } from 'lucide-react'
 
 import { getPRActivity } from '@/api/endpoints'
+import type { PRActivityResponse, PRActivityRow } from '@/api/endpoints'
 import { Sk } from '@/components/ui/skeleton'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { useOrganization } from '@/contexts/OrganizationContext'
 
 export function PRActivityReport() {
-  const { selectedOrganization } = useOrganization()
-  const orgSlug = selectedOrganization?.slug ?? ''
-
-  const [since, setSince] = useState(() => isoDaysAgo(30))
+  const orgSlug = useOrgSlug()
+  const [since, setSince] = useState(defaultSince)
   const [appliedSince, setAppliedSince] = useState(since)
-
-  const { data, error, isFetching, refetch } = useQuery({
-    enabled: !!orgSlug,
-    queryFn: ({ signal }) => getPRActivity(orgSlug, appliedSince, signal),
-    queryKey: ['prActivity', orgSlug, appliedSince],
-    staleTime: 60_000,
-  })
-
-  const rows = data?.rows ?? []
-  const maxCreated = useMemo(
-    () => rows.reduce((m, r) => Math.max(m, r.created), 0),
-    [rows],
+  const { data, error, isFetching, loading, refetch, rows } = usePRActivity(
+    orgSlug,
+    appliedSince,
   )
-  const maxMerged = useMemo(
-    () => rows.reduce((m, r) => Math.max(m, r.merged), 0),
-    [rows],
-  )
-  const totalCreated = rows.reduce((s, r) => s + r.created, 0)
-  const totalMerged = rows.reduce((s, r) => s + r.merged, 0)
-
-  function fetchActivity() {
-    if (since === appliedSince) {
-      void refetch()
-    } else {
-      setAppliedSince(since)
-    }
-  }
-
-  function downloadCsv() {
-    const header = ['Member', 'Login', 'Email', 'Created', 'Merged']
-    const lines = rows.map((r) =>
-      [r.display_name ?? r.login, r.login, r.email ?? '', r.created, r.merged]
-        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
-        .join(','),
-    )
-    const csv = [header.join(','), ...lines].join('\n')
-    const blob = new Blob([csv], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.download = `pr-activity-${appliedSince}.csv`
-    a.href = url
-    a.click()
-    URL.revokeObjectURL(url)
-  }
 
   return (
     <div className="flex flex-col gap-5">
-      {/* Toolbar */}
-      <div className="border-tertiary bg-primary flex flex-wrap items-end gap-4 rounded-lg border p-[18px]">
-        <label className="flex flex-col gap-1">
-          <span className="text-overline text-tertiary tracking-wide uppercase">
-            Since (inclusive)
-          </span>
-          <input
-            className="border-tertiary bg-tertiary text-primary h-8 rounded border px-2 font-mono text-xs"
-            onChange={(e) => setSince(e.target.value)}
-            type="date"
-            value={since}
-          />
-        </label>
-        <button
-          className="bg-warning text-warning inline-flex h-8 items-center gap-1.5 rounded px-3 text-xs font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
-          disabled={!orgSlug || isFetching}
-          onClick={fetchActivity}
-        >
-          <RefreshCw className={isFetching ? 'animate-spin' : ''} size={11} />
-          Fetch activity
-        </button>
-        <button
-          className="border-tertiary text-primary hover:bg-secondary inline-flex h-8 items-center gap-1.5 rounded border px-3 text-xs transition-colors disabled:opacity-50"
-          disabled={rows.length === 0}
-          onClick={downloadCsv}
-        >
-          <Download size={11} />
-          Download CSV
-        </button>
-        <span className="text-tertiary ml-auto self-center text-xs">
-          {isFetching
-            ? 'Fetching…'
-            : error
-              ? 'Failed to load activity.'
-              : data
-                ? `Done — ${data.members} member${data.members === 1 ? '' : 's'}.`
-                : null}
-        </span>
-      </div>
+      <Toolbar
+        appliedSince={appliedSince}
+        data={data}
+        error={error}
+        isFetching={isFetching}
+        onSinceChange={setSince}
+        orgSlug={orgSlug}
+        refetch={refetch}
+        rows={rows}
+        setAppliedSince={setAppliedSince}
+        since={since}
+      />
 
       {/* Table card */}
       <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
-        {isFetching && !data ? (
-          <ActivityRowsSkeleton />
-        ) : error ? (
-          <div className="text-danger py-10 text-center text-sm">
-            Failed to load PR activity.{' '}
-            <button className="underline" onClick={() => void refetch()}>
-              Retry
-            </button>
-          </div>
-        ) : rows.length === 0 ? (
-          <div className="text-tertiary py-10 text-center text-sm">
-            No pull request activity since {appliedSince}.
-          </div>
-        ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-tertiary border-b">
-                <th className="text-overline text-tertiary px-[18px] py-2.5 text-left font-normal tracking-wide uppercase">
-                  Member
-                </th>
-                <th className="text-overline text-tertiary w-48 px-4 py-2.5 text-right font-normal tracking-wide uppercase">
-                  Created
-                </th>
-                <th className="text-overline text-tertiary w-48 px-[18px] py-2.5 text-right font-normal tracking-wide uppercase">
-                  Merged ↓
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row, i) => (
-                <tr
-                  className={`border-tertiary hover:bg-secondary transition-colors ${
-                    i === rows.length - 1 ? 'border-0' : 'border-b'
-                  }`}
-                  key={row.login}
-                >
-                  <td className="px-[18px] py-2.5">
-                    <UserIdentity
-                      actor={row.login}
-                      displayName={row.display_name}
-                      email={row.email}
-                      size="small"
-                    />
-                  </td>
-                  <td className="px-4 py-2.5">
-                    <CountCell max={maxCreated} value={row.created} />
-                  </td>
-                  <td className="px-[18px] py-2.5">
-                    <CountCell max={maxMerged} value={row.merged} />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-            <tfoot>
-              <tr className="border-tertiary border-t">
-                <td className="text-secondary px-[18px] py-3 text-xs font-medium tracking-wide uppercase">
-                  Total ({rows.length})
-                </td>
-                <td className="text-primary px-4 py-3 text-right font-mono text-xs tabular-nums">
-                  {totalCreated}
-                </td>
-                <td className="text-primary px-[18px] py-3 text-right font-mono text-xs tabular-nums">
-                  {totalMerged}
-                </td>
-              </tr>
-            </tfoot>
-          </table>
-        )}
+        <ActivityTableCard
+          appliedSince={appliedSince}
+          error={error}
+          loading={loading}
+          refetch={refetch}
+          rows={rows}
+        />
       </div>
     </div>
   )
@@ -205,6 +76,116 @@ function ActivityRowsSkeleton() {
   )
 }
 
+function ActivityTable({ rows }: { rows: PRActivityRow[] }) {
+  const maxCreated = rows.reduce((m, r) => Math.max(m, r.created), 0)
+  const maxMerged = rows.reduce((m, r) => Math.max(m, r.merged), 0)
+  const totalCreated = rows.reduce((s, r) => s + r.created, 0)
+  const totalMerged = rows.reduce((s, r) => s + r.merged, 0)
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-tertiary border-b">
+          <th className="text-overline text-tertiary px-[18px] py-2.5 text-left font-normal tracking-wide uppercase">
+            Member
+          </th>
+          <th className="text-overline text-tertiary w-48 px-4 py-2.5 text-right font-normal tracking-wide uppercase">
+            Created
+          </th>
+          <th className="text-overline text-tertiary w-48 px-[18px] py-2.5 text-right font-normal tracking-wide uppercase">
+            Merged ↓
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr
+            className={`border-tertiary hover:bg-secondary transition-colors ${
+              i === rows.length - 1 ? 'border-0' : 'border-b'
+            }`}
+            key={row.login}
+          >
+            <td className="px-[18px] py-2.5">
+              <UserIdentity
+                actor={row.login}
+                displayName={row.display_name}
+                email={row.email}
+                size="small"
+              />
+            </td>
+            <td className="px-4 py-2.5">
+              <CountCell max={maxCreated} value={row.created} />
+            </td>
+            <td className="px-[18px] py-2.5">
+              <CountCell max={maxMerged} value={row.merged} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+      <tfoot>
+        <tr className="border-tertiary border-t">
+          <td className="text-secondary px-[18px] py-3 text-xs font-medium tracking-wide uppercase">
+            Total ({rows.length})
+          </td>
+          <td className="text-primary px-4 py-3 text-right font-mono text-xs tabular-nums">
+            {totalCreated}
+          </td>
+          <td className="text-primary px-[18px] py-3 text-right font-mono text-xs tabular-nums">
+            {totalMerged}
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  )
+}
+
+function ActivityTableCard({
+  appliedSince,
+  error,
+  loading,
+  refetch,
+  rows,
+}: {
+  appliedSince: string
+  error: unknown
+  loading: boolean
+  refetch: () => Promise<unknown>
+  rows: PRActivityRow[]
+}) {
+  if (loading) return <ActivityRowsSkeleton />
+  if (error) {
+    return (
+      <div className="text-danger py-10 text-center text-sm">
+        Failed to load PR activity.{' '}
+        <button className="underline" onClick={() => void refetch()}>
+          Retry
+        </button>
+      </div>
+    )
+  }
+  if (rows.length === 0) {
+    return (
+      <div className="text-tertiary py-10 text-center text-sm">
+        No pull request activity since {appliedSince}.
+      </div>
+    )
+  }
+  return <ActivityTable rows={rows} />
+}
+
+/** Apply the chosen `since`; refetch directly when it is unchanged. */
+function applySince(
+  since: string,
+  appliedSince: string,
+  setAppliedSince: (value: string) => void,
+  refetch: () => Promise<unknown>,
+) {
+  if (since === appliedSince) {
+    void refetch()
+  } else {
+    setAppliedSince(since)
+  }
+}
+
 /** Number with an amber bar sized to its share of the column max. */
 function CountCell({ max, value }: { max: number; value: number }) {
   const pct = max > 0 ? (value / max) * 100 : 0
@@ -234,9 +215,132 @@ function CountCell({ max, value }: { max: number; value: number }) {
   )
 }
 
+/** Default report window: 30 days back from today. */
+function defaultSince(): string {
+  return isoDaysAgo(30)
+}
+
+function downloadCsv(rows: PRActivityRow[], appliedSince: string) {
+  const header = ['Member', 'Login', 'Email', 'Created', 'Merged']
+  const lines = rows.map((r) =>
+    [r.display_name ?? r.login, r.login, r.email ?? '', r.created, r.merged]
+      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+      .join(','),
+  )
+  const csv = [header.join(','), ...lines].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.download = `pr-activity-${appliedSince}.csv`
+  a.href = url
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
 /** YYYY-MM-DD for a date `days` before today (local time). */
 function isoDaysAgo(days: number): string {
   const d = new Date()
   d.setDate(d.getDate() - days)
   return d.toISOString().slice(0, 10)
+}
+
+/** "1 member" / "2 members" */
+function pluralize(count: number, noun: string): string {
+  const suffix = count === 1 ? '' : 's'
+  return `${count} ${noun}${suffix}`
+}
+
+function StatusText({
+  data,
+  error,
+  isFetching,
+}: {
+  data?: PRActivityResponse
+  error: unknown
+  isFetching: boolean
+}) {
+  if (isFetching) return <>Fetching…</>
+  if (error) return <>Failed to load activity.</>
+  if (data) return <>{`Done — ${pluralize(data.members, 'member')}.`}</>
+  return null
+}
+
+function Toolbar({
+  appliedSince,
+  data,
+  error,
+  isFetching,
+  onSinceChange,
+  orgSlug,
+  refetch,
+  rows,
+  setAppliedSince,
+  since,
+}: {
+  appliedSince: string
+  data?: PRActivityResponse
+  error: unknown
+  isFetching: boolean
+  onSinceChange: (value: string) => void
+  orgSlug: string
+  refetch: () => Promise<unknown>
+  rows: PRActivityRow[]
+  setAppliedSince: (value: string) => void
+  since: string
+}) {
+  return (
+    <div className="border-tertiary bg-primary flex flex-wrap items-end gap-4 rounded-lg border p-[18px]">
+      <label className="flex flex-col gap-1">
+        <span className="text-overline text-tertiary tracking-wide uppercase">
+          Since (inclusive)
+        </span>
+        <input
+          className="border-tertiary bg-tertiary text-primary h-8 rounded border px-2 font-mono text-xs"
+          onChange={(e) => onSinceChange(e.target.value)}
+          type="date"
+          value={since}
+        />
+      </label>
+      <button
+        className="bg-warning text-warning inline-flex h-8 items-center gap-1.5 rounded px-3 text-xs font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
+        disabled={!orgSlug || isFetching}
+        onClick={() =>
+          applySince(since, appliedSince, setAppliedSince, refetch)
+        }
+      >
+        <RefreshCw className={isFetching ? 'animate-spin' : ''} size={11} />
+        Fetch activity
+      </button>
+      <button
+        className="border-tertiary text-primary hover:bg-secondary inline-flex h-8 items-center gap-1.5 rounded border px-3 text-xs transition-colors disabled:opacity-50"
+        disabled={rows.length === 0}
+        onClick={() => downloadCsv(rows, appliedSince)}
+      >
+        <Download size={11} />
+        Download CSV
+      </button>
+      <span className="text-tertiary ml-auto self-center text-xs">
+        <StatusText data={data} error={error} isFetching={isFetching} />
+      </span>
+    </div>
+  )
+}
+
+function useOrgSlug(): string {
+  const { selectedOrganization } = useOrganization()
+  return selectedOrganization?.slug ?? ''
+}
+
+function usePRActivity(orgSlug: string, since: string) {
+  const query = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => getPRActivity(orgSlug, since, signal),
+    queryKey: ['prActivity', orgSlug, since],
+    staleTime: 60_000,
+  })
+  return {
+    ...query,
+    loading: query.isFetching && !query.data,
+    rows: query.data?.rows ?? [],
+  }
 }

--- a/src/components/reports/PRActivityReport.tsx
+++ b/src/components/reports/PRActivityReport.tsx
@@ -1,0 +1,242 @@
+import { useMemo, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { Download, RefreshCw } from 'lucide-react'
+
+import { getPRActivity } from '@/api/endpoints'
+import { Sk } from '@/components/ui/skeleton'
+import { UserIdentity } from '@/components/ui/user-identity'
+import { useOrganization } from '@/contexts/OrganizationContext'
+
+export function PRActivityReport() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
+
+  const [since, setSince] = useState(() => isoDaysAgo(30))
+  const [appliedSince, setAppliedSince] = useState(since)
+
+  const { data, error, isFetching, refetch } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => getPRActivity(orgSlug, appliedSince, signal),
+    queryKey: ['prActivity', orgSlug, appliedSince],
+    staleTime: 60_000,
+  })
+
+  const rows = data?.rows ?? []
+  const maxCreated = useMemo(
+    () => rows.reduce((m, r) => Math.max(m, r.created), 0),
+    [rows],
+  )
+  const maxMerged = useMemo(
+    () => rows.reduce((m, r) => Math.max(m, r.merged), 0),
+    [rows],
+  )
+  const totalCreated = rows.reduce((s, r) => s + r.created, 0)
+  const totalMerged = rows.reduce((s, r) => s + r.merged, 0)
+
+  function fetchActivity() {
+    if (since === appliedSince) {
+      void refetch()
+    } else {
+      setAppliedSince(since)
+    }
+  }
+
+  function downloadCsv() {
+    const header = ['Member', 'Login', 'Email', 'Created', 'Merged']
+    const lines = rows.map((r) =>
+      [r.display_name ?? r.login, r.login, r.email ?? '', r.created, r.merged]
+        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+        .join(','),
+    )
+    const csv = [header.join(','), ...lines].join('\n')
+    const blob = new Blob([csv], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.download = `pr-activity-${appliedSince}.csv`
+    a.href = url
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Toolbar */}
+      <div className="border-tertiary bg-primary flex flex-wrap items-end gap-4 rounded-lg border p-[18px]">
+        <label className="flex flex-col gap-1">
+          <span className="text-overline text-tertiary tracking-wide uppercase">
+            Since (inclusive)
+          </span>
+          <input
+            className="border-tertiary bg-tertiary text-primary h-8 rounded border px-2 font-mono text-xs"
+            onChange={(e) => setSince(e.target.value)}
+            type="date"
+            value={since}
+          />
+        </label>
+        <button
+          className="bg-warning text-warning inline-flex h-8 items-center gap-1.5 rounded px-3 text-xs font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
+          disabled={!orgSlug || isFetching}
+          onClick={fetchActivity}
+        >
+          <RefreshCw className={isFetching ? 'animate-spin' : ''} size={11} />
+          Fetch activity
+        </button>
+        <button
+          className="border-tertiary text-primary hover:bg-secondary inline-flex h-8 items-center gap-1.5 rounded border px-3 text-xs transition-colors disabled:opacity-50"
+          disabled={rows.length === 0}
+          onClick={downloadCsv}
+        >
+          <Download size={11} />
+          Download CSV
+        </button>
+        <span className="text-tertiary ml-auto self-center text-xs">
+          {isFetching
+            ? 'Fetching…'
+            : error
+              ? 'Failed to load activity.'
+              : data
+                ? `Done — ${data.members} member${data.members === 1 ? '' : 's'}.`
+                : null}
+        </span>
+      </div>
+
+      {/* Table card */}
+      <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
+        {isFetching && !data ? (
+          <ActivityRowsSkeleton />
+        ) : error ? (
+          <div className="text-danger py-10 text-center text-sm">
+            Failed to load PR activity.{' '}
+            <button className="underline" onClick={() => void refetch()}>
+              Retry
+            </button>
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="text-tertiary py-10 text-center text-sm">
+            No pull request activity since {appliedSince}.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-tertiary border-b">
+                <th className="text-overline text-tertiary px-[18px] py-2.5 text-left font-normal tracking-wide uppercase">
+                  Member
+                </th>
+                <th className="text-overline text-tertiary w-48 px-4 py-2.5 text-right font-normal tracking-wide uppercase">
+                  Created
+                </th>
+                <th className="text-overline text-tertiary w-48 px-[18px] py-2.5 text-right font-normal tracking-wide uppercase">
+                  Merged ↓
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr
+                  className={`border-tertiary hover:bg-secondary transition-colors ${
+                    i === rows.length - 1 ? 'border-0' : 'border-b'
+                  }`}
+                  key={row.login}
+                >
+                  <td className="px-[18px] py-2.5">
+                    <UserIdentity
+                      actor={row.login}
+                      displayName={row.display_name}
+                      email={row.email}
+                      size="small"
+                    />
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <CountCell max={maxCreated} value={row.created} />
+                  </td>
+                  <td className="px-[18px] py-2.5">
+                    <CountCell max={maxMerged} value={row.merged} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-tertiary border-t">
+                <td className="text-secondary px-[18px] py-3 text-xs font-medium tracking-wide uppercase">
+                  Total ({rows.length})
+                </td>
+                <td className="text-primary px-4 py-3 text-right font-mono text-xs tabular-nums">
+                  {totalCreated}
+                </td>
+                <td className="text-primary px-[18px] py-3 text-right font-mono text-xs tabular-nums">
+                  {totalMerged}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ActivityRowsSkeleton() {
+  return (
+    <table aria-busy className="w-full text-sm">
+      <tbody>
+        {Array.from({ length: 8 }, (_, i) => (
+          <tr className="border-tertiary border-b last:border-0" key={i}>
+            <td className="px-[18px] py-2.5">
+              <div className="flex items-center gap-2">
+                <Sk h={20} r={999} w={20} />
+                <Sk line w={120} />
+              </div>
+            </td>
+            <td className="px-4 py-2.5">
+              <div className="flex justify-end">
+                <Sk h={16} r={3} w="70%" />
+              </div>
+            </td>
+            <td className="px-[18px] py-2.5">
+              <div className="flex justify-end">
+                <Sk h={16} r={3} w="70%" />
+              </div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+/** Number with an amber bar sized to its share of the column max. */
+function CountCell({ max, value }: { max: number; value: number }) {
+  const pct = max > 0 ? (value / max) * 100 : 0
+  return (
+    <div className="relative flex h-6 items-center justify-end">
+      {value > 0 ? (
+        <div
+          className="absolute inset-y-0 left-0 rounded-sm"
+          style={{
+            background: 'var(--background-color-warning)',
+            width: `${pct}%`,
+          }}
+        />
+      ) : null}
+      <span
+        className="relative z-10 px-2 font-mono text-xs tabular-nums"
+        style={{
+          color:
+            value > 0
+              ? 'var(--text-color-primary)'
+              : 'var(--text-color-tertiary)',
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+/** YYYY-MM-DD for a date `days` before today (local time). */
+function isoDaysAgo(days: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - days)
+  return d.toISOString().slice(0, 10)
+}

--- a/src/components/reports/PRActivityReport.tsx
+++ b/src/components/reports/PRActivityReport.tsx
@@ -241,7 +241,10 @@ function downloadCsv(rows: PRActivityRow[], appliedSince: string) {
 function isoDaysAgo(days: number): string {
   const d = new Date()
   d.setDate(d.getDate() - days)
-  return d.toISOString().slice(0, 10)
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 /** "1 member" / "2 members" */

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 
 import {
+  Activity,
   BarChart3,
   GitCommitHorizontal,
   GitPullRequest,
@@ -14,6 +15,7 @@ import { CommandBar } from '@/components/CommandBar'
 import { Navigation } from '@/components/Navigation'
 import { MonthlyImprovementReport } from '@/components/reports/MonthlyImprovementReport'
 import { OpenPullRequestsReport } from '@/components/reports/OpenPullRequestsReport'
+import { PRActivityReport } from '@/components/reports/PRActivityReport'
 import { ProjectsGraphReport } from '@/components/reports/ProjectsGraphReport'
 import { ScoreHistoryReport } from '@/components/reports/ScoreHistoryReport'
 import { TeamKPIReport } from '@/components/reports/TeamKPIReport'
@@ -38,6 +40,12 @@ const REPORTS: Report[] = [
     id: 'open-pull-requests',
     label: 'Open Pull Requests',
     subtitle: 'Open pull requests, filterable by team and project type',
+  },
+  {
+    description: 'PRs created and merged per member',
+    id: 'pr-activity',
+    label: 'PR Activity',
+    subtitle: 'PRs created and merged per team member, since a chosen date',
   },
   {
     description: 'Service dependency graph',
@@ -117,6 +125,8 @@ export function ReportsPage() {
                         <Network className="mt-0.5 size-3.5 shrink-0" />
                       ) : r.id === 'open-pull-requests' ? (
                         <GitPullRequest className="mt-0.5 size-3.5 shrink-0" />
+                      ) : r.id === 'pr-activity' ? (
+                        <Activity className="mt-0.5 size-3.5 shrink-0" />
                       ) : (
                         <TrendingUp className="mt-0.5 size-3.5 shrink-0" />
                       )}
@@ -144,6 +154,7 @@ export function ReportsPage() {
             {activeId === 'team-kpi' && <TeamKPIReport />}
             {activeId === 'monthly-improvement' && <MonthlyImprovementReport />}
             {activeId === 'open-pull-requests' && <OpenPullRequestsReport />}
+            {activeId === 'pr-activity' && <PRActivityReport />}
             {activeId === 'score-history' && <ScoreHistoryReport />}
             {activeId === 'projects-graph' && <ProjectsGraphReport />}
           </div>


### PR DESCRIPTION
## Summary

Adds a **PR Activity** report to the Reports section showing pull requests
created and merged per team member since a chosen date. Pairs with
AWeber-Imbi/imbi-api#457, which provides the
`GET /organizations/{org_slug}/pull-requests/activity` endpoint.

## Problem

There was no in-app view of per-member PR throughput. Seeing who opened and
merged how many PRs over a window required ad-hoc queries.

## Solution

New `PRActivityReport` registered in `ReportsPage` (id `pr-activity`):

- Table of members with **Created** and **Merged** counts, each with an inline
  amber bar sized to its share of the column max, plus a totals footer.
- Members render through the canonical `UserIdentity` widget (avatar, display
  name, profile link); GitHub logins that don't resolve to an Imbi user fall
  back to the raw login.
- "Since (inclusive)" date filter (defaults to 30 days ago), a Fetch action, a
  client-side **Download CSV**, and a status line (`Done — N members.`).
- Footprint-matched loading skeleton; org-scoped via `OrganizationContext` like
  the other reports.
- Adds `getPRActivity` + `PRActivityResponse` / `PRActivityRow` to
  `src/api/endpoints.ts`.

## Notes

- Scoped to the selected organization (consistent with every other report),
  rather than all organizations.
- Shows Created + Merged only — PR comment activity isn't synced to ClickHouse.

## Testing

- `npm run lint` (oxlint) — 0 errors; `tsc --noEmit` — clean.
- Not yet manually verified rendering against the live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
