### PR TITLE
Fix sync toasts replaying stale and foreign run results

### DIFF
--- a/src/hooks/__tests__/useCommitSync.test.tsx
+++ b/src/hooks/__tests__/useCommitSync.test.tsx
@@ -207,6 +207,42 @@ describe('useCommitSync', () => {
     )
   })
 
+  it('refetches and toasts a joined run despite a stale idle status', async () => {
+    vi.mocked(endpoints.getProjectCommitSyncStatus)
+      // Stale cache: the poll hasn't seen the foreign run yet.
+      .mockResolvedValueOnce(status())
+      // The post-join invalidation observes the run in flight.
+      .mockResolvedValueOnce(status({ status: 'running' }))
+      .mockResolvedValue(
+        status({ commits_synced: 4, status: 'success', tags_synced: 1 }),
+      )
+    vi.mocked(endpoints.syncProjectCommitsAndTags).mockResolvedValue({
+      enqueued: false,
+    })
+    const client = makeClient()
+    const { result } = renderHook(() => useCommitSync('acme', 'p1', true), {
+      wrapper: makeWrapper(client),
+    })
+    await waitFor(() =>
+      expect(endpoints.getProjectCommitSyncStatus).toHaveBeenCalled(),
+    )
+    await act(async () => {
+      result.current.sync()
+    })
+    // Joining must invalidate too, or the idle cache never starts polling.
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['commitSyncStatus', 'acme', 'p1'],
+      })
+    })
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        'Synced 4 commit(s) and 1 tag(s)',
+      ),
+    )
+  })
+
   it('invokes onComplete without a toast for an unwatched run', async () => {
     vi.mocked(endpoints.getProjectCommitSyncStatus)
       .mockResolvedValueOnce(status({ status: 'running' }))

--- a/src/hooks/__tests__/useCommitSync.test.tsx
+++ b/src/hooks/__tests__/useCommitSync.test.tsx
@@ -25,13 +25,16 @@ vi.mock('sonner', () => ({
   toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
 }))
 
-function makeWrapper() {
-  const client = new QueryClient({
+function makeClient() {
+  return new QueryClient({
     defaultOptions: {
       mutations: { retry: false },
       queries: { gcTime: 0, retry: false },
     },
   })
+}
+
+function makeWrapper(client: QueryClient = makeClient()) {
   return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   )
@@ -92,5 +95,138 @@ describe('useCommitSync', () => {
       wrapper: makeWrapper(),
     })
     await waitFor(() => expect(result.current.isSyncing).toBe(true))
+  })
+
+  it('does not toast a stale terminal status on mount', async () => {
+    vi.mocked(endpoints.getProjectCommitSyncStatus).mockResolvedValue(
+      status({ commits_synced: 5, status: 'success', tags_synced: 2 }),
+    )
+    renderHook(() => useCommitSync('acme', 'p1', true), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() =>
+      expect(endpoints.getProjectCommitSyncStatus).toHaveBeenCalled(),
+    )
+    await act(async () => {})
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('toasts and invokes onComplete when a watched run succeeds', async () => {
+    vi.mocked(endpoints.getProjectCommitSyncStatus)
+      .mockResolvedValueOnce(status())
+      .mockResolvedValueOnce(status({ status: 'running' }))
+      .mockResolvedValue(
+        status({ commits_synced: 5, status: 'success', tags_synced: 2 }),
+      )
+    vi.mocked(endpoints.syncProjectCommitsAndTags).mockResolvedValue({
+      enqueued: true,
+    })
+    const onComplete = vi.fn()
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useCommitSync('acme', 'p1', true, onComplete),
+      { wrapper: makeWrapper(client) },
+    )
+    await waitFor(() =>
+      expect(endpoints.getProjectCommitSyncStatus).toHaveBeenCalled(),
+    )
+    await act(async () => {
+      result.current.sync()
+    })
+    // The mutation's onSuccess invalidation refetches → 'running'.
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+    // Simulate the next poll observing the terminal state.
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['commitSyncStatus', 'acme', 'p1'],
+      })
+    })
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        'Synced 5 commit(s) and 2 tag(s)',
+      ),
+    )
+    expect(onComplete).toHaveBeenCalled()
+  })
+
+  it('toasts a watched run that completes before the first refetch', async () => {
+    vi.mocked(endpoints.getProjectCommitSyncStatus)
+      .mockResolvedValueOnce(status())
+      // Fast job: the refetch after enqueue is already terminal.
+      .mockResolvedValueOnce(
+        status({ commits_synced: 5, status: 'success', tags_synced: 2 }),
+      )
+      // A later foreign run observed by this instance.
+      .mockResolvedValueOnce(status({ status: 'running' }))
+      .mockResolvedValue(
+        status({ commits_synced: 9, status: 'success', tags_synced: 9 }),
+      )
+    vi.mocked(endpoints.syncProjectCommitsAndTags).mockResolvedValue({
+      enqueued: true,
+    })
+    const onComplete = vi.fn()
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useCommitSync('acme', 'p1', true, onComplete),
+      { wrapper: makeWrapper(client) },
+    )
+    await waitFor(() =>
+      expect(endpoints.getProjectCommitSyncStatus).toHaveBeenCalled(),
+    )
+    await act(async () => {
+      result.current.sync()
+    })
+    // The onSuccess invalidation refetches straight to 'success'.
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        'Synced 5 commit(s) and 2 tag(s)',
+      ),
+    )
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    // Foreign run: running → success. onComplete fires but no toast,
+    // because `watching` was consumed by the fast job's result.
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['commitSyncStatus', 'acme', 'p1'],
+      })
+    })
+    // Ensure the 'running' state renders before the terminal poll, as it
+    // would between real poll intervals.
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['commitSyncStatus', 'acme', 'p1'],
+      })
+    })
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(2))
+    // Only the "started" toast and the fast job's result toast.
+    expect(toast.success).toHaveBeenCalledTimes(2)
+    expect(toast.success).not.toHaveBeenCalledWith(
+      'Synced 9 commit(s) and 9 tag(s)',
+    )
+  })
+
+  it('invokes onComplete without a toast for an unwatched run', async () => {
+    vi.mocked(endpoints.getProjectCommitSyncStatus)
+      .mockResolvedValueOnce(status({ status: 'running' }))
+      .mockResolvedValue(
+        status({ commits_synced: 3, status: 'success', tags_synced: 1 }),
+      )
+    const onComplete = vi.fn()
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useCommitSync('acme', 'p1', true, onComplete),
+      { wrapper: makeWrapper(client) },
+    )
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+    // Someone else's run finishes; the next poll observes it.
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['commitSyncStatus', 'acme', 'p1'],
+      })
+    })
+    await waitFor(() => expect(onComplete).toHaveBeenCalled())
+    expect(toast.success).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useCommitSync.ts
+++ b/src/hooks/useCommitSync.ts
@@ -37,14 +37,21 @@ export function useCommitSync(
       isActive(query.state.data?.status) ? POLL_MS : false,
   })
 
-  // Toast the terminal result when a poll observes the run leaving the
-  // active state. The ref guards against toasting stale state on mount.
+  // The backend reports the persistent status of the project's most recent
+  // run (any requester), so a toast is only warranted when this user asked
+  // for a sync (`watching`) and a poll then observes the run leaving the
+  // active state. `onComplete` still fires on any observed active → success
+  // transition so background refreshes happen for other users' runs too.
+  const watching = useRef(false)
   const previous = useRef<CommitSyncState | undefined>(undefined)
   useEffect(() => {
     const data = statusQuery.data
     if (!data) return
-    if (!isActive(data.status) && data.status !== previous.current) {
-      announceTerminal(data)
+    if (isActive(previous.current) && !isActive(data.status)) {
+      if (watching.current) {
+        announceTerminal(data)
+        watching.current = false
+      }
       if (data.status === 'success') onCompleteRef.current?.()
     }
     previous.current = data.status
@@ -57,6 +64,13 @@ export function useCommitSync(
         extractApiErrorDetail(err) ?? 'Failed to start commit & tag sync',
       ),
     onSuccess: (res) => {
+      // The user asked for this run (or joined the one already in
+      // progress), so watch for its terminal result.
+      watching.current = true
+      // The POST returning means the backend flipped the run to queued;
+      // prime `previous` so a fast job whose first refetch already reads
+      // a terminal status still counts as an active → terminal transition.
+      previous.current = 'queued'
       if (res.enqueued) {
         toast.success('Commit & tag sync started')
         void queryClient.invalidateQueries({

--- a/src/hooks/useCommitSync.ts
+++ b/src/hooks/useCommitSync.ts
@@ -73,12 +73,15 @@ export function useCommitSync(
       previous.current = 'queued'
       if (res.enqueued) {
         toast.success('Commit & tag sync started')
-        void queryClient.invalidateQueries({
-          queryKey: ['commitSyncStatus', orgSlug, projectId],
-        })
       } else {
         toast.info('A commit & tag sync is already in progress')
       }
+      // Refresh even when joining an existing run: a stale cached 'idle'
+      // status would otherwise keep refetchInterval off and this client
+      // would never observe the run finishing.
+      void queryClient.invalidateQueries({
+        queryKey: ['commitSyncStatus', orgSlug, projectId],
+      })
     },
   })
 

--- a/src/hooks/usePRSync.ts
+++ b/src/hooks/usePRSync.ts
@@ -73,12 +73,15 @@ export function usePRSync(
       previous.current = 'queued'
       if (res.enqueued) {
         toast.success('PR sync started')
-        void queryClient.invalidateQueries({
-          queryKey: ['prSyncStatus', orgSlug, projectId],
-        })
       } else {
         toast.info('A PR sync is already in progress')
       }
+      // Refresh even when joining an existing run: a stale cached 'idle'
+      // status would otherwise keep refetchInterval off and this client
+      // would never observe the run finishing.
+      void queryClient.invalidateQueries({
+        queryKey: ['prSyncStatus', orgSlug, projectId],
+      })
     },
   })
 

--- a/src/hooks/usePRSync.ts
+++ b/src/hooks/usePRSync.ts
@@ -38,15 +38,22 @@ export function usePRSync(
       isActive(query.state.data?.status) ? POLL_MS : false,
   })
 
-  // Toast the terminal result when a poll observes the run leaving the
-  // active state. The ref guards against toasting stale state on mount.
+  // The backend reports the persistent status of the project's most recent
+  // run (any requester), so a toast is only warranted when this user asked
+  // for a sync (`watching`) and a poll then observes the run leaving the
+  // active state. `onComplete` still fires on any observed active → success
+  // transition so background refreshes happen for other users' runs too.
+  const watching = useRef(false)
   const previous = useRef<PRSyncState | undefined>(undefined)
   // fallow-ignore-next-line complexity
   useEffect(() => {
     const data = statusQuery.data
     if (!data) return
-    if (!isActive(data.status) && data.status !== previous.current) {
-      announceTerminal(data)
+    if (isActive(previous.current) && !isActive(data.status)) {
+      if (watching.current) {
+        announceTerminal(data)
+        watching.current = false
+      }
       if (data.status === 'success') onCompleteRef.current?.()
     }
     previous.current = data.status
@@ -57,6 +64,13 @@ export function usePRSync(
     onError: (err) =>
       toast.error(extractApiErrorDetail(err) ?? 'Failed to start PR sync'),
     onSuccess: (res) => {
+      // The user asked for this run (or joined the one already in
+      // progress), so watch for its terminal result.
+      watching.current = true
+      // The POST returning means the backend flipped the run to queued;
+      // prime `previous` so a fast job whose first refetch already reads
+      // a terminal status still counts as an active → terminal transition.
+      previous.current = 'queued'
       if (res.enqueued) {
         toast.success('PR sync started')
         void queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary
Scope commit/tag and PR sync result toasts to the user who requested the run, and stop replaying the last run's result on every page mount.

## Problem
`useCommitSync` and `usePRSync` poll a per-project sync-status endpoint that returns the persistent status of the project's most recent run, by any requester. The toast guard compared the fetched status to a component-scoped ref that resets to `undefined` on every mount, so:

- Navigating back to the Deployments tab or Project Doctor re-toasted the result of a long-finished sync, every time.
- Syncs enqueued by other users toasted their results at you whenever your client observed the run finish.

## Solution
Announce a terminal status only when this hook instance asked for the run: a `watching` ref is set when the user enqueues a sync (or joins one already in progress) and consumed when a poll observes the run leaving the active state. `previous` is primed to `'queued'` on enqueue so a job that completes faster than the first refetch still counts as an active → terminal transition (otherwise its toast would be silently dropped and the watching flag would leak onto a later foreign run). The `onComplete` data invalidation still fires on any observed active → success transition, so other users' syncs silently refresh your data without toasting.

## Impact
UI-only behavior change, no API changes. Users stop seeing duplicate/foreign sync toasts; their own sync feedback is unchanged.

## Testing
- Four new regression tests in `useCommitSync.test.tsx`: stale terminal status on mount does not toast; a watched run toasts and fires `onComplete`; a foreign run fires `onComplete` without toasting; a fast job completing before the first refetch still toasts exactly once and does not leak onto a later foreign run.
- Full vitest suite (70 files, 523 tests), `npm run lint`, `npm run format:check`, and `tsc --noEmit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)