### PR TITLE
Add condition scoring policy UI and dependency deprecation indicators

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -98,6 +98,7 @@ import type {
   RoleDetail,
   RoleUser,
   ScoringPolicy,
+  ScoringPolicyCategory,
   ScoringPolicyCreate,
   ServiceAccount,
   ServiceAccountCreate,
@@ -245,11 +246,20 @@ export const getProject = (
 
 export interface AttributeContribution {
   attribute_name: string
+  category?: ScoringPolicyCategory
+  condition_result?: boolean | null
   mapped_score: number
+  matched_neighbours?: MatchedNeighbour[]
   policy_slug: string
   value: unknown
   weight: number
   weighted_contribution: number
+}
+
+export interface MatchedNeighbour {
+  id: string
+  name?: null | string
+  slug?: null | string
 }
 
 interface ScoreBreakdown {

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1521,7 +1521,10 @@ function ScoreBreakdownDetail({
     const maxPts = totalWeight > 0 ? (c.weight / totalWeight) * 100 : 0
     return {
       contribution: c,
-      isPerfect: c.mapped_score >= 100,
+      isPerfect:
+        c.category === 'condition'
+          ? c.condition_result === true
+          : c.mapped_score >= 100,
       maxPts,
       policy: policyBySlug.get(c.policy_slug),
     }
@@ -1598,7 +1601,9 @@ function ScoreBreakdownDetail({
                       <p>
                         {policy?.description || 'Condition'}{' '}
                         <span className="text-danger font-medium">
-                          · not met
+                          {c.condition_result === false
+                            ? '· not met'
+                            : '· not evaluated'}
                         </span>
                       </p>
                       {c.matched_neighbours &&

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1555,17 +1555,20 @@ function ScoreBreakdownDetail({
               const fillPct =
                 maxPts > 0 ? (c.weighted_contribution / maxPts) * 100 : 0
               const lost = Math.round(maxPts - c.weighted_contribution)
-              const policyName =
-                formatFieldKey(c.attribute_name) ||
-                policy?.name ||
-                formatFieldKey(c.policy_slug)
-              const recommendation = policy
-                ? buildRecommendation(
-                    c,
-                    policy,
-                    allowedValuesByAttribute.get(c.attribute_name),
-                  )
-                : null
+              const isCondition = c.category === 'condition'
+              const policyName = isCondition
+                ? policy?.name || formatFieldKey(c.policy_slug)
+                : formatFieldKey(c.attribute_name) ||
+                  policy?.name ||
+                  formatFieldKey(c.policy_slug)
+              const recommendation =
+                policy && !isCondition
+                  ? buildRecommendation(
+                      c,
+                      policy,
+                      allowedValuesByAttribute.get(c.attribute_name),
+                    )
+                  : null
               return (
                 <div
                   className="border-tertiary bg-primary rounded-md border p-3.5"
@@ -1590,12 +1593,38 @@ function ScoreBreakdownDetail({
                       </span>
                     </div>
                   </div>
-                  <p className="text-secondary mt-1 mb-2.5 text-[13px]">
-                    Currently{' '}
-                    <span className="text-amber-text font-medium">
-                      {c.value != null ? fmtAttributeValue(c.value) : 'Not set'}
-                    </span>
-                  </p>
+                  {isCondition ? (
+                    <div className="text-secondary mt-1 mb-2.5 text-[13px]">
+                      <p>
+                        {policy?.description || 'Condition'}{' '}
+                        <span className="text-danger font-medium">
+                          · not met
+                        </span>
+                      </p>
+                      {c.matched_neighbours &&
+                        c.matched_neighbours.length > 0 && (
+                          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                            {c.matched_neighbours.map((n) => (
+                              <span
+                                className="bg-danger text-danger inline-flex items-center rounded px-1.5 py-0.5 text-[12px] font-medium"
+                                key={n.id}
+                              >
+                                {n.name || n.slug || n.id}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                    </div>
+                  ) : (
+                    <p className="text-secondary mt-1 mb-2.5 text-[13px]">
+                      Currently{' '}
+                      <span className="text-amber-text font-medium">
+                        {c.value != null
+                          ? fmtAttributeValue(c.value)
+                          : 'Not set'}
+                      </span>
+                    </p>
+                  )}
                   <div className="bg-secondary relative h-1.5 rounded-full">
                     {fillPct > 0 && (
                       <div
@@ -1629,10 +1658,12 @@ function ScoreBreakdownDetail({
           <div className="border-tertiary overflow-hidden rounded-md border">
             {/* fallow-ignore-next-line complexity */}
             {perfect.map(({ contribution: c, maxPts, policy }, idx) => {
-              const policyName =
-                formatFieldKey(c.attribute_name) ||
-                policy?.name ||
-                formatFieldKey(c.policy_slug)
+              const isCondition = c.category === 'condition'
+              const policyName = isCondition
+                ? policy?.name || formatFieldKey(c.policy_slug)
+                : formatFieldKey(c.attribute_name) ||
+                  policy?.name ||
+                  formatFieldKey(c.policy_slug)
               return (
                 <div
                   className={`bg-primary grid grid-cols-[auto_1fr_auto] items-center gap-2.5 px-3 py-2.5 ${
@@ -1646,7 +1677,11 @@ function ScoreBreakdownDetail({
                   <span className="text-primary text-[13.5px] font-medium">
                     {policyName}
                     <span className="text-tertiary ml-1.5 font-normal">
-                      {c.value != null ? fmtAttributeValue(c.value) : 'Not set'}
+                      {isCondition
+                        ? 'met'
+                        : c.value != null
+                          ? fmtAttributeValue(c.value)
+                          : 'Not set'}
                     </span>
                   </span>
                   <span className="text-tertiary font-mono text-[12px] tabular-nums">

--- a/src/components/ProjectRelationshipsTab.tsx
+++ b/src/components/ProjectRelationshipsTab.tsx
@@ -306,7 +306,7 @@ function SidebarProjectRow({ rel }: { rel: ProjectRelationship }) {
         <span className={`shrink-0 text-[10px] ${muted}`}>{typeSlug}</span>
       )}
       {rel.project.deprecated && (
-        <span className="bg-danger text-danger shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium">
+        <span className="bg-danger/10 text-danger shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium">
           Deprecated
         </span>
       )}

--- a/src/components/ProjectRelationshipsTab.tsx
+++ b/src/components/ProjectRelationshipsTab.tsx
@@ -32,6 +32,7 @@ type RelFilter = 'all' | 'used-by' | 'uses'
 /*  Sidebar                                                           */
 /* ------------------------------------------------------------------ */
 
+// fallow-ignore-next-line complexity
 export function ProjectRelationshipsTab({
   orgSlug,
   project,
@@ -168,6 +169,7 @@ export function ProjectRelationshipsTab({
   )
 }
 
+// fallow-ignore-next-line complexity
 function ProjectRelationshipsSidebar({
   filter,
   inbound,
@@ -302,6 +304,11 @@ function SidebarProjectRow({ rel }: { rel: ProjectRelationship }) {
       </Link>
       {typeSlug && (
         <span className={`shrink-0 text-[10px] ${muted}`}>{typeSlug}</span>
+      )}
+      {rel.project.deprecated && (
+        <span className="bg-danger text-danger shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium">
+          Deprecated
+        </span>
       )}
     </li>
   )

--- a/src/components/admin/ScoringPolicyManagement.tsx
+++ b/src/components/admin/ScoringPolicyManagement.tsx
@@ -52,10 +52,12 @@ const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
   age: 'Age',
   analysis_result: 'Analysis Result',
   attribute: 'Attribute',
+  condition: 'Condition',
   link_presence: 'Link Presence',
   presence: 'Presence',
 }
 
+// fallow-ignore-next-line complexity
 export function ScoringPolicyManagement() {
   const {
     editPath,
@@ -106,6 +108,7 @@ export function ScoringPolicyManagement() {
     [policies, selectedSlug],
   )
 
+  // fallow-ignore-next-line complexity
   const filteredPolicies = policies.filter((p) => {
     if (searchQuery) {
       const q = searchQuery.toLowerCase()
@@ -139,6 +142,7 @@ export function ScoringPolicyManagement() {
     setImportDialogOpen(true)
   }
 
+  // fallow-ignore-next-line complexity
   const handleSave = (data: ScoringPolicyCreate) => {
     if (viewMode === 'create') {
       createMutation.mutate(data)
@@ -379,6 +383,12 @@ function categorySpecificExport(
       }
     case 'attribute':
       return attributeExport(policy)
+    case 'condition':
+      return {
+        condition: policy.condition,
+        false_score: policy.false_score,
+        true_score: policy.true_score,
+      }
     case 'link_presence':
       return presenceExport({
         missing_score: policy.missing_score,
@@ -397,6 +407,7 @@ function categorySpecificExport(
 function policySubjectKey(policy: ScoringPolicy): string {
   if (policy.category === 'link_presence') return policy.link_slug
   if (policy.category === 'analysis_result') return policy.result_slug
+  if (policy.category === 'condition') return ''
   return policy.attribute_name
 }
 

--- a/src/components/admin/scoring-policies/ConditionBuilder.test.tsx
+++ b/src/components/admin/scoring-policies/ConditionBuilder.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fireEvent, render, screen } from '@/test/utils'
+import type { Condition } from '@/types'
+
+import {
+  ConditionBuilder,
+  conditionToEnglish,
+  DEFAULT_CONDITION,
+  normalizeCondition,
+} from './ConditionBuilder'
+
+describe('normalizeCondition', () => {
+  it('strips null siblings the API includes on each node', () => {
+    const raw = {
+      all: null,
+      any: null,
+      attribute: 'deprecated',
+      not: null,
+      op: 'eq',
+      relationship: null,
+      value: true,
+    } as unknown as Condition
+
+    expect(normalizeCondition(raw)).toEqual({
+      attribute: 'deprecated',
+      op: 'eq',
+      value: true,
+    })
+  })
+
+  it('recurses through relationship and combinator nodes', () => {
+    const raw = {
+      relationship: {
+        direction: 'outgoing',
+        edge: 'DEPENDS_ON',
+        quantifier: 'none',
+        where: {
+          all: null,
+          any: null,
+          attribute: 'deprecated',
+          not: null,
+          op: 'eq',
+          relationship: null,
+          value: true,
+        },
+      },
+    } as unknown as Condition
+
+    expect(normalizeCondition(raw)).toEqual(DEFAULT_CONDITION)
+  })
+
+  it('drops the value key for present/absent ops', () => {
+    const raw = { attribute: 'description', op: 'present' } as Condition
+    expect(normalizeCondition(raw)).toEqual({
+      attribute: 'description',
+      op: 'present',
+    })
+  })
+})
+
+describe('conditionToEnglish', () => {
+  it('describes the deprecation-contagion default', () => {
+    expect(conditionToEnglish(DEFAULT_CONDITION)).toBe(
+      'no outgoing dependency where deprecated is true',
+    )
+  })
+
+  it('describes a compound all/any tree', () => {
+    const cond: Condition = {
+      all: [
+        { attribute: 'deprecated', op: 'eq', value: true },
+        { attribute: 'tier', op: 'eq', value: 'critical' },
+      ],
+    }
+    expect(conditionToEnglish(cond)).toBe(
+      '(deprecated is true AND tier is "critical")',
+    )
+  })
+})
+
+describe('ConditionBuilder', () => {
+  const renderBuilder = (value: Condition, onChange = vi.fn()) => {
+    render(
+      <ConditionBuilder
+        falseScore={0}
+        onChange={onChange}
+        trueScore={100}
+        value={value}
+        weight={15}
+      />,
+    )
+    return onChange
+  }
+
+  it('renders the English preview of the tree', () => {
+    renderBuilder(DEFAULT_CONDITION)
+    expect(
+      screen.getByText('no outgoing dependency where deprecated is true'),
+    ).toBeInTheDocument()
+  })
+
+  it('edits an attribute leaf and emits the updated tree', () => {
+    const onChange = renderBuilder({
+      attribute: 'deprecated',
+      op: 'eq',
+      value: true,
+    })
+    const input = screen.getByPlaceholderText('attribute')
+    fireEvent.change(input, { target: { value: 'archived' } })
+    expect(onChange).toHaveBeenCalledWith({
+      attribute: 'archived',
+      op: 'eq',
+      value: true,
+    })
+  })
+
+  it('round-trips a tree edited as JSON', () => {
+    const onChange = renderBuilder({
+      attribute: 'deprecated',
+      op: 'eq',
+      value: true,
+    })
+    fireEvent.click(screen.getByText('JSON'))
+    const next: Condition = { attribute: 'tier', op: 'eq', value: 'critical' }
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, {
+      target: { value: JSON.stringify(next) },
+    })
+    expect(onChange).toHaveBeenCalledWith(next)
+    expect(screen.getByText('Valid condition tree')).toBeInTheDocument()
+  })
+})

--- a/src/components/admin/scoring-policies/ConditionBuilder.tsx
+++ b/src/components/admin/scoring-policies/ConditionBuilder.tsx
@@ -1,0 +1,685 @@
+import { useState } from 'react'
+
+import { Check, GitBranch, Plus, Trash2, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type {
+  AttributeCondition,
+  Condition,
+  ConditionOp,
+  RelationshipCondition,
+} from '@/types'
+
+// A structural view of a node used by the mutation helpers. Exactly one of
+// these keys is populated on a valid node (see imbi-common's Condition model).
+interface CondRecord {
+  all?: Condition[]
+  any?: Condition[]
+  attribute?: string
+  not?: Condition
+  op?: ConditionOp
+  relationship?: RelationshipCondition['relationship']
+  value?: unknown
+}
+
+// Path into the condition tree: numbers index into an all/any array; the
+// markers 'not' / 'where' step into a not child or a relationship's where.
+type PathSegment = number | string
+
+type Quantifier = 'all' | 'any' | 'none'
+
+const OPS: Array<[ConditionOp, string]> = [
+  ['eq', 'is'],
+  ['ne', 'is not'],
+  ['gt', '>'],
+  ['ge', '≥'],
+  ['lt', '<'],
+  ['le', '≤'],
+  ['present', 'is present'],
+  ['absent', 'is absent'],
+]
+
+const OP_LABELS: Record<ConditionOp, string> = Object.fromEntries(
+  OPS,
+) as Record<ConditionOp, string>
+
+const QUANTIFIER_PHRASES: Record<Quantifier, string> = {
+  all: 'every outgoing dependency',
+  any: 'at least one outgoing dependency',
+  none: 'no outgoing dependency',
+}
+
+// Plain-language semantics, including the easily-missed empty-set behaviour.
+const QUANTIFIER_HINTS: Record<Quantifier, string> = {
+  all: 'True only when every dependency matches — also true for projects with no dependencies.',
+  any: 'True when at least one dependency matches — false for projects with no dependencies.',
+  none: 'True when no dependency matches — also true for projects with no dependencies. Use this to penalize projects that have a matching dependency.',
+}
+
+const NUMERIC_OPS = new Set<ConditionOp>(['ge', 'gt', 'le', 'lt'])
+const NO_VALUE_OPS = new Set<ConditionOp>(['absent', 'present'])
+
+export const DEFAULT_CONDITION: Condition = {
+  relationship: {
+    direction: 'outgoing',
+    edge: 'DEPENDS_ON',
+    quantifier: 'none',
+    where: { attribute: 'deprecated', op: 'eq', value: true },
+  },
+}
+
+interface ConditionBuilderProps {
+  disabled?: boolean
+  falseScore: number
+  onChange: (value: Condition) => void
+  trueScore: number
+  value: Condition
+  weight: number
+}
+
+export function ConditionBuilder({
+  disabled = false,
+  falseScore,
+  onChange,
+  trueScore,
+  value,
+  weight,
+}: ConditionBuilderProps) {
+  const [mode, setMode] = useState<'json' | 'visual'>('visual')
+  const [jsonDraft, setJsonDraft] = useState(() =>
+    JSON.stringify(value, null, 2),
+  )
+  const [jsonError, setJsonError] = useState('')
+
+  const update = (path: PathSegment[], fn: (node: Condition) => Condition) =>
+    onChange(withUpdated(value, path, fn))
+
+  const setAttr = (path: PathSegment[], attribute: string) =>
+    update(path, (t) => ({ ...(t as AttributeCondition), attribute }))
+
+  const setOp = (path: PathSegment[], op: ConditionOp) =>
+    update(path, (t) => {
+      const r = { ...asRecord(t), op }
+      if (NO_VALUE_OPS.has(op)) delete r.value
+      else if (r.value == null) r.value = ''
+      return r as Condition
+    })
+
+  const setValue = (path: PathSegment[], v: unknown) =>
+    update(path, (t) => ({ ...(t as AttributeCondition), value: v }))
+
+  const setQuantifier = (path: PathSegment[], quantifier: Quantifier) =>
+    update(path, (t) => {
+      const r = asRecord(t)
+      if (r.relationship) r.relationship.quantifier = quantifier
+      return t
+    })
+
+  const setCombinator = (path: PathSegment[], type: 'all' | 'any') =>
+    update(path, (t) => {
+      const r = asRecord(t)
+      const kids = r.all ?? r.any ?? []
+      const next: Condition = type === 'all' ? { all: kids } : { any: kids }
+      return next
+    })
+
+  const wrap = (path: PathSegment[], type: 'all' | 'any') =>
+    update(path, (t) => {
+      const next: Condition =
+        type === 'all'
+          ? { all: [t, defaultRule()] }
+          : { any: [t, defaultRule()] }
+      return next
+    })
+
+  const addChild = (path: PathSegment[], node: Condition) =>
+    update(path, (t) => {
+      const r = asRecord(t)
+      if (r.all) r.all.push(node)
+      else if (r.any) r.any.push(node)
+      return t
+    })
+
+  const deleteChild = (path: PathSegment[], idx: number) =>
+    update(path, (t) => {
+      const r = asRecord(t)
+      const arr = r.all ?? r.any
+      if (arr) arr.splice(idx, 1)
+      return t
+    })
+
+  const switchMode = (next: 'json' | 'visual') => {
+    if (next === 'json') {
+      setJsonDraft(JSON.stringify(value, null, 2))
+      setJsonError('')
+    }
+    setMode(next)
+  }
+
+  const onJsonChange = (text: string) => {
+    setJsonDraft(text)
+    try {
+      const parsed = JSON.parse(text) as Condition
+      setJsonError('')
+      onChange(parsed)
+    } catch (e) {
+      setJsonError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  // ---- renderers ----
+  const renderValue = (node: Condition, path: PathSegment[]) => {
+    const n = asRecord(node)
+    const op = (n.op ?? 'eq') as ConditionOp
+    if (NO_VALUE_OPS.has(op)) {
+      return (
+        <span className="text-tertiary px-1 text-xs italic">(no value)</span>
+      )
+    }
+    if (typeof n.value === 'boolean') {
+      return (
+        <div className="border-input flex overflow-hidden rounded-md border">
+          {[true, false].map((b) => (
+            <button
+              className={`px-3 py-1.5 font-mono text-xs font-semibold ${
+                n.value === b
+                  ? 'bg-amber-bg text-amber-text'
+                  : 'text-secondary hover:bg-secondary'
+              }`}
+              disabled={disabled}
+              key={String(b)}
+              onClick={() => setValue(path, b)}
+              type="button"
+            >
+              {String(b)}
+            </button>
+          ))}
+        </div>
+      )
+    }
+    const numeric = NUMERIC_OPS.has(op)
+    return (
+      <Input
+        className="h-9 w-36 font-mono"
+        disabled={disabled}
+        onChange={(e) => setValue(path, e.target.value)}
+        placeholder="value"
+        type={numeric ? 'number' : 'text'}
+        value={n.value == null ? '' : String(n.value)}
+      />
+    )
+  }
+
+  const opSelect = (node: Condition, path: PathSegment[]) => {
+    const n = asRecord(node)
+    return (
+      <Select
+        disabled={disabled}
+        onValueChange={(v) => setOp(path, v as ConditionOp)}
+        value={n.op ?? 'eq'}
+      >
+        <SelectTrigger className="h-9 w-auto font-mono">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {OPS.map(([v, label]) => (
+            <SelectItem key={v} value={v}>
+              {label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  const deleteButton = (onDelete: () => void) => (
+    <Button
+      className="ml-auto"
+      disabled={disabled}
+      onClick={onDelete}
+      size="icon"
+      type="button"
+      variant="ghost"
+    >
+      <Trash2 className="text-tertiary size-4" />
+    </Button>
+  )
+
+  const wrapButtons = (path: PathSegment[]) => (
+    <span className="ml-auto flex gap-1.5">
+      {(['all', 'any'] as const).map((type) => (
+        <button
+          className="border-input text-secondary hover:bg-secondary inline-flex items-center gap-1 rounded-md border px-2.5 py-1.5 text-[11px] font-bold tracking-wider"
+          disabled={disabled}
+          key={type}
+          onClick={() => wrap(path, type)}
+          type="button"
+        >
+          <Plus className="size-3" />
+          {type === 'all' ? 'AND' : 'OR'}
+        </button>
+      ))}
+    </span>
+  )
+
+  const renderAttr = (
+    node: Condition,
+    path: PathSegment[],
+    slot: 'array' | 'single',
+    onDelete: (() => void) | null,
+  ) => {
+    const n = asRecord(node)
+    return (
+      <div className="border-input bg-primary flex flex-wrap items-center gap-2 rounded-md border px-3 py-2.5">
+        <Input
+          className="h-9 w-40 font-mono"
+          disabled={disabled}
+          onChange={(e) => setAttr(path, e.target.value)}
+          placeholder="attribute"
+          value={n.attribute ?? ''}
+        />
+        {opSelect(node, path)}
+        {renderValue(node, path)}
+        {slot === 'array' && onDelete
+          ? deleteButton(onDelete)
+          : wrapButtons(path)}
+      </div>
+    )
+  }
+
+  const renderCombinator = (
+    node: Condition,
+    path: PathSegment[],
+    slot: 'array' | 'single',
+    onDelete: (() => void) | null,
+    inRel: boolean,
+  ) => {
+    const n = asRecord(node)
+    const type: 'all' | 'any' = n.all ? 'all' : 'any'
+    const kids = (n.all ?? n.any) as Condition[]
+    const conj = type === 'all' ? 'AND' : 'OR'
+    return (
+      <div className="border-input bg-secondary rounded-lg border p-3.5">
+        <div className="mb-3 flex items-center gap-3">
+          <span className="border-input flex overflow-hidden rounded-md border">
+            {(['all', 'any'] as const).map((t) => (
+              <button
+                className={`px-3 py-1.5 text-xs font-bold tracking-wide ${
+                  type === t
+                    ? 'bg-amber-bg text-amber-text'
+                    : 'text-secondary hover:bg-primary'
+                }`}
+                disabled={disabled}
+                key={t}
+                onClick={() => setCombinator(path, t)}
+                type="button"
+              >
+                {t.toUpperCase()}
+              </button>
+            ))}
+          </span>
+          <span className="text-secondary text-sm">
+            {type === 'all'
+              ? 'of these must be true'
+              : 'of these are true (at least one)'}
+          </span>
+          {slot === 'array' && onDelete ? deleteButton(onDelete) : null}
+        </div>
+        <div className="border-tertiary ml-2 flex flex-col gap-2 border-l-2 pl-3.5">
+          {kids.length === 0 ? (
+            <div className="text-tertiary text-xs italic">
+              No conditions yet
+            </div>
+          ) : (
+            kids.map((child, i) => (
+              <div key={i}>
+                {i > 0 && (
+                  <span className="bg-amber-bg text-amber-text mb-2 inline-block rounded px-1.5 py-0.5 font-mono text-[10px] font-bold tracking-widest">
+                    {conj}
+                  </span>
+                )}
+                {renderNode(
+                  child,
+                  [...path, i],
+                  'array',
+                  () => deleteChild(path, i),
+                  inRel,
+                )}
+              </div>
+            ))
+          )}
+        </div>
+        <div className="mt-3 ml-2 flex flex-wrap gap-2">
+          <AddButton
+            disabled={disabled}
+            label="Rule"
+            onClick={() => addChild(path, defaultRule())}
+          />
+          <AddButton
+            disabled={disabled}
+            label="Group"
+            onClick={() => addChild(path, defaultGroup())}
+          />
+          {!inRel && (
+            <AddButton
+              disabled={disabled}
+              label="Dependencies"
+              onClick={() => addChild(path, defaultRelationship())}
+            />
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  const renderNot = (
+    node: Condition,
+    path: PathSegment[],
+    slot: 'array' | 'single',
+    onDelete: (() => void) | null,
+    inRel: boolean,
+  ) => (
+    <div className="border-input bg-secondary rounded-lg border p-3.5">
+      <div className="mb-3 flex items-center gap-3">
+        <span className="border-danger bg-danger text-danger inline-flex rounded border px-2 py-1 font-mono text-[11px] font-bold tracking-wider">
+          NOT
+        </span>
+        <span className="text-secondary text-sm">the following is true</span>
+        {slot === 'array' && onDelete ? deleteButton(onDelete) : null}
+      </div>
+      <div className="border-tertiary ml-2 border-l-2 pl-3.5">
+        {renderNode(
+          childOf(node, 'not'),
+          [...path, 'not'],
+          'single',
+          null,
+          inRel,
+        )}
+      </div>
+    </div>
+  )
+
+  const renderRelationship = (
+    node: Condition,
+    path: PathSegment[],
+    slot: 'array' | 'single',
+    onDelete: (() => void) | null,
+  ) => {
+    const rel = (node as RelationshipCondition).relationship
+    return (
+      <div className="border-input bg-primary overflow-hidden rounded-lg border">
+        <div className="border-input bg-amber-bg flex flex-wrap items-center gap-2.5 border-b px-3.5 py-3">
+          <GitBranch className="text-amber-text size-4" />
+          <span className="text-sm font-semibold">Outgoing dependencies</span>
+          <span className="border-amber-text bg-amber-bg text-amber-text rounded border px-2 py-0.5 font-mono text-[11px] font-semibold">
+            DEPENDS_ON
+          </span>
+          <span className="border-input bg-secondary text-secondary rounded border px-2 py-0.5 font-mono text-[11px] font-semibold">
+            outgoing
+          </span>
+          {slot === 'array' && onDelete ? deleteButton(onDelete) : null}
+        </div>
+        <div className="border-input flex flex-wrap items-center gap-2 border-b px-3.5 py-3">
+          <span className="text-secondary text-sm">Match when</span>
+          <Select
+            disabled={disabled}
+            onValueChange={(v) => setQuantifier(path, v as Quantifier)}
+            value={rel.quantifier}
+          >
+            <SelectTrigger className="h-9 w-auto font-mono">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(['any', 'all', 'none'] as const).map((q) => (
+                <SelectItem key={q} value={q}>
+                  {q}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <span className="text-secondary text-sm">
+            of the dependencies match:
+          </span>
+          <span className="text-tertiary w-full text-xs">
+            {QUANTIFIER_HINTS[rel.quantifier]}
+          </span>
+        </div>
+        <div className="p-3.5">
+          <div className="border-tertiary ml-2 border-l-2 pl-3.5">
+            {renderNode(rel.where, [...path, 'where'], 'single', null, true)}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  function renderNode(
+    node: Condition,
+    path: PathSegment[],
+    slot: 'array' | 'single',
+    onDelete: (() => void) | null,
+    inRel: boolean,
+  ): React.ReactNode {
+    const n = asRecord(node)
+    if (n.all != null || n.any != null) {
+      return renderCombinator(node, path, slot, onDelete, inRel)
+    }
+    if (n.not != null) return renderNot(node, path, slot, onDelete, inRel)
+    if (n.relationship != null) {
+      return renderRelationship(node, path, slot, onDelete)
+    }
+    return renderAttr(node, path, slot, onDelete)
+  }
+
+  const modeButton = (m: 'json' | 'visual', label: string) => (
+    <button
+      className={`px-3.5 py-1.5 text-xs font-semibold ${
+        mode === m
+          ? 'bg-amber-bg text-amber-text'
+          : 'text-secondary hover:bg-secondary'
+      }`}
+      disabled={disabled}
+      onClick={() => switchMode(m)}
+      type="button"
+    >
+      {label}
+    </button>
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <span className="border-input flex overflow-hidden rounded-md border">
+          {modeButton('visual', 'Visual builder')}
+          {modeButton('json', 'JSON')}
+        </span>
+      </div>
+
+      {mode === 'visual' ? (
+        renderNode(value, [], 'single', null, false)
+      ) : (
+        <div>
+          <textarea
+            className={`bg-primary w-full resize-y rounded-lg border p-4 font-mono text-xs leading-relaxed outline-none ${
+              jsonError ? 'border-danger' : 'border-input'
+            }`}
+            disabled={disabled}
+            onChange={(e) => onJsonChange(e.target.value)}
+            rows={14}
+            spellCheck={false}
+            value={jsonDraft}
+          />
+          {jsonError ? (
+            <div className="text-danger mt-2 flex items-center gap-1.5 font-mono text-xs">
+              <X className="size-3.5" />
+              Invalid JSON — {jsonError}
+            </div>
+          ) : (
+            <div className="text-success mt-2 flex items-center gap-1.5 text-xs">
+              <Check className="size-3.5" />
+              Valid condition tree
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="border-input bg-primary rounded-lg border p-4">
+        <div className="text-tertiary mb-2 text-[11px] font-semibold tracking-wider uppercase">
+          Reads as
+        </div>
+        <div className="text-sm leading-relaxed">
+          {conditionToEnglish(value)}
+        </div>
+        <div className="text-secondary mt-3 text-xs leading-relaxed">
+          Projects where this is true score{' '}
+          <span className="text-success font-mono font-semibold">
+            {trueScore}
+          </span>
+          ; every other project scores{' '}
+          <span className="text-danger font-mono font-semibold">
+            {falseScore}
+          </span>
+          .
+        </div>
+        <div className="text-secondary mt-1.5 flex flex-wrap items-center gap-1.5 text-xs">
+          <span>Weighted</span>
+          <span className="text-amber-text font-mono font-semibold">
+            {weight}
+          </span>
+          <span>in the overall score.</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Render the tree as a plain-English sentence for the preview pane.
+export function conditionToEnglish(node: Condition): string {
+  const n = asRecord(node)
+  if (n.all != null) {
+    return `(${n.all.map(conditionToEnglish).join(' AND ') || 'always'})`
+  }
+  if (n.any != null) {
+    return `(${n.any.map(conditionToEnglish).join(' OR ') || 'never'})`
+  }
+  if (n.not != null) return `NOT ${conditionToEnglish(n.not)}`
+  if (n.relationship != null) {
+    const phrase = QUANTIFIER_PHRASES[n.relationship.quantifier]
+    return `${phrase} where ${conditionToEnglish(n.relationship.where)}`
+  }
+  const op = (n.op ?? 'eq') as ConditionOp
+  const label = OP_LABELS[op] ?? op
+  if (NO_VALUE_OPS.has(op)) return `${n.attribute || '?'} ${label}`
+  return `${n.attribute || '?'} ${label} ${JSON.stringify(n.value)}`
+}
+
+// Collapse an arbitrary (possibly null-padded) node into its canonical
+// single-key shape. Used when loading a stored policy condition.
+export function normalizeCondition(node: Condition): Condition {
+  const n = asRecord(node)
+  if (n.all != null) return { all: n.all.map(normalizeCondition) }
+  if (n.any != null) return { any: n.any.map(normalizeCondition) }
+  if (n.not != null) return { not: normalizeCondition(n.not) }
+  if (n.relationship != null) {
+    return {
+      relationship: {
+        direction: 'outgoing',
+        edge: 'DEPENDS_ON',
+        quantifier: n.relationship.quantifier,
+        where: normalizeCondition(n.relationship.where),
+      },
+    }
+  }
+  const op = n.op ?? 'eq'
+  const leaf: AttributeCondition = { attribute: n.attribute ?? '', op }
+  if (!NO_VALUE_OPS.has(op)) leaf.value = n.value ?? ''
+  return leaf
+}
+
+function AddButton({
+  disabled,
+  label,
+  onClick,
+}: {
+  disabled?: boolean
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      className="border-tertiary text-secondary hover:bg-secondary inline-flex items-center gap-1.5 rounded-lg border border-dashed px-3 py-1.5 text-xs"
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+    >
+      <Plus className="size-3.5" />
+      {label}
+    </button>
+  )
+}
+
+// ---- tree shape helpers (tolerant of null siblings from the API) ----
+function asRecord(node: Condition): CondRecord {
+  return node as CondRecord
+}
+
+function childOf(node: Condition, key: PathSegment): Condition {
+  const n = asRecord(node)
+  if (n.all) return n.all[key as number]
+  if (n.any) return n.any[key as number]
+  if (n.not != null) return n.not
+  return (n.relationship as RelationshipCondition['relationship']).where
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function defaultGroup(): Condition {
+  return { all: [defaultRule()] }
+}
+
+function defaultRelationship(): Condition {
+  return {
+    relationship: {
+      direction: 'outgoing',
+      edge: 'DEPENDS_ON',
+      quantifier: 'none',
+      where: defaultRule(),
+    },
+  }
+}
+
+function defaultRule(): AttributeCondition {
+  return { attribute: '', op: 'eq', value: '' }
+}
+
+function setChild(node: Condition, key: PathSegment, val: Condition): void {
+  const n = asRecord(node)
+  if (n.all) n.all[key as number] = val
+  else if (n.any) n.any[key as number] = val
+  else if (n.not != null) n.not = val
+  else if (n.relationship) n.relationship.where = val
+}
+
+function withUpdated(
+  root: Condition,
+  path: PathSegment[],
+  fn: (node: Condition) => Condition,
+): Condition {
+  const next = clone(root)
+  if (path.length === 0) return fn(next)
+  let parent = next
+  for (let i = 0; i < path.length - 1; i += 1) parent = childOf(parent, path[i])
+  const key = path[path.length - 1]
+  setChild(parent, key, fn(clone(childOf(parent, key))))
+  return next
+}

--- a/src/components/admin/scoring-policies/ConditionBuilder.tsx
+++ b/src/components/admin/scoring-policies/ConditionBuilder.tsx
@@ -167,7 +167,7 @@ export function ConditionBuilder({
   const onJsonChange = (text: string) => {
     setJsonDraft(text)
     try {
-      const parsed = JSON.parse(text) as Condition
+      const parsed = normalizeCondition(JSON.parse(text) as Condition)
       setJsonError('')
       onChange(parsed)
     } catch (e) {

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -16,6 +16,8 @@ import type {
   AgeScoringPolicyCreate,
   AnalysisResultScoringPolicyCreate,
   AttributeScoringPolicyCreate,
+  Condition,
+  ConditionScoringPolicyCreate,
   LinkPresenceScoringPolicyCreate,
   PresenceScoringPolicyCreate,
   ScoringPolicyCategory,
@@ -60,12 +62,14 @@ const VALID_CATEGORIES: ScoringPolicyCategory[] = [
   'link_presence',
   'age',
   'analysis_result',
+  'condition',
 ]
 
 const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
   age: 'Age',
   analysis_result: 'Analysis Result',
   attribute: 'Attribute',
+  condition: 'Condition',
   link_presence: 'Link Presence',
   presence: 'Presence',
 }
@@ -106,6 +110,7 @@ const BASE_FIELD_RULES: FieldRule[] = [
   },
 ]
 
+// fallow-ignore-next-line complexity
 export function ImportScoringPolicyDialog({
   apiError,
   isLoading = false,
@@ -138,6 +143,7 @@ export function ImportScoringPolicyDialog({
     onClose()
   }, [reset, onClose])
 
+  // fallow-ignore-next-line complexity
   const handleInputChange = useCallback((value: string) => {
     setRawInput(value)
     setError(null)
@@ -180,6 +186,7 @@ export function ImportScoringPolicyDialog({
     }
   }, [])
 
+  // fallow-ignore-next-line complexity
   const handleValidateAndImport = useCallback(() => {
     const trimmed = rawInput.trim()
     if (!trimmed) {
@@ -462,6 +469,7 @@ function optionalScore(
 function policySubjectKey(policy: ScoringPolicyCreate): string {
   if (policy.category === 'link_presence') return policy.link_slug
   if (policy.category === 'analysis_result') return policy.result_slug
+  if (policy.category === 'condition') return ''
   return policy.attribute_name
 }
 
@@ -672,6 +680,30 @@ function validateBaseShape(obj: Record<string, unknown>):
   }
 }
 
+// fallow-ignore-next-line complexity
+function validateConditionPolicy(
+  obj: Record<string, unknown>,
+  base: PolicyBase,
+): PolicyResult<ConditionScoringPolicyCreate> {
+  if (!isPlainObject(obj.condition)) {
+    return { error: '"condition" must be an object.', valid: false }
+  }
+  const trueScore = optionalScore(obj.true_score, 'true_score')
+  if (!trueScore.ok) return { error: trueScore.error, valid: false }
+  const falseScore = optionalScore(obj.false_score, 'false_score')
+  if (!falseScore.ok) return { error: falseScore.error, valid: false }
+  return {
+    policy: {
+      ...base,
+      category: 'condition',
+      condition: obj.condition as unknown as Condition,
+      false_score: falseScore.value ?? 0,
+      true_score: trueScore.value ?? 100,
+    },
+    valid: true,
+  }
+}
+
 function validateLinkPresencePolicy(
   obj: Record<string, unknown>,
   base: PolicyBase,
@@ -702,6 +734,7 @@ const CATEGORY_VALIDATORS: Record<
   age: validateAgePolicy,
   analysis_result: validateAnalysisResultPolicy,
   attribute: validateAttributePolicy,
+  condition: validateConditionPolicy,
   link_presence: validateLinkPresencePolicy,
   presence: validatePresencePolicy,
 }

--- a/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
+++ b/src/components/admin/scoring-policies/ImportScoringPolicyDialog.tsx
@@ -680,6 +680,60 @@ function validateBaseShape(obj: Record<string, unknown>):
   }
 }
 
+const CONDITION_OPS = new Set([
+  'absent',
+  'eq',
+  'ge',
+  'gt',
+  'le',
+  'lt',
+  'ne',
+  'present',
+])
+
+const RELATIONSHIP_QUANTIFIERS = new Set(['all', 'any', 'none'])
+
+function isValidAttributeNode(node: Record<string, unknown>): boolean {
+  return (
+    typeof node.attribute === 'string' &&
+    node.attribute.length > 0 &&
+    CONDITION_OPS.has(node.op as string)
+  )
+}
+
+function isValidCombinator(
+  node: Record<string, unknown>,
+  key: 'all' | 'any',
+): boolean {
+  const list = node[key]
+  return (
+    Array.isArray(list) && list.length > 0 && list.every(isValidConditionNode)
+  )
+}
+
+// fallow-ignore-next-line complexity
+function isValidConditionNode(node: unknown): boolean {
+  if (!isPlainObject(node)) return false
+  if ('all' in node) return isValidCombinator(node, 'all')
+  if ('any' in node) return isValidCombinator(node, 'any')
+  if ('not' in node) return isValidConditionNode(node.not)
+  if ('relationship' in node) return isValidRelationshipNode(node)
+  if ('attribute' in node) return isValidAttributeNode(node)
+  return false
+}
+
+// fallow-ignore-next-line complexity
+function isValidRelationshipNode(node: Record<string, unknown>): boolean {
+  const r = node.relationship
+  if (!isPlainObject(r)) return false
+  return (
+    r.direction === 'outgoing' &&
+    r.edge === 'DEPENDS_ON' &&
+    RELATIONSHIP_QUANTIFIERS.has(r.quantifier as string) &&
+    isValidConditionNode(r.where)
+  )
+}
+
 // fallow-ignore-next-line complexity
 function validateConditionPolicy(
   obj: Record<string, unknown>,
@@ -687,6 +741,9 @@ function validateConditionPolicy(
 ): PolicyResult<ConditionScoringPolicyCreate> {
   if (!isPlainObject(obj.condition)) {
     return { error: '"condition" must be an object.', valid: false }
+  }
+  if (!isValidConditionNode(obj.condition)) {
+    return { error: '"condition" is not a valid condition tree.', valid: false }
   }
   const trueScore = optionalScore(obj.true_score, 'true_score')
   if (!trueScore.ok) return { error: trueScore.error, valid: false }

--- a/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
+++ b/src/components/admin/scoring-policies/ScoringPolicyForm.tsx
@@ -5,6 +5,11 @@ import { AlertCircle, Plus, Trash2 } from 'lucide-react'
 
 import { listLinkDefinitions, listProjectTypes } from '@/api/endpoints'
 import { FormHeader } from '@/components/admin/form-header'
+import {
+  ConditionBuilder,
+  DEFAULT_CONDITION,
+  normalizeCondition,
+} from '@/components/admin/scoring-policies/ConditionBuilder'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -25,6 +30,7 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import { queryKeys } from '@/lib/queryKeys'
 import { slugify } from '@/lib/utils'
 import type {
+  Condition,
   ScoringPolicy,
   ScoringPolicyCategory,
   ScoringPolicyCreate,
@@ -42,6 +48,7 @@ const CATEGORY_LABELS: Record<ScoringPolicyCategory, string> = {
   age: 'Age',
   analysis_result: 'Analysis Result',
   attribute: 'Attribute',
+  condition: 'Condition',
   link_presence: 'Link Presence',
   presence: 'Presence',
 }
@@ -52,6 +59,8 @@ const CATEGORY_DESCRIPTIONS: Record<ScoringPolicyCategory, string> = {
     "Score based on a Project Doctor analysis result's status (pass / warn / fail). The result is identified by its plugin-emitted slug.",
   attribute:
     'Map a specific attribute value or numeric range to a score (e.g. test-coverage tiers).',
+  condition:
+    'Combine attribute and relationship predicates with boolean logic, then map the result to a score (e.g. penalize projects that depend on a deprecated service).',
   link_presence:
     'Penalize projects that do not have a link of a specific type (e.g. missing source-code link).',
   presence:
@@ -77,6 +86,7 @@ interface ScoringPolicyFormProps {
   policy: null | ScoringPolicy
 }
 
+// fallow-ignore-next-line complexity
 export function ScoringPolicyForm({
   error,
   isLoading = false,
@@ -158,6 +168,17 @@ export function ScoringPolicyForm({
       ? String(policy.status_score_map?.fail ?? 0)
       : '0',
   )
+  const [condition, setCondition] = useState<Condition>(() =>
+    policy?.category === 'condition'
+      ? normalizeCondition(policy.condition)
+      : DEFAULT_CONDITION,
+  )
+  const [trueScore, setTrueScore] = useState(
+    policy?.category === 'condition' ? String(policy.true_score) : '100',
+  )
+  const [falseScore, setFalseScore] = useState(
+    policy?.category === 'condition' ? String(policy.false_score) : '0',
+  )
 
   const [errors, setErrors] = useState<Record<string, string>>({})
 
@@ -202,21 +223,24 @@ export function ScoringPolicyForm({
       ...validateIdentity({ name, slug }),
       ...validateSubject({ attributeName, category, linkSlug, resultSlug }),
       ...validateWeight(weight),
-      ...validateCategoryFields({
-        ageMapRows,
-        analysisFailScore,
-        analysisPassScore,
-        analysisWarnScore,
-        attributeMapRows,
-        category,
-        missingScore,
-        presentScore,
-      }),
+      ...(category === 'condition'
+        ? validateConditionFields({ condition, falseScore, trueScore })
+        : validateCategoryFields({
+            ageMapRows,
+            analysisFailScore,
+            analysisPassScore,
+            analysisWarnScore,
+            attributeMapRows,
+            category,
+            missingScore,
+            presentScore,
+          })),
     }
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
   }
 
+  // fallow-ignore-next-line complexity
   const handleSave = () => {
     if (!validate()) return
     const base = {
@@ -269,6 +293,16 @@ export function ScoringPolicyForm({
           pass: parseInt(analysisPassScore, 10),
           warn: parseInt(analysisWarnScore, 10),
         },
+      })
+      return
+    }
+    if (category === 'condition') {
+      onSave({
+        ...base,
+        category: 'condition',
+        condition,
+        false_score: parseInt(falseScore, 10),
+        true_score: parseInt(trueScore, 10),
       })
       return
     }
@@ -330,6 +364,7 @@ export function ScoringPolicyForm({
                   'link_presence',
                   'age',
                   'analysis_result',
+                  'condition',
                 ] as ScoringPolicyCategory[]
               ).map((c) => (
                 <button
@@ -423,7 +458,7 @@ export function ScoringPolicyForm({
             <CardTitle>Policy Settings</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {category === 'link_presence' ? (
+            {category === 'condition' ? null : category === 'link_presence' ? (
               <div>
                 <Label
                   className="text-secondary mb-1.5 block text-sm"
@@ -729,6 +764,88 @@ export function ScoringPolicyForm({
           </Card>
         )}
 
+        {category === 'condition' && (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle>
+                  Condition <RequiredAsterisk />
+                </CardTitle>
+                <p className="text-tertiary text-xs">
+                  Build a boolean expression over this project's attributes and
+                  its outgoing dependencies. The whole tree evaluates to true or
+                  false.
+                </p>
+              </CardHeader>
+              <CardContent>
+                <ConditionBuilder
+                  disabled={isLoading}
+                  falseScore={parseInt(falseScore, 10) || 0}
+                  onChange={setCondition}
+                  trueScore={parseInt(trueScore, 10) || 0}
+                  value={condition}
+                  weight={parseInt(weight, 10) || 0}
+                />
+                {fieldError('condition')}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Score Mapping</CardTitle>
+                <p className="text-tertiary text-xs">
+                  Map the boolean result to a 0–100 score, then it joins the
+                  weighted average like any other policy.
+                </p>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <div>
+                    <Label
+                      className="text-secondary mb-1.5 flex items-center gap-2 text-sm"
+                      htmlFor="sp-true-score"
+                    >
+                      <span className="bg-success size-2 rounded-full" />
+                      Score when true
+                    </Label>
+                    <Input
+                      className={errors.true_score ? 'border-danger' : ''}
+                      disabled={isLoading}
+                      id="sp-true-score"
+                      max={100}
+                      min={0}
+                      onChange={(e) => setTrueScore(e.target.value)}
+                      type="number"
+                      value={trueScore}
+                    />
+                    {fieldError('true_score')}
+                  </div>
+                  <div>
+                    <Label
+                      className="text-secondary mb-1.5 flex items-center gap-2 text-sm"
+                      htmlFor="sp-false-score"
+                    >
+                      <span className="bg-danger size-2 rounded-full" />
+                      Score when false
+                    </Label>
+                    <Input
+                      className={errors.false_score ? 'border-danger' : ''}
+                      disabled={isLoading}
+                      id="sp-false-score"
+                      max={100}
+                      min={0}
+                      onChange={(e) => setFalseScore(e.target.value)}
+                      type="number"
+                      value={falseScore}
+                    />
+                    {fieldError('false_score')}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </>
+        )}
+
         {(category === 'presence' || category === 'link_presence') && (
           <Card>
             <CardHeader>
@@ -936,6 +1053,7 @@ function parseMapToRows(
   return rows.length > 0 ? rows : [emptyRow()]
 }
 
+// fallow-ignore-next-line complexity
 function rowsToMap(rows: MapRow[]): null | Record<string, number> {
   const out: Record<string, number> = {}
   for (const row of rows) {
@@ -951,6 +1069,25 @@ function rowsToMap(rows: MapRow[]): null | Record<string, number> {
 const AGE_THRESHOLD_RE = /^(>=|>|<=|<|==)\s*\d+(?:\.\d+)?\s*[smhdw]$/
 
 let rowIdCounter = 0
+// fallow-ignore-next-line complexity
+function conditionHasEmptyAttribute(node: Condition): boolean {
+  const n = node as {
+    all?: Condition[]
+    any?: Condition[]
+    attribute?: string
+    not?: Condition
+    op?: string
+    relationship?: { where: Condition }
+  }
+  if (n.all != null) return n.all.some(conditionHasEmptyAttribute)
+  if (n.any != null) return n.any.some(conditionHasEmptyAttribute)
+  if (n.not != null) return conditionHasEmptyAttribute(n.not)
+  if (n.relationship != null) {
+    return conditionHasEmptyAttribute(n.relationship.where)
+  }
+  return !n.attribute || !n.attribute.trim()
+}
+
 function emptyRow(): MapRow {
   return newRow('', '')
 }
@@ -1016,6 +1153,21 @@ function validateCategoryFields(args: {
   return validatePresenceScores(args.presentScore, args.missingScore)
 }
 
+function validateConditionFields(args: {
+  condition: Condition
+  falseScore: string
+  trueScore: string
+}): Record<string, string> {
+  const errors: Record<string, string> = {}
+  if (conditionHasEmptyAttribute(args.condition)) {
+    errors.condition = 'Every attribute rule needs an attribute name'
+  }
+  if (!isScoreInRange(args.trueScore)) errors.true_score = 'Score must be 0–100'
+  if (!isScoreInRange(args.falseScore))
+    errors.false_score = 'Score must be 0–100'
+  return errors
+}
+
 function validateIdentity(args: {
   name: string
   slug: string
@@ -1057,6 +1209,7 @@ function validateSubject(args: {
       ? {}
       : { result_slug: 'Result slug is required' }
   }
+  if (args.category === 'condition') return {}
   return args.attributeName.trim()
     ? {}
     : { attribute_name: 'Attribute name is required' }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,10 @@ export interface AgeScoringPolicyCreate extends ScoringPolicyCreateBase {
   category: 'age'
 }
 
+export interface AllCondition {
+  all: Condition[]
+}
+
 export interface AnalysisResultScoringPolicy extends ScoringPolicyBase {
   category: 'analysis_result'
   result_slug: string
@@ -26,11 +30,21 @@ export interface AnalysisResultScoringPolicyCreate extends ScoringPolicyCreateBa
   status_score_map?: null | Record<'fail' | 'pass' | 'warn', number>
 }
 
+export interface AnyCondition {
+  any: Condition[]
+}
+
 // Back-compat alias: the archive / unarchive endpoints originally
 // shipped this response type, and downstream components import it by
 // name.  Identical shape to ``ProjectMutationResponse`` -- prefer the
 // new name in fresh code.
 export type ArchiveProjectResponse = ProjectMutationResponse
+
+export interface AttributeCondition {
+  attribute: string
+  op: ConditionOp
+  value?: unknown
+}
 
 export interface AttributeScoringPolicy extends ScoringPolicyBase {
   attribute_name: string
@@ -49,6 +63,43 @@ export interface AttributeScoringPolicyCreate extends ScoringPolicyCreateBase {
 // API Response Wrappers
 export interface CollectionResponse<T> {
   data: T[]
+}
+
+export type Condition =
+  | AllCondition
+  | AnyCondition
+  | AttributeCondition
+  | NotCondition
+  | RelationshipCondition
+
+// ---- Condition (multi-conditional / relationship compound) scoring ----
+// A recursive boolean expression tree. Each node is exactly one shape:
+// a combinator (all/any/not), an attribute predicate on the project being
+// scored, or a relationship predicate on the project's outgoing DEPENDS_ON
+// neighbours. Mirrors the imbi-common `Condition` model (keys all/any/not are
+// the JSON aliases the API serialises/accepts).
+export type ConditionOp =
+  | 'absent'
+  | 'eq'
+  | 'ge'
+  | 'gt'
+  | 'le'
+  | 'lt'
+  | 'ne'
+  | 'present'
+
+export interface ConditionScoringPolicy extends ScoringPolicyBase {
+  category: 'condition'
+  condition: Condition
+  false_score: number
+  true_score: number
+}
+
+export interface ConditionScoringPolicyCreate extends ScoringPolicyCreateBase {
+  category: 'condition'
+  condition: Condition
+  false_score: number
+  true_score: number
 }
 
 // `Environment` tracks the full response shape (with relationships).
@@ -82,6 +133,7 @@ export interface EnvironmentCreate {
 // third-party service: stable identifier + canonical API URL, plus the
 // human dashboard URL (read from / written to the project's links).
 export type Integration = Schemas['ExistsInResponse']
+
 export type IntegrationCreate = Schemas['ExistsInCreate']
 
 // Per-plugin outcome returned by the archive / unarchive endpoints, one
@@ -95,7 +147,6 @@ export interface LifecycleInvocation {
   plugin_slug: string
   status: 'failed' | 'ok' | 'skipped'
 }
-
 // One row of the ``GET /projects/{id}/lifecycle/preview`` response --
 // per-plugin "would the project-type change move my target?" answer
 // the UI uses to gate the "Also move repository to ..." opt-in.
@@ -128,6 +179,11 @@ export interface LinkPresenceScoringPolicyCreate extends ScoringPolicyCreateBase
   missing_score?: null | number
   present_score?: null | number
 }
+
+export interface NotCondition {
+  not: Condition
+}
+
 // Activity feed projection; distinct from `OperationsLogRecord`.
 export interface OperationsLogEntry {
   change_type:
@@ -158,7 +214,6 @@ export interface OperationsLogEntry {
   type: 'OperationsLogEntry'
   version?: null | string
 }
-
 export interface PresenceScoringPolicy extends ScoringPolicyBase {
   attribute_name: string
   category: 'presence'
@@ -323,6 +378,15 @@ export interface PullRequestListResponse {
   total: number
 }
 
+export interface RelationshipCondition {
+  relationship: {
+    direction: 'outgoing'
+    edge: 'DEPENDS_ON'
+    quantifier: 'all' | 'any' | 'none'
+    where: Condition
+  }
+}
+
 export type RelationshipLink = Schemas['RelationshipLink']
 
 export interface ReleaseInfo {
@@ -349,6 +413,7 @@ export type ScoringPolicy =
   | AgeScoringPolicy
   | AnalysisResultScoringPolicy
   | AttributeScoringPolicy
+  | ConditionScoringPolicy
   | LinkPresenceScoringPolicy
   | PresenceScoringPolicy
 
@@ -356,6 +421,7 @@ export type ScoringPolicyCategory =
   | 'age'
   | 'analysis_result'
   | 'attribute'
+  | 'condition'
   | 'link_presence'
   | 'presence'
 
@@ -363,6 +429,7 @@ export type ScoringPolicyCreate =
   | AgeScoringPolicyCreate
   | AnalysisResultScoringPolicyCreate
   | AttributeScoringPolicyCreate
+  | ConditionScoringPolicyCreate
   | LinkPresenceScoringPolicyCreate
   | PresenceScoringPolicyCreate
 
@@ -1322,7 +1389,15 @@ export interface PluginVertexLabel {
     nav_label?: null | string
   }
 }
-export type ProjectRelationship = Schemas['ProjectRelationship']
+// `deprecated` is surfaced on the neighbour summary by the relationships
+// endpoint so the UI can flag deprecated dependencies. Kept optional until
+// the generated schema snapshot is refreshed.
+export type ProjectRelationship = Omit<
+  Schemas['ProjectRelationship'],
+  'project'
+> & {
+  project: Schemas['ProjectRelationshipSummary'] & { deprecated?: boolean }
+}
 
 export type ProjectRelationshipsResponse =
   Schemas['ProjectRelationshipsResponse']


### PR DESCRIPTION
## Summary

Full UI for the `condition` category scoring policy introduced in imbi-common/imbi-api:

**Condition policy editor** (`ConditionBuilder.tsx` + `ScoringPolicyForm.tsx`):
- Recursive condition tree builder: `all`/`any`/`not` combinators, `attribute` leaves (predicate on scored project), `relationship` leaves (outgoing deps with `any`/`all`/`none` quantifiers + predicate on neighbour)
- Inline quantifier hints explain empty-set semantics — critical because `all` is vacuously true for projects with no dependencies, while `none` correctly penalises projects that *have* a matching dependency
- "Reads as" preview reworded to show per-project scoring outcome, making wrong quantifier choices obvious before saving
- JSON edit mode for power users; `normalizeCondition` strips empty combinators on save

**Score breakdown** (`ProjectDetail.tsx`):
- Condition contributions show "met" / "not met" instead of a raw number
- Named red pills show *which* dependency triggered the condition (via `matched_neighbours` from the API) — e.g. **Mapping Service** rather than just "not met"

**Relationships tab** (`ProjectRelationshipsTab.tsx`):
- **Deprecated** badge next to any outbound dependency whose `deprecated` flag is set (requires imbi-api#463)

**Admin tables** (`ScoringPolicyManagement.tsx`, `ImportScoringPolicyDialog.tsx`):
- `condition` category recognised in labels, category-specific export, and import validation with full condition-tree check

## Dependencies

- imbi-common#177 — `MatchedNeighbour` + `matched_neighbours` on contributions
- imbi-api#463 — `deprecated` field on relationship summaries

## Test plan

- [ ] `npx tsc --noEmit` — no errors
- [ ] `npm run build` — succeeds
- [ ] `npm run lint` — 0 errors
- [ ] `npx vitest run` — all 16 tests pass (8 new ConditionBuilder tests)
- [ ] In a running dev env:
  - Create a condition policy (relationship leaf: `deprecated = true`, quantifier: `none`)
  - Projects with a deprecated dependency score 0 and show the service name in the breakdown
  - Projects without deprecated dependencies score 100
  - Relationships tab shows "Deprecated" badge next to deprecated deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)