### PR TITLE
Fix integration/link collision and add integration editing

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1838,6 +1838,17 @@ export const createProjectService = (
     data,
   )
 
+export const updateProjectService = (
+  orgSlug: string,
+  projectId: string,
+  serviceSlug: string,
+  data: ProjectServiceEdgeCreate,
+) =>
+  apiClient.put<ProjectServiceEdge>(
+    `/organizations/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(projectId)}/services/${encodeURIComponent(serviceSlug)}`,
+    data,
+  )
+
 export const deleteProjectService = (
   orgSlug: string,
   projectId: string,

--- a/src/components/EditLinksCard.tsx
+++ b/src/components/EditLinksCard.tsx
@@ -6,12 +6,22 @@ import { getIcon, useIconRegistryVersion } from '@/lib/icons'
 import type { LinkDefinition } from '@/types'
 
 interface EditLinksCardProps {
+  /**
+   * Slugs of integrations the project is connected to. An integration's
+   * dashboard URL is mirrored into `links` keyed by the integration slug and
+   * is managed from the Integrations card, so those keys are hidden here: they
+   * never render as an editable link row and are never offered as a link type
+   * to add. This keeps the two from colliding when an integration slug also
+   * matches a link definition.
+   */
+  integrationSlugs?: Set<string>
   linkDefs: LinkDefinition[]
   links: Record<string, string>
   onPatch: (links: Record<string, string>) => Promise<void>
 }
 
 export function EditLinksCard({
+  integrationSlugs,
   linkDefs,
   links,
   onPatch,
@@ -33,23 +43,28 @@ export function EditLinksCard({
     return m
   }, [linkDefs])
 
+  const isIntegrationKey = useMemo(
+    () => (slug: string) => integrationSlugs?.has(slug) ?? false,
+    [integrationSlugs],
+  )
+
   const visibleKeys = useMemo(
     () =>
       Object.keys(serverMap)
-        .filter((slug) => defBySlug.has(slug))
+        .filter((slug) => defBySlug.has(slug) && !isIntegrationKey(slug))
         .sort((a, b) =>
           defBySlug.get(a)!.name.localeCompare(defBySlug.get(b)!.name),
         ),
-    [serverMap, defBySlug],
+    [serverMap, defBySlug, isIntegrationKey],
   )
 
   const unassignedKeys = useMemo(() => {
     const visible = new Set(visibleKeys)
     return linkDefs
-      .filter((d) => !visible.has(d.slug))
+      .filter((d) => !visible.has(d.slug) && !isIntegrationKey(d.slug))
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((d) => d.slug)
-  }, [linkDefs, visibleKeys])
+  }, [linkDefs, visibleKeys, isIntegrationKey])
 
   return (
     <EditableKeyValueMap

--- a/src/components/IntegrationsCard.tsx
+++ b/src/components/IntegrationsCard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ExternalLink, Plus, Trash2 } from 'lucide-react'
+import { ExternalLink, Pencil, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 
 import {
@@ -9,6 +9,7 @@ import {
   deleteProjectService,
   listIntegrations,
   listProjectServices,
+  updateProjectService,
 } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import {
@@ -65,6 +66,9 @@ export function IntegrationsCard({
 }: IntegrationsCardProps) {
   const queryClient = useQueryClient()
   const [addOpen, setAddOpen] = useState(false)
+  // When set, the dialog edits the connected integration with this slug
+  // instead of adding a new one.
+  const [editSlug, setEditSlug] = useState<null | string>(null)
   const [form, setForm] = useState(EMPTY_FORM)
   const [deleteTarget, setDeleteTarget] = useState<null | string>(null)
 
@@ -117,6 +121,27 @@ export function IntegrationsCard({
     },
   })
 
+  const updateMutation = useMutation({
+    mutationFn: (serviceSlug: string) =>
+      updateProjectService(orgSlug, projectId, serviceSlug, {
+        canonical_url: form.canonicalUrl.trim() || null,
+        dashboard_url: form.dashboardUrl.trim() || null,
+        identifier: form.identifier.trim(),
+        integration_slug: serviceSlug,
+      }),
+    onError: (error) => {
+      toast.error(
+        `Failed to update integration: ${extractApiErrorDetail(error)}`,
+      )
+    },
+    onSuccess: () => {
+      toast.success('Integration updated')
+      setEditSlug(null)
+      setForm(EMPTY_FORM)
+      invalidate()
+    },
+  })
+
   const deleteMutation = useMutation({
     mutationFn: (serviceSlug: string) =>
       deleteProjectService(orgSlug, projectId, serviceSlug),
@@ -131,8 +156,17 @@ export function IntegrationsCard({
     },
   })
 
+  const isEdit = editSlug !== null
+  const dialogOpen = addOpen || isEdit
+  const submitting = createMutation.isPending || updateMutation.isPending
   const canSubmit =
-    !!form.serviceSlug && !!form.identifier.trim() && !createMutation.isPending
+    !!form.serviceSlug && !!form.identifier.trim() && !submitting
+
+  const closeDialog = () => {
+    setAddOpen(false)
+    setEditSlug(null)
+    setForm(EMPTY_FORM)
+  }
 
   return (
     <Card>
@@ -172,7 +206,7 @@ export function IntegrationsCard({
                 <TableHead>Identifier</TableHead>
                 <TableHead>API URL</TableHead>
                 <TableHead>Dashboard URL</TableHead>
-                <TableHead className="w-12" />
+                <TableHead className="w-24" />
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -189,14 +223,32 @@ export function IntegrationsCard({
                     <UrlCell url={svc.dashboard_url} />
                   </TableCell>
                   <TableCell>
-                    <Button
-                      aria-label={`Remove ${svc.integration_name} integration`}
-                      onClick={() => setDeleteTarget(svc.integration_slug)}
-                      size="sm"
-                      variant="ghost"
-                    >
-                      <Trash2 className="size-4" />
-                    </Button>
+                    <div className="flex items-center justify-end gap-1">
+                      <Button
+                        aria-label={`Edit ${svc.integration_name} integration`}
+                        onClick={() => {
+                          setForm({
+                            canonicalUrl: svc.canonical_url ?? '',
+                            dashboardUrl: svc.dashboard_url ?? '',
+                            identifier: svc.identifier,
+                            serviceSlug: svc.integration_slug,
+                          })
+                          setEditSlug(svc.integration_slug)
+                        }}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        <Pencil className="size-4" />
+                      </Button>
+                      <Button
+                        aria-label={`Remove ${svc.integration_name} integration`}
+                        onClick={() => setDeleteTarget(svc.integration_slug)}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))}
@@ -205,31 +257,49 @@ export function IntegrationsCard({
         )}
       </CardContent>
 
-      <Dialog onOpenChange={setAddOpen} open={addOpen}>
+      <Dialog
+        onOpenChange={(open) => {
+          if (!open) closeDialog()
+        }}
+        open={dialogOpen}
+      >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Add Integration</DialogTitle>
+            <DialogTitle>
+              {isEdit ? 'Edit Integration' : 'Add Integration'}
+            </DialogTitle>
           </DialogHeader>
           <div className="space-y-4 p-6">
             <div className="space-y-2">
               <Label htmlFor="integration-service">Integration</Label>
-              <Select
-                onValueChange={(value) =>
-                  setForm((f) => ({ ...f, serviceSlug: value }))
-                }
-                value={form.serviceSlug}
-              >
-                <SelectTrigger id="integration-service">
-                  <SelectValue placeholder="Select an integration…" />
-                </SelectTrigger>
-                <SelectContent>
-                  {connectableServices.map((svc) => (
-                    <SelectItem key={svc.slug} value={svc.slug}>
-                      {svc.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              {isEdit ? (
+                <Input
+                  disabled
+                  id="integration-service"
+                  value={
+                    services.find((s) => s.integration_slug === editSlug)
+                      ?.integration_name ?? editSlug
+                  }
+                />
+              ) : (
+                <Select
+                  onValueChange={(value) =>
+                    setForm((f) => ({ ...f, serviceSlug: value }))
+                  }
+                  value={form.serviceSlug}
+                >
+                  <SelectTrigger id="integration-service">
+                    <SelectValue placeholder="Select an integration…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {connectableServices.map((svc) => (
+                      <SelectItem key={svc.slug} value={svc.slug}>
+                        {svc.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
             </div>
             <div className="space-y-2">
               <Label htmlFor="integration-identifier">Identifier</Label>
@@ -266,14 +336,17 @@ export function IntegrationsCard({
             </div>
           </div>
           <DialogFooter>
-            <Button onClick={() => setAddOpen(false)} variant="outline">
+            <Button onClick={closeDialog} variant="outline">
               Cancel
             </Button>
             <Button
               disabled={!canSubmit}
-              onClick={() => createMutation.mutate()}
+              onClick={() => {
+                if (editSlug) updateMutation.mutate(editSlug)
+                else createMutation.mutate()
+              }}
             >
-              Add
+              {isEdit ? 'Save' : 'Add'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/IntegrationsCard.tsx
+++ b/src/components/IntegrationsCard.tsx
@@ -259,7 +259,7 @@ export function IntegrationsCard({
 
       <Dialog
         onOpenChange={(open) => {
-          if (!open) closeDialog()
+          if (!open && !submitting) closeDialog()
         }}
         open={dialogOpen}
       >
@@ -336,7 +336,11 @@ export function IntegrationsCard({
             </div>
           </div>
           <DialogFooter>
-            <Button onClick={closeDialog} variant="outline">
+            <Button
+              disabled={submitting}
+              onClick={closeDialog}
+              variant="outline"
+            >
               Cancel
             </Button>
             <Button

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -695,8 +695,8 @@ export function ProjectDetail({
       (project.services || []).map((svc) => svc.integration_slug),
     )
     const defLinks = Object.entries(project.links || {})
+      .filter(([key]) => !serviceSlugs.has(key))
       .map(([key, url]) => {
-        if (serviceSlugs.has(key)) return null
         const def = linkDefMap[key]
         if (!def) return null
         const safeUrl = sanitizeHttpUrl(url)

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -685,9 +685,18 @@ export function ProjectDetail({
   //   2. live integration dashboard links from project.services (edges only,
   //      so orphaned link entries never appear), name/icon from the
   //      integration.
+  // An integration's dashboard is mirrored into project.links keyed by the
+  // integration slug. When that slug also matches a link definition it would
+  // otherwise render twice (once here, once from `services`), so skip any
+  // links key that belongs to a connected integration and let `services`
+  // own it.
   const externalLinks = useMemo(() => {
+    const serviceSlugs = new Set(
+      (project.services || []).map((svc) => svc.integration_slug),
+    )
     const defLinks = Object.entries(project.links || {})
       .map(([key, url]) => {
+        if (serviceSlugs.has(key)) return null
         const def = linkDefMap[key]
         if (!def) return null
         const safeUrl = sanitizeHttpUrl(url)

--- a/src/components/ProjectSettingsTab.tsx
+++ b/src/components/ProjectSettingsTab.tsx
@@ -186,6 +186,9 @@ export function ProjectSettingsTab({ project }: { project: Project }) {
       )}
       {!linkDefsLoading && !linkDefsError && linkDefs.length > 0 && (
         <EditLinksCard
+          integrationSlugs={
+            new Set((project.services || []).map((s) => s.integration_slug))
+          }
           linkDefs={linkDefs}
           links={project.links || {}}
           onPatch={(entries) => patch('/links', entries)}

--- a/src/components/__tests__/EditLinksCard.test.tsx
+++ b/src/components/__tests__/EditLinksCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { EditLinksCard } from '@/components/EditLinksCard'
+import { render, screen } from '@/test/utils'
+import type { LinkDefinition } from '@/types'
+
+function linkDef(slug: string, name: string): LinkDefinition {
+  return {
+    icon: null,
+    name,
+    slug,
+    url_template: null,
+  } as unknown as LinkDefinition
+}
+
+describe('EditLinksCard integration-slug collision', () => {
+  const linkDefs = [
+    linkDef('documentation', 'Documentation'),
+    linkDef('sonarqube', 'SonarQube'),
+  ]
+
+  it('hides a links key that belongs to a connected integration', () => {
+    render(
+      <EditLinksCard
+        integrationSlugs={new Set(['sonarqube'])}
+        linkDefs={linkDefs}
+        links={{
+          documentation: 'https://docs.example.com',
+          sonarqube: 'https://sonar.example.com/dashboard',
+        }}
+        onPatch={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+
+    // The genuine project link still renders as an editable row.
+    expect(screen.getByText('Documentation')).toBeInTheDocument()
+    // The integration-owned key is not shown as an editable row, even though
+    // it matches a link definition slug.
+    expect(screen.queryByText('SonarQube')).not.toBeInTheDocument()
+    // and its dashboard URL is not exposed for inline editing here.
+    expect(
+      screen.queryByDisplayValue('https://sonar.example.com/dashboard'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('still renders the row when no integration owns the slug', () => {
+    render(
+      <EditLinksCard
+        integrationSlugs={new Set()}
+        linkDefs={linkDefs}
+        links={{ sonarqube: 'https://sonar.example.com/dashboard' }}
+        onPatch={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+
+    expect(screen.getByText('SonarQube')).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/IntegrationsCard.test.tsx
+++ b/src/components/__tests__/IntegrationsCard.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as endpoints from '@/api/endpoints'
 import { IntegrationsCard } from '@/components/IntegrationsCard'
-import { render, screen } from '@/test/utils'
+import { fireEvent, render, screen, waitFor } from '@/test/utils'
 
 // fallow-ignore-next-line unresolved-import
 vi.mock('@/api/endpoints', () => ({
@@ -10,6 +10,7 @@ vi.mock('@/api/endpoints', () => ({
   deleteProjectService: vi.fn(),
   listIntegrations: vi.fn(),
   listProjectServices: vi.fn(),
+  updateProjectService: vi.fn(),
 }))
 
 vi.mock('sonner', () => ({
@@ -71,5 +72,42 @@ describe('IntegrationsCard', () => {
     expect(await screen.findByText('SonarQube')).toBeInTheDocument()
     // both canonical + dashboard cells render the em-dash placeholder
     expect(screen.getAllByText('—')).toHaveLength(2)
+  })
+
+  it('edits a connected integration via the edit dialog', async () => {
+    vi.mocked(endpoints.listProjectServices).mockResolvedValue([
+      {
+        canonical_url: 'https://api.aweber.ghe.com/repositories/138841',
+        dashboard_url: 'https://aweber.ghe.com/org/webform',
+        identifier: '138841',
+        integration_name: 'GitHub',
+        integration_slug: 'github',
+      },
+    ])
+    vi.mocked(endpoints.updateProjectService).mockResolvedValue({
+      canonical_url: 'https://api.aweber.ghe.com/repositories/138841',
+      dashboard_url: 'https://aweber.ghe.com/org/webform',
+      identifier: '999',
+      integration_name: 'GitHub',
+      integration_slug: 'github',
+    })
+
+    render(<IntegrationsCard orgSlug="aweber" projectId="p1" />)
+
+    fireEvent.click(await screen.findByLabelText('Edit GitHub integration'))
+
+    // Dialog prefills the identifier from the row.
+    const identifier = await screen.findByDisplayValue('138841')
+    fireEvent.change(identifier, { target: { value: '999' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(endpoints.updateProjectService).toHaveBeenCalledWith(
+        'aweber',
+        'p1',
+        'github',
+        expect.objectContaining({ identifier: '999' }),
+      ),
+    )
   })
 })


### PR DESCRIPTION
## Summary

Fixes the integration/link collision that duplicated an integration's dashboard link and coupled it to the project's editable links, and adds the ability to edit a connected integration's attributes.

## Problem

An integration's dashboard URL is mirrored into `Project.links` keyed by the integration slug. The header link bar renders two un-deduped sources — link-definition links and integration service edges — and the Links card renders every `Project.links` key that matches a link definition. When an integration slug **collides with a link-definition slug** (e.g. SonarQube):

- The dashboard rendered **twice** in the header (`SonarQube | SonarQube`).
- It appeared as an **editable Links-card row** whose deletion silently wiped the integration's dashboard attribute (the cascade in the reported bug).

GitHub avoided this only by luck — no link definition matched its slug. There was also no way to edit a connected integration's identifier/URLs.

## Solution

- **ProjectDetail** — skip header `defLinks` whose key is a connected integration slug; the integration renders once from its service edge.
- **EditLinksCard** — exclude integration-slug keys from the editable rows and the "add link type" picker, removing the cascade-delete path. The full links map is still patched, so the mirrored key survives unrelated edits.
- **ProjectSettingsTab** — pass connected integration slugs to `EditLinksCard`.
- **IntegrationsCard** — add a per-row Edit dialog (identifier, API URL, dashboard URL) backed by the new `updateProjectService` PUT.
- Regression tests for the collision exclusion and the edit flow.

Because the fix is applied at render time, **existing broken data (e.g. the current SonarQube) renders correctly with no migration.**

## Depends on

- AWeber-Imbi/imbi-api#482 (the `PUT .../services/{slug}` endpoint the edit dialog calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
