### PR TITLE
Add global Maintenance admin page

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -957,6 +957,54 @@ export const rescoreProject = (projectId: string) =>
     project_id: projectId,
   })
 
+// Global maintenance operations (admin Maintenance page)
+
+export interface MaintenanceOperation {
+  completed_at?: null | string
+  description?: null | string
+  failures?: null | Record<string, string>
+  label: string
+  progress?: MaintenanceProgress | null
+  running: boolean
+  slug: string
+  started_at?: null | string
+  started_by?: null | string
+  state: MaintenanceRunState
+}
+
+export interface MaintenanceProgress {
+  failed?: null | number
+  in_flight?: null | number
+  remaining?: null | number
+  skipped?: null | number
+  succeeded?: null | number
+  total?: null | number
+}
+
+export type MaintenanceRunState =
+  | 'abandoned'
+  | 'cancelled'
+  | 'completed'
+  | 'idle'
+  | 'running'
+
+export const getMaintenanceOperations = (signal?: AbortSignal) =>
+  apiClient.get<MaintenanceOperation[]>(
+    '/maintenance/operations',
+    undefined,
+    signal,
+  )
+
+export const runMaintenanceOperation = (slug: string) =>
+  apiClient.post<{ run_id: string; total: number }>(
+    `/maintenance/operations/${encodeURIComponent(slug)}/run`,
+  )
+
+export const cancelMaintenanceOperation = (slug: string) =>
+  apiClient.post<MaintenanceOperation>(
+    `/maintenance/operations/${encodeURIComponent(slug)}/cancel`,
+  )
+
 export interface AnalysisReport {
   created_at: string
   id: string

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -26,6 +26,7 @@ import {
   Users,
   UsersRound,
   Webhook,
+  Wrench,
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -41,6 +42,7 @@ import { EnvironmentManagement } from './admin/EnvironmentManagement'
 import { GraphQueryManagement } from './admin/GraphQueryManagement'
 import { IntegrationsManagement } from './admin/integrations/IntegrationsManagement'
 import { LinkDefinitionManagement } from './admin/LinkDefinitionManagement'
+import { MaintenanceManagement } from './admin/MaintenanceManagement'
 import { OrganizationManagement } from './admin/OrganizationManagement'
 import { PluginsManagement } from './admin/PluginsManagement'
 import { ProjectTypeManagement } from './admin/ProjectTypeManagement'
@@ -61,6 +63,7 @@ type AdminSection =
   | 'graph-query'
   | 'integrations'
   | 'link-definitions'
+  | 'maintenance'
   | 'oauth'
   | 'organizations'
   | 'overview'
@@ -86,6 +89,7 @@ const VALID_SECTIONS: AdminSection[] = [
   'integrations',
   'link-definitions',
   'document-templates',
+  'maintenance',
   'oauth',
   'organizations',
   'overview',
@@ -236,6 +240,13 @@ export function Admin() {
       icon: Network,
       id: 'graph-query',
       label: 'Graph Query',
+      scope: 'system',
+    },
+    {
+      description: 'Run global background maintenance operations',
+      icon: Wrench,
+      id: 'maintenance',
+      label: 'Maintenance',
       scope: 'system',
     },
     {
@@ -433,6 +444,7 @@ export function Admin() {
             {currentSection === 'assistant' && <AssistantManagement />}
             {currentSection === 'oauth' && <AuthProvidersManagement />}
             {currentSection === 'graph-query' && <GraphQueryManagement />}
+            {currentSection === 'maintenance' && <MaintenanceManagement />}
             {currentSection === 'plugins' && <PluginsManagement />}
           </div>
         </main>

--- a/src/components/admin/MaintenanceManagement.tsx
+++ b/src/components/admin/MaintenanceManagement.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react'
+
+import { Play, RefreshCw } from 'lucide-react'
+
+import type { MaintenanceOperation } from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { Sk } from '@/components/ui/skeleton'
+import { useMaintenanceOperations } from '@/hooks/useMaintenanceOperations'
+import { extractApiErrorDetail } from '@/lib/apiError'
+import { formatRelativeDate } from '@/lib/formatDate'
+
+// Global maintenance page: renders whatever operations the backend
+// registry returns — no slugs are hardcoded here, so new operations
+// appear without UI changes.
+export function MaintenanceManagement() {
+  const {
+    cancel,
+    cancelingSlug,
+    error,
+    isError,
+    isLoading,
+    operations,
+    run,
+    runningSlug,
+  } = useMaintenanceOperations()
+  const [confirming, setConfirming] = useState<MaintenanceOperation | null>(
+    null,
+  )
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-primary text-2xl font-semibold tracking-tight">
+          Maintenance
+        </h1>
+        <p className="text-secondary mt-1 text-sm">
+          Global background operations — each run applies to every project
+          across all organizations.
+        </p>
+      </div>
+
+      {isError ? (
+        <Card>
+          <CardContent className="text-destructive py-8 text-center text-sm">
+            {extractApiErrorDetail(error) ??
+              'Failed to load maintenance operations'}
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="divide-border/50 divide-y p-0">
+            {isLoading ? (
+              Array.from({ length: 4 }).map((_, i) => (
+                <div
+                  className="flex items-center justify-between px-4 py-3"
+                  key={`sk-${i}`}
+                >
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Sk line w="30%" />
+                    <Sk line w="55%" />
+                  </div>
+                  <Sk h={32} w={72} />
+                </div>
+              ))
+            ) : operations.length === 0 ? (
+              <div className="text-muted-foreground py-12 text-center text-sm">
+                No maintenance operations are available.
+              </div>
+            ) : (
+              operations.map((op) => (
+                <OperationRow
+                  canceling={cancelingSlug === op.slug}
+                  key={op.slug}
+                  onCancel={() => cancel(op.slug)}
+                  onRun={() => setConfirming(op)}
+                  op={op}
+                  starting={runningSlug === op.slug}
+                />
+              ))
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <ConfirmDialog
+        confirmLabel="Run"
+        description={
+          confirming
+            ? `"${confirming.label}" runs across every project in all organizations. This may take a while and generate significant load.`
+            : ''
+        }
+        onCancel={() => setConfirming(null)}
+        onConfirm={() => {
+          if (confirming) run(confirming.slug)
+          setConfirming(null)
+        }}
+        open={confirming !== null}
+        title={confirming ? `Run ${confirming.label}?` : ''}
+      />
+    </div>
+  )
+}
+
+function OperationRow({
+  canceling,
+  onCancel,
+  onRun,
+  op,
+  starting,
+}: {
+  canceling: boolean
+  onCancel: () => void
+  onRun: () => void
+  op: MaintenanceOperation
+  starting: boolean
+}) {
+  const running = op.state === 'running'
+  return (
+    <div className="flex items-center gap-4 px-4 py-3">
+      <div className="min-w-0 flex-1">
+        <div className="text-primary text-sm font-medium">{op.label}</div>
+        {op.description && (
+          <div className="text-secondary mt-0.5 text-xs">{op.description}</div>
+        )}
+      </div>
+      <OperationStatus op={op} />
+      <div className="flex shrink-0 items-center gap-2">
+        {running && (
+          <Button
+            disabled={canceling}
+            onClick={onCancel}
+            size="sm"
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+        )}
+        <Button
+          disabled={running || starting}
+          onClick={onRun}
+          size="sm"
+          variant="outline"
+        >
+          <Play className="size-3.5" />
+          Run
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function OperationStatus({ op }: { op: MaintenanceOperation }) {
+  const progress = op.progress
+  if (op.state === 'running') {
+    const total = progress?.total ?? null
+    const remaining = progress?.remaining ?? null
+    const failed = progress?.failed ?? 0
+    const done = total != null && remaining != null ? total - remaining : null
+    return (
+      <div className="shrink-0 text-right">
+        <div className="text-amber-text flex items-center justify-end gap-2 text-xs">
+          <RefreshCw className="size-3.5 animate-spin" />
+          <span>
+            {done != null && total != null
+              ? `${done} of ${total} — ${remaining} remaining`
+              : 'Running'}
+          </span>
+          {failed > 0 && (
+            <span className="text-destructive">{failed} failed</span>
+          )}
+        </div>
+        <div className="text-tertiary mt-0.5 text-xs">
+          Started {formatRelativeDate(op.started_at)}
+          {op.started_by ? ` by ${op.started_by}` : ''}
+        </div>
+      </div>
+    )
+  }
+  if (
+    op.state === 'completed' ||
+    op.state === 'cancelled' ||
+    op.state === 'abandoned'
+  ) {
+    return (
+      <div className="shrink-0 text-right">
+        <div className="text-tertiary text-xs">
+          Last run {op.state}
+          {op.completed_at ? ` ${formatRelativeDate(op.completed_at)}` : ''}
+        </div>
+        {progress && (
+          <div className="text-tertiary mt-0.5 text-xs">
+            {progress.succeeded ?? 0} succeeded
+            {(progress.skipped ?? 0) > 0 && `, ${progress.skipped} skipped`}
+            {(progress.failed ?? 0) > 0 && (
+              <span className="text-destructive">
+                {`, ${progress.failed} failed`}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+  return null
+}

--- a/src/components/admin/MaintenanceManagement.tsx
+++ b/src/components/admin/MaintenanceManagement.tsx
@@ -17,13 +17,13 @@ import { formatRelativeDate } from '@/lib/formatDate'
 export function MaintenanceManagement() {
   const {
     cancel,
-    cancelingSlug,
+    cancelingSlugs,
     error,
     isError,
     isLoading,
     operations,
     run,
-    runningSlug,
+    runningSlugs,
   } = useMaintenanceOperations()
   const [confirming, setConfirming] = useState<MaintenanceOperation | null>(
     null,
@@ -71,12 +71,12 @@ export function MaintenanceManagement() {
             ) : (
               operations.map((op) => (
                 <OperationRow
-                  canceling={cancelingSlug === op.slug}
+                  canceling={cancelingSlugs.has(op.slug)}
                   key={op.slug}
                   onCancel={() => cancel(op.slug)}
                   onRun={() => setConfirming(op)}
                   op={op}
-                  starting={runningSlug === op.slug}
+                  starting={runningSlugs.has(op.slug)}
                 />
               ))
             )}

--- a/src/components/admin/__tests__/MaintenanceManagement.test.tsx
+++ b/src/components/admin/__tests__/MaintenanceManagement.test.tsx
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiError } from '@/api/client'
+import type { MaintenanceOperation } from '@/api/endpoints'
+import { fireEvent, render, screen, waitFor, within } from '@/test/utils'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', () => ({
+  cancelMaintenanceOperation: vi.fn(),
+  getMaintenanceOperations: vi.fn(),
+  runMaintenanceOperation: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+const operation = (
+  overrides: Partial<MaintenanceOperation> = {},
+): MaintenanceOperation => ({
+  description: 'Does a thing to every project.',
+  label: 'Do Thing',
+  running: false,
+  slug: 'do-thing',
+  state: 'idle',
+  ...overrides,
+})
+
+// Render, wait for the registry rows, click the first Run button, and
+// return the opened confirmation dialog.
+const openRunConfirmation = async () => {
+  const { MaintenanceManagement } = await import('../MaintenanceManagement')
+  render(<MaintenanceManagement />)
+  await waitFor(() => expect(screen.getByText('Do Thing')).toBeInTheDocument())
+  fireEvent.click(screen.getAllByRole('button', { name: /run/i })[0])
+  return screen.findByRole('alertdialog')
+}
+
+describe('MaintenanceManagement', () => {
+  beforeEach(async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.getMaintenanceOperations).mockResolvedValue([
+      operation(),
+      operation({
+        description: 'Other global operation.',
+        label: 'Other Thing',
+        slug: 'other-thing',
+      }),
+    ])
+  })
+
+  it('renders one row per registry operation', async () => {
+    const { MaintenanceManagement } = await import('../MaintenanceManagement')
+    render(<MaintenanceManagement />)
+    await waitFor(() =>
+      expect(screen.getByText('Do Thing')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('Other Thing')).toBeInTheDocument()
+    expect(screen.getByText('Other global operation.')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /run/i })).toHaveLength(2)
+  })
+
+  it('shows an empty state when the registry is empty', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.getMaintenanceOperations).mockResolvedValue([])
+    const { MaintenanceManagement } = await import('../MaintenanceManagement')
+    render(<MaintenanceManagement />)
+    await waitFor(() =>
+      expect(
+        screen.getByText('No maintenance operations are available.'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('shows an error banner when the registry fetch fails', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.getMaintenanceOperations).mockRejectedValue(
+      new Error('boom'),
+    )
+    const { MaintenanceManagement } = await import('../MaintenanceManagement')
+    render(<MaintenanceManagement />)
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
+  })
+
+  it('confirms before starting a run', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.runMaintenanceOperation).mockResolvedValue({
+      run_id: 'r1',
+      total: 5,
+    })
+    const dialog = await openRunConfirmation()
+    expect(within(dialog).getByText('Run Do Thing?')).toBeInTheDocument()
+    expect(endpoints.runMaintenanceOperation).not.toHaveBeenCalled()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Run' }))
+    await waitFor(() =>
+      expect(endpoints.runMaintenanceOperation).toHaveBeenCalledWith(
+        'do-thing',
+      ),
+    )
+  })
+
+  it('renders progress and disables Run while running', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.getMaintenanceOperations).mockResolvedValue([
+      operation({
+        progress: {
+          failed: 1,
+          in_flight: 1,
+          remaining: 3,
+          skipped: 0,
+          succeeded: 6,
+          total: 10,
+        },
+        running: true,
+        started_at: '2026-07-13T00:00:00Z',
+        started_by: 'admin@example.com',
+        state: 'running',
+      }),
+    ])
+    const { MaintenanceManagement } = await import('../MaintenanceManagement')
+    render(<MaintenanceManagement />)
+    await waitFor(() =>
+      expect(screen.getByText('7 of 10 — 3 remaining')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('1 failed')).toBeInTheDocument()
+    expect(screen.getByText(/by admin@example\.com/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /run/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('tolerates a running operation without progress', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.getMaintenanceOperations).mockResolvedValue([
+      operation({ running: true, state: 'running' }),
+    ])
+    const { MaintenanceManagement } = await import('../MaintenanceManagement')
+    render(<MaintenanceManagement />)
+    await waitFor(() => expect(screen.getByText('Running')).toBeInTheDocument())
+  })
+
+  it('toasts info when the run 409s', async () => {
+    const endpoints = await import('@/api/endpoints')
+    vi.mocked(endpoints.runMaintenanceOperation).mockRejectedValue(
+      new ApiError(409, 'Conflict', { detail: 'already running' }),
+    )
+    const dialog = await openRunConfirmation()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Run' }))
+    const { toast } = await import('sonner')
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        'That operation is already running',
+      ),
+    )
+  })
+})

--- a/src/hooks/useMaintenanceOperations.ts
+++ b/src/hooks/useMaintenanceOperations.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -50,6 +50,14 @@ export function useMaintenanceOperations() {
   const invalidate = () =>
     void queryClient.invalidateQueries({ queryKey: QUERY_KEY })
 
+  // Pending slugs are tracked per call (not via mutation.variables, which
+  // only reflects the latest call) so overlapping runs on different rows
+  // each keep their own button disabled until their request settles.
+  const [pendingRuns, setPendingRuns] = useState<ReadonlySet<string>>(new Set())
+  const [pendingCancels, setPendingCancels] = useState<ReadonlySet<string>>(
+    new Set(),
+  )
+
   const runMutation = useMutation({
     mutationFn: (slug: string) => runMaintenanceOperation(slug),
     onError: (err) => {
@@ -62,6 +70,9 @@ export function useMaintenanceOperations() {
         )
       }
     },
+    onMutate: (slug) => setPendingRuns((prev) => new Set(prev).add(slug)),
+    onSettled: (_res, _err, slug) =>
+      setPendingRuns((prev) => withoutSlug(prev, slug)),
     onSuccess: (res) => {
       toast.success(`Operation started for ${res.total} project(s)`)
       invalidate()
@@ -74,6 +85,9 @@ export function useMaintenanceOperations() {
       toast.error(
         extractApiErrorDetail(err) ?? 'Failed to cancel the operation',
       ),
+    onMutate: (slug) => setPendingCancels((prev) => new Set(prev).add(slug)),
+    onSettled: (_res, _err, slug) =>
+      setPendingCancels((prev) => withoutSlug(prev, slug)),
     onSuccess: () => {
       toast.info('Operation cancelled')
       invalidate()
@@ -82,15 +96,13 @@ export function useMaintenanceOperations() {
 
   return {
     cancel: cancelMutation.mutate,
-    cancelingSlug: cancelMutation.isPending
-      ? cancelMutation.variables
-      : undefined,
+    cancelingSlugs: pendingCancels,
     error: query.error,
     isError: query.isError,
     isLoading: query.isLoading,
     operations: query.data ?? [],
     run: runMutation.mutate,
-    runningSlug: runMutation.isPending ? runMutation.variables : undefined,
+    runningSlugs: pendingRuns,
   }
 }
 
@@ -105,4 +117,13 @@ function announceTerminal(op: MaintenanceOperation): void {
   } else if (op.state === 'abandoned') {
     toast.error(`${op.label} was abandoned before completing`)
   }
+}
+
+function withoutSlug(
+  set: ReadonlySet<string>,
+  slug: string,
+): ReadonlySet<string> {
+  const next = new Set(set)
+  next.delete(slug)
+  return next
 }

--- a/src/hooks/useMaintenanceOperations.ts
+++ b/src/hooks/useMaintenanceOperations.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { ApiError } from '@/api/client'
+import type { MaintenanceOperation, MaintenanceRunState } from '@/api/endpoints'
+import {
+  cancelMaintenanceOperation,
+  getMaintenanceOperations,
+  runMaintenanceOperation,
+} from '@/api/endpoints'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+const POLL_MS = 3000
+const QUERY_KEY = ['maintenance-operations']
+
+// Drives the admin Maintenance page: fetches the operation registry,
+// polls while any global run is in flight, and toasts each operation's
+// terminal outcome so the admin gets feedback even though the work
+// happens across the server fleet.
+export function useMaintenanceOperations() {
+  const queryClient = useQueryClient()
+
+  const query = useQuery({
+    queryFn: ({ signal }) => getMaintenanceOperations(signal),
+    queryKey: QUERY_KEY,
+    // Poll only while at least one operation is running.
+    refetchInterval: (q) =>
+      q.state.data?.some((op) => op.state === 'running') ? POLL_MS : false,
+  })
+
+  // Toast each operation's terminal transition (running -> done). The
+  // ref guards against toasting historical state on first observation.
+  const previous = useRef<Map<string, MaintenanceRunState> | null>(null)
+  useEffect(() => {
+    const data = query.data
+    if (!data) return
+    const seen = previous.current
+    if (seen) {
+      for (const op of data) {
+        if (seen.get(op.slug) === 'running' && op.state !== 'running') {
+          announceTerminal(op)
+        }
+      }
+    }
+    previous.current = new Map(data.map((op) => [op.slug, op.state]))
+  }, [query.data])
+
+  const invalidate = () =>
+    void queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+
+  const runMutation = useMutation({
+    mutationFn: (slug: string) => runMaintenanceOperation(slug),
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 409) {
+        toast.info('That operation is already running')
+        invalidate()
+      } else {
+        toast.error(
+          extractApiErrorDetail(err) ?? 'Failed to start the operation',
+        )
+      }
+    },
+    onSuccess: (res) => {
+      toast.success(`Operation started for ${res.total} project(s)`)
+      invalidate()
+    },
+  })
+
+  const cancelMutation = useMutation({
+    mutationFn: (slug: string) => cancelMaintenanceOperation(slug),
+    onError: (err) =>
+      toast.error(
+        extractApiErrorDetail(err) ?? 'Failed to cancel the operation',
+      ),
+    onSuccess: () => {
+      toast.info('Operation cancelled')
+      invalidate()
+    },
+  })
+
+  return {
+    cancel: cancelMutation.mutate,
+    cancelingSlug: cancelMutation.isPending
+      ? cancelMutation.variables
+      : undefined,
+    error: query.error,
+    isError: query.isError,
+    isLoading: query.isLoading,
+    operations: query.data ?? [],
+    run: runMutation.mutate,
+    runningSlug: runMutation.isPending ? runMutation.variables : undefined,
+  }
+}
+
+function announceTerminal(op: MaintenanceOperation): void {
+  const failed = op.progress?.failed ?? 0
+  if (op.state === 'completed' && failed > 0) {
+    toast.warning(`${op.label} completed with ${failed} failure(s)`)
+  } else if (op.state === 'completed') {
+    toast.success(`${op.label} completed`)
+  } else if (op.state === 'cancelled') {
+    toast.info(`${op.label} was cancelled`)
+  } else if (op.state === 'abandoned') {
+    toast.error(`${op.label} was abandoned before completing`)
+  }
+}


### PR DESCRIPTION
## Summary
Add a Maintenance section under Global Admin that runs the Project Doctor operations (analysis, rescore, deployment resync, commit/tag sync, PR sync) across all projects, with buttons rendered dynamically from the backend registry.

## Problem
The Doctor's utility actions only exist on each project's Doctor tab; admins have no way to run them platform-wide, and a hardcoded button list would need UI changes every time the backend adds an operation.

## Solution
- `MaintenanceManagement` renders one row per operation returned by `GET /maintenance/operations` — no slugs hardcoded. Running rows show a spinner, "X of Y — Z remaining", failure count, started by/at, and a Cancel action; finished rows show a last-run summary.
- `useMaintenanceOperations` polls every 3s only while a run is active, toasts terminal outcomes (completed/cancelled/abandoned, with failure warnings), and turns a 409 start into an "already running" info toast plus refetch.
- Every run goes through a confirmation dialog since these are heavy global operations.

## Impact
New `maintenance` Global Admin section; admin-only via the existing route gate and the backend's `admin:maintenance:*` permissions. Requires the companion API PR: AWeber-Imbi/imbi-api#471.

## Testing
- 7 new vitest cases covering dynamic rendering, empty/error states, the confirm flow, progress rendering, and 409 handling; oxlint/oxfmt/tsc clean.
- Verified end-to-end in the Okteto dev environment against the API PR.