### PR TITLE
Fix webhook save + config prefix after the Integration rename

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -633,9 +633,9 @@ export interface AdminEventsFilters {
    *  configured selector. Used together with `type='webhook'` to
    *  narrow within the webhook category. */
   event_type?: string
+  integration?: string
   project_id?: string
   since?: string
-  third_party_service?: string
   /** Event *category*. `'webhook'` for inbound webhook deliveries.
    *  Wider categories (e.g. system-generated events) may land in
    *  the same table later. */
@@ -658,11 +658,11 @@ export interface EventHandlerOutcome {
 export interface EventRecord {
   attributed_to: string
   id: string
+  integration: string
   metadata: Record<string, unknown>
   payload: Record<string, unknown>
   project_id: string
   recorded_at: string
-  third_party_service: string
   type: string
   /** Increments with each phase of the gateway's two-phase recording.
    *  0 = phase-1 (initial record), 1 = phase-2 (dispatch outcome). */

--- a/src/components/IntegrationsCard.tsx
+++ b/src/components/IntegrationsCard.tsx
@@ -162,7 +162,7 @@ export function IntegrationsCard({
           <IntegrationsSkeleton />
         ) : services.length === 0 ? (
           <p className="text-muted-foreground text-sm">
-            This project is not connected to any third-party services.
+            This project is not connected to any integrations.
           </p>
         ) : (
           <Table>

--- a/src/components/IntegrationsCard.tsx
+++ b/src/components/IntegrationsCard.tsx
@@ -140,8 +140,8 @@ export function IntegrationsCard({
         <div className="space-y-1.5">
           <CardTitle>Integrations</CardTitle>
           <CardDescription>
-            Third-party services this project exists in, with the stable
-            identifier and the canonical API and dashboard URLs.
+            Integrations this project exists in, with the stable identifier and
+            the canonical API and dashboard URLs.
           </CardDescription>
         </div>
         <Button
@@ -168,7 +168,7 @@ export function IntegrationsCard({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Service</TableHead>
+                <TableHead>Integration</TableHead>
                 <TableHead>Identifier</TableHead>
                 <TableHead>API URL</TableHead>
                 <TableHead>Dashboard URL</TableHead>
@@ -212,7 +212,7 @@ export function IntegrationsCard({
           </DialogHeader>
           <div className="space-y-4 p-6">
             <div className="space-y-2">
-              <Label htmlFor="integration-service">Service</Label>
+              <Label htmlFor="integration-service">Integration</Label>
               <Select
                 onValueChange={(value) =>
                   setForm((f) => ({ ...f, serviceSlug: value }))
@@ -220,7 +220,7 @@ export function IntegrationsCard({
                 value={form.serviceSlug}
               >
                 <SelectTrigger id="integration-service">
-                  <SelectValue placeholder="Select a service…" />
+                  <SelectValue placeholder="Select an integration…" />
                 </SelectTrigger>
                 <SelectContent>
                   {connectableServices.map((svc) => (

--- a/src/components/ProjectActivityLog.tsx
+++ b/src/components/ProjectActivityLog.tsx
@@ -498,8 +498,8 @@ function renderGenericEventBody(entry: EventRecord): React.ReactNode {
   return (
     <span>
       <span className="text-secondary">{label}</span>
-      {entry.third_party_service && (
-        <span className="text-tertiary"> via {entry.third_party_service}</span>
+      {entry.integration && (
+        <span className="text-tertiary"> via {entry.integration}</span>
       )}
     </span>
   )

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1178,6 +1178,11 @@ export function ProjectDetail({
               orgSlug={orgSlug}
               projectId={project.id}
               projectSlug={project.slug}
+              projectTypeSlug={
+                project.project_types?.[0]?.slug ??
+                project.project_type?.slug ??
+                ''
+              }
               teamSlug={project.team.slug}
             />
           </TabsContent>

--- a/src/components/__tests__/IntegrationsCard.test.tsx
+++ b/src/components/__tests__/IntegrationsCard.test.tsx
@@ -51,7 +51,7 @@ describe('IntegrationsCard', () => {
     render(<IntegrationsCard orgSlug="aweber" projectId="p1" />)
 
     expect(
-      await screen.findByText(/not connected to any third-party services/i),
+      await screen.findByText(/not connected to any integrations/i),
     ).toBeInTheDocument()
   })
 

--- a/src/components/admin/WebhookHistory.tsx
+++ b/src/components/admin/WebhookHistory.tsx
@@ -38,7 +38,7 @@ export function WebhookHistory({ eventId }: WebhookHistoryProps) {
   const orgSlug = selectedOrganization?.slug ?? ''
   const { projectsById } = useProjectsSlimMap(orgSlug)
 
-  const [tps, setTps] = useState('')
+  const [integration, setIntegration] = useState('')
   const [eventType, setEventType] = useState('')
   const [projectId, setProjectId] = useState('')
   const [timeRange, setTimeRange] = useState<TimeRange>('7d')
@@ -50,13 +50,13 @@ export function WebhookHistory({ eventId }: WebhookHistoryProps) {
     // (e.g. `pull_request`) sits in `metadata.event_type` and the API
     // exposes that as the `event_type` query parameter.
     const f: AdminEventsFilters = { type: 'webhook' }
-    if (tps) f.third_party_service = tps
+    if (integration) f.integration = integration
     if (eventType) f.event_type = eventType
     if (projectId) f.project_id = projectId
     const since = sinceFromRange(timeRange)
     if (since) f.since = since
     return f
-  }, [tps, eventType, projectId, timeRange])
+  }, [integration, eventType, projectId, timeRange])
 
   const {
     data,
@@ -71,10 +71,10 @@ export function WebhookHistory({ eventId }: WebhookHistoryProps) {
   const pinnedQuery = useWebhookEvent(eventId)
 
   // fallow-ignore-next-line complexity
-  const tpsOptions = useMemo(() => {
+  const integrationOptions = useMemo(() => {
     const set = new Set<string>()
     for (const e of data?.entries ?? []) {
-      if (e.third_party_service) set.add(e.third_party_service)
+      if (e.integration) set.add(e.integration)
     }
     return Array.from(set).sort()
   }, [data?.entries])
@@ -86,19 +86,22 @@ export function WebhookHistory({ eventId }: WebhookHistoryProps) {
     <div className="space-y-4">
       <div className="flex flex-wrap items-end gap-2">
         <div className="min-w-40">
-          <label className="text-secondary mb-1 block text-xs" htmlFor="wh-tps">
-            Third-party service
+          <label
+            className="text-secondary mb-1 block text-xs"
+            htmlFor="wh-integration"
+          >
+            Integration
           </label>
           <Select
-            onValueChange={(v) => setTps(v === '__all' ? '' : v)}
-            value={tps || '__all'}
+            onValueChange={(v) => setIntegration(v === '__all' ? '' : v)}
+            value={integration || '__all'}
           >
-            <SelectTrigger className="h-8" id="wh-tps">
-              <SelectValue placeholder="All services" />
+            <SelectTrigger className="h-8" id="wh-integration">
+              <SelectValue placeholder="All integrations" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="__all">All services</SelectItem>
-              {tpsOptions.map((slug) => (
+              <SelectItem value="__all">All integrations</SelectItem>
+              {integrationOptions.map((slug) => (
                 <SelectItem key={slug} value={slug}>
                   {slug}
                 </SelectItem>

--- a/src/components/admin/WebhookHistoryRow.tsx
+++ b/src/components/admin/WebhookHistoryRow.tsx
@@ -65,7 +65,7 @@ export function WebhookHistoryRow({
         <span className="text-secondary text-sm tabular-nums">
           {new Date(event.recorded_at).toLocaleString()}
         </span>
-        <Badge variant="secondary">{event.third_party_service}</Badge>
+        <Badge variant="secondary">{event.integration}</Badge>
         <span className="text-primary text-sm font-medium">
           {eventTypeLabel}
         </span>

--- a/src/components/admin/WebhookManagement.tsx
+++ b/src/components/admin/WebhookManagement.tsx
@@ -157,10 +157,10 @@ export function WebhookManagement() {
         <Card>
           <CardContent className="p-4">
             <CardDescription className="text-secondary">
-              With Service
+              With Integration
             </CardDescription>
             <div className="text-info mt-1 text-2xl">
-              {filteredWebhooks.filter((w) => w.third_party_service).length}
+              {filteredWebhooks.filter((w) => w.integration).length}
             </div>
           </CardContent>
         </Card>
@@ -221,11 +221,11 @@ export function WebhookManagement() {
           },
           {
             cellAlign: 'left',
-            header: 'Service',
+            header: 'Integration',
             headerAlign: 'left',
             key: 'service',
             render: (wh) =>
-              (wh.third_party_service?.name as string | undefined) || (
+              (wh.integration?.name as string | undefined) || (
                 <span className="text-tertiary">--</span>
               ),
           },

--- a/src/components/admin/__tests__/WebhookHistoryRow.test.tsx
+++ b/src/components/admin/__tests__/WebhookHistoryRow.test.tsx
@@ -9,11 +9,11 @@ function makeEvent(overrides: Partial<EventRecord> = {}): EventRecord {
   return {
     attributed_to: '',
     id: 'evt-1',
+    integration: 'github-enterprise-cloud',
     metadata: {},
     payload: {},
     project_id: 'proj-1',
     recorded_at: '2026-04-01T12:00:00Z',
-    third_party_service: 'github-enterprise-cloud',
     type: 'pull_request',
     ...overrides,
   }

--- a/src/components/admin/integrations/IntegrationDetail.tsx
+++ b/src/components/admin/integrations/IntegrationDetail.tsx
@@ -112,9 +112,7 @@ export function IntegrationDetail({
   })
   const webhookUrls = webhooks
     .filter(
-      (w) =>
-        (w.third_party_service?.slug as string | undefined) ===
-        integration?.slug,
+      (w) => (w.integration?.slug as string | undefined) === integration?.slug,
     )
     .map((w) => ({
       name: w.name,
@@ -162,6 +160,27 @@ export function IntegrationDetail({
     onError: (err) => toast.error(`Save failed: ${extractApiErrorDetail(err)}`),
     onSuccess: invalidate,
   })
+
+  // Inline rename of the integration's display name. The slug is immutable
+  // via the API, so only ``name`` is patched here.
+  const [savingName, setSavingName] = useState(false)
+  const nameInputRef = useRef<HTMLInputElement>(null)
+  const nameEdit = useInlineEdit<string>({
+    initial: integration?.name ?? '',
+    onCommit: async (next) => {
+      const trimmed = next.trim()
+      if (!trimmed || trimmed === integration?.name) return
+      setSavingName(true)
+      try {
+        await patchMutation.mutateAsync({ name: trimmed })
+      } finally {
+        setSavingName(false)
+      }
+    },
+  })
+  useEffect(() => {
+    if (nameEdit.isEditing) nameInputRef.current?.focus()
+  }, [nameEdit.isEditing])
 
   const assignmentMutation = useMutation({
     mutationFn: ({ kind, slugs }: { kind: string; slugs: string[] }) =>
@@ -273,9 +292,34 @@ export function IntegrationDetail({
 
             <div className="mb-6 flex items-start justify-between gap-5">
               <div className="flex flex-wrap items-center gap-3">
-                <h1 className="text-primary text-2xl font-semibold tracking-tight">
-                  {integration.name}
-                </h1>
+                {nameEdit.isEditing ? (
+                  <div className="flex flex-col">
+                    <Input
+                      className="h-9 w-72 text-2xl font-semibold"
+                      onBlur={nameEdit.handleBlur}
+                      onChange={(e) => nameEdit.setDraft(e.target.value)}
+                      onKeyDown={nameEdit.handleKeyDown}
+                      ref={nameInputRef}
+                      value={nameEdit.draft}
+                    />
+                    {nameEdit.error && (
+                      <span className="mt-1 text-xs text-red-600">
+                        {nameEdit.error}
+                      </span>
+                    )}
+                  </div>
+                ) : (
+                  <InlineDisplay
+                    hasValue
+                    onClick={nameEdit.enter}
+                    pending={savingName}
+                    readOnly={!editable}
+                  >
+                    <h1 className="text-primary text-2xl font-semibold tracking-tight">
+                      {integration.name}
+                    </h1>
+                  </InlineDisplay>
+                )}
                 <span className="text-tertiary inline-flex items-center gap-1 font-mono text-xs">
                   <Package className="size-3" />
                   {integration.plugin}

--- a/src/components/admin/integrations/IntegrationDetail.tsx
+++ b/src/components/admin/integrations/IntegrationDetail.tsx
@@ -169,7 +169,8 @@ export function IntegrationDetail({
     initial: integration?.name ?? '',
     onCommit: async (next) => {
       const trimmed = next.trim()
-      if (!trimmed || trimmed === integration?.name) return
+      if (trimmed === integration?.name) return
+      if (!trimmed) throw new Error('Name is required')
       setSavingName(true)
       try {
         await patchMutation.mutateAsync({ name: trimmed })

--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -91,9 +91,9 @@ export function WebhookDetail({ onBack, onEdit, webhook }: WebhookDetailProps) {
               </div>
             </div>
             <div>
-              <div className="text-secondary text-sm">Third-Party Service</div>
+              <div className="text-secondary text-sm">Integration</div>
               <div className="text-primary mt-1">
-                {(webhook.third_party_service?.name as string | undefined) || (
+                {(webhook.integration?.name as string | undefined) || (
                   <span className="text-tertiary">None</span>
                 )}
               </div>
@@ -122,14 +122,14 @@ export function WebhookDetail({ onBack, onEdit, webhook }: WebhookDetailProps) {
                 </div>
               </div>
             )}
-            {webhook.identity_plugin_slug && (
+            {webhook.identity_integration_slug && (
               <div>
                 <div className="text-secondary text-sm">
-                  Identity Plugin Slug
+                  Identity Integration Slug
                 </div>
                 <div className="mt-1">
                   <code className="bg-secondary text-primary rounded px-2 py-1 text-sm">
-                    {webhook.identity_plugin_slug}
+                    {webhook.identity_integration_slug}
                   </code>
                 </div>
               </div>

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -172,7 +172,7 @@ export function WebhookForm({
     }
   }
 
-  const handleServiceChange = (newIntegration: string) => {
+  const handleIntegrationChange = (newIntegration: string) => {
     setIntegrationSlug(newIntegration)
     if (!newIntegration) {
       setIdentifierSelector('')
@@ -429,7 +429,7 @@ export function WebhookForm({
               project resolution.{' '}
               {isEditing && (
                 <span className="text-tertiary text-xs">
-                  Changing the service will auto-regenerate the slug.
+                  Changing the integration will auto-regenerate the slug.
                 </span>
               )}
             </p>
@@ -447,7 +447,7 @@ export function WebhookForm({
                 <Select
                   disabled={isLoading}
                   onValueChange={(v) =>
-                    handleServiceChange(v === 'none' ? '' : v)
+                    handleIntegrationChange(v === 'none' ? '' : v)
                   }
                   value={integrationSlug || 'none'}
                 >

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -61,8 +61,8 @@ export function WebhookForm({
   const [icon, setIcon] = useState(webhook?.icon || '')
   const handleIconChange = useIconWithCleanup(icon, setIcon)
   const [secret, setSecret] = useState('')
-  const [tpsSlug, setTpsSlug] = useState(
-    (webhook?.third_party_service?.slug as string | undefined) ||
+  const [integrationSlug, setIntegrationSlug] = useState(
+    (webhook?.integration?.slug as string | undefined) ||
       defaultServiceSlug ||
       '',
   )
@@ -72,8 +72,8 @@ export function WebhookForm({
   const [userSubjectSelector, setUserSubjectSelector] = useState(
     webhook?.user_subject_selector || '',
   )
-  const [identityPluginSlug, setIdentityPluginSlug] = useState(
-    webhook?.identity_plugin_slug || '',
+  const [identityIntegrationSlug, setIdentityIntegrationSlug] = useState(
+    webhook?.identity_integration_slug || '',
   )
   const [eventTypeSelector, setEventTypeSelector] = useState(
     webhook?.event_type_selector || '',
@@ -107,21 +107,21 @@ export function WebhookForm({
           'Slug must start with a letter and contain only lowercase letters, numbers, and hyphens'
       }
     }
-    if (identifierSelector && !tpsSlug) {
+    if (identifierSelector && !integrationSlug) {
       newErrors.identifier_selector =
-        'Identifier selector requires a third-party service'
+        'Identifier selector requires an integration'
     }
-    if (userSubjectSelector && !tpsSlug) {
+    if (userSubjectSelector && !integrationSlug) {
       newErrors.user_subject_selector =
-        'User subject selector requires a third-party service'
+        'User subject selector requires an integration'
     }
-    if (identityPluginSlug && !tpsSlug) {
-      newErrors.identity_plugin_slug =
-        'Identity plugin slug requires a third-party service'
+    if (identityIntegrationSlug && !integrationSlug) {
+      newErrors.identity_integration_slug =
+        'Identity integration slug requires an integration'
     }
-    if (eventTypeSelector && !tpsSlug) {
+    if (eventTypeSelector && !integrationSlug) {
       newErrors.event_type_selector =
-        'Event type selector requires a third-party service'
+        'Event type selector requires an integration'
     }
     for (let i = 0; i < rules.length; i++) {
       if (!rules[i].filter_expression.trim()) {
@@ -143,7 +143,8 @@ export function WebhookForm({
       event_type_selector: eventTypeSelector.trim() || null,
       icon: icon.trim() || null,
       identifier_selector: identifierSelector.trim() || null,
-      identity_plugin_slug: identityPluginSlug.trim() || null,
+      identity_integration_slug: identityIntegrationSlug.trim() || null,
+      integration_slug: integrationSlug || null,
       name: name.trim(),
       rules: rules.map((r) => ({
         filter_expression: r.filter_expression.trim(),
@@ -151,7 +152,6 @@ export function WebhookForm({
         handler_config: r.handler_config,
       })),
       secret: secret.trim() || null,
-      third_party_service_slug: tpsSlug || null,
       user_subject_selector: userSubjectSelector.trim() || null,
       // Include slug only when editing so the PATCH can update it.
       ...(isEditing ? { slug: slug.trim() } : {}),
@@ -172,18 +172,18 @@ export function WebhookForm({
     }
   }
 
-  const handleServiceChange = (newTps: string) => {
-    setTpsSlug(newTps)
-    if (!newTps) {
+  const handleServiceChange = (newIntegration: string) => {
+    setIntegrationSlug(newIntegration)
+    if (!newIntegration) {
       setIdentifierSelector('')
       setUserSubjectSelector('')
-      setIdentityPluginSlug('')
+      setIdentityIntegrationSlug('')
       setEventTypeSelector('')
     }
     // In edit mode, auto-update the displayed slug to the computed value
     // so the user can see what will be saved if they don't override it.
     if (isEditing) {
-      setSlug(computePreviewSlug(newTps, name))
+      setSlug(computePreviewSlug(newIntegration, name))
     }
   }
 
@@ -290,7 +290,7 @@ export function WebhookForm({
               {!isEditing && name && (
                 <p className="text-tertiary mt-1 text-xs">
                   Slug will be auto-generated:{' '}
-                  <code>{computePreviewSlug(tpsSlug, name)}</code>
+                  <code>{computePreviewSlug(integrationSlug, name)}</code>
                 </p>
               )}
             </div>
@@ -421,12 +421,12 @@ export function WebhookForm({
           </CardContent>
         </Card>
 
-        {/* Third-Party Service Binding */}
+        {/* Integration Binding */}
         <Card>
           <CardContent className="space-y-4 pt-6">
             <p className="text-secondary mb-4 text-sm">
-              Optionally link this webhook to a third-party service for
-              automatic project resolution.{' '}
+              Optionally link this webhook to an integration for automatic
+              project resolution.{' '}
               {isEditing && (
                 <span className="text-tertiary text-xs">
                   Changing the service will auto-regenerate the slug.
@@ -438,9 +438,9 @@ export function WebhookForm({
               <div>
                 <Label
                   className="text-secondary mb-1.5 block text-sm"
-                  htmlFor="webhook-tps"
+                  htmlFor="webhook-integration"
                 >
-                  Third-Party Service
+                  Integration
                 </Label>
                 {/* Radix disallows '' as a SelectItem value, so 'none' is
                     the empty sentinel and gets translated at the boundary. */}
@@ -449,9 +449,9 @@ export function WebhookForm({
                   onValueChange={(v) =>
                     handleServiceChange(v === 'none' ? '' : v)
                   }
-                  value={tpsSlug || 'none'}
+                  value={integrationSlug || 'none'}
                 >
-                  <SelectTrigger id="webhook-tps">
+                  <SelectTrigger id="webhook-integration">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -465,7 +465,7 @@ export function WebhookForm({
                 </Select>
               </div>
 
-              {tpsSlug && (
+              {integrationSlug && (
                 <>
                   <div>
                     <Label className="text-secondary mb-1.5 block text-sm">
@@ -528,32 +528,34 @@ export function WebhookForm({
 
                   <div>
                     <Label className="text-secondary mb-1.5 block text-sm">
-                      Identity Plugin Slug{' '}
+                      Identity Integration Slug{' '}
                       <span className="text-tertiary text-xs">(optional)</span>
                     </Label>
                     <Input
                       className={`font-mono text-sm ${
-                        errors.identity_plugin_slug ? 'border-red-500' : ''
+                        errors.identity_integration_slug ? 'border-red-500' : ''
                       }`}
                       disabled={isLoading}
-                      onChange={(e) => setIdentityPluginSlug(e.target.value)}
+                      onChange={(e) =>
+                        setIdentityIntegrationSlug(e.target.value)
+                      }
                       placeholder="e.g., github"
-                      value={identityPluginSlug}
+                      value={identityIntegrationSlug}
                     />
-                    {errors.identity_plugin_slug && (
+                    {errors.identity_integration_slug && (
                       <div
                         className={
                           'text-danger mt-1 flex items-center gap-1 text-xs'
                         }
                       >
                         <AlertCircle className="size-3" />
-                        {errors.identity_plugin_slug}
+                        {errors.identity_integration_slug}
                       </div>
                     )}
                     <p className="text-tertiary mt-1 text-xs">
                       Override which identity plugin resolves the user. Leave
                       blank to fall back to identity plugins attached to the
-                      third-party service.
+                      integration.
                     </p>
                   </div>
 

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -68,6 +68,7 @@ interface ConfigurationTabProps {
   orgSlug: string
   projectId: string
   projectSlug: string
+  projectTypeSlug: string
   teamSlug: string
 }
 
@@ -130,6 +131,7 @@ export function ConfigurationTab({
   orgSlug,
   projectId,
   projectSlug,
+  projectTypeSlug,
   teamSlug,
 }: ConfigurationTabProps) {
   const queryClient = useQueryClient()
@@ -208,6 +210,7 @@ export function ConfigurationTab({
       org_slug: orgSlug,
       project_id: projectId,
       project_slug: projectSlug,
+      project_type_slug: projectTypeSlug,
       team_slug: teamSlug,
     }
     return raw.replace(/\$\{([^}]+)\}/g, (match, name: string) =>

--- a/src/components/search/SearchResultsPanel.tsx
+++ b/src/components/search/SearchResultsPanel.tsx
@@ -65,6 +65,13 @@ const ENTITY_STYLES: Record<
     label: 'Environment',
     text: 'text-entity-config',
   },
+  Integration: {
+    dot: 'bg-entity-config',
+    hex: '#7A7873',
+    label: 'Integration',
+    round: true,
+    text: 'text-entity-config',
+  },
   LinkDefinition: {
     dot: 'bg-entity-schema',
     hex: '#8C82D4',
@@ -115,13 +122,6 @@ const ENTITY_STYLES: Record<
     dot: 'bg-entity-config',
     hex: '#7A7873',
     label: 'Team',
-    round: true,
-    text: 'text-entity-config',
-  },
-  ThirdPartyService: {
-    dot: 'bg-entity-config',
-    hex: '#7A7873',
-    label: '3rd-Party Service',
     round: true,
     text: 'text-entity-config',
   },

--- a/src/hooks/useDeploymentResync.ts
+++ b/src/hooks/useDeploymentResync.ts
@@ -39,7 +39,7 @@ function onResyncError(err: unknown): void {
 }
 
 // Build the "X event(s) recorded • Y release(s) created" headline shown
-// on both the project-level and TPS-wide success toasts. Skips counters
+// on both the project-level and integration-wide success toasts. Skips counters
 // that are zero so the summary stays short on idle remotes.
 // fallow-ignore-next-line complexity
 function summarize(s: DeploymentResyncSummary): string {

--- a/src/lib/status-colors.ts
+++ b/src/lib/status-colors.ts
@@ -1,6 +1,6 @@
 import type { BadgeProps } from '@/components/ui/badge'
 
-/** Map third-party-service status strings to semantic Badge variants. */
+/** Map integration status strings to semantic Badge variants. */
 const STATUS_VARIANTS: Record<string, BadgeProps['variant']> = {
   active: 'success',
   deprecated: 'warning',

--- a/src/types/api-generated.ts
+++ b/src/types/api-generated.ts
@@ -3322,8 +3322,8 @@ export interface components {
          * @description Request model for creating a Project EXISTS_IN link.
          */
         ExistsInCreate: {
-            /** Third Party Service Slug */
-            third_party_service_slug: string;
+            /** Integration Slug */
+            integration_slug: string;
             /** Identifier */
             identifier: string;
             /** Canonical Url */
@@ -3336,10 +3336,10 @@ export interface components {
          * @description Response model for a Project EXISTS_IN link.
          */
         ExistsInResponse: {
-            /** Third Party Service Slug */
-            third_party_service_slug: string;
-            /** Third Party Service Name */
-            third_party_service_name: string;
+            /** Integration Slug */
+            integration_slug: string;
+            /** Integration Name */
+            integration_name: string;
             /** Identifier */
             identifier: string;
             /** Canonical Url */
@@ -4897,8 +4897,8 @@ export interface components {
             icon?: string | null;
             /** Secret */
             secret?: string | null;
-            /** Third Party Service Slug */
-            third_party_service_slug?: string | null;
+            /** Integration Slug */
+            integration_slug?: string | null;
             /**
              * Identifier Selector
              * @description JSON Path expression to extract project identifier
@@ -4910,10 +4910,10 @@ export interface components {
              */
             user_subject_selector?: string | null;
             /**
-             * Identity Plugin Slug
-             * @description Optional override for the identity plugin slug used to resolve the Imbi user; falls back to identity plugins attached to the third-party service when unset.
+             * Identity Integration Slug
+             * @description Optional override for the identity integration slug used to resolve the Imbi user; falls back to identity plugins attached to the integration when unset.
              */
-            identity_plugin_slug?: string | null;
+            identity_integration_slug?: string | null;
             /**
              * Event Type Selector
              * @description Resolves the activity-feed event type for each webhook. Values starting with "/" are JSON pointers evaluated against the request body; otherwise the value is treated as an HTTP header name (case-insensitive). When the header is absent, the literal selector value is used as the label.
@@ -4939,16 +4939,16 @@ export interface components {
             icon?: string | null;
             /** Notification Path — system-generated, read-only */
             notification_path: string;
-            /** Third Party Service */
-            third_party_service?: {
+            /** Integration */
+            integration?: {
                 [key: string]: unknown;
             } | null;
             /** Identifier Selector */
             identifier_selector?: string | null;
             /** User Subject Selector */
             user_subject_selector?: string | null;
-            /** Identity Plugin Slug */
-            identity_plugin_slug?: string | null;
+            /** Identity Integration Slug */
+            identity_integration_slug?: string | null;
             /** Event Type Selector */
             event_type_selector?: string | null;
             /**
@@ -5010,8 +5010,8 @@ export interface components {
             notification_path: string;
             /** Secret */
             secret?: string | null;
-            /** Third Party Service Slug */
-            third_party_service_slug?: string | null;
+            /** Integration Slug */
+            integration_slug?: string | null;
             /**
              * Identifier Selector
              * @description JSON Path expression to extract project identifier
@@ -5023,10 +5023,10 @@ export interface components {
              */
             user_subject_selector?: string | null;
             /**
-             * Identity Plugin Slug
-             * @description Optional override for the identity plugin slug used to resolve the Imbi user; falls back to identity plugins attached to the third-party service when unset.
+             * Identity Integration Slug
+             * @description Optional override for the identity integration slug used to resolve the Imbi user; falls back to identity plugins attached to the integration when unset.
              */
-            identity_plugin_slug?: string | null;
+            identity_integration_slug?: string | null;
             /**
              * Event Type Selector
              * @description Resolves the activity-feed event type for each webhook. Values starting with "/" are JSON pointers evaluated against the request body; otherwise the value is treated as an HTTP header name (case-insensitive). When the header is absent, the literal selector value is used as the label.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -270,7 +270,7 @@ export interface Project {
     team?: RelationshipLink
   }
   score?: null | number
-  // Read-only EXISTS_IN connections (third-party service relationships).
+  // Read-only EXISTS_IN connections (integration relationships).
   // Maintained via the project-services endpoints / Integrations panel,
   // not by editing `identifiers`.
   services?: ProjectServiceEdge[]
@@ -1127,7 +1127,7 @@ export interface PluginAssignmentResponse {
   plugin_id: string
   plugin_slug: string
   plugin_type: PluginType
-  // Parent third-party service so the UI can show which service
+  // Parent integration so the UI can show which integration
   // powers the tab.
   service_icon?: null | string
   service_name?: null | string


### PR DESCRIPTION
## Summary

Two UI fixes surfaced while testing 2.13.2 admin/config screens, both stemming from the backend's Third-Party Service → Integration rename that the UI hadn't fully caught up to.

## Problem

1. **Webhook edit/save failed.** The API renamed webhook fields to `integration_slug` / `identity_integration_slug` and returns the linked integration under `integration`; events expose an `integration` field; the search node label is now `Integration`. The UI still sent `third_party_service_slug` / `identity_plugin_slug` and read `third_party_service`, so saving a webhook that had an `identifier_selector` returned `400 identifier_selector requires integration_slug`.
2. **Config prefix showed a raw placeholder.** The project Configuration tab expands an assignment's `path_prefix` for display, but its variable map omitted `project_type_slug` (which the backend template whitelist allows), so `/pse/${project_type_slug}/vllm` rendered the literal `${project_type_slug}`.

## Solution

**Integration rename (UI):**
- `WebhookForm` sends `integration_slug` + `identity_integration_slug`, reads `webhook.integration.slug`; local state and labels renamed.
- `WebhookDetail` / `WebhookManagement` read `webhook.integration`.
- `WebhookHistory` / `WebhookHistoryRow` use the event `integration` field/filter (also fixes the `?integration=` query param via `endpoints.ts`).
- `ProjectActivityLog` reads `entry.integration`; `SearchResultsPanel` entity key is `Integration`.
- `api-generated.ts` webhook/ExistsIn schemas hand-patched to match the running API. **Full regen deferred** — a DB-less spec dump drops the blueprint-enhanced response models, so a proper `codegen:fetch` against a live backend should follow.
- Added inline **rename of the integration display name** on `IntegrationDetail` via PATCH (name only; slug is immutable in the API).
- Assorted labels/comments updated to "Integration".

**Config prefix:**
- `ConfigurationTab` adds `project_type_slug` to the expansion vars; `ProjectDetail` passes the project's first project-type slug. Display-only; `${environment}` stays unexpanded (varies per row).

## Testing
- `tsc --noEmit` clean; `oxlint` 0 errors (unchanged warning baseline); `oxfmt` clean.
- `vitest` full suite: 536 passing.
- Verified the running Vite dev module serves the updated `ConfigurationTab` / `ProjectDetail`.

## Notes
- The backend still carries un-renamed `third_party_service:*` permission slugs (`imbi-api/auth/seed.py`) — out of scope here, part of the same unfinished migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)