### PR TITLE
Make the Documents surface responsive below lg

### DIFF
--- a/src/components/documents/DocumentsFilterRail.tsx
+++ b/src/components/documents/DocumentsFilterRail.tsx
@@ -1,4 +1,6 @@
-import { Search } from 'lucide-react'
+import { useState } from 'react'
+
+import { ChevronDown, Search, SlidersHorizontal } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -33,24 +35,53 @@ export function DocumentsFilterRail({
   totalFiltered,
 }: Props) {
   const activeCount = active.size
+  // Below `lg` the rail sits above content as a bar; tags collapse behind a
+  // "Filters" disclosure so they don't push the content down. At `lg`+ it is
+  // the sticky sidebar and tags are always shown.
+  const [open, setOpen] = useState(false)
   return (
     <aside
       aria-disabled={disabled || undefined}
       className={cn(
-        'sticky top-5 self-start',
+        'lg:sticky lg:top-5 lg:self-start',
         disabled && 'pointer-events-none opacity-50 select-none',
       )}
     >
-      <div className="relative mb-3">
-        <Search className="text-tertiary pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
-        <Input
-          className="h-8 pl-8 text-xs"
-          disabled={disabled}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search documents"
-          tabIndex={disabled ? -1 : undefined}
-          value={search}
-        />
+      <div className="mb-3 flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="text-tertiary pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+          <Input
+            className="h-8 pl-8 text-xs"
+            disabled={disabled}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search documents"
+            tabIndex={disabled ? -1 : undefined}
+            value={search}
+          />
+        </div>
+        {tags.length > 0 && (
+          <Button
+            aria-expanded={open}
+            className="shrink-0 gap-1.5 lg:hidden"
+            disabled={disabled}
+            onClick={() => setOpen((o) => !o)}
+            size="sm"
+            tabIndex={disabled ? -1 : undefined}
+            variant="outline"
+          >
+            <SlidersHorizontal className="size-3.5" />
+            Filters
+            {activeCount > 0 && (
+              <span className="text-tertiary tabular-nums">{activeCount}</span>
+            )}
+            <ChevronDown
+              className={cn(
+                'size-3 transition-transform',
+                open && 'rotate-180',
+              )}
+            />
+          </Button>
+        )}
       </div>
 
       {activeCount > 0 && (
@@ -71,11 +102,11 @@ export function DocumentsFilterRail({
       )}
 
       {tags.length > 0 && (
-        <div>
+        <div className={cn(open ? 'block' : 'hidden', 'lg:block')}>
           <div className="text-overline text-tertiary mb-1.5 uppercase">
             Tags
           </div>
-          <div className="flex flex-col gap-0.5">
+          <div className="flex flex-wrap gap-1.5 lg:flex-col lg:flex-nowrap lg:gap-0.5">
             {tags.map((t) => {
               const count = counts[t.slug] ?? 0
               if (!count) return null
@@ -114,7 +145,7 @@ function TagButton({
   return (
     <button
       className={cn(
-        'flex w-full items-center gap-2 rounded-md border-0 px-2 py-1 text-left transition-colors',
+        'flex w-auto items-center gap-2 rounded-md border-0 px-2 py-1 text-left transition-colors lg:w-full',
         active ? 'bg-secondary' : 'bg-transparent hover:bg-secondary',
       )}
       onClick={onClick}
@@ -132,7 +163,7 @@ function TagButton({
       />
       <span
         className={cn(
-          'flex-1 truncate text-[12.5px]',
+          'truncate text-[12.5px] lg:flex-1',
           active || highlighted ? 'font-medium text-primary' : 'text-secondary',
         )}
       >

--- a/src/components/documents/DocumentsIndexTable.tsx
+++ b/src/components/documents/DocumentsIndexTable.tsx
@@ -36,7 +36,7 @@ export function DocumentsIndexTable({
   const { filtered } = filter
 
   return (
-    <div className="grid grid-cols-[220px_1fr] items-start gap-5">
+    <div className="grid grid-cols-1 items-start gap-5 lg:grid-cols-[220px_1fr]">
       <DocumentsFilterRail
         active={filter.active}
         counts={filter.counts}
@@ -49,32 +49,34 @@ export function DocumentsIndexTable({
       />
 
       <div>
-        <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
-          <div
-            className="border-tertiary bg-secondary text-overline text-tertiary grid items-center gap-3.5 border-b px-3.5 py-2 uppercase"
-            style={{ gridTemplateColumns: GRID_COLUMNS }}
-          >
-            <span>Attached to</span>
-            <span>Document</span>
-            <span>Tags</span>
-            <span>Author</span>
-            <span className="text-right">Updated</span>
-            <span />
-          </div>
-          {filtered.map((n) => (
-            <IndexRow
-              displayNames={displayNames}
-              document={n}
-              key={n.id}
-              onOpen={onOpen}
-              onTogglePin={onTogglePin}
-            />
-          ))}
-          {filtered.length === 0 && (
-            <div className="text-tertiary px-8 py-10 text-center text-sm">
-              No documents match.
+        <div className="overflow-x-auto">
+          <div className="border-tertiary bg-primary min-w-180 overflow-hidden rounded-lg border">
+            <div
+              className="border-tertiary bg-secondary text-overline text-tertiary grid items-center gap-3.5 border-b px-3.5 py-2 uppercase"
+              style={{ gridTemplateColumns: GRID_COLUMNS }}
+            >
+              <span>Attached to</span>
+              <span>Document</span>
+              <span>Tags</span>
+              <span>Author</span>
+              <span className="text-right">Updated</span>
+              <span />
             </div>
-          )}
+            {filtered.map((n) => (
+              <IndexRow
+                displayNames={displayNames}
+                document={n}
+                key={n.id}
+                onOpen={onOpen}
+                onTogglePin={onTogglePin}
+              />
+            ))}
+            {filtered.length === 0 && (
+              <div className="text-tertiary px-8 py-10 text-center text-sm">
+                No documents match.
+              </div>
+            )}
+          </div>
         </div>
         <div className="text-tertiary mt-3 text-xs">
           {filtered.length} {filtered.length === 1 ? 'document' : 'documents'}

--- a/src/components/documents/DocumentsPinboard.tsx
+++ b/src/components/documents/DocumentsPinboard.tsx
@@ -54,7 +54,7 @@ export function DocumentsPinboard({
   const rest = useMemo(() => filtered.filter((n) => !n.is_pinned), [filtered])
 
   return (
-    <div className="grid grid-cols-[220px_1fr] gap-5">
+    <div className="grid grid-cols-1 gap-5 lg:grid-cols-[220px_1fr]">
       <DocumentsFilterRail
         active={filter.active}
         counts={filter.counts}
@@ -67,9 +67,9 @@ export function DocumentsPinboard({
       />
 
       <div>
-        <section className="mb-6 flex items-start gap-3.5">
+        <section className="mb-6 flex flex-col items-stretch gap-3.5 sm:flex-row sm:items-start">
           {pinned.length > 0 && (
-            <div className="grid min-w-0 flex-1 grid-cols-2 gap-3.5">
+            <div className="grid min-w-0 flex-1 grid-cols-1 gap-3.5 sm:grid-cols-2">
               {pinned.map((n) => (
                 <HeroCard
                   displayNames={displayNames}
@@ -89,8 +89,8 @@ export function DocumentsPinboard({
           />
         </section>
 
-        <section>
-          <div className="border-tertiary bg-primary overflow-hidden rounded-lg border">
+        <section className="overflow-x-auto">
+          <div className="border-tertiary bg-primary min-w-160 overflow-hidden rounded-lg border">
             <div
               className="border-tertiary bg-secondary text-overline text-tertiary grid items-center gap-3.5 border-b px-3.5 py-2 uppercase"
               style={{ gridTemplateColumns: gridColumns(showAuthor) }}

--- a/src/components/documents/DocumentsPinboardNew.tsx
+++ b/src/components/documents/DocumentsPinboardNew.tsx
@@ -107,7 +107,7 @@ export function DocumentsPinboardNew({
   const showPreview = mode !== 'write'
 
   return (
-    <div className="grid grid-cols-[220px_1fr] gap-5">
+    <div className="grid grid-cols-1 gap-5 lg:grid-cols-[220px_1fr]">
       {/* Rail stays visible but disabled while composing — preserves spatial continuity. */}
       <DocumentsFilterRail
         active={EMPTY_ACTIVE}
@@ -195,14 +195,14 @@ export function DocumentsPinboardNew({
           <div
             className={cn(
               'mt-5 grid min-h-140 border-t border-tertiary',
-              mode === 'split' ? 'grid-cols-2' : 'grid-cols-1',
+              mode === 'split' ? 'grid-cols-1 md:grid-cols-2' : 'grid-cols-1',
             )}
           >
             {showEditor && (
               <textarea
                 className={cn(
                   'min-h-140 w-full resize-none border-0 bg-primary px-7 py-5 font-mono text-[13px] leading-[1.65] text-primary outline-none placeholder:text-tertiary',
-                  mode === 'split' && 'border-r border-tertiary',
+                  mode === 'split' && 'border-tertiary md:border-r',
                 )}
                 onChange={(e) => setContent(e.target.value)}
                 placeholder="Start writing… Markdown supported."
@@ -211,7 +211,14 @@ export function DocumentsPinboardNew({
               />
             )}
             {showPreview && (
-              <div className="flex flex-col">
+              // In split view the preview needs a second column — below md
+              // there isn't one, so fall back to a single writing pane.
+              <div
+                className={cn(
+                  mode === 'split' ? 'hidden md:flex' : 'flex',
+                  'flex-col',
+                )}
+              >
                 <div className="border-tertiary bg-primary text-overline text-tertiary flex items-center gap-1.5 border-b px-5 py-2 uppercase">
                   <Eye className="size-3" />
                   Preview

--- a/src/components/documents/DocumentsPinboardReader.tsx
+++ b/src/components/documents/DocumentsPinboardReader.tsx
@@ -239,7 +239,7 @@ export function DocumentsPinboardReader({
 
   // Reader is navigable from the same tab; filter rail keeps rail semantics.
   return (
-    <div className="grid grid-cols-[220px_1fr] gap-5">
+    <div className="grid grid-cols-1 gap-5 lg:grid-cols-[220px_1fr]">
       <DocumentsFilterRail
         active={EMPTY_ACTIVE}
         counts={counts}
@@ -253,67 +253,72 @@ export function DocumentsPinboardReader({
       />
 
       <div>
-        <div className="mb-3.5 grid grid-cols-[minmax(0,1fr)_260px] items-start gap-5">
+        <div className="mb-3.5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1fr)_260px]">
           <div className="flex flex-wrap items-center gap-2.5">
             <Button onClick={onBack} size="sm" variant="ghost">
               <ArrowLeft className="size-3" />
               All documents
             </Button>
             <div className="ml-auto flex items-center gap-1">
-              {showComments && (
-                <SegmentedControl
-                  ariaLabel="Comment filter"
-                  className="mr-1"
-                  onValueChange={(v) => setCommentFilter(v as CommentFilter)}
-                  value={commentFilter}
-                >
-                  <SegmentedControlItem value="open">
-                    <CircleDot className="size-3" />
-                    Open
-                    <span className="text-tertiary tabular-nums">
-                      {commentCounts.open}
-                    </span>
-                  </SegmentedControlItem>
-                  <SegmentedControlItem value="resolved">
-                    <CheckCircle2 className="size-3" />
-                    Resolved
-                    <span className="text-tertiary tabular-nums">
-                      {commentCounts.resolved}
-                    </span>
-                  </SegmentedControlItem>
-                  <SegmentedControlItem value="all">
-                    <List className="size-3" />
-                    All
-                    <span className="text-tertiary tabular-nums">
-                      {commentCounts.all}
-                    </span>
-                  </SegmentedControlItem>
-                </SegmentedControl>
-              )}
-              <Button
-                className="gap-1.5"
-                onClick={() => setShowComments((v) => !v)}
-                size="sm"
-                variant="ghost"
-              >
-                {showComments ? (
-                  <>
-                    <EyeOff className="size-3" />
-                    Hide inline comments
-                  </>
-                ) : (
-                  <>
-                    <Eye className="size-3" />
-                    Show inline comments
-                    {inlineThreads.length > 0 && (
+              {/* Inline comments are a desktop-width affordance — the margin
+                  needs room the phone doesn't have; the bottom discussion
+                  still carries the conversation there. */}
+              <div className="hidden items-center gap-1 lg:flex">
+                {showComments && (
+                  <SegmentedControl
+                    ariaLabel="Comment filter"
+                    className="mr-1"
+                    onValueChange={(v) => setCommentFilter(v as CommentFilter)}
+                    value={commentFilter}
+                  >
+                    <SegmentedControlItem value="open">
+                      <CircleDot className="size-3" />
+                      Open
                       <span className="text-tertiary tabular-nums">
-                        {inlineThreads.length}
+                        {commentCounts.open}
                       </span>
-                    )}
-                  </>
+                    </SegmentedControlItem>
+                    <SegmentedControlItem value="resolved">
+                      <CheckCircle2 className="size-3" />
+                      Resolved
+                      <span className="text-tertiary tabular-nums">
+                        {commentCounts.resolved}
+                      </span>
+                    </SegmentedControlItem>
+                    <SegmentedControlItem value="all">
+                      <List className="size-3" />
+                      All
+                      <span className="text-tertiary tabular-nums">
+                        {commentCounts.all}
+                      </span>
+                    </SegmentedControlItem>
+                  </SegmentedControl>
                 )}
-              </Button>
-              <span className="bg-tertiary mx-1 h-5 w-px" />
+                <Button
+                  className="gap-1.5"
+                  onClick={() => setShowComments((v) => !v)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  {showComments ? (
+                    <>
+                      <EyeOff className="size-3" />
+                      Hide inline comments
+                    </>
+                  ) : (
+                    <>
+                      <Eye className="size-3" />
+                      Show inline comments
+                      {inlineThreads.length > 0 && (
+                        <span className="text-tertiary tabular-nums">
+                          {inlineThreads.length}
+                        </span>
+                      )}
+                    </>
+                  )}
+                </Button>
+                <span className="bg-tertiary mx-1 h-5 w-px" />
+              </div>
               <Button
                 className="gap-1.5"
                 onClick={onTogglePin}
@@ -359,17 +364,17 @@ export function DocumentsPinboardReader({
 
         <div
           className={cn(
-            'grid items-start gap-5',
+            'grid grid-cols-1 items-start gap-5',
             showComments
-              ? 'grid-cols-[minmax(0,1fr)_220px_300px]'
-              : 'grid-cols-[minmax(0,1fr)_260px]',
+              ? 'lg:grid-cols-[minmax(0,1fr)_220px_300px]'
+              : 'lg:grid-cols-[minmax(0,1fr)_260px]',
           )}
         >
-          <article className="border-tertiary bg-primary rounded-lg border px-8 py-7">
+          <article className="border-tertiary bg-primary rounded-lg border px-5 py-6 lg:px-8 lg:py-7">
             {showAttachment && document.attached_to && (
               <DocumentAttachmentBadge attachment={document.attached_to} />
             )}
-            <h1 className="text-primary m-0 text-[26px] leading-[1.2] font-medium tracking-[-0.015em]">
+            <h1 className="text-primary m-0 text-[22px] leading-[1.2] font-medium tracking-[-0.015em] lg:text-[26px]">
               {title}
             </h1>
 
@@ -431,9 +436,9 @@ export function DocumentsPinboardReader({
             </div>
           </article>
 
-          <div className="sticky top-5 flex flex-col gap-4">
+          <div className="flex flex-col gap-4 lg:sticky lg:top-5">
             {headings.length > 0 && (
-              <div>
+              <div className="hidden lg:block">
                 <div className="text-overline text-tertiary mb-2 uppercase">
                   On this page
                 </div>
@@ -500,7 +505,7 @@ export function DocumentsPinboardReader({
           </div>
 
           {showComments && (
-            <div className="relative" ref={marginRef}>
+            <div className="relative hidden lg:block" ref={marginRef}>
               <RightCommentBar
                 articleRef={articleRef}
                 busy={commentsBusy}
@@ -527,7 +532,7 @@ export function DocumentsPinboardReader({
           )}
         </div>
 
-        <div className="grid grid-cols-[minmax(0,1fr)_260px] gap-5">
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_260px]">
           <BottomDiscussion
             busy={commentsBusy}
             currentUserEmail={currentUserEmail}

--- a/src/components/documents/DocumentsPinboardSkeleton.tsx
+++ b/src/components/documents/DocumentsPinboardSkeleton.tsx
@@ -37,10 +37,10 @@ function DocumentsFeedSkeleton() {
  */
 function DocumentsPinboardSkeleton() {
   return (
-    <div aria-busy className="grid grid-cols-[220px_1fr] gap-5">
+    <div aria-busy className="grid grid-cols-1 gap-5 lg:grid-cols-[220px_1fr]">
       <FilterRailSkeleton />
       <div>
-        <section className="mb-6 grid grid-cols-2 gap-3.5">
+        <section className="mb-6 grid grid-cols-1 gap-3.5 sm:grid-cols-2">
           <HeroCardSkeleton />
           <HeroCardSkeleton />
         </section>


### PR DESCRIPTION
## Summary

Makes the whole org-wide Documents experience usable on narrow screens. The reader, index table, pinboard, and editor were built on fixed pixel grid tracks (a 220px rail plus fixed sidebars) that never collapsed.

> **Stacked on #460** (attachment eyebrow). Base is `feature/documents-attachment-context` so this diff shows only the responsive changes; once #460 merges, GitHub retargets this to `main`.

## Problem

Every Documents surface used `grid-cols-[220px_1fr]` (rail + content) plus additional fixed sidebars, none of which reflowed. Below ~900px the article/table had almost no room, the inline-comment margin overflowed, and the editor's Split view was unusable.

## Solution

- **Filter rail** — below `lg` it becomes a full-width bar: search stays visible, tags collapse behind a **Filters** disclosure and wrap as chips. At `lg`+ it remains the sticky vertical sidebar. (Rail behavior chosen with the maintainer.)
- **Shared shell** — `grid-cols-[220px_1fr]` → single column below `lg` across reader, pinboard, index table, editor, and skeleton.
- **Reader** — the TOC/related sidebar and the inline-comment margin collapse below `lg` (the bottom discussion still carries the conversation); article padding and title size ease down on mobile.
- **Tables** — index and pinboard tables scroll horizontally inside a `min-width` container so columns keep their shape (the responsive card Feed remains the primary small-screen view).
- **Editor** — Split falls back to a single writing pane below `md`, where there's no room for a second column.
- **Hero cards** — stack single-column below `sm`.

All changes are Tailwind breakpoint / layout only, using the existing design tokens. No API changes — imbi-ui only.

## Testing

- `tsc --noEmit`, `oxlint`, `oxfmt`, `vitest` (documents suite), and `npm run build` all pass.
- **Live responsive verification in the running app is still pending** — no dev server / backend was available while authoring. Recommend a quick pass at mobile/tablet widths before merge.