### PR TITLE
Add version-formats editors for orgs and project types

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -19,6 +19,7 @@ import {
   Network,
   Puzzle,
   Shield,
+  SlidersHorizontal,
   Sparkles,
   StickyNote,
   Target,
@@ -34,6 +35,7 @@ import { AdminOverview } from './admin/AdminOverview'
 import { AssistantManagement } from './admin/AssistantManagement'
 import { AuthProvidersManagement } from './admin/AuthProvidersManagement'
 import { BlueprintManagement } from './admin/BlueprintManagement'
+import { DefaultSettingsManagement } from './admin/DefaultSettingsManagement'
 import { DocumentTemplateManagement } from './admin/DocumentTemplateManagement'
 import { EnvironmentManagement } from './admin/EnvironmentManagement'
 import { GraphQueryManagement } from './admin/GraphQueryManagement'
@@ -54,6 +56,7 @@ import { WebhookManagement } from './admin/WebhookManagement'
 type AdminSection =
   | 'assistant'
   | 'blueprints'
+  | 'default-settings'
   | 'document-templates'
   | 'environments'
   | 'graph-query'
@@ -78,6 +81,7 @@ const DEFAULT_ADMIN_SECTION: AdminSection = 'overview'
 const VALID_SECTIONS: AdminSection[] = [
   'assistant',
   'blueprints',
+  'default-settings',
   'environments',
   'graph-query',
   'link-definitions',
@@ -105,6 +109,7 @@ interface SectionDef {
   scope: 'org' | 'system'
 }
 
+// fallow-ignore-next-line complexity
 export function Admin() {
   const navigate = useNavigate()
   const { section, slug } = useParams<{ section?: string; slug?: string }>()
@@ -136,6 +141,13 @@ export function Admin() {
       icon: FileJson,
       id: 'blueprints',
       label: 'Blueprints',
+      scope: 'org',
+    },
+    {
+      description: 'Organization-wide defaults, including version formats',
+      icon: SlidersHorizontal,
+      id: 'default-settings',
+      label: 'Default Settings',
       scope: 'org',
     },
     {
@@ -267,6 +279,7 @@ export function Admin() {
   const allSections = [...orgAdminSections, ...systemAdminSections]
   const currentSectionData = allSections.find((s) => s.id === currentSection)
 
+  // fallow-ignore-next-line complexity
   const renderSectionButton = (sectionDef: SectionDef) => {
     const Icon = sectionDef.icon
     const isActive = currentSection === sectionDef.id
@@ -391,6 +404,9 @@ export function Admin() {
           {/* Section Content */}
           <div className="p-8">
             {currentSection === 'overview' && <AdminOverview />}
+            {currentSection === 'default-settings' && (
+              <DefaultSettingsManagement key={selectedOrganization?.slug} />
+            )}
             {currentSection === 'teams' && <TeamManagement />}
             {currentSection === 'environments' && <EnvironmentManagement />}
             {currentSection === 'project-types' && <ProjectTypeManagement />}

--- a/src/components/admin/DefaultSettingsManagement.tsx
+++ b/src/components/admin/DefaultSettingsManagement.tsx
@@ -33,7 +33,10 @@ export function DefaultSettingsManagement() {
   const [rows, setRows] = useState<FormatRow[]>(() => buildRows(baseFormats))
   const [editorOpen, setEditorOpen] = useState(false)
   const [editing, setEditing] = useState<FormatRow | null>(null)
-  const baseline = useRef(JSON.stringify(baseFormats))
+  // Normalize through buildRows/toFormats so the baseline matches the editor's
+  // canonical ordering (built-ins first); otherwise a differently-ordered
+  // baseFormats reads as dirty on mount.
+  const baseline = useRef(JSON.stringify(toFormats(buildRows(baseFormats))))
 
   const mutation = useMutation({
     mutationFn: (operations: PatchOperation[]) =>
@@ -140,6 +143,7 @@ export function DefaultSettingsManagement() {
           initialExample={editing?.example}
           initialName={editing?.label}
           initialPattern={editing?.pattern}
+          key={editing?.id ?? 'new'}
           onCancel={closeEditor}
           onSave={saveFormat}
           title={editing ? 'Edit custom format' : 'Add custom format'}

--- a/src/components/admin/DefaultSettingsManagement.tsx
+++ b/src/components/admin/DefaultSettingsManagement.tsx
@@ -1,0 +1,181 @@
+import { useRef, useState } from 'react'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Plus, Save } from 'lucide-react'
+
+import { updateOrganization } from '@/api/endpoints'
+import { Alert } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { buildDiffPatch } from '@/lib/json-patch'
+import {
+  buildRows,
+  type FormatRow,
+  nextRowId,
+  toFormats,
+} from '@/lib/versionFormats'
+import type { PatchOperation, TagFormat } from '@/types'
+
+import { FormatEditor } from './version-formats/FormatEditor'
+import { FormatList } from './version-formats/FormatList'
+import { VersionTester } from './version-formats/VersionTester'
+
+// Keyed by the selected org's slug at the Admin call site, so it remounts (and
+// re-seeds from the new org's formats) whenever the active organization
+// changes — no resync effect needed.
+// fallow-ignore-next-line complexity
+export function DefaultSettingsManagement() {
+  const { selectedOrganization } = useOrganization()
+  const queryClient = useQueryClient()
+  const orgSlug = selectedOrganization?.slug
+  const baseFormats = orgTagFormats(selectedOrganization)
+
+  const [rows, setRows] = useState<FormatRow[]>(() => buildRows(baseFormats))
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [editing, setEditing] = useState<FormatRow | null>(null)
+  const baseline = useRef(JSON.stringify(baseFormats))
+
+  const mutation = useMutation({
+    mutationFn: (operations: PatchOperation[]) =>
+      updateOrganization(orgSlug ?? '', operations),
+    onSuccess: () => {
+      baseline.current = JSON.stringify(toFormats(rows))
+      return queryClient.invalidateQueries({ queryKey: ['organizations'] })
+    },
+  })
+
+  if (!orgSlug) {
+    return (
+      <div className="text-tertiary py-12 text-center">
+        Select an organization to manage default settings.
+      </div>
+    )
+  }
+
+  const formats = toFormats(rows)
+  const dirty = JSON.stringify(formats) !== baseline.current
+
+  const toggleRow = (id: string) =>
+    setRows((rs) =>
+      rs.map((r) => (r.id === id ? { ...r, enabled: !r.enabled } : r)),
+    )
+  const removeRow = (id: string) =>
+    setRows((rs) => rs.filter((r) => r.id !== id))
+  const closeEditor = () => {
+    setEditing(null)
+    setEditorOpen(false)
+  }
+  const saveFormat = (label: string, pattern: string, example: string) => {
+    setRows((rs) =>
+      editing
+        ? rs.map((r) =>
+            r.id === editing.id ? { ...r, example, label, pattern } : r,
+          )
+        : [
+            ...rs,
+            {
+              builtin: false,
+              description: 'Custom version format.',
+              enabled: true,
+              example,
+              id: nextRowId(),
+              label,
+              pattern,
+            },
+          ],
+    )
+    closeEditor()
+  }
+  const handleSave = () => {
+    const operations = buildDiffPatch(
+      { tag_formats: baseFormats },
+      { tag_formats: formats },
+      { fields: ['tag_formats'] },
+    )
+    if (operations.length > 0) mutation.mutate(operations)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-primary text-base font-medium">
+            Supported version formats
+          </h2>
+          <p className="text-secondary mt-1 max-w-xl text-sm">
+            Releases are validated against these patterns. They can be
+            overridden for specific project types.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            disabled={mutation.isPending}
+            onClick={() => {
+              setEditing(null)
+              setEditorOpen(true)
+            }}
+            variant="outline"
+          >
+            <Plus className="mr-2 size-4" />
+            Add custom format
+          </Button>
+          <Button
+            className="bg-action text-action-foreground hover:bg-action-hover"
+            disabled={!dirty || mutation.isPending}
+            onClick={handleSave}
+          >
+            <Save className="mr-2 size-4" />
+            {mutation.isPending ? 'Saving...' : 'Save changes'}
+          </Button>
+        </div>
+      </div>
+
+      <SaveStatus
+        isError={mutation.isError}
+        saved={!dirty && mutation.isSuccess}
+      />
+
+      {editorOpen && (
+        <FormatEditor
+          initialExample={editing?.example}
+          initialName={editing?.label}
+          initialPattern={editing?.pattern}
+          onCancel={closeEditor}
+          onSave={saveFormat}
+          title={editing ? 'Edit custom format' : 'Add custom format'}
+        />
+      )}
+
+      <FormatList
+        disabled={mutation.isPending}
+        onDelete={removeRow}
+        onEdit={(row) => {
+          setEditing(row)
+          setEditorOpen(true)
+        }}
+        onToggle={toggleRow}
+        rows={rows}
+      />
+
+      <VersionTester formats={formats} />
+    </div>
+  )
+}
+
+function orgTagFormats(org: unknown): TagFormat[] {
+  return (org as null | { tag_formats?: TagFormat[] })?.tag_formats ?? []
+}
+
+function SaveStatus({ isError, saved }: { isError: boolean; saved: boolean }) {
+  if (isError) {
+    return (
+      <Alert variant="danger">Failed to save default version formats.</Alert>
+    )
+  }
+  if (saved) {
+    return (
+      <p className="text-success text-sm">Default version formats saved.</p>
+    )
+  }
+  return null
+}

--- a/src/components/admin/project-types/ProjectTypeForm.tsx
+++ b/src/components/admin/project-types/ProjectTypeForm.tsx
@@ -28,7 +28,9 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { useIconWithCleanup } from '@/hooks/useIconWithCleanup'
 import { PROJECT_TYPE_BASE_FIELDS_SET } from '@/lib/constants'
 import { extractDynamicFields, slugify } from '@/lib/utils'
-import type { ProjectType, ProjectTypeCreate } from '@/types'
+import type { ProjectType, ProjectTypeCreate, TagFormat } from '@/types'
+
+import { VersionFormatsEditor } from './VersionFormatsEditor'
 
 interface ProjectTypeFormProps {
   error?: null | { message?: string; response?: { data?: { detail?: string } } }
@@ -71,9 +73,18 @@ export function ProjectTypeForm({
     if (checked) setDeployable(false)
   }
   const handleIconChange = useIconWithCleanup(icon, setIcon)
+  const [tagFormats, setTagFormats] = useState<TagFormat[]>(
+    (projectType as null | { tag_formats?: TagFormat[] })?.tag_formats ?? [],
+  )
   const [orgSlug, setOrgSlug] = useState(
     projectType?.organization.slug || selectedOrganization?.slug || '',
   )
+  const inheritedFormats =
+    (
+      organizations.find((o) => o.slug === orgSlug) as
+        | undefined
+        | { tag_formats?: TagFormat[] }
+    )?.tag_formats ?? []
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [dynamicFormData, setDynamicFormData] = useState<
     Record<string, unknown>
@@ -120,6 +131,7 @@ export function ProjectTypeForm({
       name: name.trim(),
       releasable,
       slug: slug.trim(),
+      tag_formats: tagFormats,
       ...dynamicFormData,
     })
   }
@@ -369,6 +381,14 @@ export function ProjectTypeForm({
                 </div>
               </div>
             </div>
+
+            <VersionFormatsEditor
+              disabled={isLoading}
+              inherited={inheritedFormats}
+              onChange={setTagFormats}
+              projectTypeName={name}
+              value={tagFormats}
+            />
 
             {/* Dynamic Blueprint Fields */}
             {ptSchema && (

--- a/src/components/admin/project-types/VersionFormatsEditor.tsx
+++ b/src/components/admin/project-types/VersionFormatsEditor.tsx
@@ -1,0 +1,441 @@
+import { useState } from 'react'
+
+import { AlertTriangle, Check, Lock, Pencil, Plus, Trash2 } from 'lucide-react'
+
+import { Alert } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import {
+  BUILTIN_FORMATS,
+  builtinForPattern,
+  fullMatch,
+  isValidPattern,
+} from '@/lib/versionFormats'
+import type { TagFormat } from '@/types'
+
+interface FormatRow {
+  builtin: boolean
+  description: string
+  enabled: boolean
+  example: string
+  id: string
+  label: string
+  pattern: string
+}
+
+interface FormatTableRowProps {
+  disabled: boolean
+  onDelete: () => void
+  onEdit: () => void
+  onToggle: () => void
+  row: FormatRow
+}
+
+interface VersionFormatsEditorProps {
+  disabled?: boolean
+  inherited: TagFormat[]
+  onChange: (next: TagFormat[]) => void
+  projectTypeName: string
+  value: TagFormat[]
+}
+
+let rowSeq = 0
+const nextRowId = () => `vf-${(rowSeq += 1)}`
+
+// Build the editor's working rows from a persisted `TagFormat[]`: every
+// built-in preset appears (toggled on when its pattern is present), and any
+// persisted pattern that isn't a built-in is appended as an enabled custom row.
+function buildRows(formats: TagFormat[]): FormatRow[] {
+  const enabled = new Set(formats.map((f) => f.pattern))
+  const rows: FormatRow[] = BUILTIN_FORMATS.map((b) => ({
+    builtin: true,
+    description: b.description,
+    enabled: enabled.has(b.pattern),
+    example: b.example,
+    id: nextRowId(),
+    label: b.label,
+    pattern: b.pattern,
+  }))
+  for (const f of formats) {
+    if (!builtinForPattern(f.pattern)) {
+      rows.push({
+        builtin: false,
+        description: 'Custom version format.',
+        enabled: true,
+        example: '',
+        id: nextRowId(),
+        label: f.label,
+        pattern: f.pattern,
+      })
+    }
+  }
+  return rows
+}
+
+const toFormats = (rows: FormatRow[]): TagFormat[] =>
+  rows
+    .filter((r) => r.enabled)
+    .map(({ label, pattern }) => ({ label, pattern }))
+
+const toggleAriaLabel = (row: FormatRow): string =>
+  row.enabled ? `Disable ${row.label}` : `Enable ${row.label}`
+
+// fallow-ignore-next-line complexity
+export function VersionFormatsEditor({
+  disabled = false,
+  inherited,
+  onChange,
+  projectTypeName,
+  value,
+}: VersionFormatsEditorProps) {
+  const [override, setOverride] = useState(value.length > 0)
+  const [rows, setRows] = useState<FormatRow[]>(() => buildRows(value))
+
+  // Inline add/edit editor state.
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [editId, setEditId] = useState<null | string>(null)
+  const [fName, setFName] = useState('')
+  const [fPattern, setFPattern] = useState('')
+  const [fTest, setFTest] = useState('')
+
+  const ptName = projectTypeName.trim() || 'these'
+
+  // The persisted output is empty when inheriting (the backend then falls back
+  // to the organization defaults) and the enabled rows when overriding.
+  const commit = (nextOverride: boolean, nextRows: FormatRow[]) => {
+    setOverride(nextOverride)
+    setRows(nextRows)
+    onChange(nextOverride ? toFormats(nextRows) : [])
+  }
+
+  const handleOverrideToggle = (checked: boolean) => {
+    if (checked && toFormats(rows).length === 0) {
+      // Seed the editable set from the inherited defaults so overriding starts
+      // from the current behaviour rather than an empty (and meaningless) set.
+      commit(true, buildRows(inherited))
+    } else {
+      commit(checked, rows)
+    }
+  }
+
+  const toggleRow = (id: string) => {
+    commit(
+      override,
+      rows.map((r) => (r.id === id ? { ...r, enabled: !r.enabled } : r)),
+    )
+  }
+
+  const removeRow = (id: string) => {
+    commit(
+      override,
+      rows.filter((r) => r.id !== id),
+    )
+  }
+
+  const openAdd = () => {
+    setEditId(null)
+    setFName('')
+    setFPattern('')
+    setFTest('')
+    setEditorOpen(true)
+  }
+
+  const openEdit = (row: FormatRow) => {
+    setEditId(row.id)
+    setFName(row.label)
+    setFPattern(row.pattern)
+    setFTest(row.example)
+    setEditorOpen(true)
+  }
+
+  const closeEditor = () => {
+    setEditorOpen(false)
+    setEditId(null)
+    setFName('')
+    setFPattern('')
+    setFTest('')
+  }
+
+  const patternValid = !fPattern || isValidPattern(fPattern)
+  const canSave = !!fName.trim() && !!fPattern.trim() && patternValid
+  const testMatch =
+    fTest && fPattern && patternValid && fullMatch(fPattern, fTest)
+  const testNo =
+    fTest && fPattern && patternValid && !fullMatch(fPattern, fTest)
+
+  const saveFormat = () => {
+    if (!canSave) return
+    const label = fName.trim()
+    const pattern = fPattern.trim()
+    const example = fTest.trim()
+    let next: FormatRow[]
+    if (editId) {
+      next = rows.map((r) =>
+        r.id === editId ? { ...r, example, label, pattern } : r,
+      )
+    } else {
+      next = [
+        ...rows,
+        {
+          builtin: false,
+          description: 'Custom version format.',
+          enabled: true,
+          example,
+          id: nextRowId(),
+          label,
+          pattern,
+        },
+      ]
+    }
+    commit(override, next)
+    closeEditor()
+  }
+
+  return (
+    <div className="border-input border-t pt-4">
+      <div className="flex items-start justify-between gap-6">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="text-foreground text-sm font-medium">
+              Version formats
+            </span>
+            {override ? (
+              <Badge variant="warning">Overriding defaults</Badge>
+            ) : (
+              <Badge variant="neutral">Using defaults</Badge>
+            )}
+          </div>
+          <p className="text-tertiary mt-1 max-w-2xl text-xs leading-relaxed">
+            By default, {ptName} projects inherit the organization&apos;s
+            supported version formats. Override to validate releases against a
+            set specific to this project type.
+          </p>
+        </div>
+        <Switch
+          aria-label="Override organization version formats"
+          checked={override}
+          disabled={disabled}
+          onCheckedChange={handleOverrideToggle}
+        />
+      </div>
+
+      {!override && <InheritedFormats inherited={inherited} />}
+
+      {override && (
+        <div className="mt-4 space-y-4">
+          <Alert variant="warning">
+            These formats <strong>replace</strong> the organization defaults.{' '}
+            {ptName} releases will be validated only against the enabled formats
+            below — the inherited defaults will not apply.
+          </Alert>
+
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-tertiary text-xs font-semibold tracking-wide uppercase">
+              Project type formats
+            </span>
+            <Button
+              disabled={disabled}
+              onClick={openAdd}
+              size="sm"
+              variant="outline"
+            >
+              <Plus className="mr-1.5 size-3.5" />
+              Add custom format
+            </Button>
+          </div>
+
+          {editorOpen && (
+            <div className="border-input rounded-lg border p-4">
+              <div className="text-tertiary mb-3 text-xs font-semibold tracking-wide uppercase">
+                {editId ? 'Edit custom format' : 'Add custom format'}
+              </div>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_1.5fr]">
+                <div>
+                  <Label className="text-secondary mb-1.5 block text-xs">
+                    Name
+                  </Label>
+                  <Input
+                    onChange={(e) => setFName(e.target.value)}
+                    placeholder="e.g. Build number"
+                    value={fName}
+                  />
+                </div>
+                <div>
+                  <Label className="text-secondary mb-1.5 block text-xs">
+                    Pattern · regular expression
+                  </Label>
+                  <Input
+                    className="font-mono text-xs"
+                    onChange={(e) => setFPattern(e.target.value)}
+                    placeholder="^build-\d+$"
+                    value={fPattern}
+                  />
+                  {!patternValid && (
+                    <div className="text-danger mt-1.5 flex items-center gap-1 text-xs">
+                      <AlertTriangle className="size-3" />
+                      Not a valid regular expression.
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <span className="text-tertiary text-xs">Try it</span>
+                <Input
+                  className="max-w-65 font-mono text-xs"
+                  onChange={(e) => setFTest(e.target.value)}
+                  placeholder="Test a version"
+                  value={fTest}
+                />
+                {testMatch && <Badge variant="success">Match</Badge>}
+                {testNo && <Badge variant="danger">No match</Badge>}
+              </div>
+              <div className="mt-4 flex justify-end gap-2">
+                <Button onClick={closeEditor} size="sm" variant="ghost">
+                  Cancel
+                </Button>
+                <Button
+                  className="bg-action text-action-foreground hover:bg-action-hover"
+                  disabled={!canSave}
+                  onClick={saveFormat}
+                  size="sm"
+                >
+                  Save format
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className="divide-input border-input divide-y rounded-lg border">
+            <div className="bg-secondary text-tertiary grid grid-cols-[minmax(0,1.4fr)_minmax(0,1.6fr)_auto_auto] items-center gap-4 px-4 py-2.5 text-xs font-semibold tracking-wide uppercase">
+              <span>Format</span>
+              <span>Pattern</span>
+              <span className="text-center">On</span>
+              <span className="w-14" />
+            </div>
+            {rows.map((row) => (
+              <FormatTableRow
+                disabled={disabled}
+                key={row.id}
+                onDelete={() => removeRow(row.id)}
+                onEdit={() => openEdit(row)}
+                onToggle={() => toggleRow(row.id)}
+                row={row}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FormatTableRow({
+  disabled,
+  onDelete,
+  onEdit,
+  onToggle,
+  row,
+}: FormatTableRowProps) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1.4fr)_minmax(0,1.6fr)_auto_auto] items-start gap-4 px-4 py-3.5">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-primary text-sm font-medium">{row.label}</span>
+          {row.builtin ? (
+            <Badge variant="neutral">Built-in</Badge>
+          ) : (
+            <Badge variant="accent">Custom</Badge>
+          )}
+        </div>
+        <div className="text-tertiary mt-0.5 text-xs leading-snug">
+          {row.description}
+        </div>
+      </div>
+      <div className="min-w-0">
+        <code className="bg-secondary text-secondary block rounded px-2 py-1.5 font-mono text-xs break-all">
+          {row.pattern}
+        </code>
+        {row.example && (
+          <div className="text-tertiary mt-1 text-xs">
+            Matches{' '}
+            <span className="text-secondary font-mono">{row.example}</span>
+          </div>
+        )}
+      </div>
+      <div className="flex justify-center pt-0.5">
+        <Switch
+          aria-label={toggleAriaLabel(row)}
+          checked={row.enabled}
+          disabled={disabled}
+          onCheckedChange={onToggle}
+        />
+      </div>
+      <div className="flex w-14 justify-end gap-0.5">
+        {!row.builtin && (
+          <>
+            <Button
+              aria-label="Edit format"
+              disabled={disabled}
+              onClick={onEdit}
+              size="icon"
+              variant="ghost"
+            >
+              <Pencil className="size-3.5" />
+            </Button>
+            <Button
+              aria-label="Delete format"
+              disabled={disabled}
+              onClick={onDelete}
+              size="icon"
+              variant="ghost"
+            >
+              <Trash2 className="size-3.5" />
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function InheritedFormats({ inherited }: { inherited: TagFormat[] }) {
+  return (
+    <div className="border-input bg-secondary mt-4 rounded-lg border p-4">
+      <div className="text-tertiary mb-3 flex items-center gap-1.5 text-xs font-semibold tracking-wide uppercase">
+        <Lock className="size-3" />
+        Inherited from organization defaults
+      </div>
+      {inherited.length === 0 ? (
+        <p className="text-tertiary text-xs leading-relaxed">
+          The organization defines no version formats, so any non-empty version
+          is accepted. Set defaults in the organization&apos;s settings, or
+          override here.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {inherited.map((f) => (
+            <div
+              className="border-input bg-background grid grid-cols-1 items-center gap-2 rounded-lg border px-3 py-2.5 sm:grid-cols-[190px_minmax(0,1fr)]"
+              key={f.pattern}
+            >
+              <span className="text-secondary flex items-center gap-1.5 text-sm font-medium">
+                <Check className="text-success size-3.5 shrink-0" />
+                {f.label}
+              </span>
+              <span className="text-tertiary font-mono text-xs break-all">
+                {f.pattern}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      <p className="text-tertiary mt-3 text-xs leading-relaxed">
+        Managed in the organization&apos;s default settings. These apply to
+        every project type that doesn&apos;t define its own.
+      </p>
+    </div>
+  )
+}

--- a/src/components/admin/project-types/VersionFormatsEditor.tsx
+++ b/src/components/admin/project-types/VersionFormatsEditor.tsx
@@ -1,37 +1,36 @@
 import { useState } from 'react'
 
-import { AlertTriangle, Check, Lock, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Check, Lock, Plus } from 'lucide-react'
 
 import { Alert } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import {
-  BUILTIN_FORMATS,
-  builtinForPattern,
-  fullMatch,
-  isValidPattern,
+  buildRows,
+  type FormatRow,
+  nextRowId,
+  toFormats,
 } from '@/lib/versionFormats'
 import type { TagFormat } from '@/types'
 
-interface FormatRow {
-  builtin: boolean
-  description: string
-  enabled: boolean
-  example: string
-  id: string
-  label: string
-  pattern: string
+import { FormatEditor } from '../version-formats/FormatEditor'
+import { FormatList } from '../version-formats/FormatList'
+
+interface InheritedFormatsProps {
+  inherited: TagFormat[]
 }
 
-interface FormatTableRowProps {
+interface OverridePanelProps {
   disabled: boolean
-  onDelete: () => void
-  onEdit: () => void
-  onToggle: () => void
-  row: FormatRow
+  onRemove: (id: string) => void
+  onToggle: (id: string) => void
+  onUpsert: (
+    editingId: null | string,
+    row: TagFormat & { example: string },
+  ) => void
+  ptName: string
+  rows: FormatRow[]
 }
 
 interface VersionFormatsEditorProps {
@@ -42,48 +41,6 @@ interface VersionFormatsEditorProps {
   value: TagFormat[]
 }
 
-let rowSeq = 0
-const nextRowId = () => `vf-${(rowSeq += 1)}`
-
-// Build the editor's working rows from a persisted `TagFormat[]`: every
-// built-in preset appears (toggled on when its pattern is present), and any
-// persisted pattern that isn't a built-in is appended as an enabled custom row.
-function buildRows(formats: TagFormat[]): FormatRow[] {
-  const enabled = new Set(formats.map((f) => f.pattern))
-  const rows: FormatRow[] = BUILTIN_FORMATS.map((b) => ({
-    builtin: true,
-    description: b.description,
-    enabled: enabled.has(b.pattern),
-    example: b.example,
-    id: nextRowId(),
-    label: b.label,
-    pattern: b.pattern,
-  }))
-  for (const f of formats) {
-    if (!builtinForPattern(f.pattern)) {
-      rows.push({
-        builtin: false,
-        description: 'Custom version format.',
-        enabled: true,
-        example: '',
-        id: nextRowId(),
-        label: f.label,
-        pattern: f.pattern,
-      })
-    }
-  }
-  return rows
-}
-
-const toFormats = (rows: FormatRow[]): TagFormat[] =>
-  rows
-    .filter((r) => r.enabled)
-    .map(({ label, pattern }) => ({ label, pattern }))
-
-const toggleAriaLabel = (row: FormatRow): string =>
-  row.enabled ? `Disable ${row.label}` : `Enable ${row.label}`
-
-// fallow-ignore-next-line complexity
 export function VersionFormatsEditor({
   disabled = false,
   inherited,
@@ -93,13 +50,6 @@ export function VersionFormatsEditor({
 }: VersionFormatsEditorProps) {
   const [override, setOverride] = useState(value.length > 0)
   const [rows, setRows] = useState<FormatRow[]>(() => buildRows(value))
-
-  // Inline add/edit editor state.
-  const [editorOpen, setEditorOpen] = useState(false)
-  const [editId, setEditId] = useState<null | string>(null)
-  const [fName, setFName] = useState('')
-  const [fPattern, setFPattern] = useState('')
-  const [fTest, setFTest] = useState('')
 
   const ptName = projectTypeName.trim() || 'these'
 
@@ -112,13 +62,10 @@ export function VersionFormatsEditor({
   }
 
   const handleOverrideToggle = (checked: boolean) => {
-    if (checked && toFormats(rows).length === 0) {
-      // Seed the editable set from the inherited defaults so overriding starts
-      // from the current behaviour rather than an empty (and meaningless) set.
-      commit(true, buildRows(inherited))
-    } else {
-      commit(checked, rows)
-    }
+    // Seed the editable set from the inherited defaults so overriding starts
+    // from the current behaviour rather than an empty (meaningless) set.
+    const seeded = checked && toFormats(rows).length === 0
+    commit(checked, seeded ? buildRows(inherited) : rows)
   }
 
   const toggleRow = (id: string) => {
@@ -135,64 +82,30 @@ export function VersionFormatsEditor({
     )
   }
 
-  const openAdd = () => {
-    setEditId(null)
-    setFName('')
-    setFPattern('')
-    setFTest('')
-    setEditorOpen(true)
-  }
-
-  const openEdit = (row: FormatRow) => {
-    setEditId(row.id)
-    setFName(row.label)
-    setFPattern(row.pattern)
-    setFTest(row.example)
-    setEditorOpen(true)
-  }
-
-  const closeEditor = () => {
-    setEditorOpen(false)
-    setEditId(null)
-    setFName('')
-    setFPattern('')
-    setFTest('')
-  }
-
-  const patternValid = !fPattern || isValidPattern(fPattern)
-  const canSave = !!fName.trim() && !!fPattern.trim() && patternValid
-  const testMatch =
-    fTest && fPattern && patternValid && fullMatch(fPattern, fTest)
-  const testNo =
-    fTest && fPattern && patternValid && !fullMatch(fPattern, fTest)
-
-  const saveFormat = () => {
-    if (!canSave) return
-    const label = fName.trim()
-    const pattern = fPattern.trim()
-    const example = fTest.trim()
-    let next: FormatRow[]
-    if (editId) {
-      next = rows.map((r) =>
-        r.id === editId ? { ...r, example, label, pattern } : r,
-      )
-    } else {
-      next = [
-        ...rows,
-        {
-          builtin: false,
-          description: 'Custom version format.',
-          enabled: true,
-          example,
-          id: nextRowId(),
-          label,
-          pattern,
-        },
-      ]
-    }
+  const upsert = (
+    editingId: null | string,
+    row: TagFormat & { example: string },
+  ) => {
+    const next = editingId
+      ? rows.map((r) => (r.id === editingId ? { ...r, ...row } : r))
+      : [
+          ...rows,
+          {
+            builtin: false,
+            description: 'Custom version format.',
+            enabled: true,
+            id: nextRowId(),
+            ...row,
+          },
+        ]
     commit(override, next)
-    closeEditor()
   }
+
+  const statusBadge = override ? (
+    <Badge variant="warning">Overriding defaults</Badge>
+  ) : (
+    <Badge variant="neutral">Using defaults</Badge>
+  )
 
   return (
     <div className="border-input border-t pt-4">
@@ -202,11 +115,7 @@ export function VersionFormatsEditor({
             <span className="text-foreground text-sm font-medium">
               Version formats
             </span>
-            {override ? (
-              <Badge variant="warning">Overriding defaults</Badge>
-            ) : (
-              <Badge variant="neutral">Using defaults</Badge>
-            )}
+            {statusBadge}
           </div>
           <p className="text-tertiary mt-1 max-w-2xl text-xs leading-relaxed">
             By default, {ptName} projects inherit the organization&apos;s
@@ -222,186 +131,23 @@ export function VersionFormatsEditor({
         />
       </div>
 
-      {!override && <InheritedFormats inherited={inherited} />}
-
-      {override && (
-        <div className="mt-4 space-y-4">
-          <Alert variant="warning">
-            These formats <strong>replace</strong> the organization defaults.{' '}
-            {ptName} releases will be validated only against the enabled formats
-            below — the inherited defaults will not apply.
-          </Alert>
-
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-tertiary text-xs font-semibold tracking-wide uppercase">
-              Project type formats
-            </span>
-            <Button
-              disabled={disabled}
-              onClick={openAdd}
-              size="sm"
-              variant="outline"
-            >
-              <Plus className="mr-1.5 size-3.5" />
-              Add custom format
-            </Button>
-          </div>
-
-          {editorOpen && (
-            <div className="border-input rounded-lg border p-4">
-              <div className="text-tertiary mb-3 text-xs font-semibold tracking-wide uppercase">
-                {editId ? 'Edit custom format' : 'Add custom format'}
-              </div>
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_1.5fr]">
-                <div>
-                  <Label className="text-secondary mb-1.5 block text-xs">
-                    Name
-                  </Label>
-                  <Input
-                    onChange={(e) => setFName(e.target.value)}
-                    placeholder="e.g. Build number"
-                    value={fName}
-                  />
-                </div>
-                <div>
-                  <Label className="text-secondary mb-1.5 block text-xs">
-                    Pattern · regular expression
-                  </Label>
-                  <Input
-                    className="font-mono text-xs"
-                    onChange={(e) => setFPattern(e.target.value)}
-                    placeholder="^build-\d+$"
-                    value={fPattern}
-                  />
-                  {!patternValid && (
-                    <div className="text-danger mt-1.5 flex items-center gap-1 text-xs">
-                      <AlertTriangle className="size-3" />
-                      Not a valid regular expression.
-                    </div>
-                  )}
-                </div>
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2">
-                <span className="text-tertiary text-xs">Try it</span>
-                <Input
-                  className="max-w-65 font-mono text-xs"
-                  onChange={(e) => setFTest(e.target.value)}
-                  placeholder="Test a version"
-                  value={fTest}
-                />
-                {testMatch && <Badge variant="success">Match</Badge>}
-                {testNo && <Badge variant="danger">No match</Badge>}
-              </div>
-              <div className="mt-4 flex justify-end gap-2">
-                <Button onClick={closeEditor} size="sm" variant="ghost">
-                  Cancel
-                </Button>
-                <Button
-                  className="bg-action text-action-foreground hover:bg-action-hover"
-                  disabled={!canSave}
-                  onClick={saveFormat}
-                  size="sm"
-                >
-                  Save format
-                </Button>
-              </div>
-            </div>
-          )}
-
-          <div className="divide-input border-input divide-y rounded-lg border">
-            <div className="bg-secondary text-tertiary grid grid-cols-[minmax(0,1.4fr)_minmax(0,1.6fr)_auto_auto] items-center gap-4 px-4 py-2.5 text-xs font-semibold tracking-wide uppercase">
-              <span>Format</span>
-              <span>Pattern</span>
-              <span className="text-center">On</span>
-              <span className="w-14" />
-            </div>
-            {rows.map((row) => (
-              <FormatTableRow
-                disabled={disabled}
-                key={row.id}
-                onDelete={() => removeRow(row.id)}
-                onEdit={() => openEdit(row)}
-                onToggle={() => toggleRow(row.id)}
-                row={row}
-              />
-            ))}
-          </div>
-        </div>
+      {override ? (
+        <OverridePanel
+          disabled={disabled}
+          onRemove={removeRow}
+          onToggle={toggleRow}
+          onUpsert={upsert}
+          ptName={ptName}
+          rows={rows}
+        />
+      ) : (
+        <InheritedFormats inherited={inherited} />
       )}
     </div>
   )
 }
 
-function FormatTableRow({
-  disabled,
-  onDelete,
-  onEdit,
-  onToggle,
-  row,
-}: FormatTableRowProps) {
-  return (
-    <div className="grid grid-cols-[minmax(0,1.4fr)_minmax(0,1.6fr)_auto_auto] items-start gap-4 px-4 py-3.5">
-      <div className="min-w-0">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-primary text-sm font-medium">{row.label}</span>
-          {row.builtin ? (
-            <Badge variant="neutral">Built-in</Badge>
-          ) : (
-            <Badge variant="accent">Custom</Badge>
-          )}
-        </div>
-        <div className="text-tertiary mt-0.5 text-xs leading-snug">
-          {row.description}
-        </div>
-      </div>
-      <div className="min-w-0">
-        <code className="bg-secondary text-secondary block rounded px-2 py-1.5 font-mono text-xs break-all">
-          {row.pattern}
-        </code>
-        {row.example && (
-          <div className="text-tertiary mt-1 text-xs">
-            Matches{' '}
-            <span className="text-secondary font-mono">{row.example}</span>
-          </div>
-        )}
-      </div>
-      <div className="flex justify-center pt-0.5">
-        <Switch
-          aria-label={toggleAriaLabel(row)}
-          checked={row.enabled}
-          disabled={disabled}
-          onCheckedChange={onToggle}
-        />
-      </div>
-      <div className="flex w-14 justify-end gap-0.5">
-        {!row.builtin && (
-          <>
-            <Button
-              aria-label="Edit format"
-              disabled={disabled}
-              onClick={onEdit}
-              size="icon"
-              variant="ghost"
-            >
-              <Pencil className="size-3.5" />
-            </Button>
-            <Button
-              aria-label="Delete format"
-              disabled={disabled}
-              onClick={onDelete}
-              size="icon"
-              variant="ghost"
-            >
-              <Trash2 className="size-3.5" />
-            </Button>
-          </>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function InheritedFormats({ inherited }: { inherited: TagFormat[] }) {
+function InheritedFormats({ inherited }: InheritedFormatsProps) {
   return (
     <div className="border-input bg-secondary mt-4 rounded-lg border p-4">
       <div className="text-tertiary mb-3 flex items-center gap-1.5 text-xs font-semibold tracking-wide uppercase">
@@ -411,8 +157,8 @@ function InheritedFormats({ inherited }: { inherited: TagFormat[] }) {
       {inherited.length === 0 ? (
         <p className="text-tertiary text-xs leading-relaxed">
           The organization defines no version formats, so any non-empty version
-          is accepted. Set defaults in the organization&apos;s settings, or
-          override here.
+          is accepted. Set defaults in the organization&apos;s default settings,
+          or override here.
         </p>
       ) : (
         <div className="space-y-2">
@@ -436,6 +182,79 @@ function InheritedFormats({ inherited }: { inherited: TagFormat[] }) {
         Managed in the organization&apos;s default settings. These apply to
         every project type that doesn&apos;t define its own.
       </p>
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function OverridePanel({
+  disabled,
+  onRemove,
+  onToggle,
+  onUpsert,
+  ptName,
+  rows,
+}: OverridePanelProps) {
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [editing, setEditing] = useState<FormatRow | null>(null)
+
+  const close = () => {
+    setEditing(null)
+    setEditorOpen(false)
+  }
+
+  const save = (label: string, pattern: string, example: string) => {
+    onUpsert(editing?.id ?? null, { example, label, pattern })
+    close()
+  }
+
+  return (
+    <div className="mt-4 space-y-4">
+      <Alert variant="warning">
+        These formats <strong>replace</strong> the organization defaults.{' '}
+        {ptName} releases will be validated only against the enabled formats
+        below — the inherited defaults will not apply.
+      </Alert>
+
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-tertiary text-xs font-semibold tracking-wide uppercase">
+          Project type formats
+        </span>
+        <Button
+          disabled={disabled}
+          onClick={() => {
+            setEditing(null)
+            setEditorOpen(true)
+          }}
+          size="sm"
+          variant="outline"
+        >
+          <Plus className="mr-1.5 size-3.5" />
+          Add custom format
+        </Button>
+      </div>
+
+      {editorOpen && (
+        <FormatEditor
+          initialExample={editing?.example}
+          initialName={editing?.label}
+          initialPattern={editing?.pattern}
+          onCancel={close}
+          onSave={save}
+          title={editing ? 'Edit custom format' : 'Add custom format'}
+        />
+      )}
+
+      <FormatList
+        disabled={disabled}
+        onDelete={onRemove}
+        onEdit={(row) => {
+          setEditing(row)
+          setEditorOpen(true)
+        }}
+        onToggle={onToggle}
+        rows={rows}
+      />
     </div>
   )
 }

--- a/src/components/admin/project-types/VersionFormatsEditor.tsx
+++ b/src/components/admin/project-types/VersionFormatsEditor.tsx
@@ -239,6 +239,7 @@ function OverridePanel({
           initialExample={editing?.example}
           initialName={editing?.label}
           initialPattern={editing?.pattern}
+          key={editing?.id ?? 'new'}
           onCancel={close}
           onSave={save}
           title={editing ? 'Edit custom format' : 'Add custom format'}

--- a/src/components/admin/version-formats/FormatEditor.tsx
+++ b/src/components/admin/version-formats/FormatEditor.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+
+import { AlertTriangle } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { fullMatch, isValidPattern } from '@/lib/versionFormats'
+
+interface FormatEditorProps {
+  initialExample?: string
+  initialName?: string
+  initialPattern?: string
+  onCancel: () => void
+  onSave: (label: string, pattern: string, example: string) => void
+  title: string
+}
+
+// fallow-ignore-next-line complexity
+export function FormatEditor({
+  initialExample = '',
+  initialName = '',
+  initialPattern = '',
+  onCancel,
+  onSave,
+  title,
+}: FormatEditorProps) {
+  const [name, setName] = useState(initialName)
+  const [pattern, setPattern] = useState(initialPattern)
+  const [test, setTest] = useState(initialExample)
+
+  const patternValid = !pattern || isValidPattern(pattern)
+  const canSave = !!name.trim() && !!pattern.trim() && patternValid
+  const matched =
+    !!test && !!pattern && patternValid && fullMatch(pattern, test)
+  const noMatch = !!test && !!pattern && patternValid && !matched
+
+  return (
+    <div className="border-input rounded-lg border p-4">
+      <div className="text-tertiary mb-3 text-xs font-semibold tracking-wide uppercase">
+        {title}
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_1.5fr]">
+        <div>
+          <Label className="text-secondary mb-1.5 block text-xs">Name</Label>
+          <Input
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Build number"
+            value={name}
+          />
+        </div>
+        <div>
+          <Label className="text-secondary mb-1.5 block text-xs">
+            Pattern · regular expression
+          </Label>
+          <Input
+            className="font-mono text-xs"
+            onChange={(e) => setPattern(e.target.value)}
+            placeholder="^build-\d+$"
+            value={pattern}
+          />
+          {!patternValid && (
+            <div className="text-danger mt-1.5 flex items-center gap-1 text-xs">
+              <AlertTriangle className="size-3" />
+              Not a valid regular expression.
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="text-tertiary text-xs">Try it</span>
+        <Input
+          className="max-w-65 font-mono text-xs"
+          onChange={(e) => setTest(e.target.value)}
+          placeholder="Test a version"
+          value={test}
+        />
+        {matched && <Badge variant="success">Match</Badge>}
+        {noMatch && <Badge variant="danger">No match</Badge>}
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <Button onClick={onCancel} size="sm" variant="ghost">
+          Cancel
+        </Button>
+        <Button
+          className="bg-action text-action-foreground hover:bg-action-hover"
+          disabled={!canSave}
+          onClick={() => onSave(name.trim(), pattern.trim(), test.trim())}
+          size="sm"
+        >
+          Save format
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/version-formats/FormatList.tsx
+++ b/src/components/admin/version-formats/FormatList.tsx
@@ -1,0 +1,125 @@
+import { Pencil, Trash2 } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { type FormatRow, toggleAriaLabel } from '@/lib/versionFormats'
+
+interface FormatListProps {
+  disabled?: boolean
+  onDelete: (id: string) => void
+  onEdit: (row: FormatRow) => void
+  onToggle: (id: string) => void
+  rows: FormatRow[]
+}
+
+interface FormatTableRowProps {
+  disabled: boolean
+  onDelete: () => void
+  onEdit: () => void
+  onToggle: () => void
+  row: FormatRow
+}
+
+const GRID =
+  'grid grid-cols-[minmax(0,1.4fr)_minmax(0,1.6fr)_auto_auto] gap-4 px-4'
+
+export function FormatList({
+  disabled = false,
+  onDelete,
+  onEdit,
+  onToggle,
+  rows,
+}: FormatListProps) {
+  return (
+    <div className="divide-input border-input divide-y rounded-lg border">
+      <div
+        className={`${GRID} bg-secondary text-tertiary items-center py-2.5 text-xs font-semibold tracking-wide uppercase`}
+      >
+        <span>Format</span>
+        <span>Pattern</span>
+        <span className="text-center">On</span>
+        <span className="w-14" />
+      </div>
+      {rows.map((row) => (
+        <FormatTableRow
+          disabled={disabled}
+          key={row.id}
+          onDelete={() => onDelete(row.id)}
+          onEdit={() => onEdit(row)}
+          onToggle={() => onToggle(row.id)}
+          row={row}
+        />
+      ))}
+    </div>
+  )
+}
+
+function FormatTableRow({
+  disabled,
+  onDelete,
+  onEdit,
+  onToggle,
+  row,
+}: FormatTableRowProps) {
+  return (
+    <div className={`${GRID} items-start py-3.5`}>
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-primary text-sm font-medium">{row.label}</span>
+          {row.builtin ? (
+            <Badge variant="neutral">Built-in</Badge>
+          ) : (
+            <Badge variant="accent">Custom</Badge>
+          )}
+        </div>
+        <div className="text-tertiary mt-0.5 text-xs leading-snug">
+          {row.description}
+        </div>
+      </div>
+      <div className="min-w-0">
+        <code className="bg-secondary text-secondary block rounded px-2 py-1.5 font-mono text-xs break-all">
+          {row.pattern}
+        </code>
+        {row.example && (
+          <div className="text-tertiary mt-1 text-xs">
+            Matches{' '}
+            <span className="text-secondary font-mono">{row.example}</span>
+          </div>
+        )}
+      </div>
+      <div className="flex justify-center pt-0.5">
+        <Switch
+          aria-label={toggleAriaLabel(row)}
+          checked={row.enabled}
+          disabled={disabled}
+          onCheckedChange={onToggle}
+        />
+      </div>
+      <div className="flex w-14 justify-end gap-0.5">
+        {!row.builtin && (
+          <>
+            <Button
+              aria-label="Edit format"
+              disabled={disabled}
+              onClick={onEdit}
+              size="icon"
+              variant="ghost"
+            >
+              <Pencil className="size-3.5" />
+            </Button>
+            <Button
+              aria-label="Delete format"
+              disabled={disabled}
+              onClick={onDelete}
+              size="icon"
+              variant="ghost"
+            >
+              <Trash2 className="size-3.5" />
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/version-formats/VersionTester.tsx
+++ b/src/components/admin/version-formats/VersionTester.tsx
@@ -59,8 +59,11 @@ function VersionTesterResults({
   return (
     <>
       <div className="mt-4 flex max-w-md flex-col gap-2.5">
-        {results.map((r) => (
-          <div className="flex items-center justify-between" key={r.label}>
+        {results.map((r, i) => (
+          <div
+            className="flex items-center justify-between"
+            key={`${i}-${r.label}`}
+          >
             <span className="text-secondary text-sm">{r.label}</span>
             {r.matched ? (
               <Badge variant="success">Match</Badge>

--- a/src/components/admin/version-formats/VersionTester.tsx
+++ b/src/components/admin/version-formats/VersionTester.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+
+import { CircleCheck, CircleX } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { fullMatch } from '@/lib/versionFormats'
+import type { TagFormat } from '@/types'
+
+interface VersionTesterProps {
+  formats: TagFormat[]
+}
+
+// Checks a candidate version against every enabled format and reports which
+// accept it — mirrors the backend's "matches any configured format" rule.
+export function VersionTester({ formats }: VersionTesterProps) {
+  const [value, setValue] = useState('')
+
+  const results = formats.map((f) => ({
+    label: f.label,
+    matched: !!value && fullMatch(f.pattern, value),
+  }))
+  const matchCount = results.filter((r) => r.matched).length
+
+  return (
+    <div>
+      <h2 className="text-primary mt-8 text-base font-medium">
+        Test a version string
+      </h2>
+      <p className="text-secondary mt-1 mb-3 text-sm">
+        Check a version against every enabled format.
+      </p>
+      <div className="border-input rounded-lg border p-4">
+        <Input
+          className="max-w-90 font-mono text-sm"
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="e.g. 2.11.5"
+          value={value}
+        />
+        {value ? (
+          <VersionTesterResults matchCount={matchCount} results={results} />
+        ) : (
+          <div className="text-tertiary mt-4 text-sm">
+            Enter a version to see which formats accept it.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function VersionTesterResults({
+  matchCount,
+  results,
+}: {
+  matchCount: number
+  results: { label: string; matched: boolean }[]
+}) {
+  return (
+    <>
+      <div className="mt-4 flex max-w-md flex-col gap-2.5">
+        {results.map((r) => (
+          <div className="flex items-center justify-between" key={r.label}>
+            <span className="text-secondary text-sm">{r.label}</span>
+            {r.matched ? (
+              <Badge variant="success">Match</Badge>
+            ) : (
+              <Badge variant="neutral">No match</Badge>
+            )}
+          </div>
+        ))}
+      </div>
+      {matchCount > 0 ? (
+        <div className="text-success mt-4 inline-flex items-center gap-1.5 text-sm">
+          <CircleCheck className="size-4" />
+          Accepted — {matchCount} {matchCount === 1 ? 'format' : 'formats'}.
+        </div>
+      ) : (
+        <div className="text-danger mt-4 inline-flex items-center gap-1.5 text-sm">
+          <CircleX className="size-4" />
+          Rejected — no enabled format matches this version.
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,5 +28,11 @@ export const ENVIRONMENT_BASE_FIELDS = [
 ]
 export const ENVIRONMENT_BASE_FIELDS_SET = new Set(ENVIRONMENT_BASE_FIELDS)
 
-export const PROJECT_TYPE_BASE_FIELDS = [...NODE_BASE_FIELDS, 'id']
+export const PROJECT_TYPE_BASE_FIELDS = [
+  ...NODE_BASE_FIELDS,
+  'deployable',
+  'releasable',
+  'tag_formats',
+  'id',
+]
 export const PROJECT_TYPE_BASE_FIELDS_SET = new Set(PROJECT_TYPE_BASE_FIELDS)

--- a/src/lib/versionFormats.ts
+++ b/src/lib/versionFormats.ts
@@ -1,14 +1,26 @@
 import type { TagFormat } from '@/types'
 
+// A row in the version-format editor: a `TagFormat` plus display metadata and
+// UI state (`enabled`, `builtin`, a stable `id`).
+export interface FormatRow {
+  builtin: boolean
+  description: string
+  enabled: boolean
+  example: string
+  id: string
+  label: string
+  pattern: string
+}
+
 // Built-in presets surfaced as toggleable rows in the version-format editor.
 // Only `label`/`pattern` are persisted (as `TagFormat`); `description` and
 // `example` are display-only metadata that lives here in the UI.
-export interface BuiltinFormat extends TagFormat {
+interface BuiltinFormat extends TagFormat {
   description: string
   example: string
 }
 
-export const BUILTIN_FORMATS: BuiltinFormat[] = [
+const BUILTIN_FORMATS: BuiltinFormat[] = [
   {
     description:
       'MAJOR.MINOR.PATCH with optional pre-release and build metadata.',
@@ -39,8 +51,38 @@ export const BUILTIN_FORMATS: BuiltinFormat[] = [
 
 const BUILTIN_BY_PATTERN = new Map(BUILTIN_FORMATS.map((f) => [f.pattern, f]))
 
-export function builtinForPattern(pattern: string): BuiltinFormat | undefined {
-  return BUILTIN_BY_PATTERN.get(pattern)
+let rowSeq = 0
+
+/**
+ * Build the editor's working rows from a persisted `TagFormat[]`: every
+ * built-in preset appears (toggled on when its pattern is present), and any
+ * persisted pattern that isn't a built-in is appended as an enabled custom row.
+ */
+export function buildRows(formats: TagFormat[]): FormatRow[] {
+  const enabled = new Set(formats.map((f) => f.pattern))
+  const rows: FormatRow[] = BUILTIN_FORMATS.map((b) => ({
+    builtin: true,
+    description: b.description,
+    enabled: enabled.has(b.pattern),
+    example: b.example,
+    id: nextRowId(),
+    label: b.label,
+    pattern: b.pattern,
+  }))
+  for (const f of formats) {
+    if (!builtinForPattern(f.pattern)) {
+      rows.push({
+        builtin: false,
+        description: 'Custom version format.',
+        enabled: true,
+        example: '',
+        id: nextRowId(),
+        label: f.label,
+        pattern: f.pattern,
+      })
+    }
+  }
+  return rows
 }
 
 /**
@@ -65,4 +107,24 @@ export function isValidPattern(pattern: string): boolean {
   } catch {
     return false
   }
+}
+
+export function nextRowId(): string {
+  rowSeq += 1
+  return `vf-${rowSeq}`
+}
+
+/** The enabled rows reduced to the persisted `TagFormat[]` shape. */
+export function toFormats(rows: FormatRow[]): TagFormat[] {
+  return rows
+    .filter((r) => r.enabled)
+    .map(({ label, pattern }) => ({ label, pattern }))
+}
+
+export function toggleAriaLabel(row: FormatRow): string {
+  return row.enabled ? `Disable ${row.label}` : `Enable ${row.label}`
+}
+
+function builtinForPattern(pattern: string): BuiltinFormat | undefined {
+  return BUILTIN_BY_PATTERN.get(pattern)
 }

--- a/src/lib/versionFormats.ts
+++ b/src/lib/versionFormats.ts
@@ -92,8 +92,7 @@ export function buildRows(formats: TagFormat[]): FormatRow[] {
  */
 export function fullMatch(pattern: string, value: string): boolean {
   try {
-    const match = new RegExp(pattern).exec(value)
-    return match !== null && match.index === 0 && match[0] === value
+    return new RegExp(`^(?:${pattern})$`).test(value)
   } catch {
     return false
   }

--- a/src/lib/versionFormats.ts
+++ b/src/lib/versionFormats.ts
@@ -1,0 +1,68 @@
+import type { TagFormat } from '@/types'
+
+// Built-in presets surfaced as toggleable rows in the version-format editor.
+// Only `label`/`pattern` are persisted (as `TagFormat`); `description` and
+// `example` are display-only metadata that lives here in the UI.
+export interface BuiltinFormat extends TagFormat {
+  description: string
+  example: string
+}
+
+export const BUILTIN_FORMATS: BuiltinFormat[] = [
+  {
+    description:
+      'MAJOR.MINOR.PATCH with optional pre-release and build metadata.',
+    example: '2.11.5',
+    label: 'Semantic versioning',
+    pattern:
+      '^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-([0-9A-Za-z-.]+))?(?:\\+([0-9A-Za-z-.]+))?$',
+  },
+  {
+    description: 'Year and month, with an optional patch segment.',
+    example: '2026.06',
+    label: 'Calendar versioning',
+    pattern: '^\\d{4}\\.\\d{1,2}(?:\\.\\d{1,2})?$',
+  },
+  {
+    description: '7 to 40 character hexadecimal commit hash.',
+    example: '7d4f2a3b',
+    label: 'Git short SHA',
+    pattern: '^[0-9a-f]{7,40}$',
+  },
+  {
+    description: 'Accepts any non-empty string. Use as a catch-all.',
+    example: 'nightly-build',
+    label: 'Any format',
+    pattern: '^.+$',
+  },
+]
+
+const BUILTIN_BY_PATTERN = new Map(BUILTIN_FORMATS.map((f) => [f.pattern, f]))
+
+export function builtinForPattern(pattern: string): BuiltinFormat | undefined {
+  return BUILTIN_BY_PATTERN.get(pattern)
+}
+
+/**
+ * Whole-string match, mirroring the backend's `re.fullmatch` semantics so the
+ * in-form tester agrees with server-side validation. Returns false for an
+ * invalid pattern rather than throwing.
+ */
+export function fullMatch(pattern: string, value: string): boolean {
+  try {
+    const match = new RegExp(pattern).exec(value)
+    return match !== null && match.index === 0 && match[0] === value
+  } catch {
+    return false
+  }
+}
+
+/** Return whether `pattern` is a valid (compilable) regular expression. */
+export function isValidPattern(pattern: string): boolean {
+  try {
+    new RegExp(pattern)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -296,6 +296,7 @@ export interface ProjectTypeCreate {
   name: string
   releasable?: boolean
   slug: string
+  tag_formats?: TagFormat[]
 }
 
 export interface PullRequest {
@@ -1528,6 +1529,13 @@ export interface Tag {
   organization: { name: string; slug: string }
   slug: string
   updated_at?: null | string
+}
+
+// A named release/deploy tag-format policy. Mirrors `imbi_common.models.
+// TagFormat`; carried as a list on both organizations and project types.
+export interface TagFormat {
+  label: string
+  pattern: string
 }
 
 // Documents & tags. Inlined here (not from api-generated.ts) because the


### PR DESCRIPTION
## Summary

Adds the UI for configurable version (tag) formats at both the organization and project-type levels, from the Claude Design mockups (`Project Type Edit.dc.html` / `General Settings.dc.html`).

## Changes

### Project type form (`4a757ea4`)
- **`VersionFormatsEditor`** in the project type form: an override toggle, a read-only "inherited from organization defaults" panel, and an inline add/edit editor with a live regex tester and built-in presets (Semver, CalVer, Git short SHA, Any) plus custom rows.

### Org Default Settings page (`6cb83ee7`)
- New admin section **Default Settings** (org scope, `DefaultSettingsManagement`, keyed by org slug) that edits the org's `tag_formats`. Save issues a JSON-Patch `PATCH /organizations/{slug}` and invalidates the org query.
- A **"Test a version string"** panel that reports per-format and overall accept/reject (matches-any, mirroring the backend).

### Shared
- Extracted shared pieces to `components/admin/version-formats/` (`FormatList`, `FormatEditor`, `VersionTester`) + `lib/versionFormats.ts` (`buildRows`/`toFormats`/`nextRowId`/`toggleAriaLabel`/`FormatRow`). `fullMatch` mirrors backend `re.fullmatch`.
- `TagFormat` type + `tag_formats` on `ProjectTypeCreate`; `tag_formats`/`deployable`/`releasable` added to `PROJECT_TYPE_BASE_FIELDS` so `...dynamicFormData` doesn't clobber them.

## Notes

- Fallow gate: editing `Admin.tsx` re-attributed its pre-existing large `Admin`/`renderSectionButton` functions as "introduced" — suppressed with `// fallow-ignore-next-line complexity` (alongside the new form components).
- tsc / oxlint / oxfmt / production build all pass locally.
- Depends on the imbi-api `tag_formats` fields being deployed; openapi types should be regenerated (`npm run codegen:fetch`) once the backend ships.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
