### PR TITLE
Add environment add/remove to the project Environments card

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1051,8 +1051,9 @@ export function ProjectDetail({
               </Card>
 
               {/* Environments — nests here when the right column is taller
-                  than Project details; otherwise drops below (see envSpanFull). */}
-              {!envSpanFull && sortedEnvironments.length > 0 && (
+                  than Project details; otherwise drops below (see envSpanFull).
+                  Rendered even when empty so environments can be added. */}
+              {!envSpanFull && (
                 <Swap
                   ready={envCardReady}
                   skeleton={
@@ -1153,7 +1154,7 @@ export function ProjectDetail({
 
           {/* Environments — full-width row below both columns when the right
               column is shorter than Project details. */}
-          {envSpanFull && sortedEnvironments.length > 0 && (
+          {envSpanFull && (
             <Swap
               ready={envCardReady}
               skeleton={

--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -1,28 +1,43 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
+import { useQuery } from '@tanstack/react-query'
 import {
   CheckCircle2,
   Clock,
   ExternalLink,
   LoaderCircle,
   type LucideIcon,
+  Plus,
   RotateCcw,
+  Trash2,
   XCircle,
 } from 'lucide-react'
 
-import type {
-  ProjectSchemaResponse,
-  ProjectSchemaSectionProperty,
+import {
+  listEnvironments,
+  type ProjectSchemaResponse,
+  type ProjectSchemaSectionProperty,
 } from '@/api/endpoints'
 import { AttributeValue } from '@/components/ui/attribute-value'
 import { Badge, type BadgeProps } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { EnvironmentBadge } from '@/components/ui/environment-badge'
 import { isFieldEditable } from '@/components/ui/inline-edit/field-policy'
 import { InlineField } from '@/components/ui/inline-edit/InlineField'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { useEnvironmentEdgePatch } from '@/hooks/useEnvironmentEdgePatch'
 import { useLoginToEmail } from '@/hooks/useLoginToEmail'
+import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
 import { formatFieldKey } from '@/lib/project-field-formatting'
 import { sanitizeHttpUrl } from '@/lib/utils'
 import type { DeploymentStatus, Project } from '@/types'
@@ -106,6 +121,7 @@ const RESERVED_ENV_KEYS = new Set([
   'version',
 ])
 
+// fallow-ignore-next-line complexity
 export function ProjectEnvironmentsCard({
   deploymentStatus,
   environments,
@@ -117,14 +133,81 @@ export function ProjectEnvironmentsCard({
     () => environmentAttributeDefs(projectSchema),
     [projectSchema],
   )
-  const { patch, pendingKey } = useEnvironmentEdgePatch(orgSlug, projectId)
+  const { patch, pendingKey, replaceAll, replacing } = useEnvironmentEdgePatch(
+    orgSlug,
+    projectId,
+  )
   const { displayNames, loginToEmail } = useLoginToEmail()
+
+  const [adding, setAdding] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<null | string>(null)
+
+  const { data: orgEnvironments = [] } = useQuery({
+    queryFn: ({ signal }) => listEnvironments(orgSlug, signal),
+    queryKey: ['environments', orgSlug],
+  })
+
+  const unassignedEnvs = useMemo(() => {
+    const assigned = new Set(environments.map((e) => e.slug))
+    return orgEnvironments
+      .filter((e) => !assigned.has(e.slug))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [orgEnvironments, environments])
+
+  const formAttrDefs = useMemo(
+    () =>
+      Object.entries(attrDefs).filter(([key, def]) => isDraftField(key, def)),
+    [attrDefs],
+  )
+
+  const handleAdd = async (slug: string, fields: Record<string, unknown>) => {
+    const map = buildEdgeMap(environments)
+    map[slug] = fields
+    await replaceAll(map)
+    setAdding(false)
+  }
+
+  const handleRemove = async (slug: string) => {
+    setPendingDelete(null)
+    const map = buildEdgeMap(environments)
+    delete map[slug]
+    try {
+      await replaceAll(map)
+    } catch {
+      // replaceAll already surfaced the error.
+    }
+  }
+
+  const pendingDeleteEnv = environments.find((e) => e.slug === pendingDelete)
+
   return (
     <Card>
-      <CardHeader>
+      <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle>Environments</CardTitle>
+        {!adding && unassignedEnvs.length > 0 && (
+          <button
+            className="text-secondary hover:bg-secondary hover:text-primary inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-xs transition-colors"
+            onClick={() => setAdding(true)}
+            type="button"
+          >
+            <Plus className="size-3" />
+            Add environment
+          </button>
+        )}
       </CardHeader>
       <CardContent>
+        {adding && (
+          <AddEnvironmentForm
+            attrDefs={formAttrDefs}
+            onCancel={() => setAdding(false)}
+            onSubmit={handleAdd}
+            options={unassignedEnvs}
+            saving={replacing}
+          />
+        )}
+        {environments.length === 0 && !adding && (
+          <p className="text-tertiary text-sm">No environments.</p>
+        )}
         <div className="space-y-0">
           {/* fallow-ignore-next-line complexity */}
           {environments.map((env) => {
@@ -143,9 +226,10 @@ export function ProjectEnvironmentsCard({
               : null
             const attrs = dynamicAttributes(env)
             const urlDef = attrDefs.url ?? URL_DEF
+            const showUrlBlock = isFieldEditable('url', urlDef) || !!displayUrl
             return (
               <div
-                className="border-tertiary border-b py-4 last:border-0"
+                className="group border-tertiary border-b py-4 last:border-0"
                 key={env.slug}
               >
                 <div className="flex items-center gap-x-4 gap-y-2">
@@ -173,7 +257,7 @@ export function ProjectEnvironmentsCard({
                   {/* URL — pinned to the right of the header line; never wraps
                       (clips before dropping to a new line) with a quick-open
                       link, and inline-editable when the schema allows it. */}
-                  {isFieldEditable('url', urlDef) || displayUrl ? (
+                  {showUrlBlock ? (
                     <div className="ml-auto flex min-w-0 items-center gap-1.5 overflow-hidden pl-4 whitespace-nowrap">
                       {isFieldEditable('url', urlDef) ? (
                         <InlineField
@@ -199,6 +283,17 @@ export function ProjectEnvironmentsCard({
                       ) : null}
                     </div>
                   ) : null}
+
+                  {/* Remove — revealed on row hover (and keyboard focus). */}
+                  <button
+                    aria-label={`Remove ${env.name} environment`}
+                    className={`text-secondary hover:text-danger shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 ${showUrlBlock ? '' : 'ml-auto'}`}
+                    disabled={replacing}
+                    onClick={() => setPendingDelete(env.slug)}
+                    type="button"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
                 </div>
 
                 {deployment?.performedBy || attrs.length > 0 ? (
@@ -227,6 +322,7 @@ export function ProjectEnvironmentsCard({
 
                     {/* Blueprint edge attributes — inline-editable when the
                         schema marks them editable, else read-only. */}
+                    {/* fallow-ignore-next-line complexity */}
                     {attrs.map(({ key, rawValue }) => {
                       const def = attrDefs[key]
                       const display = (
@@ -264,8 +360,193 @@ export function ProjectEnvironmentsCard({
           })}
         </div>
       </CardContent>
+
+      <ConfirmDialog
+        confirmLabel="Remove"
+        description="This will remove the environment from the project along with any environment-specific attribute values."
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => {
+          if (pendingDelete) void handleRemove(pendingDelete)
+        }}
+        open={pendingDelete !== null}
+        title={
+          pendingDeleteEnv
+            ? `Remove ${pendingDeleteEnv.name} environment?`
+            : 'Remove environment?'
+        }
+      />
     </Card>
   )
+}
+
+// Inline form for attaching an environment to the project: pick an
+// unassigned environment, optionally set the URL and any blueprint-defined
+// edge attributes. Drafts are discarded on cancel (the parent unmounts it).
+function AddEnvironmentForm({
+  attrDefs,
+  onCancel,
+  onSubmit,
+  options,
+  saving,
+}: {
+  attrDefs: [string, ProjectSchemaSectionProperty][]
+  onCancel: () => void
+  onSubmit: (slug: string, fields: Record<string, unknown>) => Promise<void>
+  options: { name: string; slug: string }[]
+  saving: boolean
+}) {
+  const [slug, setSlug] = useState('')
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  const setDraft = (key: string, value: string) =>
+    setDrafts((d) => ({ ...d, [key]: value }))
+
+  const submit = async () => {
+    if (!slug) return
+    try {
+      await onSubmit(slug, coerceDrafts(drafts, Object.fromEntries(attrDefs)))
+    } catch {
+      // Parent surfaced the error; keep the form open for retry.
+    }
+  }
+
+  return (
+    <div className="border-tertiary mb-4 flex flex-wrap items-end gap-3 border-b pb-4">
+      <div className="w-44">
+        <div className={OVERLINE_CLASS}>Environment</div>
+        <Select onValueChange={setSlug} value={slug}>
+          <SelectTrigger className="text-sm">
+            <SelectValue placeholder="Select…" />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((env) => (
+              <SelectItem key={env.slug} value={env.slug}>
+                {env.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="min-w-56 flex-1">
+        <div className={OVERLINE_CLASS}>URL</div>
+        <Input
+          className="text-sm"
+          onChange={(e) => setDraft('url', e.target.value)}
+          placeholder="https://…"
+          value={drafts.url ?? ''}
+        />
+      </div>
+      {attrDefs.map(([key, def]) => (
+        <div className="w-44" key={key}>
+          <div className={OVERLINE_CLASS}>
+            {def.title || formatFieldKey(key)}
+          </div>
+          <AttrDraftInput
+            def={def}
+            label={def.title || formatFieldKey(key)}
+            onChange={(v) => setDraft(key, v)}
+            value={drafts[key] ?? ''}
+          />
+        </div>
+      ))}
+      <div className="flex gap-2">
+        <Button
+          disabled={!slug || saving}
+          onClick={submit}
+          size="sm"
+          type="button"
+        >
+          Add
+        </Button>
+        <Button
+          disabled={saving}
+          onClick={onCancel}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// Draft input for one blueprint edge attribute: enum defs render as a
+// select, everything else as a text/number input.
+// fallow-ignore-next-line complexity
+function AttrDraftInput({
+  def,
+  label,
+  onChange,
+  value,
+}: {
+  def: ProjectSchemaSectionProperty
+  label: string
+  onChange: (value: string) => void
+  value: string
+}) {
+  if (def.enum?.length) {
+    return (
+      <Select onValueChange={onChange} value={value}>
+        <SelectTrigger className="text-sm">
+          <SelectValue placeholder="Select…" />
+        </SelectTrigger>
+        <SelectContent>
+          {def.enum.map((option) => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+  return (
+    <Input
+      className="text-sm"
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={label}
+      type={NUMERIC_TYPES.has(def.type ?? '') ? 'number' : 'text'}
+      value={value}
+    />
+  )
+}
+
+const NUMERIC_TYPES = new Set(['integer', 'number'])
+
+// Full slug -> DEPLOYED_IN edge-props map for the project PATCH. Everything on
+// the environment object that isn't an Environment node field is a flattened
+// edge property and must round-trip through the wholesale edge replace.
+function buildEdgeMap(
+  environments: Environment[],
+): Record<string, Record<string, unknown>> {
+  const map: Record<string, Record<string, unknown>> = {}
+  for (const env of environments) {
+    map[env.slug] = Object.fromEntries(
+      Object.entries(env).filter(
+        ([key, value]) =>
+          !ENVIRONMENT_BASE_FIELDS_SET.has(key) && value != null,
+      ),
+    )
+  }
+  return map
+}
+
+// Convert the form's non-empty draft strings into typed edge-prop values.
+// fallow-ignore-next-line complexity
+function coerceDrafts(
+  drafts: Record<string, string>,
+  defs: Record<string, ProjectSchemaSectionProperty>,
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {}
+  for (const [key, raw] of Object.entries(drafts)) {
+    const value = raw.trim()
+    if (!value) continue
+    fields[key] = NUMERIC_TYPES.has(defs[key]?.type ?? '')
+      ? Number(value)
+      : value
+  }
+  return fields
 }
 
 // Blueprint-defined edge attributes for a single environment, ordered
@@ -298,6 +579,19 @@ function environmentAttributeDefs(
     }
   }
   return defs
+}
+
+// Add-form eligibility for a blueprint edge attribute: editable per the
+// shared policy and representable as a simple text/number/enum input.
+// Anything else stays inline-editable on the row after the environment is
+// added. URL is excluded because the form has a dedicated URL input.
+// fallow-ignore-next-line complexity
+function isDraftField(key: string, def: ProjectSchemaSectionProperty): boolean {
+  const simple =
+    Boolean(def.enum?.length) ||
+    def.type === 'string' ||
+    NUMERIC_TYPES.has(def.type ?? '')
+  return key !== 'url' && simple && isFieldEditable(key, def)
 }
 
 function ReleaseBadge({ status }: { status: string }) {

--- a/src/hooks/useEnvironmentEdgePatch.ts
+++ b/src/hooks/useEnvironmentEdgePatch.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { patchEnvironmentEdge } from '@/api/endpoints'
+import { patchEnvironmentEdge, patchProject } from '@/api/endpoints'
 import { extractApiErrorDetail } from '@/lib/apiError'
 
 export interface UseEnvironmentEdgePatchResult {
@@ -11,6 +11,15 @@ export interface UseEnvironmentEdgePatchResult {
   patch: (envSlug: string, key: string, value: unknown) => Promise<void>
   /** `${envSlug}/${key}` of the in-flight save, for per-field pending UI. */
   pendingKey: null | string
+  /**
+   * Replace the project's full environment set. Takes the complete
+   * slug -> edge-props map — the backend swaps the DEPLOYED_IN edges
+   * wholesale, so omitted environments (or omitted attributes on kept
+   * environments) are dropped.
+   */
+  replaceAll: (map: Record<string, Record<string, unknown>>) => Promise<void>
+  /** True while a replaceAll save is in flight. */
+  replacing: boolean
 }
 
 /**
@@ -25,6 +34,14 @@ export function useEnvironmentEdgePatch(
 ): UseEnvironmentEdgePatchResult {
   const qc = useQueryClient()
   const [pendingKey, setPendingKey] = useState<null | string>(null)
+  const [replacing, setReplacing] = useState(false)
+
+  const invalidate = useCallback(() => {
+    qc.invalidateQueries({ queryKey: ['project', orgSlug, projectId] })
+    qc.invalidateQueries({
+      queryKey: ['currentReleases', orgSlug, projectId],
+    })
+  }, [qc, orgSlug, projectId])
 
   const patch = useCallback(
     async (envSlug: string, key: string, value: unknown) => {
@@ -34,10 +51,7 @@ export function useEnvironmentEdgePatch(
         await patchEnvironmentEdge(orgSlug, projectId, envSlug, {
           [key]: value === '' || value === undefined ? null : value,
         })
-        qc.invalidateQueries({ queryKey: ['project', orgSlug, projectId] })
-        qc.invalidateQueries({
-          queryKey: ['currentReleases', orgSlug, projectId],
-        })
+        invalidate()
       } catch (error) {
         toast.error(`Save failed: ${extractApiErrorDetail(error)}`)
         throw error
@@ -45,8 +59,28 @@ export function useEnvironmentEdgePatch(
         setPendingKey(null)
       }
     },
-    [qc, orgSlug, projectId],
+    [orgSlug, projectId, invalidate],
   )
 
-  return { patch, pendingKey }
+  const replaceAll = useCallback(
+    async (map: Record<string, Record<string, unknown>>) => {
+      setReplacing(true)
+      try {
+        // `add` upserts the member, so the first-ever environment
+        // assignment succeeds against an RFC 6902 strict server.
+        await patchProject(orgSlug, projectId, [
+          { op: 'add', path: '/environments', value: map },
+        ])
+        invalidate()
+      } catch (error) {
+        toast.error(`Save failed: ${extractApiErrorDetail(error)}`)
+        throw error
+      } finally {
+        setReplacing(false)
+      }
+    },
+    [orgSlug, projectId, invalidate],
+  )
+
+  return { patch, pendingKey, replaceAll, replacing }
 }


### PR DESCRIPTION
## Summary
Restores the ability to manage which environments a project is deployed in, now directly on the project overview's Environments card.

## Problem
The Environments card redesign (#414) removed the Environments card from the project Settings tab, which was the only place environments could be attached to or detached from a project. Since then there has been no way to manage a project's environments in the UI — only the per-attribute inline editing on the overview card survived.

## Solution
- An **Add environment** button in the Environments card header opens an inline form with a picker of the organization's unassigned environments, a URL input, and inputs for editable blueprint-defined `DEPLOYED_IN` edge attributes (enum defs render as selects, string/number defs as inputs; other types remain inline-editable on the row after adding).
- Each environment row gets a **remove** button revealed on hover (and keyboard focus), confirmed via `ConfirmDialog` before saving.
- Both actions go through a new `replaceAll` on `useEnvironmentEdgePatch`, which submits the complete slug → edge-props map. This matters because the backend project PATCH replaces the `DEPLOYED_IN` edges wholesale — any omitted attribute on an untouched environment would be dropped, so the map is rebuilt from the current environment set on every save.
- The card now renders even when a project has no environments, so the first one can be added (previously the card was hidden entirely).

## Impact
UI-only; no backend changes. Uses the existing project PATCH (`add /environments`) that the old Settings-tab card used. The orphaned `EditEnvironmentsCard` component is left in place and can be deleted in a follow-up.

## Testing
- `npm run build`, `npm run lint`, `npm run format:check`, and `fallow audit` (pre-commit) — clean.
- `npm run test` — 536 passing.
- Live verification against the okteto dev environment pending (login required at time of writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)