### PR TITLE
Show document attachment context in org-wide reader

### DIFF
--- a/src/components/documents/DocumentAttachmentBadge.test.tsx
+++ b/src/components/documents/DocumentAttachmentBadge.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '@/test/utils'
+import type { DocumentAttachment } from '@/types'
+
+import { DocumentAttachmentBadge } from './DocumentAttachmentBadge'
+
+describe('DocumentAttachmentBadge', () => {
+  it('links a project attachment to its project page', () => {
+    const attachment: DocumentAttachment = {
+      id: '42',
+      kind: 'project',
+      name: 'imbi-api',
+    }
+    render(<DocumentAttachmentBadge attachment={attachment} />)
+
+    expect(screen.getByText('Project')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'imbi-api' })
+    expect(link).toHaveAttribute('href', '/projects/42')
+  })
+
+  it('labels a project-type attachment without a link', () => {
+    const attachment: DocumentAttachment = {
+      id: 'api',
+      kind: 'project_type',
+      name: 'API',
+    }
+    render(<DocumentAttachmentBadge attachment={attachment} />)
+
+    expect(screen.getByText('Project type')).toBeInTheDocument()
+    expect(screen.getByText('API')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('labels a user attachment as Personal, falling back to id', () => {
+    const attachment: DocumentAttachment = {
+      id: 'gavinr@aweber.com',
+      kind: 'user',
+      name: '',
+    }
+    render(<DocumentAttachmentBadge attachment={attachment} />)
+
+    expect(screen.getByText('Personal')).toBeInTheDocument()
+    expect(screen.getByText('gavinr@aweber.com')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/documents/DocumentAttachmentBadge.tsx
+++ b/src/components/documents/DocumentAttachmentBadge.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router-dom'
+
+import { FolderKanban, Layers, User } from 'lucide-react'
+
+import type { DocumentAttachment } from '@/types'
+
+const KIND_META: Record<
+  DocumentAttachment['kind'],
+  { icon: typeof User; label: string }
+> = {
+  project: { icon: FolderKanban, label: 'Project' },
+  project_type: { icon: Layers, label: 'Project type' },
+  user: { icon: User, label: 'Personal' },
+}
+
+/**
+ * The attachment eyebrow shown above a document's title in the org-wide
+ * reader, where the container no longer implies what the document is
+ * bound to. Encodes the attachment kind (project, project type, or
+ * personal) with a matching icon and label; the project name links to
+ * the project.
+ */
+export function DocumentAttachmentBadge({
+  attachment,
+}: {
+  attachment: DocumentAttachment
+}) {
+  const { icon: Icon, label } = KIND_META[attachment.kind]
+  const name = attachment.name || attachment.id
+
+  return (
+    <div className="mb-2.5 flex items-center gap-1.5 text-[12.5px] leading-none">
+      <Icon className="text-tertiary size-3.5 shrink-0" />
+      <span className="text-overline text-tertiary uppercase">{label}</span>
+      <span className="text-tertiary">·</span>
+      {attachment.kind === 'project' ? (
+        <Link
+          className="text-secondary hover:text-action truncate font-medium no-underline"
+          to={`/projects/${attachment.id}`}
+        >
+          {name}
+        </Link>
+      ) : (
+        <span className="text-secondary truncate font-medium">{name}</span>
+      )}
+    </div>
+  )
+}

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -36,6 +36,7 @@ import { RightCommentBar } from './comments/RightCommentBar'
 import { SelectionToolbar } from './comments/SelectionToolbar'
 import { useCommentLastVisit } from './comments/useCommentLastVisit'
 import { useInlineComments } from './comments/useInlineComments'
+import { DocumentAttachmentBadge } from './DocumentAttachmentBadge'
 import { DocumentsFilterRail } from './DocumentsFilterRail'
 import {
   documentTitle,
@@ -83,6 +84,9 @@ interface Props {
   onTogglePin: () => void
   orgSlug: string
   projectId: null | string
+  /** Show the attachment eyebrow — only in the org-wide reader, where the
+   * container no longer implies what the document is bound to. */
+  showAttachment?: boolean
 }
 
 // fallow-ignore-next-line complexity
@@ -107,6 +111,7 @@ export function DocumentsPinboardReader({
   onTogglePin,
   orgSlug,
   projectId,
+  showAttachment = false,
 }: Props) {
   const [search, setSearch] = useState('')
   const [commentFilter, setCommentFilter] = useState<CommentFilter>('open')
@@ -361,6 +366,9 @@ export function DocumentsPinboardReader({
           )}
         >
           <article className="border-tertiary bg-primary rounded-lg border px-8 py-7">
+            {showAttachment && document.attached_to && (
+              <DocumentAttachmentBadge attachment={document.attached_to} />
+            )}
             <h1 className="text-primary m-0 text-[26px] leading-[1.2] font-medium tracking-[-0.015em]">
               {title}
             </h1>

--- a/src/components/documents/DocumentsTab.tsx
+++ b/src/components/documents/DocumentsTab.tsx
@@ -115,6 +115,7 @@ export function DocumentsTab({
         onTogglePin={() => ctl.togglePin(document)}
         orgSlug={orgSlug}
         projectId={scope.commentsProjectId}
+        showAttachment={scope.templateContext === 'org'}
       />
     )
   }


### PR DESCRIPTION
## Summary

Adds an attachment eyebrow above the title in the org-wide Documents reader so you can immediately see what a document is attached to.

## Problem

The top-level (org-wide) Documents interface lets you open a document that may be attached to a **user** (personal), a **project type**, or a **project** — but the reader showed no indication of which. Unlike the project tab and the user-profile documents tab, the org-wide reader's container implies no owner, so that context was simply lost once you opened a document.

## Solution

A quiet eyebrow directly above the document title that encodes the attachment kind, reusing the app's existing icon vocabulary and design-system tokens:

- **Project** — `FolderKanban` icon, name links to `/projects/{id}`
- **Project type** — `Layers` icon
- **Personal** (user) — `User` icon

It's gated on `scope.templateContext === 'org'`, so it appears **only** in the org-wide reader. This deliberately avoids a redundant `Personal · <same user>` line on the user-profile documents tab (which also carries a null project id, so a project-id gate would have been wrong).

The data was already present on `document.attached_to`; the reader just never rendered it. No API/backend changes — imbi-ui only.

## Testing

- New unit test `DocumentAttachmentBadge.test.tsx` covers all three kinds (project links to `/projects/{id}`; project-type and user render without a link; user name falls back to id). Passing.
- `tsc --noEmit`, `oxfmt`, and `oxlint` clean on the changed files.

Visual verification in the running app is still pending (no dev server was up while authoring).