### PR TITLE
Fix Configuration tab prefix ignoring project-type mapping

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1228,11 +1228,6 @@ export function ProjectDetail({
               orgSlug={orgSlug}
               projectId={project.id}
               projectSlug={project.slug}
-              projectTypeSlug={
-                project.project_types?.[0]?.slug ??
-                project.project_type?.slug ??
-                ''
-              }
               teamSlug={project.team.slug}
             />
           </TabsContent>

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -68,7 +68,6 @@ interface ConfigurationTabProps {
   orgSlug: string
   projectId: string
   projectSlug: string
-  projectTypeSlug: string
   teamSlug: string
 }
 
@@ -131,7 +130,6 @@ export function ConfigurationTab({
   orgSlug,
   projectId,
   projectSlug,
-  projectTypeSlug,
   teamSlug,
 }: ConfigurationTabProps) {
   const queryClient = useQueryClient()
@@ -202,15 +200,19 @@ export function ConfigurationTab({
   const configuredPrefix = (() => {
     const raw = activeAssignment?.options?.path_prefix
     if (typeof raw !== 'string' || !raw) return ''
-    // Expand the same variables the backend's plugin template expander
-    // supports, so users see a concrete prefix instead of `${...}`.
+    // Expand the variables we can resolve client-side, so users see a
+    // concrete prefix instead of `${...}`.
     // ${environment} stays unexpanded — it varies per row, and rendering
     // any single env's value would be misleading at the panel level.
+    // ${project_type_slug} also stays unexpanded: a plugin may remap it
+    // (e.g. the AWS integration's project_type_path_map: apis -> api) via
+    // an integration-level option the client doesn't have, so the raw
+    // project-type slug would be wrong wherever a mapping exists. The
+    // backend applies the mapping when it resolves real keys.
     const vars: Record<string, string> = {
       org_slug: orgSlug,
       project_id: projectId,
       project_slug: projectSlug,
-      project_type_slug: projectTypeSlug,
       team_slug: teamSlug,
     }
     return raw.replace(/\$\{([^}]+)\}/g, (match, name: string) =>


### PR DESCRIPTION
## Summary

The project **Configuration** tab expands `${project_type_slug}` in the displayed path prefix using the project's *raw* project-type slug. When a plugin remaps that segment through an integration-level option — e.g. the AWS integration's `project_type_path_map` (`scheduled-jobs → job`, `apis → api`, …) — the client has no access to that map, so the prefix it shows is wrong wherever a mapping exists.

## Problem

For a `scheduled-jobs` project with `project_type_path_map: { scheduled-jobs: job, ... }`, the tab displayed:

```
Prefix: /conv/scheduled-jobs/account-interstitial-reset
```

but the backend actually reads/writes SSM parameters under the mapped segment `/conv/job/...`. The wrong value is most visible on projects with no config values, where the prefix line is the only thing rendered. This made the mapping look broken even though the backend applies it correctly.

The mapping is a plugin-specific integration option; replicating it in the generic `ConfigurationTab` would leak plugin knowledge into shared UI, and the client doesn't receive the map anyway.

## Solution

- Stop substituting `${project_type_slug}` client-side; leave it as the template variable so the UI never renders a segment it can't correctly resolve. `team_slug` / `project_slug` / `org_slug` / `project_id` still expand as before.
- The backend continues to apply the mapping when it resolves real keys, so listed keys are unaffected.
- Drop the now-unused `projectTypeSlug` prop from `ConfigurationTab` and its `ProjectDetail` call site.

Result: the prefix now shows `/conv/${project_type_slug}/account-interstitial-reset` instead of a wrong concrete segment.

## Notes / out of scope

Two related backend/data issues surfaced during investigation and are **not** addressed here: the configuration endpoint returns HTTP 500 (instead of an empty result) when no environment/AWS account resolves, and the tab shows no keys for projects that have no environments recorded in Imbi.

## Testing

- `tsc --noEmit` clean
- `npm run lint` — 0 errors
- Verified the stored map and backend key resolution against the live API; the UI change itself was not rendered live.