### PR TITLE
Consolidate webhook admin into a single tabbed section

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -11,7 +11,6 @@ import {
   FileJson,
   FolderTree,
   Globe,
-  History,
   KeyRound,
   Layers,
   LayoutDashboard,
@@ -51,8 +50,7 @@ import { ScoringPolicyManagement } from './admin/ScoringPolicyManagement'
 import { ServiceAccountManagement } from './admin/ServiceAccountManagement'
 import { TeamManagement } from './admin/TeamManagement'
 import { UserManagement } from './admin/UserManagement'
-import { WebhookHistory } from './admin/WebhookHistory'
-import { WebhookManagement } from './admin/WebhookManagement'
+import { Webhooks } from './admin/Webhooks'
 
 type AdminSection =
   | 'assistant'
@@ -74,7 +72,6 @@ type AdminSection =
   | 'service-accounts'
   | 'teams'
   | 'users'
-  | 'webhook-history'
   | 'webhooks'
 
 // The admin section shown when none is specified in the URL.
@@ -100,7 +97,6 @@ const VALID_SECTIONS: AdminSection[] = [
   'service-accounts',
   'teams',
   'users',
-  'webhook-history',
   'webhooks',
 ]
 
@@ -204,15 +200,7 @@ export function Admin() {
       scope: 'org',
     },
     {
-      description:
-        'Browse recent inbound webhook deliveries and dispatch outcomes',
-      icon: History,
-      id: 'webhook-history',
-      label: 'Webhook History',
-      scope: 'org',
-    },
-    {
-      description: 'Configure inbound webhook processing',
+      description: 'Inbound endpoints and their delivery activity',
       icon: Webhook,
       id: 'webhooks',
       label: 'Webhooks',
@@ -421,10 +409,7 @@ export function Admin() {
             {currentSection === 'environments' && <EnvironmentManagement />}
             {currentSection === 'project-types' && <ProjectTypeManagement />}
             {currentSection === 'integrations' && <IntegrationsManagement />}
-            {currentSection === 'webhooks' && <WebhookManagement />}
-            {currentSection === 'webhook-history' && (
-              <WebhookHistory eventId={slug} />
-            )}
+            {currentSection === 'webhooks' && <Webhooks />}
             {currentSection === 'link-definitions' && (
               <LinkDefinitionManagement />
             )}

--- a/src/components/admin/WebhookHistoryRow.tsx
+++ b/src/components/admin/WebhookHistoryRow.tsx
@@ -46,7 +46,7 @@ export function WebhookHistoryRow({
         : 'secondary'
 
   const onCopyLink = () => {
-    const url = `${window.location.origin}/admin/webhook-history/${encodeURIComponent(event.id)}`
+    const url = `${window.location.origin}/admin/webhooks?tab=history&event=${encodeURIComponent(event.id)}`
     void navigator.clipboard.writeText(url)
   }
 

--- a/src/components/admin/Webhooks.tsx
+++ b/src/components/admin/Webhooks.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 
 import { listWebhooks } from '@/api/endpoints'
+import { Sk, Swap } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useAdminNav } from '@/hooks/useAdminNav'
@@ -60,11 +61,15 @@ export function Webhooks() {
       <TabsList className="mb-6">
         <TabsTrigger value="endpoints">
           Endpoints
-          {webhooks !== undefined && (
-            <span className="bg-secondary text-secondary ml-2 rounded-full px-2 py-0.5 font-mono text-xs">
-              {webhooks.length}
+          <Swap
+            className="ml-2 inline-flex"
+            ready={webhooks !== undefined}
+            skeleton={<Sk h={18} r={9999} w={22} />}
+          >
+            <span className="bg-secondary text-secondary rounded-full px-2 py-0.5 font-mono text-xs">
+              {webhooks?.length}
             </span>
-          )}
+          </Swap>
         </TabsTrigger>
         <TabsTrigger value="history">Delivery history</TabsTrigger>
       </TabsList>

--- a/src/components/admin/Webhooks.tsx
+++ b/src/components/admin/Webhooks.tsx
@@ -1,0 +1,79 @@
+import { useSearchParams } from 'react-router-dom'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { listWebhooks } from '@/api/endpoints'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { useAdminNav } from '@/hooks/useAdminNav'
+
+import { WebhookHistory } from './WebhookHistory'
+import { WebhookManagement } from './WebhookManagement'
+
+type WebhookTab = 'endpoints' | 'history'
+
+// Consolidates the former "Webhooks" and "Webhook History" admin sections into
+// a single section with two tabs. Per-endpoint create/edit/detail views (driven
+// by a URL slug) are rendered full-bleed without the tab chrome, matching the
+// existing management flow.
+// fallow-ignore-next-line complexity
+export function Webhooks() {
+  const { viewMode } = useAdminNav()
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const tab: WebhookTab =
+    searchParams.get('tab') === 'history' ? 'history' : 'endpoints'
+  const eventId = searchParams.get('event') ?? undefined
+
+  const { data: webhooks } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => listWebhooks(orgSlug as string, signal),
+    queryKey: ['webhooks', orgSlug],
+  })
+
+  // A webhook sub-page (create/edit/detail) uses the URL slug; show it on its
+  // own without tabs, the same as the standalone management view did.
+  if (viewMode !== 'list') {
+    return <WebhookManagement />
+  }
+
+  const onTabChange = (value: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.delete('event')
+        if (value === 'history') {
+          next.set('tab', 'history')
+        } else {
+          next.delete('tab')
+        }
+        return next
+      },
+      { replace: true },
+    )
+  }
+
+  return (
+    <Tabs onValueChange={onTabChange} value={tab}>
+      <TabsList className="mb-6">
+        <TabsTrigger value="endpoints">
+          Endpoints
+          {webhooks !== undefined && (
+            <span className="bg-secondary text-secondary ml-2 rounded-full px-2 py-0.5 font-mono text-xs">
+              {webhooks.length}
+            </span>
+          )}
+        </TabsTrigger>
+        <TabsTrigger value="history">Delivery history</TabsTrigger>
+      </TabsList>
+      <TabsContent value="endpoints">
+        <WebhookManagement />
+      </TabsContent>
+      <TabsContent value="history">
+        <WebhookHistory eventId={eventId} />
+      </TabsContent>
+    </Tabs>
+  )
+}


### PR DESCRIPTION
## Summary
Consolidates the two admin sidebar items — **Webhooks** and **Webhook History** — into a single **Webhooks** section with two tabs, per the [Webhooks Consolidated](https://claude.ai/design/p/2fc481f2-d062-416e-adae-10e689b3b887?file=Webhooks+Consolidated.dc.html) design mockup.

## Problem
Inbound webhook endpoints and their delivery activity were split across two separate left-nav destinations, so viewing an endpoint and its recent deliveries meant switching sections.

## Solution
- New `Webhooks.tsx` wraps the existing `WebhookManagement` (Endpoints) and `WebhookHistory` (Delivery history) views in tabs.
- Active tab is driven by a `?tab=history` search param, so it's linkable and survives reload; **Endpoints** is the default.
- Per-endpoint create/edit/detail views (URL slug present) still render full-bleed without tab chrome, preserving the existing CRUD flow.
- The history row **copy link** now points at `/admin/webhooks?tab=history&event=<id>`.
- Removed the standalone `webhook-history` section from `Admin.tsx`.

No backward-compat redirect for the old `/admin/webhook-history` URL (not needed).

## Verification
- `tsc --noEmit`, `oxlint`, `oxfmt --check`: clean
- `vitest run src/components/admin`: 37 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)