### PR TITLE
Show integration links by name/icon in project header

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -33,6 +33,7 @@ import {
   getScoreTrend,
   listCurrentReleases,
   listIdentityPlugins,
+  listIntegrations,
   listLinkDefinitions,
   listProjectDocuments,
   listProjectPlugins,
@@ -299,6 +300,15 @@ export function ProjectDetail({
     enabled: !!orgSlug,
     queryFn: ({ signal }) => listLinkDefinitions(orgSlug, signal),
     queryKey: ['linkDefinitions', orgSlug],
+  })
+
+  // Org integrations supply the name/icon for integration dashboard links in
+  // the header bar; shares IntegrationsCard's cache key.
+  const { data: orgIntegrations = [] } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) => listIntegrations(orgSlug, signal),
+    queryKey: ['integrations', orgSlug],
+    staleTime: 60 * 1000,
   })
 
   // Overview-tab-only queries: skip when the user lands on a deeper tab
@@ -659,25 +669,63 @@ export function ProjectDetail({
     [linkDefs],
   )
 
-  const externalLinks = useMemo(
-    () =>
-      Object.entries(project.links || {})
-        // fallow-ignore-next-line complexity
-        .map(([key, url]) => {
-          const safeUrl = sanitizeHttpUrl(url)
-          if (!safeUrl) return null
-          const def = linkDefMap[key]
-          return {
-            Icon: getIcon(def?.icon),
-            key,
-            label: def?.name || key.replace(/_/g, ' '),
-            url: safeUrl,
-          }
-        })
-        .filter((link): link is NonNullable<typeof link> => link !== null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [project.links, linkDefMap, iconRegistryVersion],
+  const integrationMap = useMemo(
+    () => Object.fromEntries(orgIntegrations.map((i) => [i.slug, i])),
+    [orgIntegrations],
   )
+
+  // The header bar merges two sources, sorted together alphabetically:
+  //   1. project.links entries that resolve to an org link definition
+  //      (name/icon from the definition). Keys without a definition are
+  //      skipped — integration dashboard links live in links keyed by
+  //      integration slug and are rendered from `services` below, and any
+  //      other undefined key is an orphaned link we no longer surface.
+  //   2. live integration dashboard links from project.services (edges only,
+  //      so orphaned link entries never appear), name/icon from the
+  //      integration.
+  const externalLinks = useMemo(() => {
+    const defLinks = Object.entries(project.links || {})
+      .map(([key, url]) => {
+        const def = linkDefMap[key]
+        if (!def) return null
+        const safeUrl = sanitizeHttpUrl(url)
+        if (!safeUrl) return null
+        return {
+          Icon: getIcon(def.icon),
+          key,
+          label: def.name || key.replace(/_/g, ' '),
+          url: safeUrl,
+        }
+      })
+      .filter((link): link is NonNullable<typeof link> => link !== null)
+
+    const serviceLinks = (project.services || [])
+      .map((svc) => {
+        const safeUrl = svc.dashboard_url
+          ? sanitizeHttpUrl(svc.dashboard_url)
+          : null
+        if (!safeUrl) return null
+        const integration = integrationMap[svc.integration_slug]
+        return {
+          Icon: getIcon(integration?.icon),
+          key: `service:${svc.integration_slug}`,
+          label: integrationLinkLabel(integration, svc),
+          url: safeUrl,
+        }
+      })
+      .filter((link): link is NonNullable<typeof link> => link !== null)
+
+    return [...defLinks, ...serviceLinks].sort((a, b) =>
+      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }),
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    project.links,
+    project.services,
+    linkDefMap,
+    integrationMap,
+    iconRegistryVersion,
+  ])
 
   const teamOptions = useMemo(
     () => teams.map((t) => ({ label: t.name, value: t.slug })),
@@ -1443,6 +1491,16 @@ function fmtAttributeValue(value: unknown): string {
   return isFinite(n) && String(value).trim() !== ''
     ? String(Math.round(n))
     : String(value)
+}
+
+// Label for an integration dashboard link in the header bar: prefer the org
+// integration's name, then the name carried on the service edge, then the raw
+// slug as a last resort.
+function integrationLinkLabel(
+  integration: undefined | { name?: null | string },
+  svc: { integration_name: null | string; integration_slug: string },
+): string {
+  return integration?.name || svc.integration_name || svc.integration_slug
 }
 
 function LinksSkeleton({ count }: { count: number }) {

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -304,12 +304,13 @@ export function ProjectDetail({
 
   // Org integrations supply the name/icon for integration dashboard links in
   // the header bar; shares IntegrationsCard's cache key.
-  const { data: orgIntegrations = [] } = useQuery({
-    enabled: !!orgSlug,
-    queryFn: ({ signal }) => listIntegrations(orgSlug, signal),
-    queryKey: ['integrations', orgSlug],
-    staleTime: 60 * 1000,
-  })
+  const { data: orgIntegrations = [], isPending: orgIntegrationsPending } =
+    useQuery({
+      enabled: !!orgSlug,
+      queryFn: ({ signal }) => listIntegrations(orgSlug, signal),
+      queryKey: ['integrations', orgSlug],
+      staleTime: 60 * 1000,
+    })
 
   // Overview-tab-only queries: skip when the user lands on a deeper tab
   // (e.g. /projects/:id/logs via deep link) — the overview cards that
@@ -906,7 +907,7 @@ export function ProjectDetail({
         {externalLinks.length > 0 && (
           <Swap
             className="mt-3"
-            ready={!linkDefsPending}
+            ready={!linkDefsPending && !orgIntegrationsPending}
             skeleton={<LinksSkeleton count={externalLinks.length} />}
           >
             <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary

Fixes how integration dashboard links render in the project detail **header link bar**. They now show the integration's **name and icon**, sort in alphabetically with the org-defined links, show only the **dashboard** URL, and **orphaned entries no longer appear**.

## Problem

The header bar iterated `project.links` uniformly, resolving each entry's label/icon from an org link definition and falling back to the raw key + a generic external-link icon otherwise. Integration dashboard links are stored in `project.links` keyed by the **integration slug** (written by lifecycle plugins), so they surfaced as raw slugs like `github-enterprise-cloud` / `ghec` with a generic icon, dangling at the end of the bar.

Worse, when an `EXISTS_IN` edge is removed by a path that doesn't also strip the mirrored link, the stale `links` entry lingers — and it can't be cleaned up from the UI, because the Links editor card (`EditLinksCard`) only lists keys that resolve to a link definition. So orphaned integration links rendered in the header with no way to remove them.

## Solution

Build the header bar from two merged, alphabetically-sorted (by label) sources:

- **Project links** — `project.links` entries that resolve to an org link definition (label + icon from the definition). Keys without a definition are skipped.
- **Integration links** — live dashboard links from `project.services` (which is derived from `EXISTS_IN` edges only), labeled with the integration's name + icon. The icon is joined from the org integrations list (`listIntegrations`, cache shared with `IntegrationsCard`); only `dashboard_url` is rendered.

Because integration links now come from `project.services` (live edges), **orphaned `links` keys are naturally excluded** — they render nowhere. Raw-slug rendering is gone.

## Notes

- Behavior change: a `links` key that is neither a link definition nor a live integration edge is no longer rendered. Normal links always have a definition (they're added via the link-type picker), so in practice this only drops orphaned integration entries.
- The stale entries still exist in stored `Project.links` (just hidden); cleaning the stored data is handled separately out-of-band.

## Testing

- `tsc --noEmit` passes
- `oxlint` — 0 errors; `oxfmt` applied; pre-commit `fallow` complexity gate passes (label fallback extracted to a helper to stay under threshold)