### PR TITLE
Show integration id as subhead in admin list

### DIFF
--- a/src/components/admin/integrations/IntegrationsManagement.tsx
+++ b/src/components/admin/integrations/IntegrationsManagement.tsx
@@ -167,14 +167,21 @@ export function IntegrationsManagement() {
             ) : (
               <Blocks className="text-tertiary size-5 shrink-0" />
             )}
-            <span
-              className={cn(
-                'truncate font-semibold',
-                unavailable ? 'text-tertiary' : 'text-primary',
+            <div className="flex min-w-0 flex-col">
+              <span
+                className={cn(
+                  'truncate font-semibold',
+                  unavailable ? 'text-tertiary' : 'text-primary',
+                )}
+              >
+                {i.name}
+              </span>
+              {i.id && (
+                <span className="text-tertiary truncate font-mono text-xs">
+                  {i.id}
+                </span>
               )}
-            >
-              {i.name}
-            </span>
+            </div>
           </div>
         )
       },


### PR DESCRIPTION
## Summary
Adds the integration's node id as a subhead beneath the integration name in the Name column of the Integrations admin table.

## Problem
The Integrations admin list showed only the display name, with no visible reference to an integration's stable id. That id is what the identity connect flow targets, so having it visible in the list makes it easier to identify and reference a specific integration.

## Solution
- Render the integration `id` beneath the name in the Name column.
- Only show the subhead when `id` is present — it is `null` for legacy integrations created before ids were persisted.
- Reuse the existing mono / `text-xs` / `text-tertiary` styling already used for slugs on the first-run quick-start cards, so the treatment is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)