### PR TITLE
Poll deployment resync as a background job

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -2163,36 +2163,57 @@ export const getDeploymentRunStatus = (
 
 // Deployment resync
 
-export interface DeploymentResyncError {
-  detail: string
-  environment?: null | string
-  project_id?: null | string
+export interface DeploymentResyncEnqueueResponse {
+  enqueued: boolean
 }
 
-export interface DeploymentResyncSummary {
-  errors: DeploymentResyncError[]
-  events_recorded: number
-  events_skipped: number
-  observed: number
-  projects: number
-  releases_created: number
-  releases_updated: number
+export type DeploymentSyncState =
+  | 'failed'
+  | 'idle'
+  | 'queued'
+  | 'running'
+  | 'success'
+
+export interface DeploymentSyncStatus {
+  error: null | string
+  errors: null | number
+  events_recorded: null | number
+  last_synced_at: null | string
+  observed: null | number
+  releases_created: null | number
+  releases_updated: null | number
+  requested_by: null | string
+  status: DeploymentSyncState
 }
 
+// Enqueue a deployment resync (background job). 202 + {enqueued} —
+// false when debounced or queueing is unavailable. Poll
+// getProjectDeploymentSyncStatus for the outcome.
 export const resyncProjectDeployments = (
   orgSlug: string,
   projectId: string,
   opts: { limit?: number; source?: string } = {},
-): Promise<DeploymentResyncSummary> => {
+): Promise<DeploymentResyncEnqueueResponse> => {
   const params = new URLSearchParams()
   if (opts.source) params.set('source', opts.source)
   if (opts.limit != null) params.set('limit', String(opts.limit))
   const query = params.toString()
   const search = query ? `?${query}` : ''
-  return apiClient.post<DeploymentResyncSummary>(
+  return apiClient.post<DeploymentResyncEnqueueResponse>(
     `${deploymentsBase(orgSlug, projectId)}/resync${search}`,
   )
 }
+
+export const getProjectDeploymentSyncStatus = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<DeploymentSyncStatus> =>
+  apiClient.get<DeploymentSyncStatus>(
+    `${deploymentsBase(orgSlug, projectId)}/sync-status`,
+    undefined,
+    signal,
+  )
 
 // Lifecycle push-sync
 

--- a/src/components/ProjectDoctorTab.tsx
+++ b/src/components/ProjectDoctorTab.tsx
@@ -116,7 +116,16 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
     },
   })
 
-  const resyncMutation = useProjectDeploymentResync(orgSlug, project.id)
+  // Invalidates the project + currentReleases + operationsLog query keys
+  // once the background backfill completes so badges and deploy widgets
+  // refresh.
+  const resync = useProjectDeploymentResync(orgSlug, project.id, () => {
+    for (const key of ['project', 'currentReleases', 'operationsLog']) {
+      void queryClient.invalidateQueries({
+        queryKey: [key, orgSlug, project.id],
+      })
+    }
+  })
 
   // Shares the deployment:write gate: the backend requires a GitHub
   // deployment plugin (eligibility) plus a connected commit-sync plugin.
@@ -194,12 +203,12 @@ export function ProjectDoctorTab({ project }: { project: Project }) {
             )}
             {canResyncDeployments && (
               <Button
-                disabled={resyncMutation.isPending}
-                onClick={() => resyncMutation.mutate()}
+                disabled={resync.isSyncing}
+                onClick={() => resync.sync()}
                 size="sm"
                 variant="outline"
               >
-                {resyncMutation.isPending ? 'Syncing...' : 'Sync Deployments'}
+                {resync.isSyncing ? 'Syncing...' : 'Sync Deployments'}
               </Button>
             )}
             {canResyncDeployments && (

--- a/src/components/deployments/useDeploymentSync.ts
+++ b/src/components/deployments/useDeploymentSync.ts
@@ -1,15 +1,12 @@
 // Sidebar "sync" action: refreshes everything the Deployments tab reads
-// from imbi's own stores — the ClickHouse commit/tag history (background
-// job + poll, via useCommitSync) and the release/deployment state
-// resynced from the remote's deployment records.
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
+// from imbi's own stores — the ClickHouse commit/tag history and the
+// release/deployment state resynced from the remote's deployment
+// records. Both arms are background jobs (enqueue + status poll).
+import { useQueryClient } from '@tanstack/react-query'
 
-import { resyncProjectDeployments } from '@/api/endpoints'
 import { useAuth } from '@/hooks/useAuth'
 import { useCommitSync } from '@/hooks/useCommitSync'
-import { extractApiErrorDetail } from '@/lib/apiError'
-import { DEEP_RESYNC_LIMIT } from '@/lib/resync'
+import { useProjectDeploymentResync } from '@/hooks/useDeploymentResync'
 import type { UserResponse } from '@/types'
 
 const DATA_KEYS = ['recentCommits', 'releaseHistory', 'currentReleases']
@@ -32,34 +29,13 @@ export function useDeploymentSync(orgSlug: string, projectId: string) {
     commitSyncAllowed,
     invalidate,
   )
-  const resyncMutation = useMutation({
-    mutationFn: () =>
-      resyncProjectDeployments(orgSlug, projectId, {
-        limit: DEEP_RESYNC_LIMIT,
-      }),
-    onError: (err) =>
-      toast.error(extractApiErrorDetail(err) ?? 'Failed to resync releases'),
-    onSuccess: (summary) => {
-      invalidate()
-      const releases = summary.releases_created + summary.releases_updated
-      toast.success(
-        `Releases resynced — ${releases} release(s) and ` +
-          `${summary.events_recorded} event(s) updated`,
-      )
-      if (summary.errors.length > 0) {
-        toast.warning(
-          `Release resync finished with ${summary.errors.length} error(s)`,
-          { description: summary.errors[0]?.detail },
-        )
-      }
-    },
-  })
+  const resync = useProjectDeploymentResync(orgSlug, projectId, invalidate)
 
   return {
-    isSyncing: commitSync.isSyncing || resyncMutation.isPending,
+    isSyncing: commitSync.isSyncing || resync.isSyncing,
     sync: () => {
       if (commitSyncAllowed) commitSync.sync()
-      resyncMutation.mutate()
+      resync.sync()
     },
   }
 }

--- a/src/hooks/__tests__/useDeploymentResync.test.tsx
+++ b/src/hooks/__tests__/useDeploymentResync.test.tsx
@@ -87,9 +87,11 @@ describe('useProjectDeploymentResync', () => {
     )
   })
 
-  it('shows an info toast when a resync is already running', async () => {
+  it('shows an info toast when the resync was not enqueued', async () => {
+    // A stale persisted terminal status must not read as this request's
+    // outcome when nothing was enqueued (debounced or queue unavailable).
     vi.mocked(endpoints.getProjectDeploymentSyncStatus).mockResolvedValue(
-      status(),
+      status({ events_recorded: 5, status: 'success' }),
     )
     vi.mocked(endpoints.resyncProjectDeployments).mockResolvedValue({
       enqueued: false,
@@ -102,6 +104,8 @@ describe('useProjectDeploymentResync', () => {
       result.current.sync()
     })
     await waitFor(() => expect(toast.info).toHaveBeenCalled())
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(toast.warning).not.toHaveBeenCalled()
   })
 
   it('reports isSyncing while the status is active', async () => {

--- a/src/hooks/__tests__/useDeploymentResync.test.tsx
+++ b/src/hooks/__tests__/useDeploymentResync.test.tsx
@@ -2,10 +2,11 @@ import type { ReactNode } from 'react'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as endpoints from '@/api/endpoints'
-import type { DeploymentResyncSummary } from '@/api/endpoints'
+import type { DeploymentSyncStatus } from '@/api/endpoints'
 import { DEEP_RESYNC_LIMIT } from '@/lib/resync'
 
 import { useProjectDeploymentResync } from '../useDeploymentResync'
@@ -14,34 +15,46 @@ import { useProjectDeploymentResync } from '../useDeploymentResync'
 vi.mock('@/api/endpoints', async () => {
   const actual =
     await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
-  return { ...actual, resyncProjectDeployments: vi.fn() }
+  return {
+    ...actual,
+    getProjectDeploymentSyncStatus: vi.fn(),
+    resyncProjectDeployments: vi.fn(),
+  }
 })
 
 vi.mock('sonner', () => ({
-  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }))
 
-function makeWrapper() {
-  const client = new QueryClient({
+function makeClient() {
+  return new QueryClient({
     defaultOptions: {
       mutations: { retry: false },
       queries: { gcTime: 0, retry: false },
     },
   })
+}
+
+function makeWrapper(client: QueryClient = makeClient()) {
   return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   )
 }
 
-function summary(): DeploymentResyncSummary {
+function status(
+  overrides: Partial<DeploymentSyncStatus> = {},
+): DeploymentSyncStatus {
   return {
-    errors: [],
-    events_recorded: 0,
-    events_skipped: 0,
-    observed: 0,
-    projects: 1,
-    releases_created: 0,
-    releases_updated: 0,
+    error: null,
+    errors: null,
+    events_recorded: null,
+    last_synced_at: null,
+    observed: null,
+    releases_created: null,
+    releases_updated: null,
+    requested_by: null,
+    status: 'idle',
+    ...overrides,
   }
 }
 
@@ -49,13 +62,18 @@ describe('useProjectDeploymentResync', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('requests a deep backfill so historical attribution is re-resolved', async () => {
-    vi.mocked(endpoints.resyncProjectDeployments).mockResolvedValue(summary())
+    vi.mocked(endpoints.getProjectDeploymentSyncStatus).mockResolvedValue(
+      status(),
+    )
+    vi.mocked(endpoints.resyncProjectDeployments).mockResolvedValue({
+      enqueued: true,
+    })
     const { result } = renderHook(
       () => useProjectDeploymentResync('acme', 'p1'),
       { wrapper: makeWrapper() },
     )
     await act(async () => {
-      result.current.mutate()
+      result.current.sync()
     })
     await waitFor(() =>
       expect(endpoints.resyncProjectDeployments).toHaveBeenCalledWith(
@@ -64,5 +82,184 @@ describe('useProjectDeploymentResync', () => {
         { limit: DEEP_RESYNC_LIMIT },
       ),
     )
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith('Deployment resync started'),
+    )
+  })
+
+  it('shows an info toast when a resync is already running', async () => {
+    vi.mocked(endpoints.getProjectDeploymentSyncStatus).mockResolvedValue(
+      status(),
+    )
+    vi.mocked(endpoints.resyncProjectDeployments).mockResolvedValue({
+      enqueued: false,
+    })
+    const { result } = renderHook(
+      () => useProjectDeploymentResync('acme', 'p1'),
+      { wrapper: makeWrapper() },
+    )
+    await act(async () => {
+      result.current.sync()
+    })
+    await waitFor(() => expect(toast.info).toHaveBeenCalled())
+  })
+
+  it('reports isSyncing while the status is active', async () => {
+    vi.mocked(endpoints.getProjectDeploymentSyncStatus).mockResolvedValue(
+      status({ status: 'running' }),
+    )
+    const { result } = renderHook(
+      () => useProjectDeploymentResync('acme', 'p1'),
+      { wrapper: makeWrapper() },
+    )
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+  })
+
+  it('does not toast a stale terminal status on mount', async () => {
+    vi.mocked(endpoints.getProjectDeploymentSyncStatus).mockResolvedValue(
+      status({ events_recorded: 5, status: 'success' }),
+    )
+    renderHook(() => useProjectDeploymentResync('acme', 'p1'), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() =>
+      expect(endpoints.getProjectDeploymentSyncStatus).toHaveBeenCalled(),
+    )
+    await act(async () => {})
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('toasts and invokes onComplete when a watched run succeeds', async () => {
+    vi.mocked(endpoints.getProjectDeploymentSyncStatus)
+      .mockResolvedValueOnce(status())
+      .mockResolvedValueOnce(status({ status: 'running' }))
+      .mockResolvedValue(
+        status({
+          errors: 0,
+          events_recorded: 3,
+          observed: 4,
+          releases_created: 1,
+          status: 'success',
+        }),
+      )
+    vi.mocked(endpoints.resyncProjectDeployments).mockResolvedValue({
+      enqueued: true,
+    })
+    const onComplete = vi.fn()
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useProjectDeploymentResync('acme', 'p1', onComplete),
+      { wrapper: makeWrapper(client) },
+    )
+    await waitFor(() =>
+      expect(endpoints.getProjectDeploymentSyncStatus).toHaveBeenCalled(),
+    )
+    await act(async () => {
+      result.current.sync()
+    })
+    // The mutation's onSuccess invalidation refetches → 'running'.
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+    // Simulate the next poll observing the terminal state.
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['deploymentSyncStatus', 'acme', 'p1'],
+      })
+    })
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        'Resync complete: 3 event(s) recorded, 1 release(s) created',
+      ),
+    )
+    expect(onComplete).toHaveBeenCalled()
+  })
+
+  it('warns when a watched run finishes with per-env errors', async () => {
+    vi.mocked(endpoints.getProjectDeploymentSyncStatus)
+      .mockResolvedValueOnce(status())
+      .mockResolvedValueOnce(status({ status: 'running' }))
+      .mockResolvedValue(
+        status({ errors: 2, events_recorded: 1, status: 'success' }),
+      )
+    vi.mocked(endpoints.resyncProjectDeployments).mockResolvedValue({
+      enqueued: true,
+    })
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useProjectDeploymentResync('acme', 'p1'),
+      { wrapper: makeWrapper(client) },
+    )
+    await waitFor(() =>
+      expect(endpoints.getProjectDeploymentSyncStatus).toHaveBeenCalled(),
+    )
+    await act(async () => {
+      result.current.sync()
+    })
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['deploymentSyncStatus', 'acme', 'p1'],
+      })
+    })
+    await waitFor(() =>
+      expect(toast.warning).toHaveBeenCalledWith(
+        'Resync finished with 2 error(s): 1 event(s) recorded',
+      ),
+    )
+  })
+
+  it('toasts an error when a watched run fails', async () => {
+    vi.mocked(endpoints.getProjectDeploymentSyncStatus)
+      .mockResolvedValueOnce(status())
+      .mockResolvedValueOnce(status({ status: 'running' }))
+      .mockResolvedValue(status({ error: 'boom', status: 'failed' }))
+    vi.mocked(endpoints.resyncProjectDeployments).mockResolvedValue({
+      enqueued: true,
+    })
+    const onComplete = vi.fn()
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useProjectDeploymentResync('acme', 'p1', onComplete),
+      { wrapper: makeWrapper(client) },
+    )
+    await waitFor(() =>
+      expect(endpoints.getProjectDeploymentSyncStatus).toHaveBeenCalled(),
+    )
+    await act(async () => {
+      result.current.sync()
+    })
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['deploymentSyncStatus', 'acme', 'p1'],
+      })
+    })
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'Deployment resync failed: boom',
+      ),
+    )
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('invokes onComplete without a toast for an unwatched run', async () => {
+    vi.mocked(endpoints.getProjectDeploymentSyncStatus)
+      .mockResolvedValueOnce(status({ status: 'running' }))
+      .mockResolvedValue(status({ events_recorded: 3, status: 'success' }))
+    const onComplete = vi.fn()
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useProjectDeploymentResync('acme', 'p1', onComplete),
+      { wrapper: makeWrapper(client) },
+    )
+    await waitFor(() => expect(result.current.isSyncing).toBe(true))
+    // Someone else's run finishes; the next poll observes it.
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: ['deploymentSyncStatus', 'acme', 'p1'],
+      })
+    })
+    await waitFor(() => expect(onComplete).toHaveBeenCalled())
+    expect(toast.success).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useDeploymentResync.ts
+++ b/src/hooks/useDeploymentResync.ts
@@ -1,72 +1,128 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useEffect, useRef } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import type { DeploymentResyncSummary } from '@/api/endpoints'
-import { resyncProjectDeployments } from '@/api/endpoints'
+import type { DeploymentSyncState, DeploymentSyncStatus } from '@/api/endpoints'
+import {
+  getProjectDeploymentSyncStatus,
+  resyncProjectDeployments,
+} from '@/api/endpoints'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { DEEP_RESYNC_LIMIT } from '@/lib/resync'
 
-// Project-level resync. Invalidates the project + currentReleases +
-// operationsLog query keys so badges and deploy widgets refresh once
-// the backfill completes. Runs a deep backfill (``DEEP_RESYNC_LIMIT``
-// deployments per env) so a user-triggered resync also re-resolves
-// historical deploy attribution, not just the latest event.
-export function useProjectDeploymentResync(orgSlug: string, projectId: string) {
+const POLL_MS = 3000
+
+// Project-level resync, mirroring useCommitSync: the POST enqueues a
+// background backfill (deep — ``DEEP_RESYNC_LIMIT`` deployments per env,
+// so a user-triggered resync also re-resolves historical deploy
+// attribution) and the hook polls the project's sync-status while a run
+// is in flight, toasting the terminal result. `onComplete` fires on any
+// observed run completing so callers can refresh badges/widgets.
+export function useProjectDeploymentResync(
+  orgSlug: string,
+  projectId: string,
+  /** Invoked when a run completes successfully (e.g. to refresh data). */
+  onComplete?: () => void,
+) {
   const queryClient = useQueryClient()
-  return useMutation({
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
+
+  const statusQuery = useQuery({
+    enabled: !!orgSlug && !!projectId,
+    queryFn: ({ signal }): Promise<DeploymentSyncStatus> =>
+      getProjectDeploymentSyncStatus(orgSlug, projectId, signal),
+    queryKey: ['deploymentSyncStatus', orgSlug, projectId],
+    // Poll only while a run is queued/running; settle back to idle.
+    refetchInterval: (query) =>
+      isActive(query.state.data?.status) ? POLL_MS : false,
+  })
+
+  // The backend reports the persistent status of the project's most recent
+  // run (any requester), so a toast is only warranted when this user asked
+  // for a resync (`watching`) and a poll then observes the run leaving the
+  // active state. `onComplete` still fires on any observed active → success
+  // transition so background refreshes happen for other users' runs too.
+  const watching = useRef(false)
+  const previous = useRef<DeploymentSyncState | undefined>(undefined)
+  useEffect(() => {
+    const data = statusQuery.data
+    if (!data) return
+    if (isActive(previous.current) && !isActive(data.status)) {
+      if (watching.current) {
+        announceTerminal(data)
+        watching.current = false
+      }
+      if (data.status === 'success') onCompleteRef.current?.()
+    }
+    previous.current = data.status
+  }, [statusQuery.data])
+
+  const mutation = useMutation({
     mutationFn: () =>
       resyncProjectDeployments(orgSlug, projectId, {
         limit: DEEP_RESYNC_LIMIT,
       }),
-    onError: onResyncError,
-    onSuccess: (summary: DeploymentResyncSummary) => {
-      toastResult(summary)
+    onError: (err) =>
+      toast.error(
+        extractApiErrorDetail(err) ?? 'Failed to start deployment resync',
+      ),
+    onSuccess: (res) => {
+      // The user asked for this run (or joined the one already in
+      // progress), so watch for its terminal result.
+      watching.current = true
+      // The POST returning means the backend flipped the run to queued;
+      // prime `previous` so a fast job whose first refetch already reads
+      // a terminal status still counts as an active → terminal transition.
+      previous.current = 'queued'
+      if (res.enqueued) {
+        toast.success('Deployment resync started')
+      } else {
+        toast.info('A deployment resync is already in progress')
+      }
+      // Refresh even when joining an existing run: a stale cached 'idle'
+      // status would otherwise keep refetchInterval off and this client
+      // would never observe the run finishing.
       void queryClient.invalidateQueries({
-        queryKey: ['project', orgSlug, projectId],
-      })
-      void queryClient.invalidateQueries({
-        queryKey: ['currentReleases', orgSlug, projectId],
-      })
-      void queryClient.invalidateQueries({
-        queryKey: ['operationsLog', orgSlug, projectId],
+        queryKey: ['deploymentSyncStatus', orgSlug, projectId],
       })
     },
   })
+
+  const isSyncing = mutation.isPending || isActive(statusQuery.data?.status)
+  return { isSyncing, sync: mutation.mutate }
 }
 
-function onResyncError(err: unknown): void {
-  toast.error(extractApiErrorDetail(err) ?? 'Failed to resync deployments')
+// Announce a run's terminal outcome once it leaves the active state.
+function announceTerminal(data: DeploymentSyncStatus): void {
+  if (data.status === 'success') {
+    const headline = summarize(data)
+    if ((data.errors ?? 0) > 0) {
+      toast.warning(`Resync finished with ${data.errors} error(s): ${headline}`)
+    } else {
+      toast.success(`Resync complete: ${headline}`)
+    }
+  } else if (data.status === 'failed') {
+    toast.error(`Deployment resync failed: ${data.error ?? 'unknown error'}`)
+  }
+}
+
+function isActive(state: DeploymentSyncState | undefined): boolean {
+  return state === 'queued' || state === 'running'
 }
 
 // Build the "X event(s) recorded • Y release(s) created" headline shown
-// on both the project-level and integration-wide success toasts. Skips counters
-// that are zero so the summary stays short on idle remotes.
+// on the terminal toast. Skips counters that are zero so the summary
+// stays short on idle remotes.
 // fallow-ignore-next-line complexity
-function summarize(s: DeploymentResyncSummary): string {
+function summarize(s: DeploymentSyncStatus): string {
   const parts: string[] = []
-  if (s.events_recorded > 0)
+  if ((s.events_recorded ?? 0) > 0)
     parts.push(`${s.events_recorded} event(s) recorded`)
-  if (s.releases_created > 0)
+  if ((s.releases_created ?? 0) > 0)
     parts.push(`${s.releases_created} release(s) created`)
-  if (s.releases_updated > 0)
+  if ((s.releases_updated ?? 0) > 0)
     parts.push(`${s.releases_updated} release(s) updated`)
   return parts.length > 0 ? parts.join(', ') : 'Nothing to update'
-}
-
-function toastResult(s: DeploymentResyncSummary): void {
-  const headline = summarize(s)
-  if (s.errors.length > 0) {
-    toast.warning(`Resync finished with warnings: ${headline}`, {
-      description: s.errors
-        .slice(0, 5)
-        .map((e) => {
-          const env = e.environment ? ` / ${e.environment}` : ''
-          const where = e.project_id ? `${e.project_id}${env}` : 'unknown'
-          return `${where}: ${e.detail}`
-        })
-        .join(' • '),
-    })
-  } else {
-    toast.success(`Resync complete: ${headline}`)
-  }
 }

--- a/src/hooks/useDeploymentResync.ts
+++ b/src/hooks/useDeploymentResync.ts
@@ -72,14 +72,22 @@ export function useProjectDeploymentResync(
       // The user asked for this run (or joined the one already in
       // progress), so watch for its terminal result.
       watching.current = true
-      // The POST returning means the backend flipped the run to queued;
-      // prime `previous` so a fast job whose first refetch already reads
-      // a terminal status still counts as an active → terminal transition.
-      previous.current = 'queued'
       if (res.enqueued) {
+        // The POST returning means the backend flipped the run to queued;
+        // prime `previous` so a fast job whose first refetch already reads
+        // a terminal status still counts as an active → terminal transition.
+        previous.current = 'queued'
         toast.success('Deployment resync started')
       } else {
-        toast.info('A deployment resync is already in progress')
+        // enqueued:false is ambiguous — debounced (a run really is
+        // active) or queueing unavailable (nothing running). Don't prime
+        // `previous`: a stale persisted terminal status must not read as
+        // an active → terminal transition, and a genuinely active run
+        // will be observed by the poll before it finishes.
+        toast.info(
+          'Deployment resync could not be started — it may already be ' +
+            'running, or the queue is temporarily unavailable',
+        )
       }
       // Refresh even when joining an existing run: a stale cached 'idle'
       // status would otherwise keep refetchInterval off and this client


### PR DESCRIPTION
## Summary
Adapt the deployment resync UX to the API's new enqueue-and-poll contract (AWeber-Imbi/imbi-api#484), mirroring the existing commit-sync flow.

## Problem
`POST /deployments/resync` previously ran the backfill in-request and returned a summary; deep resyncs hit the API's 10-second plugin timeout and 503'd, so the "Sync Deployments" buttons consistently surfaced "Failed to resync deployments". The API now enqueues a background job and returns 202 `{enqueued}`, which the old UI code would misread as a completed summary.

## Solution
- `resyncProjectDeployments` returns the enqueue response; new `getProjectDeploymentSyncStatus` wraps `GET /deployments/sync-status`
- `useProjectDeploymentResync` rewritten on the `useCommitSync` template: enqueue, poll sync-status every 3s while queued/running, toast the terminal result (counts headline, per-env error count, or failure), and fire `onComplete` for data refreshes
- The Deployments-tab sync action and Project Doctor's "Sync Deployments" button consume the new `{isSyncing, sync}` shape; query invalidations move to `onComplete` so they run when the backfill actually finishes rather than when the POST returns

## Impact
- Requires the imbi-api change to be deployed first — against the old API the hook would treat the summary response as an enqueue response
- Buttons now stay in the syncing state for the life of the background run (any requester), matching commit/PR sync behavior

## Testing
- Full vitest suite passes (561 tests), including a rewritten `useDeploymentResync` suite covering enqueue/join toasts, active-state polling, stale-status suppression, watched success/warning/failure toasts, and unwatched-run `onComplete`
- `npm run lint`, `npm run format:check`, and `npm run build` clean; fallow findings identical to main's baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)