### PR TITLE
Group and redesign recent activity feeds

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -39,6 +39,7 @@ import type { IdentityConnectionResponse } from '@/types'
 import { MyPullRequestCountsWidget } from './dashboard/widgets/MyPullRequestCountsWidget'
 import { MyPullRequestsWidget } from './dashboard/widgets/MyPullRequestsWidget'
 import { OutdatedComponentsWidget } from './dashboard/widgets/OutdatedComponentsWidget'
+import { ProjectActivityWidget } from './dashboard/widgets/ProjectActivityWidget'
 import { RecentActivityWidget } from './dashboard/widgets/RecentActivityWidget'
 import { RecentDeploymentsWidget } from './dashboard/widgets/RecentDeploymentsWidget'
 import { StatWidget } from './dashboard/widgets/StatWidget'
@@ -65,6 +66,7 @@ type WidgetId =
   | 'my-pull-request-counts'
   | 'my-pull-requests'
   | 'outdated-components'
+  | 'project-activity'
   | 'recent-activity'
   | 'recent-deployments'
   | 'stat-active-deployments'
@@ -110,7 +112,6 @@ const availableWidgets: WidgetConfig[] = [
     category: 'activity',
     columnSpan: 2,
     description: 'Latest actions and updates across projects',
-    hidden: true,
     icon: '📝',
     id: 'recent-activity',
     name: 'Recent Activity',
@@ -122,6 +123,14 @@ const availableWidgets: WidgetConfig[] = [
     icon: '🚀',
     id: 'recent-deployments',
     name: 'Recent Deployments',
+  },
+  {
+    category: 'activity',
+    columnSpan: 2,
+    description: 'Compact, project-centric feed of recent activity',
+    icon: '📌',
+    id: 'project-activity',
+    name: 'Project Activity',
   },
   {
     category: 'stats',
@@ -163,6 +172,7 @@ const WIDGET_IDS: ReadonlySet<WidgetId> = new Set<WidgetId>([
   'my-pull-request-counts',
   'my-pull-requests',
   'outdated-components',
+  'project-activity',
   'recent-activity',
   'recent-deployments',
   'stat-active-deployments',
@@ -358,6 +368,9 @@ export function Dashboard({
     'my-pull-requests': () => <MyPullRequestsWidget />,
     'outdated-components': () => (
       <OutdatedComponentsWidget onProjectSelect={onProjectSelect} />
+    ),
+    'project-activity': () => (
+      <ProjectActivityWidget onProjectSelect={onProjectSelect} />
     ),
     'recent-activity': () => (
       <RecentActivityWidget

--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -1,23 +1,54 @@
 import type { ReactElement } from 'react'
+import { useMemo, useState } from 'react'
 
+import { ChevronRight } from 'lucide-react'
+
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { Sk } from '@/components/ui/skeleton'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { usePluginOpsLogTemplates } from '@/hooks/usePluginOpsLogTemplates'
-import { formatRelativeDate } from '@/lib/formatDate'
 import type { ActivityFeedEntry, OperationsLogEntry } from '@/types'
 
+import {
+  ActivityFilter,
+  ALL_ACTORS,
+  filterEntries,
+} from './activityFeed/ActivityFilter'
+import type { ActivityFilterValue } from './activityFeed/ActivityFilter'
+import { ClusterEvents } from './activityFeed/ClusterEvents'
+import { clusterView } from './activityFeed/clusterView'
+import {
+  ACTIVITY_GROUP_WINDOW_MS,
+  entryClusterKey,
+  entryTimeIso,
+  entryTimeMs,
+  entryTone,
+} from './activityFeed/entryAdapters'
+import { sectionByDay } from './activityFeed/grouping'
+import type { ActivityCluster } from './activityFeed/grouping'
 import { renderActivityTemplate } from './activityFeed/renderActivityTemplate'
+import { StatusChip, StatusDot } from './activityFeed/StatusChip'
 import { Button } from './ui/button'
 import { Card } from './ui/card'
+
+// NOTE: The feed API has no correlation/run id, so groups are approximated by
+// clustering consecutive same-actor+project entries (see grouping.ts). A
+// backend `group_id` would let clusterMeta report true per-run breakdowns
+// (e.g. "1 failed · 6 skipped") instead of a per-change_type count.
 
 interface ActivityLineProps {
   activity: ActivityFeedEntry
   onProjectSelect?: (projectName: string) => void
   onUserSelect?: (userName: string) => void
-  // When the activity is an ops-log entry whose plugin ships a template
-  // for the embedded ``action``, return the rendered label string;
-  // otherwise return ``null`` so the line falls back to the legacy
-  // hand-built sentence.
+  renderTemplate: (entry: OperationsLogEntry) => null | string
+}
+
+interface ClusterRowProps {
+  cluster: ActivityCluster<ActivityFeedEntry>
+  expanded: boolean
+  onProjectSelect?: (projectName: string) => void
+  onToggle: () => void
+  onUserSelect?: (userName: string) => void
   renderTemplate: (entry: OperationsLogEntry) => null | string
 }
 
@@ -54,12 +85,23 @@ export function RecentActivity({
   onUserSelect,
 }: RecentActivityProps) {
   const { templates } = usePluginOpsLogTemplates()
+  const [filter, setFilter] = useState<ActivityFilterValue>(ALL_ACTORS)
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+
+  const sections = useMemo(
+    () =>
+      sectionByDay(filterEntries(activities ?? [], filter), {
+        keyOf: entryClusterKey,
+        timeOf: entryTimeMs,
+        windowMs: ACTIVITY_GROUP_WINDOW_MS,
+      }),
+    [activities, filter],
+  )
+
   if (isLoading) {
     return (
       <Card className="p-6">
-        {!hideHeading && (
-          <h2 className="text-primary mb-6 text-xl">Recent Activity</h2>
-        )}
+        <Heading hidden={hideHeading} />
         <ActivityFeedSkeleton rows={5} />
       </Card>
     )
@@ -68,9 +110,7 @@ export function RecentActivity({
   if (!activities || activities.length === 0) {
     return (
       <Card className="p-6">
-        {!hideHeading && (
-          <h2 className="text-primary mb-6 text-xl">Recent Activity</h2>
-        )}
+        <Heading hidden={hideHeading} />
         <div className="text-muted-foreground py-8 text-center">
           No recent activity
         </div>
@@ -78,67 +118,64 @@ export function RecentActivity({
     )
   }
 
-  const activityList = (
-    <div className="max-h-[calc(100vh-380px)] space-y-4 overflow-y-auto pr-2">
-      {activities.map((activity) => (
-        <div
-          className="border-tertiary border-b pb-4 last:border-0 last:pb-0"
-          key={activityKey(activity)}
-        >
-          <div className="flex gap-3">
-            <UserIdentity
-              displayName={activity.display_name}
-              email={activity.email_address}
-              hideName
-              linkToProfile={false}
-              size="floating"
-            />
+  const toggle = (key: string) =>
+    setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))
 
-            <div className="min-w-0 flex-1">
-              <ActivityLine
-                activity={activity}
-                onProjectSelect={onProjectSelect}
-                onUserSelect={onUserSelect}
-                renderTemplate={(opsEntry) =>
-                  renderActivityTemplate(opsEntry, templates)
-                }
-              />
-
-              <p className="text-tertiary mt-1 text-xs">
-                {formatRelativeDate(
-                  activity.occurred_at ||
-                    (activity.type === 'ProjectFeedEntry'
-                      ? activity.when
-                      : undefined),
-                )}
-              </p>
-            </div>
-          </div>
-        </div>
-      ))}
-
-      {isLoadingMore && <ActivityFeedSkeleton rows={3} />}
-      {/* Load More Button */}
-      {onLoadMore && !isLoadingMore && (
-        <div className="pt-4 text-center">
-          <Button
-            className="text-info hover:text-info/80 h-auto p-0 text-sm transition-colors"
-            onClick={onLoadMore}
-            variant="link"
-          >
-            Load more activity
-          </Button>
-        </div>
-      )}
-    </div>
-  )
+  const renderTemplate = (opsEntry: OperationsLogEntry) =>
+    renderActivityTemplate(opsEntry, templates)
 
   return (
     <Card className="p-6">
-      {!hideHeading && (
-        <h2 className="text-primary mb-6 text-xl">Recent Activity</h2>
-      )}
-      {activityList}
+      <div className="mb-1 flex items-center justify-between">
+        <Heading hidden={hideHeading} />
+        <ActivityFilter onChange={setFilter} value={filter} />
+      </div>
+
+      <div className="max-h-[calc(100vh-380px)] overflow-y-auto pr-2">
+        {sections.length === 0 ? (
+          <div className="text-tertiary py-8 text-center text-sm">
+            No activity matches the filter
+          </div>
+        ) : (
+          sections.map((section) => (
+            <div key={section.key}>
+              <div className="text-tertiary pt-3.5 pb-1 text-[11.5px] font-semibold tracking-wider uppercase">
+                {section.label}
+              </div>
+              <div className="relative">
+                <div
+                  className="bg-tertiary absolute w-0.5 rounded"
+                  style={{ bottom: 22, left: 5, top: 22 }}
+                />
+                {section.clusters.map((cluster) => (
+                  <ClusterRow
+                    cluster={cluster}
+                    expanded={isExpanded(cluster, expanded)}
+                    key={cluster.key}
+                    onProjectSelect={onProjectSelect}
+                    onToggle={() => toggle(cluster.key)}
+                    onUserSelect={onUserSelect}
+                    renderTemplate={renderTemplate}
+                  />
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+
+        {isLoadingMore && <ActivityFeedSkeleton rows={3} />}
+        {onLoadMore && !isLoadingMore && (
+          <div className="pt-4 text-center">
+            <Button
+              className="text-info hover:text-info/80 h-auto p-0 text-sm transition-colors"
+              onClick={onLoadMore}
+              variant="link"
+            >
+              Load more activity
+            </Button>
+          </div>
+        )}
+      </div>
     </Card>
   )
 }
@@ -160,13 +197,6 @@ function ActivityFeedSkeleton({ rows }: { rows: number }) {
       ))}
     </div>
   )
-}
-
-function activityKey(activity: ActivityFeedEntry): string {
-  if (activity.type === 'OperationsLogEntry') {
-    return `ops-${activity.id}`
-  }
-  return `feed-${activity.project_id}-${activity.what}-${activity.when ?? activity.occurred_at ?? ''}`
 }
 
 function ActivityLine({
@@ -212,6 +242,90 @@ function ActivityLine({
       userButton={userButton}
     />
   )
+}
+
+function ClusterRow({
+  cluster,
+  expanded,
+  onProjectSelect,
+  onToggle,
+  onUserSelect,
+  renderTemplate,
+}: ClusterRowProps) {
+  const { isGroup, lead, meta, tone } = clusterView(cluster)
+
+  return (
+    <div className="border-tertiary relative z-1 border-b py-3 last:border-0">
+      <div className="grid grid-cols-[26px_1fr] gap-x-3">
+        <StatusDot tone={tone} />
+        <div
+          className={`flex items-start gap-2.5 ${isGroup ? 'cursor-pointer' : ''}`}
+          onClick={isGroup ? onToggle : undefined}
+        >
+          <UserIdentity
+            displayName={lead.display_name}
+            email={lead.email_address}
+            hideName
+            linkToProfile={false}
+            size="floating"
+          />
+          <div className="min-w-0 flex-1">
+            {isGroup ? (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-[13.5px] font-semibold">
+                    {lead.display_name}
+                  </span>
+                  <StatusChip label={meta.statusLabel} tone={tone} />
+                  <span className="bg-secondary text-secondary rounded-full px-2 font-mono text-[11px]">
+                    {cluster.items.length}
+                  </span>
+                </div>
+                <div className="text-tertiary mt-0.5 text-[12.5px]">
+                  {meta.summary}
+                </div>
+              </>
+            ) : (
+              <ActivityLine
+                activity={lead}
+                onProjectSelect={onProjectSelect}
+                onUserSelect={onUserSelect}
+                renderTemplate={renderTemplate}
+              />
+            )}
+          </div>
+          <div className="mt-0.5 flex shrink-0 items-center gap-2.5">
+            <RelativeTime
+              className="text-tertiary font-mono text-[11.5px] whitespace-nowrap"
+              value={entryTimeIso(lead)}
+              variant="short"
+            />
+            {isGroup && (
+              <ChevronRight
+                className="text-tertiary size-3.75 transition-transform"
+                style={{ transform: expanded ? 'rotate(90deg)' : 'none' }}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+      {isGroup && expanded && <ClusterEvents items={cluster.items} />}
+    </div>
+  )
+}
+
+function Heading({ hidden }: { hidden?: boolean }) {
+  if (hidden) return null
+  return <h2 className="text-primary text-xl">Recent Activity</h2>
+}
+
+/** Danger clusters auto-expand (mockup's autoExpandFailed) until toggled. */
+function isExpanded(
+  cluster: ActivityCluster<ActivityFeedEntry>,
+  state: Record<string, boolean>,
+): boolean {
+  if (cluster.key in state) return state[cluster.key]
+  return cluster.items.length > 1 && entryTone(cluster.items[0]) === 'danger'
 }
 
 function OpsLogActivityLine({

--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -22,8 +22,8 @@ import {
   entryClusterKey,
   entryTimeIso,
   entryTimeMs,
-  entryTone,
 } from './activityFeed/entryAdapters'
+import { expandableRowProps } from './activityFeed/expandableRow'
 import { sectionByDay } from './activityFeed/grouping'
 import type { ActivityCluster } from './activityFeed/grouping'
 import { renderActivityTemplate } from './activityFeed/renderActivityTemplate'
@@ -260,7 +260,7 @@ function ClusterRow({
         <StatusDot tone={tone} />
         <div
           className={`flex items-start gap-2.5 ${isGroup ? 'cursor-pointer' : ''}`}
-          onClick={isGroup ? onToggle : undefined}
+          {...expandableRowProps(isGroup, expanded, onToggle)}
         >
           <UserIdentity
             displayName={lead.display_name}
@@ -325,7 +325,7 @@ function isExpanded(
   state: Record<string, boolean>,
 ): boolean {
   if (cluster.key in state) return state[cluster.key]
-  return cluster.items.length > 1 && entryTone(cluster.items[0]) === 'danger'
+  return cluster.items.length > 1 && clusterView(cluster).tone === 'danger'
 }
 
 function OpsLogActivityLine({

--- a/src/components/activityFeed/ActivityFilter.tsx
+++ b/src/components/activityFeed/ActivityFilter.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable react-refresh/only-export-components */
+import { Filter } from 'lucide-react'
+
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import type { ActivityFeedEntry } from '@/types'
+
+import { entryIsBot } from './entryAdapters'
+
+export interface ActivityFilterValue {
+  bots: boolean
+  people: boolean
+}
+
+export const ALL_ACTORS: ActivityFilterValue = { bots: true, people: true }
+
+interface ActivityFilterProps {
+  onChange: (value: ActivityFilterValue) => void
+  value: ActivityFilterValue
+}
+
+/** Funnel button + popover matching the mockup's "Filter" control. */
+export function ActivityFilter({ onChange, value }: ActivityFilterProps) {
+  const active = !(value.bots && value.people)
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className="text-secondary hover:bg-secondary relative inline-flex h-7.5 items-center gap-1.5 rounded-md px-2.5 text-[13px] transition-colors"
+          type="button"
+        >
+          <Filter className="size-3.5" />
+          Filter
+          {active && (
+            <span
+              className="size-1.5 rounded-full"
+              style={{ background: 'var(--ds-action-bg)' }}
+            />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-44 p-2">
+        <p className="text-tertiary px-1 pb-1.5 text-[11px] font-semibold tracking-wider uppercase">
+          Show
+        </p>
+        <FilterRow
+          checked={value.people}
+          label="People"
+          onToggle={(v) => onChange({ ...value, people: v })}
+        />
+        <FilterRow
+          checked={value.bots}
+          label="Bots"
+          onToggle={(v) => onChange({ ...value, bots: v })}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/** Filter already-loaded entries by actor kind (client-side only). */
+export function filterEntries(
+  entries: ActivityFeedEntry[],
+  value: ActivityFilterValue,
+): ActivityFeedEntry[] {
+  if (value.bots && value.people) return entries
+  return entries.filter((entry) =>
+    entryIsBot(entry) ? value.bots : value.people,
+  )
+}
+
+function FilterRow({
+  checked,
+  label,
+  onToggle,
+}: {
+  checked: boolean
+  label: string
+  onToggle: (value: boolean) => void
+}) {
+  return (
+    <label className="hover:bg-secondary flex cursor-pointer items-center gap-2 rounded-sm px-1 py-1.5 text-sm">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={(state) => onToggle(state === true)}
+      />
+      {label}
+    </label>
+  )
+}

--- a/src/components/activityFeed/ClusterEvents.tsx
+++ b/src/components/activityFeed/ClusterEvents.tsx
@@ -1,0 +1,52 @@
+import { RelativeTime } from '@/components/ui/RelativeTime'
+import type { ActivityFeedEntry } from '@/types'
+
+import {
+  entryEventLabel,
+  entryTimeIso,
+  entryTone,
+  entryVerb,
+} from './entryAdapters'
+import { StatusChip } from './StatusChip'
+import { toneStyle } from './tone'
+
+interface ClusterEventsProps {
+  /** Left indent (px) so rows align under the group content, not the rail. */
+  indent?: number
+  /** Cluster members to list, newest-first. */
+  items: ActivityFeedEntry[]
+}
+
+/** The expanded body of a group: one compact row per underlying event. */
+export function ClusterEvents({ indent = 38, items }: ClusterEventsProps) {
+  return (
+    <ul className="mt-2.5 flex flex-col gap-px" style={{ marginLeft: indent }}>
+      {items.map((item, i) => {
+        const tone = entryTone(item)
+        return (
+          <li
+            className="hover:bg-secondary grid grid-cols-[14px_1fr_auto] items-center gap-x-2.5 rounded-md px-2.5 py-1.5"
+            key={`${entryVerb(item)}-${entryTimeIso(item) ?? ''}-${i}`}
+          >
+            <span
+              className="size-1.75 rounded-full"
+              style={{ background: toneStyle(tone).dotVar }}
+            />
+            <span className="text-primary truncate font-mono text-xs">
+              {entryEventLabel(item)}
+            </span>
+            <span className="flex shrink-0 items-center gap-2">
+              <StatusChip label={entryVerb(item)} tone={tone} />
+              <RelativeTime
+                className="text-tertiary font-mono text-[11px]"
+                tooltip={false}
+                value={entryTimeIso(item)}
+                variant="narrow"
+              />
+            </span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/components/activityFeed/ProjectActivityFeed.tsx
+++ b/src/components/activityFeed/ProjectActivityFeed.tsx
@@ -1,0 +1,314 @@
+import { useMemo, useState } from 'react'
+
+import { ChevronRight } from 'lucide-react'
+
+import { RelativeTime } from '@/components/ui/RelativeTime'
+import { Sk } from '@/components/ui/skeleton'
+import { UserIdentity } from '@/components/ui/user-identity'
+import { swatchForName } from '@/lib/chip-colors'
+import type { ActivityFeedEntry } from '@/types'
+
+import { Card } from '../ui/card'
+import { ActivityFilter, ALL_ACTORS, filterEntries } from './ActivityFilter'
+import type { ActivityFilterValue } from './ActivityFilter'
+import { ClusterEvents } from './ClusterEvents'
+import { clusterView } from './clusterView'
+import {
+  ACTIVITY_GROUP_WINDOW_MS,
+  entryClusterKey,
+  entryNamespace,
+  entryProjectName,
+  entryProjectType,
+  entrySummaryText,
+  entryTimeIso,
+  entryTimeMs,
+} from './entryAdapters'
+import type { ClusterMeta } from './entryAdapters'
+import { clusterConsecutive } from './grouping'
+import type { ActivityCluster } from './grouping'
+import { StatusChip, StatusDot } from './StatusChip'
+import type { Tone } from './tone'
+
+interface ProjectActivityFeedProps {
+  activities: ActivityFeedEntry[]
+  isLoading?: boolean
+  isLoadingMore?: boolean
+  onLoadMore?: () => void
+  onProjectSelect?: (projectName: string) => void
+  /** Header subtitle, e.g. "Across all projects · AWeber". */
+  subtitle?: string
+}
+
+interface ProjectClusterRowProps {
+  cluster: ActivityCluster<ActivityFeedEntry>
+  expanded: boolean
+  onProjectSelect?: (projectName: string) => void
+  onToggle: () => void
+}
+
+interface ProjectFeedBodyProps {
+  clusters: ActivityCluster<ActivityFeedEntry>[]
+  expanded: Record<string, boolean>
+  hasActivities: boolean
+  isLoading?: boolean
+  isLoadingMore?: boolean
+  onLoadMore?: () => void
+  onProjectSelect?: (projectName: string) => void
+  onToggle: (key: string) => void
+}
+
+/**
+ * Compact, project-centric activity feed (dashboard widget). Unlike the
+ * full RecentActivity feed this is a flat clustered list (no date sections)
+ * that leads with the project each burst touched.
+ */
+export function ProjectActivityFeed({
+  activities,
+  isLoading,
+  isLoadingMore,
+  onLoadMore,
+  onProjectSelect,
+  subtitle,
+}: ProjectActivityFeedProps) {
+  const [filter, setFilter] = useState<ActivityFilterValue>(ALL_ACTORS)
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+
+  const clusters = useMemo(
+    () =>
+      clusterConsecutive(filterEntries(activities ?? [], filter), {
+        keyOf: entryClusterKey,
+        timeOf: entryTimeMs,
+        windowMs: ACTIVITY_GROUP_WINDOW_MS,
+      }),
+    [activities, filter],
+  )
+
+  const toggle = (key: string) =>
+    setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))
+
+  return (
+    <Card className="flex h-full flex-col overflow-hidden p-0">
+      <div className="border-tertiary flex items-start justify-between border-b px-5 py-4">
+        <div>
+          <div className="text-primary text-[15px] font-semibold">
+            Recent activity
+          </div>
+          {subtitle && (
+            <div className="text-tertiary mt-0.5 text-xs">{subtitle}</div>
+          )}
+        </div>
+        <ActivityFilter onChange={setFilter} value={filter} />
+      </div>
+
+      <div className="relative flex-1 overflow-y-auto px-4 py-1">
+        <ProjectFeedBody
+          clusters={clusters}
+          expanded={expanded}
+          hasActivities={activities.length > 0}
+          isLoading={isLoading}
+          isLoadingMore={isLoadingMore}
+          onLoadMore={onLoadMore}
+          onProjectSelect={onProjectSelect}
+          onToggle={toggle}
+        />
+      </div>
+    </Card>
+  )
+}
+
+function ProjectActorLine({
+  count,
+  isGroup,
+  lead,
+  meta,
+  tone,
+}: {
+  count: number
+  isGroup: boolean
+  lead: ActivityFeedEntry
+  meta: ClusterMeta
+  tone: Tone
+}) {
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-2">
+      <UserIdentity
+        displayName={lead.display_name}
+        email={lead.email_address}
+        hideName
+        linkToProfile={false}
+        size="small"
+      />
+      <span className="text-secondary text-[12.5px]">{lead.display_name}</span>
+      {isGroup && (
+        <>
+          <StatusChip label={meta.statusLabel} tone={tone} />
+          <span className="bg-secondary text-secondary rounded-full px-2 font-mono text-[10.5px]">
+            {count}
+          </span>
+        </>
+      )}
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function ProjectClusterRow({
+  cluster,
+  expanded,
+  onProjectSelect,
+  onToggle,
+}: ProjectClusterRowProps) {
+  const { isGroup, lead, meta, tone } = clusterView(cluster)
+
+  return (
+    <div className="border-tertiary relative z-1 border-b py-3 last:border-0">
+      <div className="grid grid-cols-[18px_1fr_auto] gap-x-3">
+        <StatusDot size={11} tone={tone} />
+        <div
+          className={`min-w-0 ${isGroup ? 'cursor-pointer' : ''}`}
+          onClick={isGroup ? onToggle : undefined}
+        >
+          <ProjectRowHeader entry={lead} onProjectSelect={onProjectSelect} />
+          <ProjectActorLine
+            count={cluster.items.length}
+            isGroup={isGroup}
+            lead={lead}
+            meta={meta}
+            tone={tone}
+          />
+          <div className="text-tertiary mt-1 text-[12.5px]">
+            {isGroup ? meta.summary : entrySummaryText(lead)}
+          </div>
+        </div>
+
+        <div className="mt-px flex shrink-0 items-center gap-2">
+          <RelativeTime
+            className="text-tertiary font-mono text-[11px] whitespace-nowrap"
+            value={entryTimeIso(lead)}
+            variant="narrow"
+          />
+          {isGroup && (
+            <ChevronRight
+              className="text-tertiary size-3.5 transition-transform"
+              style={{ transform: expanded ? 'rotate(90deg)' : 'none' }}
+            />
+          )}
+        </div>
+      </div>
+      {isGroup && expanded && (
+        <ClusterEvents indent={29} items={cluster.items} />
+      )}
+    </div>
+  )
+}
+
+// fallow-ignore-next-line complexity
+function ProjectFeedBody({
+  clusters,
+  expanded,
+  hasActivities,
+  isLoading,
+  isLoadingMore,
+  onLoadMore,
+  onProjectSelect,
+  onToggle,
+}: ProjectFeedBodyProps) {
+  if (isLoading) return <ProjectFeedSkeleton rows={5} />
+  if (clusters.length === 0) {
+    return (
+      <div className="text-tertiary py-10 text-center text-sm">
+        {hasActivities
+          ? 'No activity matches the filter'
+          : 'No recent activity'}
+      </div>
+    )
+  }
+  return (
+    <>
+      <div
+        className="bg-tertiary absolute w-0.5 rounded"
+        style={{ bottom: 20, left: 25, top: 20 }}
+      />
+      {clusters.map((cluster) => (
+        <ProjectClusterRow
+          cluster={cluster}
+          expanded={!!expanded[cluster.key]}
+          key={cluster.key}
+          onProjectSelect={onProjectSelect}
+          onToggle={() => onToggle(cluster.key)}
+        />
+      ))}
+      {isLoadingMore && <ProjectFeedSkeleton rows={2} />}
+      {onLoadMore && !isLoadingMore && (
+        <button
+          className="text-secondary hover:bg-secondary hover:text-primary w-full rounded-md py-2.5 text-center text-[12.5px] font-medium transition-colors"
+          onClick={onLoadMore}
+          type="button"
+        >
+          Load more
+        </button>
+      )}
+    </>
+  )
+}
+
+function ProjectFeedSkeleton({ rows }: { rows: number }) {
+  return (
+    <div aria-hidden className="space-y-3 py-2">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div className="flex gap-3" key={i}>
+          <Sk circle h={11} w={11} />
+          <div className="flex-1 space-y-1.5">
+            <Sk h={13} w="60%" />
+            <Sk h={11} w="40%" />
+          </div>
+          <Sk h={11} w={28} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ProjectRowHeader({
+  entry,
+  onProjectSelect,
+}: {
+  entry: ActivityFeedEntry
+  onProjectSelect?: (projectName: string) => void
+}) {
+  const project = entryProjectName(entry)
+  const projectType = entryProjectType(entry)
+  const namespace = entryNamespace(entry)
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      {project ? (
+        <button
+          className="text-primary hover:text-info truncate text-[13.5px] font-semibold transition-colors"
+          onClick={(e) => {
+            e.stopPropagation()
+            onProjectSelect?.(project)
+          }}
+          type="button"
+        >
+          {project}
+        </button>
+      ) : (
+        <span className="text-primary text-[13.5px] font-semibold">
+          Activity
+        </span>
+      )}
+      {projectType && (
+        <span className="text-tertiary text-[11px]">{projectType}</span>
+      )}
+      {namespace && (
+        <span className="text-tertiary inline-flex items-center gap-1 text-[11px]">
+          <span
+            className="size-1.5 rounded-full"
+            style={{ background: swatchForName(namespace) }}
+          />
+          {namespace}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/activityFeed/ProjectActivityFeed.tsx
+++ b/src/components/activityFeed/ProjectActivityFeed.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
 
 import { RelativeTime } from '@/components/ui/RelativeTime'
-import { Sk } from '@/components/ui/skeleton'
+import { Sk, Swap } from '@/components/ui/skeleton'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { swatchForName } from '@/lib/chip-colors'
 import type { ActivityFeedEntry } from '@/types'
@@ -24,6 +24,7 @@ import {
   entryTimeMs,
 } from './entryAdapters'
 import type { ClusterMeta } from './entryAdapters'
+import { expandableRowProps } from './expandableRow'
 import { clusterConsecutive } from './grouping'
 import type { ActivityCluster } from './grouping'
 import { StatusChip, StatusDot } from './StatusChip'
@@ -31,6 +32,8 @@ import type { Tone } from './tone'
 
 interface ProjectActivityFeedProps {
   activities: ActivityFeedEntry[]
+  /** Query failed — render a placeholder instead of an empty feed. */
+  isError?: boolean
   isLoading?: boolean
   isLoadingMore?: boolean
   onLoadMore?: () => void
@@ -50,6 +53,7 @@ interface ProjectFeedBodyProps {
   clusters: ActivityCluster<ActivityFeedEntry>[]
   expanded: Record<string, boolean>
   hasActivities: boolean
+  isError?: boolean
   isLoading?: boolean
   isLoadingMore?: boolean
   onLoadMore?: () => void
@@ -64,6 +68,7 @@ interface ProjectFeedBodyProps {
  */
 export function ProjectActivityFeed({
   activities,
+  isError,
   isLoading,
   isLoadingMore,
   onLoadMore,
@@ -105,6 +110,7 @@ export function ProjectActivityFeed({
           clusters={clusters}
           expanded={expanded}
           hasActivities={activities.length > 0}
+          isError={isError}
           isLoading={isLoading}
           isLoadingMore={isLoadingMore}
           onLoadMore={onLoadMore}
@@ -166,7 +172,7 @@ function ProjectClusterRow({
         <StatusDot size={11} tone={tone} />
         <div
           className={`min-w-0 ${isGroup ? 'cursor-pointer' : ''}`}
-          onClick={isGroup ? onToggle : undefined}
+          {...expandableRowProps(isGroup, expanded, onToggle)}
         >
           <ProjectRowHeader entry={lead} onProjectSelect={onProjectSelect} />
           <ProjectActorLine
@@ -202,18 +208,36 @@ function ProjectClusterRow({
   )
 }
 
+function ProjectFeedBody({ isLoading, ...rest }: ProjectFeedBodyProps) {
+  return (
+    <Swap
+      delay={50}
+      ready={!isLoading}
+      skeleton={<ProjectFeedSkeleton rows={5} />}
+    >
+      <ProjectFeedContent {...rest} />
+    </Swap>
+  )
+}
+
 // fallow-ignore-next-line complexity
-function ProjectFeedBody({
+function ProjectFeedContent({
   clusters,
   expanded,
   hasActivities,
-  isLoading,
+  isError,
   isLoadingMore,
   onLoadMore,
   onProjectSelect,
   onToggle,
-}: ProjectFeedBodyProps) {
-  if (isLoading) return <ProjectFeedSkeleton rows={5} />
+}: Omit<ProjectFeedBodyProps, 'isLoading'>) {
+  if (isError) {
+    return (
+      <div className="text-tertiary py-10 text-center text-sm">
+        Activity unavailable
+      </div>
+    )
+  }
   if (clusters.length === 0) {
     return (
       <div className="text-tertiary py-10 text-center text-sm">
@@ -252,15 +276,20 @@ function ProjectFeedBody({
   )
 }
 
+/** Footprint mirrors ProjectClusterRow: dot · header/actor/summary · time. */
 function ProjectFeedSkeleton({ rows }: { rows: number }) {
   return (
     <div aria-hidden className="space-y-3 py-2">
       {Array.from({ length: rows }).map((_, i) => (
-        <div className="flex gap-3" key={i}>
+        <div className="grid grid-cols-[18px_1fr_auto] gap-x-3" key={i}>
           <Sk circle h={11} w={11} />
-          <div className="flex-1 space-y-1.5">
-            <Sk h={13} w="60%" />
-            <Sk h={11} w="40%" />
+          <div className="min-w-0 space-y-1.5">
+            <Sk h={13} w="45%" />
+            <div className="flex items-center gap-2">
+              <Sk circle h={16} w={16} />
+              <Sk h={11} w="30%" />
+            </div>
+            <Sk h={11} w="60%" />
           </div>
           <Sk h={11} w={28} />
         </div>

--- a/src/components/activityFeed/StatusChip.tsx
+++ b/src/components/activityFeed/StatusChip.tsx
@@ -1,0 +1,41 @@
+import { toneStyle } from './tone'
+import type { Tone } from './tone'
+
+interface StatusChipProps {
+  label: string
+  tone: Tone
+}
+
+interface StatusDotProps {
+  /** Diameter in px. */
+  size?: number
+  tone: Tone
+}
+
+/** Pill with a leading dot + status verb, e.g. ● deployed. */
+export function StatusChip({ label, tone }: StatusChipProps) {
+  const { chip, dotVar } = toneStyle(tone)
+  return (
+    <span
+      className={`inline-flex h-5 items-center gap-1.5 rounded-sm px-2 text-[11px] font-semibold ${chip}`}
+    >
+      <span className="size-1.5 rounded-full" style={{ background: dotVar }} />
+      {label}
+    </span>
+  )
+}
+
+/** Timeline node marker: a tone-colored dot ringed by the surface color. */
+export function StatusDot({ size = 12, tone }: StatusDotProps) {
+  return (
+    <span
+      className="bg-primary block shrink-0 rounded-full"
+      style={{
+        background: toneStyle(tone).dotVar,
+        boxShadow: '0 0 0 3px var(--ds-bg-primary)',
+        height: size,
+        width: size,
+      }}
+    />
+  )
+}

--- a/src/components/activityFeed/__tests__/RecentActivityGrouping.test.tsx
+++ b/src/components/activityFeed/__tests__/RecentActivityGrouping.test.tsx
@@ -1,0 +1,90 @@
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import { render, screen } from '@/test/utils'
+import type { OperationsLogEntry } from '@/types'
+
+import { RecentActivity } from '../../RecentActivity'
+
+// Same actor + project, close in time -> one cluster. `iso` drives both the
+// occurred_at and the grouping window.
+function ops(
+  iso: string,
+  overrides: Partial<OperationsLogEntry> = {},
+): OperationsLogEntry {
+  return {
+    change_type: 'Deployed',
+    description: '',
+    display_name: 'deployer[bot]',
+    email_address: 'deployer@aweber.com',
+    environment: 'production',
+    id: Math.floor(Math.random() * 1e9),
+    occurred_at: iso,
+    project_id: 1,
+    project_name: 'ai-content',
+    recorded_at: iso,
+    recorded_by: 'deployer',
+    type: 'OperationsLogEntry',
+    version: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(endpoints, 'listPluginOpsLogTemplates').mockResolvedValue([])
+})
+
+describe('RecentActivity grouping', () => {
+  it('collapses a same-actor burst into one expandable group', async () => {
+    render(
+      <RecentActivity
+        activities={[
+          ops('2026-05-12T02:24:00.000Z'),
+          ops('2026-05-12T02:20:00.000Z'),
+          ops('2026-05-12T02:16:00.000Z'),
+        ]}
+      />,
+    )
+    // Group header: count badge + breakdown summary, collapsed by default.
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('3 deployed')).toBeInTheDocument()
+    // Detail rows (environment label) are hidden until expanded.
+    expect(screen.queryByText('production')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('3 deployed'))
+    // Expanded: one detail row per underlying event.
+    expect(screen.getAllByText('production')).toHaveLength(3)
+  })
+
+  it('does not group unrelated actors', () => {
+    render(
+      <RecentActivity
+        activities={[
+          ops('2026-05-12T02:24:00.000Z', {
+            display_name: 'Alex S',
+            email_address: 'alexs@aweber.com',
+          }),
+          ops('2026-05-12T02:20:00.000Z'),
+        ]}
+      />,
+    )
+    // Two single rows -> two sentences, no count badge.
+    expect(screen.queryByText('2 deployed')).not.toBeInTheDocument()
+    expect(screen.getByText('Alex S')).toBeInTheDocument()
+  })
+
+  it('auto-expands a failed (danger) group', () => {
+    render(
+      <RecentActivity
+        activities={[
+          ops('2026-05-12T02:24:00.000Z', { change_type: 'Rolled Back' }),
+          ops('2026-05-12T02:20:00.000Z', { change_type: 'Rolled Back' }),
+        ]}
+      />,
+    )
+    // Danger clusters start expanded, so detail rows render without a click.
+    expect(screen.getAllByText('production').length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/activityFeed/__tests__/grouping.test.ts
+++ b/src/components/activityFeed/__tests__/grouping.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { clusterConsecutive, sectionByDay } from '../grouping'
+
+interface Item {
+  actor: string
+  t: number
+}
+
+const HOUR = 60 * 60 * 1000
+const opts = {
+  keyOf: (i: Item) => i.actor,
+  timeOf: (i: Item) => i.t,
+  windowMs: HOUR,
+}
+
+// Build timestamps from LOCAL date components so bucketing (which uses local
+// calendar days) is independent of the test runner's timezone.
+function local(y: number, mo: number, d: number, h = 0, mi = 0): number {
+  return new Date(y, mo - 1, d, h, mi).getTime()
+}
+
+describe('clusterConsecutive', () => {
+  it('groups adjacent same-key items within the window', () => {
+    const items: Item[] = [
+      { actor: 'bot', t: local(2026, 7, 17, 10, 0) },
+      { actor: 'bot', t: local(2026, 7, 17, 9, 50) },
+      { actor: 'bot', t: local(2026, 7, 17, 9, 40) },
+    ]
+    const clusters = clusterConsecutive(items, opts)
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0].items).toHaveLength(3)
+    expect(clusters[0].newest).toBe(local(2026, 7, 17, 10, 0))
+    expect(clusters[0].oldest).toBe(local(2026, 7, 17, 9, 40))
+  })
+
+  it('splits when the actor changes', () => {
+    const items: Item[] = [
+      { actor: 'a', t: local(2026, 7, 17, 10, 0) },
+      { actor: 'b', t: local(2026, 7, 17, 9, 55) },
+      { actor: 'a', t: local(2026, 7, 17, 9, 50) },
+    ]
+    const clusters = clusterConsecutive(items, opts)
+    expect(clusters).toHaveLength(3)
+    expect(clusters.map((c) => c.items.length)).toEqual([1, 1, 1])
+  })
+
+  it('splits same-actor items separated by more than the window', () => {
+    const items: Item[] = [
+      { actor: 'a', t: local(2026, 7, 17, 10, 0) },
+      { actor: 'a', t: local(2026, 7, 17, 8, 0) },
+    ]
+    const clusters = clusterConsecutive(items, opts)
+    expect(clusters).toHaveLength(2)
+  })
+
+  it('keeps distinct keys across separate clusters (unique React keys)', () => {
+    const items: Item[] = [
+      { actor: 'a', t: local(2026, 7, 17, 10, 0) },
+      { actor: 'b', t: local(2026, 7, 17, 9, 0) },
+      { actor: 'a', t: local(2026, 7, 17, 8, 0) },
+    ]
+    const keys = clusterConsecutive(items, opts).map((c) => c.key)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('returns an empty list for no items', () => {
+    expect(clusterConsecutive([], opts)).toEqual([])
+  })
+})
+
+describe('sectionByDay', () => {
+  const now = local(2026, 7, 17, 12, 0)
+
+  it('buckets by local day and labels Today/Yesterday', () => {
+    const items: Item[] = [
+      { actor: 'a', t: local(2026, 7, 17, 10, 0) },
+      { actor: 'a', t: local(2026, 7, 16, 10, 0) },
+    ]
+    const sections = sectionByDay(items, { ...opts, now })
+    expect(sections).toHaveLength(2)
+    expect(sections[0].label).toBe('Today')
+    expect(sections[1].label).toBe('Yesterday')
+  })
+
+  it('does not cluster across a day boundary even within the window', () => {
+    const items: Item[] = [
+      { actor: 'a', t: local(2026, 7, 17, 0, 10) },
+      { actor: 'a', t: local(2026, 7, 16, 23, 50) },
+    ]
+    const sections = sectionByDay(items, { ...opts, now })
+    // 20 min apart but different days -> two sections, each a single cluster.
+    expect(sections).toHaveLength(2)
+    expect(sections[0].clusters).toHaveLength(1)
+    expect(sections[1].clusters).toHaveLength(1)
+  })
+})

--- a/src/components/activityFeed/clusterView.ts
+++ b/src/components/activityFeed/clusterView.ts
@@ -1,0 +1,23 @@
+import type { ActivityFeedEntry } from '@/types'
+
+import { clusterMeta, entryTone } from './entryAdapters'
+import type { ClusterMeta } from './entryAdapters'
+import type { ActivityCluster } from './grouping'
+import type { Tone } from './tone'
+
+export interface ClusterView {
+  isGroup: boolean
+  lead: ActivityFeedEntry
+  meta: ClusterMeta
+  tone: Tone
+}
+
+/** Shared view-model for a cluster row: is it a group, its lead entry, roll-up, and tone. */
+export function clusterView(
+  cluster: ActivityCluster<ActivityFeedEntry>,
+): ClusterView {
+  const isGroup = cluster.items.length > 1
+  const lead = cluster.items[0]
+  const meta = clusterMeta(cluster.items, true)
+  return { isGroup, lead, meta, tone: isGroup ? meta.tone : entryTone(lead) }
+}

--- a/src/components/activityFeed/entryAdapters.ts
+++ b/src/components/activityFeed/entryAdapters.ts
@@ -1,0 +1,148 @@
+// Adapters that project the flat `ActivityFeedEntry` union onto the generic
+// grouping primitives, plus per-entry and per-cluster presentation helpers
+// (tone, status verb, cluster summary). Kept free of JSX so it stays unit
+// testable alongside grouping.ts.
+
+import { isBotActor } from '@/components/ui/user-identity'
+import type { ActivityFeedEntry, OperationsLogEntry } from '@/types'
+
+import type { Tone } from './tone'
+
+/**
+ * Window within which consecutive same-actor+project entries collapse into one
+ * group. A backend correlation/run id would make this exact; until then an
+ * hour approximates a "burst" (a CI run, a config edit session).
+ */
+export const ACTIVITY_GROUP_WINDOW_MS = 60 * 60 * 1000
+
+/** Actor + project so a CI burst on one project groups but unrelated work does not. */
+export function entryClusterKey(entry: ActivityFeedEntry): string {
+  const actor = (entry.email_address || entry.display_name || '').toLowerCase()
+  const project = entry.project_name ?? `#${entry.project_id ?? ''}`
+  return `${actor}|${project}`
+}
+
+export function entryIsBot(entry: ActivityFeedEntry): boolean {
+  return isBotActor(entry.display_name) || isBotActor(entry.email_address)
+}
+
+export function entryProjectName(entry: ActivityFeedEntry): null | string {
+  return entry.project_name ?? null
+}
+
+export function entryTimeIso(entry: ActivityFeedEntry): string | undefined {
+  return (
+    entry.occurred_at ??
+    (entry.type === 'ProjectFeedEntry' ? entry.when : undefined) ??
+    undefined
+  )
+}
+
+export function entryTimeMs(entry: ActivityFeedEntry): number {
+  const iso =
+    entry.occurred_at ??
+    (entry.type === 'ProjectFeedEntry' ? entry.when : undefined)
+  const ms = iso ? Date.parse(iso) : NaN
+  return Number.isFinite(ms) ? ms : 0
+}
+
+const CHANGE_TYPE_TONE: Record<OperationsLogEntry['change_type'], Tone> = {
+  Configured: 'neutral',
+  Decommissioned: 'danger',
+  Deployed: 'success',
+  Migrated: 'info',
+  Provisioned: 'info',
+  Restarted: 'info',
+  'Rolled Back': 'danger',
+  Scaled: 'info',
+  Upgraded: 'info',
+}
+
+export interface ClusterMeta {
+  statusLabel: string
+  /** e.g. "3 activities" or (breakdown) "2 deployed · 1 configured". */
+  summary: string
+  tone: Tone
+}
+
+/**
+ * Roll a cluster's members up into a single tone + status label + summary.
+ * `showBreakdown` swaps the plain count for a per-verb breakdown.
+ */
+export function clusterMeta(
+  items: ActivityFeedEntry[],
+  showBreakdown: boolean,
+): ClusterMeta {
+  const tones = items.map(entryTone)
+  const tone: Tone = tones.includes('danger')
+    ? 'danger'
+    : tones.every((t) => t === 'success')
+      ? 'success'
+      : entryTone(items[0])
+
+  const verbCounts = new Map<string, number>()
+  for (const item of items) {
+    const verb = entryVerb(item)
+    verbCounts.set(verb, (verbCounts.get(verb) ?? 0) + 1)
+  }
+  const statusLabel = verbCounts.size === 1 ? entryVerb(items[0]) : 'activity'
+
+  let summary: string
+  if (showBreakdown) {
+    summary = [...verbCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([verb, count]) => `${count} ${verb}`)
+      .join(' · ')
+  } else {
+    summary = `${items.length} activities`
+  }
+  return { statusLabel, summary, tone }
+}
+
+/** Compact "target" label for an expanded event row (environment/version/type). */
+export function entryEventLabel(entry: ActivityFeedEntry): string {
+  if (entry.type === 'OperationsLogEntry') {
+    if (entry.environment) {
+      return entry.version
+        ? `${entry.environment} · ${entry.version}`
+        : entry.environment
+    }
+    return entry.version ?? entry.change_type
+  }
+  return entry.project_type || entry.what
+}
+
+/** Namespace/team label for the widget header, when the entry carries one. */
+export function entryNamespace(entry: ActivityFeedEntry): null | string {
+  return entry.type === 'ProjectFeedEntry' ? (entry.namespace ?? null) : null
+}
+
+/** Project type label for the widget header, when the entry carries one. */
+export function entryProjectType(entry: ActivityFeedEntry): null | string {
+  return entry.type === 'ProjectFeedEntry' ? (entry.project_type ?? null) : null
+}
+
+/** One-line action summary for a single row, without repeating the project. */
+export function entrySummaryText(entry: ActivityFeedEntry): string {
+  if (entry.type === 'OperationsLogEntry') {
+    const parts = [entry.change_type.toLowerCase()]
+    if (entry.version) parts.push(entry.version)
+    if (entry.environment) parts.push(`to ${entry.environment}`)
+    return parts.join(' ')
+  }
+  return entry.what === 'updated facts' ? 'updated facts' : entry.what
+}
+
+export function entryTone(entry: ActivityFeedEntry): Tone {
+  if (entry.type === 'OperationsLogEntry') {
+    return CHANGE_TYPE_TONE[entry.change_type] ?? 'neutral'
+  }
+  return entry.what === 'created' ? 'accent' : 'neutral'
+}
+
+/** Short verb for a status chip, e.g. "deployed", "created", "updated facts". */
+export function entryVerb(entry: ActivityFeedEntry): string {
+  return entry.type === 'OperationsLogEntry'
+    ? entry.change_type.toLowerCase()
+    : entry.what
+}

--- a/src/components/activityFeed/expandableRow.ts
+++ b/src/components/activityFeed/expandableRow.ts
@@ -1,0 +1,26 @@
+import type { HTMLAttributes, KeyboardEvent } from 'react'
+
+/**
+ * Interactive attributes that make a clustered feed row expandable by both
+ * pointer and keyboard (Enter/Space). Single-item rows get nothing
+ * interactive, so they stay out of the tab order.
+ */
+export function expandableRowProps(
+  isGroup: boolean,
+  expanded: boolean,
+  onToggle: () => void,
+): HTMLAttributes<HTMLDivElement> {
+  if (!isGroup) return {}
+  return {
+    'aria-expanded': expanded,
+    onClick: onToggle,
+    onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        onToggle()
+      }
+    },
+    role: 'button',
+    tabIndex: 0,
+  }
+}

--- a/src/components/activityFeed/grouping.ts
+++ b/src/components/activityFeed/grouping.ts
@@ -1,0 +1,117 @@
+// Client-side grouping for activity feeds. The feed API returns a flat,
+// newest-first list with no correlation/run id, so we approximate the
+// "grouped run" shape from the mockups by clustering *consecutive* entries
+// that share a key (actor + project) and fall within a time window of each
+// other. A cluster of one renders as a single row; two or more collapse into
+// an expandable group. See docs note in RecentActivity.tsx for where a
+// backend `group_id` would replace this heuristic.
+
+export interface ActivityCluster<T> {
+  /** Cluster members, preserving the input (newest-first) order. */
+  items: T[]
+  /** Stable key for React lists and expand/collapse state. */
+  key: string
+  /** Newest member timestamp (ms since epoch). */
+  newest: number
+  /** Oldest member timestamp (ms since epoch). */
+  oldest: number
+}
+
+export interface DaySection<T> {
+  clusters: ActivityCluster<T>[]
+  /** Local calendar-day key, e.g. `2026-07-16`. */
+  key: string
+  /** Human label: "Today", "Yesterday", "Jul 16", or "May 12, 2026". */
+  label: string
+}
+
+interface ClusterOptions<T> {
+  /** Members are grouped only when this key matches the running cluster. */
+  keyOf: (item: T) => string
+  /** Milliseconds since epoch for an item. */
+  timeOf: (item: T) => number
+  /** Max gap between adjacent members of one cluster. */
+  windowMs: number
+}
+
+/**
+ * Cluster a newest-first list into runs of adjacent, same-key items whose
+ * neighbours are within `windowMs` of each other. Order is preserved.
+ */
+export function clusterConsecutive<T>(
+  items: T[],
+  { keyOf, timeOf, windowMs }: ClusterOptions<T>,
+): ActivityCluster<T>[] {
+  const clusters: ActivityCluster<T>[] = []
+  let seq = 0
+  for (const item of items) {
+    const key = keyOf(item)
+    const time = timeOf(item)
+    const current = clusters[clusters.length - 1]
+    const groupKey = current?.key.slice(0, current.key.lastIndexOf('#'))
+    if (current && groupKey === key && current.oldest - time <= windowMs) {
+      current.items.push(item)
+      current.oldest = Math.min(current.oldest, time)
+      current.newest = Math.max(current.newest, time)
+    } else {
+      clusters.push({
+        items: [item],
+        key: `${key}#${seq++}`,
+        newest: time,
+        oldest: time,
+      })
+    }
+  }
+  return clusters
+}
+
+/**
+ * Bucket a newest-first list by local calendar day, then cluster within each
+ * day. Sectioning first keeps clusters from straddling midnight.
+ */
+export function sectionByDay<T>(
+  items: T[],
+  options: ClusterOptions<T> & { now?: number },
+): DaySection<T>[] {
+  const now = options.now ?? Date.now()
+  const sections: DaySection<T>[] = []
+  const byKey = new Map<string, DaySection<T>>()
+  for (const item of items) {
+    const day = new Date(options.timeOf(item))
+    const key = dayKey(day)
+    let section = byKey.get(key)
+    if (!section) {
+      section = { clusters: [], key, label: dayLabel(day, now) }
+      byKey.set(key, section)
+      sections.push(section)
+    }
+    section.clusters.push(item as never)
+  }
+  // The bucket temporarily holds raw items in `clusters`; cluster them now.
+  for (const section of sections) {
+    section.clusters = clusterConsecutive(
+      section.clusters as unknown as T[],
+      options,
+    )
+  }
+  return sections
+}
+
+function dayKey(d: Date): string {
+  const m = `${d.getMonth() + 1}`.padStart(2, '0')
+  const day = `${d.getDate()}`.padStart(2, '0')
+  return `${d.getFullYear()}-${m}-${day}`
+}
+
+function dayLabel(d: Date, now: number): string {
+  const today = new Date(now)
+  if (dayKey(d) === dayKey(today)) return 'Today'
+  const yesterday = new Date(now)
+  yesterday.setDate(yesterday.getDate() - 1)
+  if (dayKey(d) === dayKey(yesterday)) return 'Yesterday'
+  return d.toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    ...(d.getFullYear() === today.getFullYear() ? {} : { year: 'numeric' }),
+  })
+}

--- a/src/components/activityFeed/tone.ts
+++ b/src/components/activityFeed/tone.ts
@@ -1,0 +1,40 @@
+// Semantic tone → design-system classes/vars for activity status markers.
+// Chip classes use the per-utility DS colors (bg-*/text-*); dot colors are
+// saturated CSS vars that read on both themes without per-theme overrides.
+
+export type Tone =
+  | 'accent'
+  | 'danger'
+  | 'info'
+  | 'neutral'
+  | 'success'
+  | 'warning'
+
+export interface ToneStyle {
+  /** Tailwind classes for a status chip background + text. */
+  chip: string
+  /** CSS value for a status dot background. */
+  dotVar: string
+}
+
+const TONE_STYLES: Record<Tone, ToneStyle> = {
+  accent: { chip: 'bg-accent text-accent', dotVar: 'var(--ds-text-accent)' },
+  danger: { chip: 'bg-danger text-danger', dotVar: 'var(--ds-text-danger)' },
+  info: { chip: 'bg-info text-info', dotVar: 'var(--color-activity-info-dot)' },
+  neutral: {
+    chip: 'bg-secondary text-tertiary',
+    dotVar: 'var(--color-activity-neutral-dot)',
+  },
+  success: {
+    chip: 'bg-success text-success',
+    dotVar: 'var(--ds-text-success)',
+  },
+  warning: {
+    chip: 'bg-warning text-warning',
+    dotVar: 'var(--color-activity-warning-dot)',
+  },
+}
+
+export function toneStyle(tone: Tone): ToneStyle {
+  return TONE_STYLES[tone]
+}

--- a/src/components/dashboard/widgets/ProjectActivityWidget.tsx
+++ b/src/components/dashboard/widgets/ProjectActivityWidget.tsx
@@ -18,6 +18,7 @@ export function ProjectActivityWidget({
     data: activityData,
     fetchNextPage,
     hasNextPage,
+    isError,
     isFetchingNextPage,
     isLoading,
   } = useInfiniteActivityFeed(orgSlug)
@@ -30,6 +31,7 @@ export function ProjectActivityWidget({
     <div className="h-full">
       <ProjectActivityFeed
         activities={activityData?.activities ?? []}
+        isError={isError}
         isLoading={isLoading}
         isLoadingMore={isFetchingNextPage}
         onLoadMore={hasNextPage ? () => fetchNextPage() : undefined}

--- a/src/components/dashboard/widgets/ProjectActivityWidget.tsx
+++ b/src/components/dashboard/widgets/ProjectActivityWidget.tsx
@@ -1,0 +1,41 @@
+import { useOrganization } from '@/contexts/OrganizationContext'
+import { useInfiniteActivityFeed } from '@/hooks/useInfiniteActivityFeed'
+
+import { ProjectActivityFeed } from '../../activityFeed/ProjectActivityFeed'
+
+interface ProjectActivityWidgetProps {
+  onProjectSelect?: (projectName: string) => void
+}
+
+// Thin data-wiring wrapper (mirrors RecentActivityWidget).
+// fallow-ignore-next-line complexity
+export function ProjectActivityWidget({
+  onProjectSelect,
+}: ProjectActivityWidgetProps) {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
+  const {
+    data: activityData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useInfiniteActivityFeed(orgSlug)
+
+  const subtitle = selectedOrganization?.name
+    ? `Across all projects · ${selectedOrganization.name}`
+    : 'Across all projects'
+
+  return (
+    <div className="h-full">
+      <ProjectActivityFeed
+        activities={activityData?.activities ?? []}
+        isLoading={isLoading}
+        isLoadingMore={isFetchingNextPage}
+        onLoadMore={hasNextPage ? () => fetchNextPage() : undefined}
+        onProjectSelect={onProjectSelect}
+        subtitle={subtitle}
+      />
+    </div>
+  )
+}

--- a/src/components/ui/user-identity.tsx
+++ b/src/components/ui/user-identity.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useEffect, useState } from 'react'
 
 import { Link } from 'react-router-dom'
@@ -59,6 +60,11 @@ const SIZES: Record<Size, SizeSpec> = {
   large: { av: 44, font: 17, gap: 12, sub: true, weight: 600 },
   medium: { av: 28, font: 14, gap: 9, sub: true, weight: 500 },
   small: { av: 20, font: 13.5, gap: 7, sub: false, weight: 500 },
+}
+
+/** Whether an actor login/name reads as a bot or automation account. */
+export function isBotActor(value: null | string | undefined): boolean {
+  return value != null && BOT_PATTERN.test(value)
 }
 
 /**
@@ -255,11 +261,6 @@ function initialsOf(name: null | string): string {
     return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
   }
   return (parts[0]?.[0] ?? '?').toUpperCase()
-}
-
-/** Whether an actor login/name reads as a bot or automation account. */
-function isBotActor(value: null | string | undefined): boolean {
-  return value != null && BOT_PATTERN.test(value)
 }
 
 /** Resolve the rendered display name from the available identity fields. */

--- a/src/pages/UserProfile/RecentActivity.tsx
+++ b/src/pages/UserProfile/RecentActivity.tsx
@@ -1,11 +1,18 @@
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
 
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { Activity, ChevronRight } from 'lucide-react'
+
+import { ACTIVITY_GROUP_WINDOW_MS } from '@/components/activityFeed/entryAdapters'
+import { clusterConsecutive } from '@/components/activityFeed/grouping'
+import type { ActivityCluster } from '@/components/activityFeed/grouping'
 import { Button } from '@/components/ui/button'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { Sk } from '@/components/ui/skeleton'
 
 import { ActivityRow } from './ActivityRow'
 import { fetchActivity } from './api'
-import type { ActivityResponse } from './api'
+import type { ActivityRecord, ActivityResponse } from './api'
 
 type ActivityPage = { data: ActivityResponse; nextCursor: null | string }
 
@@ -13,6 +20,7 @@ interface RecentActivityProps {
   email: string
 }
 
+// fallow-ignore-next-line complexity
 export function RecentActivity({ email }: RecentActivityProps) {
   const {
     data,
@@ -35,7 +43,25 @@ export function RecentActivity({ email }: RecentActivityProps) {
     queryKey: ['user-activity', email],
   })
 
-  const records = data?.pages.flatMap((p) => p.data.data) ?? []
+  const records = useMemo(
+    () => data?.pages.flatMap((p) => p.data.data) ?? [],
+    [data],
+  )
+
+  // Single-user feed: cluster consecutive same-source+type bursts (e.g. a run
+  // of deploys) into one collapsible group, mirroring the dashboard grouping.
+  const clusters = useMemo(
+    () =>
+      clusterConsecutive(records, {
+        keyOf: (r) => `${r.source}|${r.type}|${r.project_slug ?? ''}`,
+        timeOf: (r) => {
+          const ms = Date.parse(r.occurred_at)
+          return Number.isFinite(ms) ? ms : 0
+        },
+        windowMs: ACTIVITY_GROUP_WINDOW_MS,
+      }),
+    [records],
+  )
 
   return (
     <section className="border-tertiary bg-primary rounded-md border p-4">
@@ -47,13 +73,7 @@ export function RecentActivity({ email }: RecentActivityProps) {
       {!isLoading && !error && records.length === 0 && (
         <p className="text-tertiary text-xs">No recent activity.</p>
       )}
-      <ul className="divide-tertiary divide-y">
-        {records.map((record) => (
-          <li key={`${record.source}-${record.id}`}>
-            <ActivityRow record={record} />
-          </li>
-        ))}
-      </ul>
+      <ClusterList clusters={clusters} />
       {isFetchingNextPage && <ActivityRowsSkeleton rows={3} />}
       {hasNextPage && !isFetchingNextPage && (
         <div className="mt-3 flex justify-center">
@@ -63,6 +83,56 @@ export function RecentActivity({ email }: RecentActivityProps) {
         </div>
       )}
     </section>
+  )
+}
+
+function ActivityGroup({
+  cluster,
+}: {
+  cluster: ActivityCluster<ActivityRecord>
+}) {
+  const [open, setOpen] = useState(false)
+  const lead = cluster.items[0]
+  return (
+    <div className="py-2">
+      <button
+        aria-expanded={open}
+        className="hover:bg-secondary flex w-full items-start gap-3 rounded-sm text-left"
+        onClick={() => setOpen((v) => !v)}
+        type="button"
+      >
+        <span className="text-tertiary mt-0.5 shrink-0">
+          <Activity className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-primary text-sm">
+            {cluster.items.length} {lead.type} activities
+          </p>
+          <p className="text-tertiary mt-0.5 flex flex-wrap items-center gap-2 text-xs">
+            <RelativeTime
+              tooltip={false}
+              value={new Date(cluster.newest).toISOString()}
+            />
+            <span className="border-tertiary rounded-sm border px-1.5 py-0.5">
+              {lead.type}
+            </span>
+          </p>
+        </div>
+        <ChevronRight
+          className="text-tertiary mt-0.5 size-4 shrink-0 transition-transform"
+          style={{ transform: open ? 'rotate(90deg)' : 'none' }}
+        />
+      </button>
+      {open && (
+        <ul className="divide-tertiary border-tertiary mt-1 ml-7 divide-y border-l pl-3">
+          {cluster.items.map((record) => (
+            <li key={rowKey(record)}>
+              <ActivityRow record={record} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   )
 }
 
@@ -83,4 +153,30 @@ function ActivityRowsSkeleton({ rows }: { rows: number }) {
       ))}
     </div>
   )
+}
+
+function ClusterList({
+  clusters,
+}: {
+  clusters: ActivityCluster<ActivityRecord>[]
+}) {
+  return (
+    <ul className="divide-tertiary divide-y">
+      {clusters.map((cluster) =>
+        cluster.items.length === 1 ? (
+          <li key={rowKey(cluster.items[0])}>
+            <ActivityRow record={cluster.items[0]} />
+          </li>
+        ) : (
+          <li key={cluster.key}>
+            <ActivityGroup cluster={cluster} />
+          </li>
+        ),
+      )}
+    </ul>
+  )
+}
+
+function rowKey(record: ActivityRecord): string {
+  return `${record.source}-${record.id}`
 }


### PR DESCRIPTION
## Summary

Redesigns the recent-activity feeds to collapse and group related events, per the Claude Design mockups (`Recent Activity Grouped` and `Recent Activity Widget`).

## Problem

The activity feeds render as a flat, ungrouped list. A burst of related events — a CI/CD run, a config-edit session, a series of deploys — shows as many separate rows, which is noisy and hard to scan.

## Solution

Introduces a shared `activityFeed` library and applies it across three feeds:

- **Shared library** (`src/components/activityFeed/`): generic consecutive-cluster grouping + day sectioning (`grouping.ts`), `ActivityFeedEntry` adapters and cluster roll-ups (`entryAdapters.ts`, `clusterView.ts`), tone mapping and status atoms (`tone.ts`, `StatusChip.tsx`, `ClusterEvents.tsx`), and a client-side actor (people/bots) filter (`ActivityFilter.tsx`).
- **Dashboard Recent Activity** (mockup #1): date-sectioned timeline with collapsible groups (status chip, count, breakdown summary, expand-to-detail). Single entries keep their existing clickable sentence rendering; failed/danger groups auto-expand.
- **Project Activity** (mockup #2): a new, compact project-centric dashboard widget registered in the widget selector.
- **User profile feed** (mockup #3): groups consecutive same-source/type bursts into collapsible rows.

Also unhides the pre-existing (hidden) `recent-activity` widget so the redesigned feed is selectable.

### Note on grouping fidelity

The `/activity-feed` API has no correlation/run id, so groups are **approximated client-side** by clustering consecutive same-actor+project entries within a time window. The mockups' exact per-run breakdowns ("1 failed · 6 skipped") need a backend `group_id`; the code notes where that would slot in. Grouping degrades to a plain "N activities" summary today.

## Testing

- `npm run test` — full suite green (554 → 557 tests); adds `grouping.test.ts` and `RecentActivityGrouping.test.tsx` (clustering, collapse/expand, auto-expand, single-row preservation).
- `tsc --noEmit`, `oxlint`, `oxfmt`, and the `fallow` audit gate all pass.

Not yet done: live in-app visual verification against the mockups (requires the running stack with seeded activity data).
