### PR TITLE
Prompt to connect identity on Deployments/Releases tabs

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -43,6 +43,7 @@ import {
   type ScoreTrend,
 } from '@/api/endpoints'
 import { DependenciesTab } from '@/components/dependencies/DependenciesTab'
+import { ConnectIdentityPrompt } from '@/components/deploy/ConnectIdentityPrompt'
 import {
   type DeploymentRunStarted,
   ReleaseModal,
@@ -1285,11 +1286,43 @@ export function ProjectDetail({
         </TabsContent>
         {isReleaseOnly && (
           <TabsContent value="releases">
+            {deploymentReadiness === 'disconnected' &&
+              resolvedIdentityPlugin && (
+                <div className="mb-4">
+                  <ConnectIdentityPrompt
+                    action="release"
+                    label={deploymentConnectLabel}
+                    onConnect={() =>
+                      navigate(
+                        `/settings/connections?connect=${encodeURIComponent(resolvedIdentityPlugin.plugin_slug)}`,
+                      )
+                    }
+                    onManage={() => navigate('/settings/connections')}
+                    serviceIcon={deploymentPlugin?.service_icon ?? null}
+                  />
+                </div>
+              )}
             <ReleasesTab orgSlug={orgSlug} project={project} />
           </TabsContent>
         )}
         {hasDeploymentsTab && (
           <TabsContent value="deployments">
+            {deploymentReadiness === 'disconnected' &&
+              resolvedIdentityPlugin && (
+                <div className="mb-4">
+                  <ConnectIdentityPrompt
+                    action="deploy"
+                    label={deploymentConnectLabel}
+                    onConnect={() =>
+                      navigate(
+                        `/settings/connections?connect=${encodeURIComponent(resolvedIdentityPlugin.plugin_slug)}`,
+                      )
+                    }
+                    onManage={() => navigate('/settings/connections')}
+                    serviceIcon={deploymentPlugin?.service_icon ?? null}
+                  />
+                </div>
+              )}
             <DeploymentsTab
               canTrigger={canTriggerDeployments}
               connectLabel={deploymentConnectLabel}

--- a/src/components/deploy/ConnectIdentityPrompt.test.tsx
+++ b/src/components/deploy/ConnectIdentityPrompt.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ConnectIdentityPrompt } from './ConnectIdentityPrompt'
+
+describe('ConnectIdentityPrompt', () => {
+  it('names the provider and wires the connect/manage actions', () => {
+    const onConnect = vi.fn()
+    const onManage = vi.fn()
+    render(
+      <ConnectIdentityPrompt
+        action="deploy"
+        label="GitHub Enterprise Cloud"
+        onConnect={onConnect}
+        onManage={onManage}
+        serviceIcon={null}
+      />,
+    )
+
+    expect(
+      screen.getByText('Not connected to GitHub Enterprise Cloud'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Connect your account to deploy this project.'),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Connect GitHub Enterprise Cloud' }),
+    )
+    expect(onConnect).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manage' }))
+    expect(onManage).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses release wording for the release action', () => {
+    render(
+      <ConnectIdentityPrompt
+        action="release"
+        label="GitHub"
+        onConnect={vi.fn()}
+        onManage={vi.fn()}
+        serviceIcon={null}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        'Connect your account to cut releases for this project.',
+      ),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/deploy/ConnectIdentityPrompt.tsx
+++ b/src/components/deploy/ConnectIdentityPrompt.tsx
@@ -1,0 +1,75 @@
+import { Plug } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { EntityIcon } from '@/components/ui/entity-icon'
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from '@/components/ui/item'
+
+interface ConnectIdentityPromptProps {
+  // What the actor is blocked from doing, used in the description copy.
+  action: 'deploy' | 'release'
+  // Identity provider display label (e.g. "GitHub Enterprise Cloud").
+  label: string
+  // Start the connection flow for this provider.
+  onConnect: () => void
+  // Open the connections management page.
+  onManage: () => void
+  // Icon of the service backing the provider; falls back to a plug glyph.
+  serviceIcon: null | string
+}
+
+// Compact prompt shown at the top of the Deployments / Releases tabs when the
+// actor has no active identity connection to the provider that powers the
+// deploy/release action.
+export function ConnectIdentityPrompt({
+  action,
+  label,
+  onConnect,
+  onManage,
+  serviceIcon,
+}: ConnectIdentityPromptProps) {
+  const target =
+    action === 'release'
+      ? 'cut releases for this project'
+      : 'deploy this project'
+
+  return (
+    <Item
+      className="border-amber-border bg-amber-bg/40"
+      size="sm"
+      variant="outline"
+    >
+      <ItemMedia variant="icon">
+        {serviceIcon ? (
+          <EntityIcon className="size-4" icon={serviceIcon} />
+        ) : (
+          <Plug className="size-4" />
+        )}
+      </ItemMedia>
+      <ItemContent>
+        <ItemTitle>Not connected to {label}</ItemTitle>
+        <ItemDescription>Connect your account to {target}.</ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <Button
+          className="text-secondary hover:text-primary h-auto p-0 text-xs font-medium hover:no-underline"
+          onClick={onManage}
+          type="button"
+          variant="link"
+        >
+          Manage
+        </Button>
+        <Button className="h-8 gap-2 text-xs" onClick={onConnect} size="sm">
+          <Plug className="size-3.5" />
+          Connect {label}
+        </Button>
+      </ItemActions>
+    </Item>
+  )
+}

--- a/src/components/ui/item.tsx
+++ b/src/components/ui/item.tsx
@@ -1,0 +1,153 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from 'react'
+
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const itemVariants = cva(
+  'group/item flex flex-wrap items-center rounded-md border border-transparent text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 [a]:hover:bg-accent/50',
+  {
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
+    variants: {
+      size: {
+        default: 'gap-4 p-4',
+        sm: 'gap-2.5 px-4 py-3',
+      },
+      variant: {
+        default: 'bg-transparent',
+        muted: 'bg-muted/50',
+        outline: 'border-border',
+      },
+    },
+  },
+)
+
+interface ItemProps
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof itemVariants> {
+  asChild?: boolean
+}
+
+const Item = React.forwardRef<HTMLDivElement, ItemProps>(
+  ({ asChild = false, className, size, variant, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'div'
+    return (
+      <Comp
+        className={cn(itemVariants({ size, variant }), className)}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+Item.displayName = 'Item'
+
+const ItemGroup = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div className={cn('flex flex-col', className)} ref={ref} {...props} />
+))
+ItemGroup.displayName = 'ItemGroup'
+
+const itemMediaVariants = cva(
+  'flex shrink-0 items-center justify-center gap-2 [&_svg]:pointer-events-none',
+  {
+    defaultVariants: {
+      variant: 'default',
+    },
+    variants: {
+      variant: {
+        default: 'self-center [&_svg]:size-4',
+        icon: 'size-8 rounded-sm border bg-muted/50 [&_svg]:size-4',
+      },
+    },
+  },
+)
+
+interface ItemMediaProps
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof itemMediaVariants> {}
+
+const ItemMedia = React.forwardRef<HTMLDivElement, ItemMediaProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div
+      className={cn(itemMediaVariants({ variant }), className)}
+      ref={ref}
+      {...props}
+    />
+  ),
+)
+ItemMedia.displayName = 'ItemMedia'
+
+const ItemContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    className={cn(
+      'flex flex-1 flex-col gap-0.5 [&+[data-item-actions]]:ml-auto',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+))
+ItemContent.displayName = 'ItemContent'
+
+const ItemTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    className={cn(
+      'flex items-center gap-2 text-sm leading-none font-medium',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+))
+ItemTitle.displayName = 'ItemTitle'
+
+const ItemDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    className={cn('text-sm leading-normal text-muted-foreground', className)}
+    ref={ref}
+    {...props}
+  />
+))
+ItemDescription.displayName = 'ItemDescription'
+
+const ItemActions = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    className={cn('flex items-center gap-2', className)}
+    data-item-actions=""
+    ref={ref}
+    {...props}
+  />
+))
+ItemActions.displayName = 'ItemActions'
+
+export {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+}


### PR DESCRIPTION
## Summary

When a user opens the **Deployments** or **Releases** tab but hasn't connected their identity to the provider that powers the deploy/release action, actions 401 on click. Previously the only cue was a passive "Connect to X" status line in the deploy nav (and nothing at all on Releases).

This adds a compact prompt at the top of both tabs — the smaller, tab-scoped counterpart of the dashboard's unconnected-integration widget — that names the provider and links to the connections page to start the flow.

## Behavior

- Shown only when `deploymentReadiness === 'disconnected'` **and** an identity plugin resolved (so there's a real connect target). Disappears once connected.
- The same deployment plugin/identity drives both tabs (release-only projects use the deployment-capability plugin), so one component serves both. All state already exists in `ProjectDetail` — no new fetching.
- Copy adapts per tab: "…to deploy this project." / "…to cut releases for this project."
- `Connect` → `/settings/connections?connect=<identity_slug>`; `Manage` → `/settings/connections`.

## Implementation

- Vendors the shadcn **`Item`** primitive (`Item` / `ItemMedia` / `ItemContent` / `ItemTitle` / `ItemDescription` / `ItemActions` / `ItemGroup`) into `components/ui`, in the repo's existing `cva` + `forwardRef` style (no shadcn CLI/registry is wired in this project — other `ui/*` components are hand-vendored the same way).
- `ConnectIdentityPrompt` composes `Item` and takes `onConnect`/`onManage` callbacks, mirroring `UnconnectedIntegrationWidget` (parent owns navigation).

## Testing

- New `ConnectIdentityPrompt.test.tsx` (provider naming, per-action copy, callback wiring)
- `tsc` clean; oxlint 0 errors; oxfmt clean; fallow audit gate clean
- `vitest` deploy/deployments/releases suites — 73 passed

## Note

Not rendered live (no local dev env stood up; prod is the live site) — verified via typecheck/lint/tests. Screenshots welcome from a preview build if useful.