### PR TITLE
Clarify Configuration tab empty state with no environments

### DIFF
--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -627,9 +627,7 @@ export function ConfigurationTab({
             <ConfigLoadError error={loadError} />
           ) : filtered.length === 0 ? (
             <div className="text-tertiary px-5 py-10 text-center text-sm">
-              {filter
-                ? `No parameters match "${filter}"`
-                : 'No configuration keys yet.'}
+              {emptyStateLabel(filter, sortedEnvironments.length > 0)}
             </div>
           ) : (
             <ParamList
@@ -1038,6 +1036,17 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
       </Button>
     </div>
   )
+}
+
+// Message for the empty key list. A project with no environments never
+// runs a per-environment query, so distinguish that from a project whose
+// environments simply have no keys yet.
+function emptyStateLabel(filter: string, hasEnvironments: boolean): string {
+  if (filter) return `No parameters match "${filter}"`
+  if (!hasEnvironments) {
+    return 'No environments are configured for this project, so there is nothing to read.'
+  }
+  return 'No configuration keys yet.'
 }
 
 function EnvRow({

--- a/src/components/project/ConfigurationTab.tsx
+++ b/src/components/project/ConfigurationTab.tsx
@@ -1042,7 +1042,8 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
 // runs a per-environment query, so distinguish that from a project whose
 // environments simply have no keys yet.
 function emptyStateLabel(filter: string, hasEnvironments: boolean): string {
-  if (filter) return `No parameters match "${filter}"`
+  const normalizedFilter = filter.trim()
+  if (normalizedFilter) return `No parameters match "${normalizedFilter}"`
   if (!hasEnvironments) {
     return 'No environments are configured for this project, so there is nothing to read.'
   }


### PR DESCRIPTION
## Summary

The project **Configuration** tab lists config keys *per environment*. When a project has no environments recorded in Imbi (`environments: []`), no per-environment query runs, so the aggregated list is empty and the tab rendered the ambiguous **"No configuration keys yet."** — which reads as "this project has no configuration" even when values exist in the backing store (they're just not reachable without an environment to scope the lookup).

This is common: roughly half of the projects in our org currently have `environments: []`.

## Solution

Distinguish the two empty cases:

- No environments configured → **"No environments are configured for this project, so there is nothing to read."**
- Environments exist but no keys → unchanged: **"No configuration keys yet."**

The message selection is factored into a small module-level `emptyStateLabel(filter, hasEnvironments)` helper (which also keeps the branching out of the large `ConfigurationTab` component).

## Scope

Per the agreed direction, this is the minimal UI-only change — a clearer empty state. It does **not** change how environments are populated, nor make the tab work without an environment. Those remain open questions.

## Testing

- `tsc --noEmit` clean
- oxlint 0 errors; pre-commit audit gate passes on the changed file