### PR TITLE
Fix webhook Identifier Selector label: JSON Pointer, not JSON Path

### DIFF
--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -469,7 +469,7 @@ export function WebhookForm({
                 <>
                   <div>
                     <Label className="text-secondary mb-1.5 block text-sm">
-                      Identifier Selector (JSON Path)
+                      Identifier Selector (JSON Pointer)
                     </Label>
                     <Input
                       className={`font-mono text-sm ${
@@ -477,7 +477,7 @@ export function WebhookForm({
                       }`}
                       disabled={isLoading}
                       onChange={(e) => setIdentifierSelector(e.target.value)}
-                      placeholder="e.g., $.repository.full_name"
+                      placeholder="e.g., /repository/id"
                       value={identifierSelector}
                     />
                     {errors.identifier_selector && (
@@ -491,8 +491,8 @@ export function WebhookForm({
                       </div>
                     )}
                     <p className="text-tertiary mt-1 text-xs">
-                      JSON Path expression to extract the project identifier
-                      from the webhook payload.
+                      JSON Pointer to extract the project identifier from the
+                      webhook payload.
                     </p>
                   </div>
 


### PR DESCRIPTION
## Summary

The webhook form labeled the **Identifier Selector** field as *"JSON Path"*, but the value is resolved as an RFC 6901 **JSON Pointer** by the gateway. This corrects the mislabeling in `WebhookForm.tsx`:

- Label: `Identifier Selector (JSON Path)` → `Identifier Selector (JSON Pointer)`
- Help text: `JSON Path expression to extract…` → `JSON Pointer to extract…`
- Placeholder: `$.repository.full_name` (JSONPath syntax) → `/repository/id` (pointer syntax)

The adjacent `user_subject_selector` field was already correctly labeled "JSON Pointer".

## Notes

- The backend field description is corrected in a companion PR (AWeber-Imbi/imbi-api). Generated types (`src/types/api-generated.ts`) still carry the old description text and should be refreshed with `npm run codegen:fetch` once the API change is deployed.

## Verification

- `oxfmt --check` passes; `oxlint` reports 0 errors (only pre-existing tailwind sort-order warnings on untouched lines).