### PR TITLE
Add mapping editor to admin integration options

### DIFF
--- a/src/components/admin/integrations/IntegrationDetail.tsx
+++ b/src/components/admin/integrations/IntegrationDetail.tsx
@@ -29,6 +29,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { InlineDisplay } from '@/components/ui/inline-edit/InlineDisplay'
 import { Input } from '@/components/ui/input'
+import { KeyValueEditor } from '@/components/ui/key-value-editor'
 import {
   Select,
   SelectContent,
@@ -690,6 +691,38 @@ function OptionRow({
           disabled={readOnly || pending}
           onCheckedChange={(checked) => onSave(checked)}
         />
+      </div>
+    )
+  }
+
+  if (option.type === 'mapping') {
+    const record =
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, number | string>)
+        : {}
+    const entries = Object.entries(record)
+    return (
+      <div className="border-tertiary flex flex-col gap-2 border-b py-2.5 last:border-b-0">
+        {label}
+        {readOnly ? (
+          entries.length === 0 ? (
+            <span className="text-primary font-mono text-sm">—</span>
+          ) : (
+            <div className="space-y-1">
+              {entries.map(([k, v]) => (
+                <span className="text-primary block font-mono text-sm" key={k}>
+                  {k} → {String(v)}
+                </span>
+              ))}
+            </div>
+          )
+        ) : (
+          <KeyValueEditor
+            disabled={pending}
+            onChange={(next) => onSave(next)}
+            value={record}
+          />
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Adds a key/value editor for integration-level plugin options of `type='mapping'` in the admin **Integration detail** form, so mappings like the AWS plugin's `project_type_path_map` (introduced in 2.13.3) can be created and edited in the UI.

## Problem

The admin integration detail form (`IntegrationDetail.tsx`) renders integration-level options with a **local** `OptionRow` that only handled `boolean`, `choices`, `integer`, and text types. Options declared as `type='mapping'` had no branch, so they fell through to the plain text input:

- The stored dict rendered as `[object Object]` (via `String(value)` in `formatValue`).
- Committing the inline text editor saved the trimmed **string**, overwriting/corrupting the dict.

A working mapping control (`KeyValueEditor`) already existed in the shared `plugin-options/OptionRow.tsx`, but that component is only wired into project-level *capability* overrides — not the admin integration-level options form. As a result there was **no way to manage `project_type_path_map` in the UI** (only via the API's `PATCH /organizations/{org}/integrations/{slug}`).

## Solution

- Render `KeyValueEditor` for `type='mapping'` options when the form is editable, persisting the full dict through the existing `saveOption` path (integration-level options are merged/replaced server-side, matching the editor's whole-object `onChange`).
- In read-only mode, display the pairs as `key → value` (or `—` when empty) instead of `[object Object]`.

## Testing

- `tsc --noEmit` passes
- `oxlint` — 0 errors (only pre-existing tailwind class-order warnings, consistent with surrounding lines)
- `oxfmt` applied

No component-render test was added: `OptionRow` is a non-exported local function and this repo has no render-test precedent for these admin components (all existing tests are hooks/lib/api/stores).