### PR TITLE
Show gateway delivery URLs on webhook capability cards

### DIFF
--- a/src/components/admin/integrations/CapabilityRow.tsx
+++ b/src/components/admin/integrations/CapabilityRow.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import { Link } from 'react-router-dom'
+
 import {
   Box,
   Check,
@@ -50,6 +52,17 @@ export interface CapabilityRowProps {
   optionValues: Record<string, unknown>
   projectScoped: boolean
   projectTypes: CapabilityProjectType[]
+  /**
+   * Gateway delivery URLs for this integration's webhooks. Only passed
+   * for webhook-surface capabilities; an empty array renders a hint to
+   * create a webhook first.
+   */
+  webhookUrls?: null | WebhookDeliveryUrl[]
+}
+
+export interface WebhookDeliveryUrl {
+  name: string
+  url: string
 }
 
 interface CapabilityOptionFieldProps {
@@ -79,6 +92,7 @@ export function CapabilityRow({
   optionValues,
   projectScoped,
   projectTypes,
+  webhookUrls,
 }: CapabilityRowProps) {
   const meta = capabilityMeta(kind)
   const Icon = meta?.icon ?? Circle
@@ -87,9 +101,11 @@ export function CapabilityRow({
   const [expanded, setExpanded] = useState(enabled)
   const [assignMode, setAssignMode] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [copiedWebhook, setCopiedWebhook] = useState<null | string>(null)
 
   const hasOptions = options.length > 0
-  const hasPanel = hasOptions || projectScoped || !!note || !!callbackUrl
+  const hasPanel =
+    hasOptions || projectScoped || !!note || !!callbackUrl || !!webhookUrls
   const showPanel = enabled && expanded && hasPanel
 
   const handleToggle = (next: boolean) => {
@@ -113,6 +129,14 @@ export function CapabilityRow({
     }
     setCopied(true)
     window.setTimeout(() => setCopied(false), 1600)
+  }
+
+  const copyWebhookUrl = (url: string) => {
+    if (navigator.clipboard) {
+      void navigator.clipboard.writeText(url).catch(() => {})
+    }
+    setCopiedWebhook(url)
+    window.setTimeout(() => setCopiedWebhook(null), 1600)
   }
 
   return (
@@ -287,6 +311,61 @@ export function CapabilityRow({
                 Add this as an authorized redirect URL in the plugin's OAuth
                 settings.
               </div>
+            </div>
+          )}
+
+          {webhookUrls && (
+            <div>
+              <div className="text-tertiary mb-2 text-xs font-semibold tracking-wide uppercase">
+                Delivery URL{webhookUrls.length > 1 ? 's' : ''}
+              </div>
+              {webhookUrls.length === 0 ? (
+                <div className="text-tertiary text-xs">
+                  No webhooks are configured for this integration yet. Create
+                  one under{' '}
+                  <Link
+                    className="text-amber-text-mid hover:underline"
+                    to="/admin/webhooks"
+                  >
+                    Admin → Webhooks
+                  </Link>{' '}
+                  to get a delivery URL.
+                </div>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {webhookUrls.map((hook) => (
+                    <div key={hook.url}>
+                      {webhookUrls.length > 1 && (
+                        <div className="text-secondary mb-1 text-xs">
+                          {hook.name}
+                        </div>
+                      )}
+                      <div className="flex max-w-130 items-center gap-2">
+                        <code className="border-tertiary bg-secondary text-primary min-w-0 flex-1 truncate rounded-md border px-3 py-2 font-mono text-xs">
+                          {hook.url}
+                        </code>
+                        <Button
+                          className="shrink-0"
+                          onClick={() => copyWebhookUrl(hook.url)}
+                          size="sm"
+                          variant="secondary"
+                        >
+                          {copiedWebhook === hook.url ? (
+                            <Check className="size-3.5" />
+                          ) : (
+                            <Copy className="size-3.5" />
+                          )}
+                          {copiedWebhook === hook.url ? 'Copied' : 'Copy'}
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                  <div className="text-tertiary text-xs">
+                    Configure the remote service (e.g. GitHub) to send webhook
+                    deliveries to this URL.
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/admin/integrations/CapabilityRow.tsx
+++ b/src/components/admin/integrations/CapabilityRow.tsx
@@ -136,7 +136,12 @@ export function CapabilityRow({
       void navigator.clipboard.writeText(url).catch(() => {})
     }
     setCopiedWebhook(url)
-    window.setTimeout(() => setCopiedWebhook(null), 1600)
+    // Only clear if this URL is still the one showing "Copied" — a stale
+    // timer from an earlier copy must not clear a newer indicator.
+    window.setTimeout(
+      () => setCopiedWebhook((current) => (current === url ? null : current)),
+      1600,
+    )
   }
 
   return (

--- a/src/components/admin/integrations/IntegrationDetail.tsx
+++ b/src/components/admin/integrations/IntegrationDetail.tsx
@@ -16,6 +16,7 @@ import {
   listCapabilityAssignments,
   listPluginPackages,
   listProjectTypes,
+  listWebhooks,
   replaceCapabilityAssignments,
   updateIntegration,
   updateIntegrationCredentials,
@@ -97,6 +98,28 @@ export function IntegrationDetail({
   const plugin = plugins.find((p) => p.slug === integration?.plugin) ?? null
   const pluginAvailable = !!plugin && plugin.enabled
   const editable = pluginAvailable
+
+  // Gateway delivery URLs for the webhook-actions capability: the org's
+  // webhooks implemented by this integration, each reachable externally
+  // at <origin>/gateway/notifications<notification_path>.
+  const hasWebhookCapability = !!plugin?.capabilities.some(
+    (c) => c.kind === 'webhook-actions',
+  )
+  const { data: webhooks = [] } = useQuery({
+    enabled: !!orgSlug && hasWebhookCapability,
+    queryFn: ({ signal }) => listWebhooks(orgSlug!, signal),
+    queryKey: ['webhooks', orgSlug],
+  })
+  const webhookUrls = webhooks
+    .filter(
+      (w) =>
+        (w.third_party_service?.slug as string | undefined) ===
+        integration?.slug,
+    )
+    .map((w) => ({
+      name: w.name,
+      url: `${gatewayOrigin()}/gateway/notifications${w.notification_path}`,
+    }))
 
   // Load current project-type assignments for each project-scoped capability.
   const scopedKinds =
@@ -369,6 +392,11 @@ export function IntegrationDetail({
                           optionValues={options}
                           projectScoped={cap.project_scoped}
                           projectTypes={projectTypes}
+                          webhookUrls={
+                            cap.kind === 'webhook-actions'
+                              ? webhookUrls
+                              : undefined
+                          }
                         />
                       )
                     })}
@@ -551,6 +579,17 @@ function formatValue(value: unknown): string {
   if (value === null || value === undefined || value === '') return '—'
   if (typeof value === 'boolean') return value ? 'Yes' : 'No'
   return String(value)
+}
+
+// The gateway is served from the same public origin as the API (the
+// ingress mounts /api and /gateway side by side). API_URL may be
+// path-only in same-origin deployments, so fall back to the page origin.
+function gatewayOrigin(): string {
+  try {
+    return new URL(API_URL).origin
+  } catch {
+    return window.location.origin
+  }
 }
 
 // One integration-level option (host, flavor, …), click-to-edit inline and

--- a/src/components/admin/integrations/__tests__/CapabilityRow.test.tsx
+++ b/src/components/admin/integrations/__tests__/CapabilityRow.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fireEvent, render, screen } from '@/test/utils'
+
+import { CapabilityRow } from '../CapabilityRow'
+
+const baseProps = {
+  assignedTypeSlugs: [],
+  description: 'Gateway-dispatched sync from webhook deliveries.',
+  enabled: true,
+  kind: 'webhook-actions',
+  label: 'Webhook actions',
+  onAssignmentChange: vi.fn(),
+  onOptionChange: vi.fn(),
+  onToggle: vi.fn(),
+  options: [],
+  optionValues: {},
+  projectScoped: false,
+  projectTypes: [],
+}
+
+describe('CapabilityRow webhook delivery URLs', () => {
+  it('renders a copyable delivery URL for each webhook', () => {
+    render(
+      <CapabilityRow
+        {...baseProps}
+        webhookUrls={[
+          {
+            name: 'GitHub Events',
+            url: 'https://imbi.example.com/gateway/notifications/abc123',
+          },
+        ]}
+      />,
+    )
+    expect(screen.getByText('Delivery URL')).toBeInTheDocument()
+    expect(
+      screen.getByText('https://imbi.example.com/gateway/notifications/abc123'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument()
+  })
+
+  it('labels each URL when the integration has multiple webhooks', () => {
+    render(
+      <CapabilityRow
+        {...baseProps}
+        webhookUrls={[
+          {
+            name: 'GitHub Events',
+            url: 'https://imbi.example.com/gateway/notifications/abc123',
+          },
+          {
+            name: 'GitHub Releases',
+            url: 'https://imbi.example.com/gateway/notifications/def456',
+          },
+        ]}
+      />,
+    )
+    expect(screen.getByText('Delivery URLs')).toBeInTheDocument()
+    expect(screen.getByText('GitHub Events')).toBeInTheDocument()
+    expect(screen.getByText('GitHub Releases')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /copy/i })).toHaveLength(2)
+  })
+
+  it('copies the URL to the clipboard', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(
+      <CapabilityRow
+        {...baseProps}
+        webhookUrls={[
+          {
+            name: 'GitHub Events',
+            url: 'https://imbi.example.com/gateway/notifications/abc123',
+          },
+        ]}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /copy/i }))
+    expect(writeText).toHaveBeenCalledWith(
+      'https://imbi.example.com/gateway/notifications/abc123',
+    )
+    expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument()
+  })
+
+  it('shows a create-webhook hint when no webhooks exist', () => {
+    render(<CapabilityRow {...baseProps} webhookUrls={[]} />)
+    expect(
+      screen.getByText(/No webhooks are configured for this integration/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Admin → Webhooks/ }),
+    ).toHaveAttribute('href', '/admin/webhooks')
+  })
+
+  it('omits the section when webhookUrls is not provided', () => {
+    render(<CapabilityRow {...baseProps} />)
+    expect(screen.queryByText(/Delivery URL/)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
The webhook-actions capability card on the Integration detail page now shows the gateway delivery URL(s) for the integration's webhooks, with a copy button — the exact URL to paste into the remote service (e.g. GitHub's webhook settings).

## Problem
Configuring the remote side of a webhook requires knowing the gateway delivery URL (`https://<host>/gateway/notifications/{webhook_id}`), but nothing in the UI shows it assembled: the Webhooks admin only displays the raw `notification_path` fragment, and nothing connects it to the integration whose plugin handles the deliveries.

## Solution
- `IntegrationDetail` fetches the org's webhooks when the plugin declares a `webhook-actions` capability, filters to those implemented by this integration (`third_party_service.slug`), and builds each full URL from the deployment origin (derived from `API_URL`, same-origin fallback) + `/gateway/notifications` + `notification_path` — mirroring how the identity callback URL is built.
- `CapabilityRow` gains an optional `webhookUrls` prop rendered in the same monospace-code-plus-Copy style as the existing Callback URL block, labeling each URL by webhook name when there are several. With no webhooks yet, it shows a hint linking to Admin → Webhooks.

## Impact
Display-only; no API changes. Worth noting for reviewers: the gateway currently verifies signatures only for PagerDuty deliveries — GitHub's `x-hub-signature-256` is redacted but not validated, so the unguessable webhook id remains the only access control on this URL.

## Testing
5 new vitest cases (single/multiple URLs, clipboard copy, empty-state hint, section omitted when not applicable); oxlint, oxfmt, and tsc clean.