### PR TITLE
Add RelativeTime component with accessible timestamp reveal

### DIFF
--- a/src/components/ProjectsView.tsx
+++ b/src/components/ProjectsView.tsx
@@ -26,6 +26,7 @@ import {
 import { matchSorter } from 'match-sorter'
 
 import { getProjectsSlim, type ProjectListItem } from '@/api/endpoints'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useTheme } from '@/contexts/ThemeContext'
@@ -34,7 +35,6 @@ import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { useLoginToEmail } from '@/hooks/useLoginToEmail'
 import { useSearchShortcut } from '@/hooks/useSearchShortcut'
 import { deriveChipColors } from '@/lib/chip-colors'
-import { formatRelativeDate } from '@/lib/formatDate'
 
 import { NewProjectDialog } from './NewProjectDialog'
 import { Button } from './ui/button'
@@ -1330,7 +1330,7 @@ function ReleaseCards({
             ) : null}
           </span>
           {release_summary.head_authored_at && (
-            <span>{formatRelativeDate(release_summary.head_authored_at)}</span>
+            <RelativeTime value={release_summary.head_authored_at} />
           )}
         </p>
       </span>
@@ -1363,7 +1363,7 @@ function ReleaseCards({
             ) : null}
           </span>
           {release_summary.latest_tag_at && (
-            <span>{formatRelativeDate(release_summary.latest_tag_at)}</span>
+            <RelativeTime value={release_summary.latest_tag_at} />
           )}
         </p>
       </span>
@@ -1424,7 +1424,7 @@ function ReleaseStamp({
               />
             ) : null}
           </span>
-          <span>{formatRelativeDate(release.deployed_at)}</span>
+          <RelativeTime value={release.deployed_at} />
         </>
       ) : (
         <span className="invisible">—</span>

--- a/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
+++ b/src/components/dashboard/widgets/MyPullRequestsWidget.tsx
@@ -11,12 +11,12 @@ import {
 
 import { getOrgPullRequests, type ProjectListItem } from '@/api/endpoints'
 import { Card } from '@/components/ui/card'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { Sk } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useGithubLogin } from '@/hooks/useGithubLogin'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import { useProjectsSlimMap } from '@/hooks/useProjectsSlimMap'
-import { relTime } from '@/lib/formatDate'
 import type { PullRequest, PullRequestListResponse } from '@/types'
 
 const PAGE_SIZE = 20
@@ -234,10 +234,7 @@ function PrRow({
           )}
         </div>
         <div className="text-tertiary text-xs">
-          {(() => {
-            const r = relTime(pr.updated_at)
-            return r === 'now' ? 'just now' : `${r} ago`
-          })()}
+          <RelativeTime tooltip={false} value={pr.updated_at} />
         </div>
       </div>
       <ChevronRight className="text-tertiary mt-0.5 size-4 shrink-0" />

--- a/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
+++ b/src/components/dashboard/widgets/RecentDeploymentsWidget.tsx
@@ -10,12 +10,12 @@ import { getProjects, listOperationsLog } from '@/api/endpoints'
 import type { OperationsLogPage } from '@/api/endpoints'
 import { Badge, type BadgeProps } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { Sk } from '@/components/ui/skeleton'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import { useEnvironments } from '@/hooks/useOrgResources'
-import { formatRelativeDate } from '@/lib/formatDate'
 import type { OperationsLogRecord, Project } from '@/types'
 
 const PAGE_SIZE = 20
@@ -211,10 +211,13 @@ function DeploymentRow({
                     linkToProfile={false}
                     size="small"
                   />
-                  <span>• {formatRelativeDate(d.occurred_at)}</span>
+                  <span>
+                    {'• '}
+                    <RelativeTime tooltip={false} value={d.occurred_at} />
+                  </span>
                 </>
               ) : (
-                <span>{formatRelativeDate(d.occurred_at)}</span>
+                <RelativeTime tooltip={false} value={d.occurred_at} />
               )}
             </div>
           </div>

--- a/src/components/deploy/DeployTab.tsx
+++ b/src/components/deploy/DeployTab.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
-import { formatDistanceToNow } from 'date-fns'
 import { Loader2, Rocket } from 'lucide-react'
 
 import {
@@ -11,6 +10,7 @@ import {
 } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { Sk } from '@/components/ui/skeleton'
 import { cn, sortEnvironments } from '@/lib/utils'
 import type { DeploymentCommit, DeploymentRef, Environment } from '@/types'
@@ -186,9 +186,10 @@ export function DeployTab({
                 {current.last_event_at ? (
                   <>
                     {' · '}
-                    {formatDistanceToNow(new Date(current.last_event_at), {
-                      addSuffix: true,
-                    })}
+                    <RelativeTime
+                      value={current.last_event_at}
+                      variant="long"
+                    />
                   </>
                 ) : null}
               </>

--- a/src/components/deployments/CurrentlyRunningCard.tsx
+++ b/src/components/deployments/CurrentlyRunningCard.tsx
@@ -12,9 +12,9 @@ import {
 
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Button } from '@/components/ui/button'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
 import type { ChipColors } from '@/lib/chip-colors'
-import { formatRelativeDate } from '@/lib/formatDate'
 import { cn, sanitizeHttpUrl } from '@/lib/utils'
 import type { ReleaseHistoryEntry } from '@/types'
 
@@ -224,9 +224,11 @@ function RollbackRow({
           <span className="text-tertiary font-mono text-xs">
             {rel.short_sha}
           </span>
-          <span className="text-tertiary text-xs">
-            {formatRelativeDate(rel.published_at)}
-          </span>
+          <RelativeTime
+            className="text-tertiary text-xs"
+            tooltip={false}
+            value={rel.published_at}
+          />
         </button>
         <Button
           className="h-7 px-2.5 text-xs"

--- a/src/components/deployments/CurrentlyRunningCard.tsx
+++ b/src/components/deployments/CurrentlyRunningCard.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 
-import { formatDistanceToNow } from 'date-fns'
 import {
   ChevronDown,
   ChevronRight,
@@ -71,9 +70,10 @@ export function CurrentlyRunningCard({
               <span className="inline-flex items-center gap-1.5">
                 <Clock size={13} />
                 Deployed{' '}
-                {formatDistanceToNow(new Date(stage.current.last_event_at), {
-                  addSuffix: true,
-                })}
+                <RelativeTime
+                  value={stage.current.last_event_at}
+                  variant="long"
+                />
               </span>
             ) : null}
             {stage.current?.performed_by ? (

--- a/src/components/deployments/PendingReleasesCard.tsx
+++ b/src/components/deployments/PendingReleasesCard.tsx
@@ -12,6 +12,7 @@ import {
 
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Button } from '@/components/ui/button'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import type { ChipColors } from '@/lib/chip-colors'
 import { formatRelativeDate } from '@/lib/formatDate'
 import { cn } from '@/lib/utils'
@@ -259,9 +260,11 @@ function ReleaseStack({
                 {rel.title ?? ''}
               </span>
               {rel.published_at ? (
-                <span className="text-tertiary shrink-0 text-xs whitespace-nowrap">
-                  {formatRelativeDate(rel.published_at)}
-                </span>
+                <RelativeTime
+                  className="text-tertiary shrink-0 text-xs whitespace-nowrap"
+                  tooltip={false}
+                  value={rel.published_at}
+                />
               ) : null}
               {isOpen ? (
                 <ChevronUp className="text-tertiary size-3.5 shrink-0" />

--- a/src/components/documents/comments/CommentItem.tsx
+++ b/src/components/documents/comments/CommentItem.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react'
 import { useMemo, useState } from 'react'
 
-import { formatDistanceToNow } from 'date-fns'
 import { Pencil, Reply, ThumbsUp, Trash2 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { cn } from '@/lib/utils'
 import type { Comment } from '@/types/comments'
@@ -62,9 +62,7 @@ export function CommentItem({
           size="small"
         />
         <span className="text-tertiary text-[11.5px]">
-          {formatDistanceToNow(new Date(comment.created_at), {
-            addSuffix: true,
-          })}
+          <RelativeTime value={comment.created_at} variant="long" />
           {comment.edited && ' · edited'}
         </span>
         {unread && (

--- a/src/components/documents/comments/MarginCommentCard.tsx
+++ b/src/components/documents/comments/MarginCommentCard.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from 'react'
 
-import { formatDistanceToNow } from 'date-fns'
 import { CheckCircle2, MessageSquare, ThumbsUp } from 'lucide-react'
 
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { cn } from '@/lib/utils'
 import type { CommentThread } from '@/types/comments'
@@ -139,9 +139,11 @@ function CollapsedCard({
           email={root.author}
           size="small"
         />
-        <span className="text-tertiary text-[11.5px]">
-          {formatDistanceToNow(new Date(root.created_at), { addSuffix: true })}
-        </span>
+        <RelativeTime
+          className="text-tertiary text-[11.5px]"
+          value={root.created_at}
+          variant="long"
+        />
         {thread.resolved && (
           <CheckCircle2 className="text-action ml-auto size-3.5" />
         )}

--- a/src/components/operations-log/opsLogHelpers.ts
+++ b/src/components/operations-log/opsLogHelpers.ts
@@ -1,4 +1,7 @@
+import { absTime } from '@/lib/formatDate'
 import type { OperationsLogRecord } from '@/types'
+
+export { absTime }
 
 export interface DayBucket {
   date: Date
@@ -31,16 +34,6 @@ interface DayBucketKey {
   date: Date
   key: string
   label: string
-}
-
-export function absTime(iso: string): string {
-  return parseUtcIso(iso).toLocaleString(undefined, {
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  })
 }
 
 export function bucketByDay(

--- a/src/components/project/ProjectPullRequestsTab.tsx
+++ b/src/components/project/ProjectPullRequestsTab.tsx
@@ -14,6 +14,7 @@ import { DiffBar } from '@/components/pull-requests/DiffBar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { Sk } from '@/components/ui/skeleton'
 import {
   Table,
@@ -25,7 +26,6 @@ import {
 } from '@/components/ui/table'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { useLoginToEmail } from '@/hooks/useLoginToEmail'
-import { relTime } from '@/lib/formatDate'
 import type { PullRequest } from '@/types'
 
 interface Props {
@@ -331,7 +331,7 @@ function PrRow({
         <DiffBar additions={pr.additions} deletions={pr.deletions} />
       </TableCell>
       <TableCell className="text-tertiary px-4 py-3 text-right text-xs tabular-nums">
-        {relTime(pr.updated_at)}
+        <RelativeTime value={pr.updated_at} variant="narrow" />
       </TableCell>
     </TableRow>
   )

--- a/src/components/releases/ReleaseHistory.tsx
+++ b/src/components/releases/ReleaseHistory.tsx
@@ -5,8 +5,8 @@ import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 import { Badge } from '@/components/ui/badge'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
-import { formatRelativeDate } from '@/lib/formatDate'
 import { cn } from '@/lib/utils'
 import type { ReleaseHistoryEntry } from '@/types'
 
@@ -85,9 +85,11 @@ function ReleaseRow({
           <CiStatusDot size={13} status={rel.ci_status} />
         </span>
         <span className="text-tertiary font-mono text-xs">{rel.short_sha}</span>
-        <span className="text-tertiary text-xs">
-          {formatRelativeDate(rel.published_at)}
-        </span>
+        <RelativeTime
+          className="text-tertiary text-xs"
+          tooltip={false}
+          value={rel.published_at}
+        />
         {isCurrent ? <Badge variant="accent">Latest</Badge> : <span />}
       </button>
       {isOpen ? (

--- a/src/components/reports/OpenPullRequestsReport.tsx
+++ b/src/components/reports/OpenPullRequestsReport.tsx
@@ -8,6 +8,7 @@ import { ExternalLink, GitPullRequest, RefreshCw } from 'lucide-react'
 import { getOrgPullRequests, type ProjectListItem } from '@/api/endpoints'
 import { DiffBar } from '@/components/pull-requests/DiffBar'
 import { Badge } from '@/components/ui/badge'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import {
   Select,
   SelectContent,
@@ -26,7 +27,6 @@ import { UserIdentity } from '@/components/ui/user-identity'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useLoginToEmail } from '@/hooks/useLoginToEmail'
 import { useProjectsSlimMap } from '@/hooks/useProjectsSlimMap'
-import { relTime } from '@/lib/formatDate'
 import type { PullRequest } from '@/types'
 
 interface AuthorInfo {
@@ -357,7 +357,7 @@ function PrRow({
         <DiffBar additions={pr.additions} deletions={pr.deletions} />
       </td>
       <td className="text-tertiary px-4 py-3 text-right text-xs tabular-nums">
-        {relTime(pr.updated_at)}
+        <RelativeTime value={pr.updated_at} variant="narrow" />
       </td>
     </tr>
   )

--- a/src/components/ui/RelativeTime.tsx
+++ b/src/components/ui/RelativeTime.tsx
@@ -1,0 +1,79 @@
+import { formatDistanceToNow } from 'date-fns'
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { absTime, formatRelativeDate, relTime } from '@/lib/formatDate'
+import { cn } from '@/lib/utils'
+
+interface RelativeTimeProps {
+  className?: string
+  /** Show a tooltip with the full absolute timestamp on hover. Defaults to true. */
+  tooltip?: boolean
+  /** ISO string or millisecond timestamp. */
+  value?: null | number | string
+  /**
+   * Controls verbosity of the relative time display.
+   * - "narrow": "4d"
+   * - "short" (default): "4d ago"
+   * - "long": "about 4 days ago"
+   */
+  variant?: RelativeTimeVariant
+}
+
+type RelativeTimeVariant = 'long' | 'narrow' | 'short'
+
+export function RelativeTime({
+  className,
+  tooltip = true,
+  value,
+  variant = 'short',
+}: RelativeTimeProps) {
+  if (value == null) return <span className={cn(className)}>—</span>
+
+  const isoString =
+    typeof value === 'number' ? new Date(value).toISOString() : value
+  const displayText = formatValue(value, variant)
+  const absoluteText = absTime(value)
+
+  const timeEl = (
+    <time
+      className={cn(className)}
+      dateTime={isoString}
+      title={tooltip ? undefined : absoluteText}
+    >
+      {displayText}
+    </time>
+  )
+
+  if (!tooltip) return timeEl
+
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>{timeEl}</TooltipTrigger>
+        <TooltipContent>{absoluteText}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+function formatValue(
+  value: number | string,
+  variant: RelativeTimeVariant,
+): string {
+  try {
+    if (variant === 'narrow') return relTime(value)
+    if (variant === 'long') {
+      return formatDistanceToNow(new Date(value), { addSuffix: true })
+    }
+    return formatRelativeDate(
+      typeof value === 'number' ? new Date(value).toISOString() : value,
+    )
+  } catch {
+    return '—'
+  }
+}

--- a/src/components/ui/__tests__/RelativeTime.test.tsx
+++ b/src/components/ui/__tests__/RelativeTime.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '@/test/utils'
+
+import { RelativeTime } from '../RelativeTime'
+
+const ISO = '2026-01-01T00:00:00Z'
+
+describe('RelativeTime', () => {
+  describe('null/undefined value', () => {
+    it('renders em-dash for null', () => {
+      render(<RelativeTime value={null} />)
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    it('renders em-dash when value is omitted', () => {
+      render(<RelativeTime />)
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+  })
+
+  describe('semantic markup', () => {
+    it('renders a <time> element with a dateTime attribute', () => {
+      render(<RelativeTime value={ISO} />)
+      const el = document.querySelector('time')
+      expect(el).not.toBeNull()
+      expect(el!.getAttribute('dateTime')).toBe(ISO)
+    })
+
+    it('passes className to the <time> element', () => {
+      render(<RelativeTime className="text-xs text-red-500" value={ISO} />)
+      const el = document.querySelector('time')
+      expect(el!.className).toContain('text-xs')
+      expect(el!.className).toContain('text-red-500')
+    })
+  })
+
+  describe('variant output shape', () => {
+    it('narrow: renders compact format without "ago"', () => {
+      render(<RelativeTime tooltip={false} value={ISO} variant="narrow" />)
+      const el = document.querySelector('time')!
+      // Value is in the past so it should be a compact token like "5mo", "1y" etc.
+      expect(el.textContent).toMatch(/^\d+(m|h|d|w|mo|y)$/)
+    })
+
+    it('short (default): renders "X ago" format', () => {
+      render(<RelativeTime tooltip={false} value={ISO} />)
+      const el = document.querySelector('time')!
+      expect(el.textContent).toMatch(/(ago|just now)/)
+    })
+
+    it('long: renders verbose "about X ago" format', () => {
+      render(<RelativeTime tooltip={false} value={ISO} variant="long" />)
+      const el = document.querySelector('time')!
+      // date-fns formatDistanceToNow with addSuffix
+      expect(el.textContent).toMatch(/ago/)
+    })
+  })
+
+  describe('tooltip={false}', () => {
+    it('sets title attribute to the absolute timestamp', () => {
+      render(<RelativeTime tooltip={false} value={ISO} />)
+      const el = document.querySelector('time')!
+      const title = el.getAttribute('title')
+      expect(title).not.toBeNull()
+      expect(title).toMatch(/2026/)
+      expect(title).toMatch(/Jan/)
+    })
+
+    it('does not render a TooltipProvider', () => {
+      const { container } = render(<RelativeTime tooltip={false} value={ISO} />)
+      // TooltipProvider adds no DOM node of its own, but the time element
+      // should be the direct root with no Radix portal siblings.
+      expect(container.firstChild?.nodeName).toBe('TIME')
+    })
+  })
+
+  describe('tooltip={true} (default)', () => {
+    it('does not set a title attribute on the <time> element', () => {
+      render(<RelativeTime value={ISO} />)
+      const el = document.querySelector('time')!
+      expect(el.getAttribute('title')).toBeNull()
+    })
+  })
+})

--- a/src/lib/__tests__/formatDate.test.ts
+++ b/src/lib/__tests__/formatDate.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatDate, formatRelativeDate, relTime } from '@/lib/formatDate'
+import {
+  absTime,
+  formatDate,
+  formatRelativeDate,
+  relTime,
+} from '@/lib/formatDate'
 
 // Fixed reference instant so relative-time math stays deterministic
 // across CI clocks. Picked as a Wednesday afternoon so day-of-week
@@ -148,5 +153,24 @@ describe('formatRelativeDate', () => {
 
   it('returns em-dash for empty string', () => {
     expect(formatRelativeDate('')).toBe('—')
+  })
+})
+
+describe('absTime', () => {
+  it('formats an ISO string as a localized date and time', () => {
+    const out = absTime('2026-03-17T15:30:00Z')
+    expect(out).toMatch(/2026/)
+    expect(out).toMatch(/Mar/)
+    expect(out).not.toBe('—')
+  })
+
+  it('accepts a millisecond timestamp', () => {
+    const out = absTime(Date.parse('2026-03-17T15:30:00Z'))
+    expect(out).toMatch(/2026/)
+    expect(out).toMatch(/Mar/)
+  })
+
+  it('returns em-dash for an unparseable input', () => {
+    expect(absTime('not-a-date')).toBe('—')
   })
 })

--- a/src/lib/formatDate.ts
+++ b/src/lib/formatDate.ts
@@ -6,6 +6,24 @@ interface DateFormatOptions {
 }
 
 /**
+ * Full absolute timestamp for tooltip reveals: "Jan 15, 2025, 3:45 PM".
+ * Accepts an ISO string or millisecond timestamp.
+ */
+export function absTime(iso: number | string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    })
+  } catch {
+    return '—'
+  }
+}
+
+/**
  * Format an ISO date string as a localized short date.
  * Returns the configured fallback (default '—') for null/undefined/invalid.
  */

--- a/src/lib/formatDate.ts
+++ b/src/lib/formatDate.ts
@@ -11,7 +11,9 @@ interface DateFormatOptions {
  */
 export function absTime(iso: number | string): string {
   try {
-    return new Date(iso).toLocaleString(undefined, {
+    const d = new Date(iso)
+    if (!Number.isFinite(d.getTime())) return '—'
+    return d.toLocaleString(undefined, {
       day: 'numeric',
       hour: 'numeric',
       minute: '2-digit',

--- a/src/pages/UserProfile/ActivityRow.tsx
+++ b/src/pages/UserProfile/ActivityRow.tsx
@@ -11,7 +11,7 @@ import {
   Zap,
 } from 'lucide-react'
 
-import { formatRelativeDate } from '@/lib/formatDate'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 
 import type { ActivityRecord } from './api'
 
@@ -26,7 +26,7 @@ export function ActivityRow({ record }: ActivityRowProps) {
       <div className="min-w-0 flex-1">
         <p className="text-primary truncate text-sm">{record.summary}</p>
         <p className="text-tertiary mt-0.5 flex flex-wrap items-center gap-2 text-xs">
-          <span>{formatRelativeDate(record.occurred_at)}</span>
+          <RelativeTime tooltip={false} value={record.occurred_at} />
           <span className="border-tertiary rounded-sm border px-1.5 py-0.5">
             {record.type}
           </span>

--- a/src/pages/UserProfile/ProfileHeader.tsx
+++ b/src/pages/UserProfile/ProfileHeader.tsx
@@ -1,5 +1,6 @@
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
-import { formatDate, formatRelativeDate } from '@/lib/formatDate'
+import { formatDate } from '@/lib/formatDate'
 import type { AdminUser } from '@/types'
 
 import type { IdentitiesResponse } from './api'
@@ -59,7 +60,7 @@ export function ProfileHeader({ identities, user }: ProfileHeaderProps) {
           {user.last_login && (
             <div>
               <dt className="text-tertiary inline">Last active </dt>
-              <dd className="inline">{formatRelativeDate(user.last_login)}</dd>
+              <RelativeTime className="inline" value={user.last_login} />
             </div>
           )}
         </dl>

--- a/src/pages/UserProfile/ProfileHeader.tsx
+++ b/src/pages/UserProfile/ProfileHeader.tsx
@@ -60,7 +60,9 @@ export function ProfileHeader({ identities, user }: ProfileHeaderProps) {
           {user.last_login && (
             <div>
               <dt className="text-tertiary inline">Last active </dt>
-              <RelativeTime className="inline" value={user.last_login} />
+              <dd className="inline">
+                <RelativeTime value={user.last_login} />
+              </dd>
             </div>
           )}
         </dl>


### PR DESCRIPTION
## Summary

Introduces a \`<RelativeTime>\` component for displaying relative timestamps with a full absolute timestamp accessible on hover, and migrates all eligible timestamp callsites across the app to use it.

## Problem

Abbreviated timestamps like \"4d\" or \"2h ago\" appear throughout the UI — Deployments tab, projects list, dashboards, comments, pull request tables — with no way for the user to see the full date and time. The Operations Log already solved this with a Radix Tooltip pattern, but that pattern can't be used inside \`<button>\` or \`<a>\` elements without creating invalid nested interactive HTML.

## Solution

- Move \`absTime()\` from \`opsLogHelpers.ts\` to \`src/lib/formatDate.ts\` alongside the other date formatters; re-export from \`opsLogHelpers.ts\` so existing imports are unaffected
- Add \`<RelativeTime>\` component (\`src/components/ui/RelativeTime.tsx\`) with:
  - \`variant\`: \`"narrow"\` ("4d") | \`"short"\` ("4d ago", default) | \`"long"\` ("about 4 days ago") — modeled on \`Intl.RelativeTimeFormat\` style names
  - \`tooltip\`: boolean (default \`true\`) — when true, wraps in a Radix \`Tooltip\`; when false, falls back to a \`title\` attribute on the \`<time>\` element (safe for use inside \`<button>\` or \`<a>\`)
  - Renders a semantic \`<time dateTime={...}>\` element in all cases
  - \`value\` accepts \`string | number | null | undefined\`; no default \`className\`
- Migrate all eligible callsites (12 files):
  - \`ProjectsView\`: 3 release summary timestamps
  - \`RecentDeploymentsWidget\`, \`MyPullRequestsWidget\`, \`ActivityRow\`: timestamps inside links (\`tooltip={false}\`)
  - \`ProfileHeader\`: last login timestamp
  - \`ProjectPullRequestsTab\`, \`OpenPullRequestsReport\`: PR updated_at in table cells (\`variant="narrow"\`)
  - \`DeployTab\`, \`CurrentlyRunningCard\`: "deployed X ago" subtitle (\`variant="long"\`)
  - \`MarginCommentCard\`, \`CommentItem\`: comment timestamps (\`variant="long"\`)
- Skipped: sites already wrapped in an explicit Tooltip (\`ProjectDetail\`, \`ProjectActivityLog\`), string interpolations (\`ConnectionTestPanel\`, \`PendingReleasesCard\` subtitle), and a computed value in \`useMemo\` (\`ProjectDetail\`)

## Impact

Mouse users hovering over any abbreviated timestamp in the UI will now see the full date and time. Screen readers get a semantic \`<time>\` element with a machine-readable \`dateTime\` attribute. No visual change to the UI.