### PR TITLE
Fix non-http environment URIs not displaying

### DIFF
--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -39,7 +39,7 @@ import { useEnvironmentEdgePatch } from '@/hooks/useEnvironmentEdgePatch'
 import { useLoginToEmail } from '@/hooks/useLoginToEmail'
 import { ENVIRONMENT_BASE_FIELDS_SET } from '@/lib/constants'
 import { formatFieldKey } from '@/lib/project-field-formatting'
-import { sanitizeHttpUrl } from '@/lib/utils'
+import { sanitizeUri } from '@/lib/utils'
 import type { DeploymentStatus, Project } from '@/types'
 
 interface DeploymentInfo {
@@ -211,12 +211,16 @@ export function ProjectEnvironmentsCard({
         <div className="space-y-0">
           {/* fallow-ignore-next-line complexity */}
           {environments.map((env) => {
-            const url =
-              typeof env.url === 'string' ? sanitizeHttpUrl(env.url) : null
-            // Protocol/trailing-slash stripped for a shorter on-screen value.
-            const displayUrl = url
-              ? url.replace(/^https?:\/\//, '').replace(/\/$/, '')
-              : null
+            const rawUrl =
+              typeof env.url === 'string' && env.url !== '' ? env.url : null
+            // Clickable for any URI scheme except the XSS-dangerous ones
+            // (javascript:/data:/vbscript:).
+            const linkUrl = sanitizeUri(env.url)
+            // Protocol/trailing-slash stripped for a shorter on-screen value on
+            // http(s) links; other schemes (postgresql://, etc.) shown as-is.
+            const displayUrl = linkUrl
+              ? linkUrl.replace(/^https?:\/\//, '').replace(/\/$/, '')
+              : rawUrl
             const urlText = (
               <span className="text-primary text-sm">{displayUrl}</span>
             )
@@ -270,11 +274,11 @@ export function ProjectEnvironmentsCard({
                       ) : (
                         urlText
                       )}
-                      {url ? (
+                      {linkUrl ? (
                         <a
                           aria-label="Open URL"
                           className="text-warning shrink-0"
-                          href={url}
+                          href={linkUrl}
                           rel="noopener noreferrer"
                           target="_blank"
                         >

--- a/src/components/ProjectEnvironmentsCard.tsx
+++ b/src/components/ProjectEnvironmentsCard.tsx
@@ -218,9 +218,12 @@ export function ProjectEnvironmentsCard({
             const linkUrl = sanitizeUri(env.url)
             // Protocol/trailing-slash stripped for a shorter on-screen value on
             // http(s) links; other schemes (postgresql://, etc.) shown as-is.
-            const displayUrl = linkUrl
-              ? linkUrl.replace(/^https?:\/\//, '').replace(/\/$/, '')
-              : rawUrl
+            let displayUrl = rawUrl
+            if (linkUrl) {
+              displayUrl = /^https?:\/\//.test(linkUrl)
+                ? linkUrl.replace(/^https?:\/\//, '').replace(/\/$/, '')
+                : linkUrl
+            }
             const urlText = (
               <span className="text-primary text-sm">{displayUrl}</span>
             )

--- a/src/components/__tests__/ProjectEnvironmentsCard.test.tsx
+++ b/src/components/__tests__/ProjectEnvironmentsCard.test.tsx
@@ -42,14 +42,16 @@ describe('ProjectEnvironmentsCard URL rendering', () => {
     expect(link).toHaveAttribute('href', 'https://prod.example.com/')
   })
 
-  it('preserves non-http URI schemes and links them', () => {
-    renderCard([env('db', 'postgresql://db.example.cloud/prod')])
+  it('preserves non-http URI schemes verbatim, including a trailing slash', () => {
+    renderCard([env('db', 'postgresql://db.example.cloud/prod/')])
 
+    // Non-http schemes are shown as-is: the trailing slash is NOT stripped
+    // (that shortening applies only to http(s) links).
     expect(
-      screen.getByText('postgresql://db.example.cloud/prod'),
+      screen.getByText('postgresql://db.example.cloud/prod/'),
     ).toBeInTheDocument()
     const link = screen.getByRole('link', { name: 'Open URL' })
-    expect(link).toHaveAttribute('href', 'postgresql://db.example.cloud/prod')
+    expect(link).toHaveAttribute('href', 'postgresql://db.example.cloud/prod/')
   })
 
   it('shows blocked schemes as-is without an anchor', () => {

--- a/src/components/__tests__/ProjectEnvironmentsCard.test.tsx
+++ b/src/components/__tests__/ProjectEnvironmentsCard.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { ProjectEnvironmentsCard } from '@/components/ProjectEnvironmentsCard'
+import { ThemeProvider } from '@/contexts/ThemeContext'
+import { render, screen } from '@/test/utils'
+import type { Project } from '@/types'
+
+type Environment = NonNullable<Project['environments']>[number]
+
+function env(slug: string, url: null | string): Environment {
+  return {
+    label_color: '#888888',
+    name: slug,
+    slug,
+    url,
+  } as unknown as Environment
+}
+
+// Covers the displayUrl/anchor rendering branches introduced by sanitizeUri:
+// http(s) links are stripped for display and linkable, non-http URI schemes are
+// shown verbatim and linkable, and blocked/invalid values are shown as-is with
+// no anchor.
+describe('ProjectEnvironmentsCard URL rendering', () => {
+  function renderCard(environments: Environment[]) {
+    return render(
+      <ThemeProvider>
+        <ProjectEnvironmentsCard
+          deploymentStatus={{}}
+          environments={environments}
+          orgSlug="acme"
+          projectId="1"
+        />
+      </ThemeProvider>,
+    )
+  }
+
+  it('strips protocol and trailing slash for http(s) URLs and links them', () => {
+    renderCard([env('prod', 'https://prod.example.com/')])
+
+    expect(screen.getByText('prod.example.com')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'Open URL' })
+    expect(link).toHaveAttribute('href', 'https://prod.example.com/')
+  })
+
+  it('preserves non-http URI schemes and links them', () => {
+    renderCard([env('db', 'postgresql://db.example.cloud/prod')])
+
+    expect(
+      screen.getByText('postgresql://db.example.cloud/prod'),
+    ).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'Open URL' })
+    expect(link).toHaveAttribute('href', 'postgresql://db.example.cloud/prod')
+  })
+
+  it('shows blocked schemes as-is without an anchor', () => {
+    renderCard([env('bad', 'javascript:alert(1)')])
+
+    expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Open URL' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows unparseable values as-is without an anchor', () => {
+    renderCard([env('weird', 'not a url')])
+
+    expect(screen.getByText('not a url')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Open URL' }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/lib/__tests__/sanitizeUri.test.ts
+++ b/src/lib/__tests__/sanitizeUri.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeHttpUrl, sanitizeUri } from '../utils'
+
+describe('sanitizeUri', () => {
+  it('accepts http(s) URLs', () => {
+    expect(sanitizeUri('https://example.com/')).toBe('https://example.com/')
+    expect(sanitizeUri('http://example.com')).toBe('http://example.com/')
+  })
+
+  it('accepts non-http URI schemes', () => {
+    expect(sanitizeUri('postgresql://db.example.cloud/prod')).toBe(
+      'postgresql://db.example.cloud/prod',
+    )
+    expect(sanitizeUri('ssh://host.example')).toBe('ssh://host.example')
+    expect(sanitizeUri('mailto:ops@example.com')).toBe('mailto:ops@example.com')
+  })
+
+  it('rejects XSS-dangerous schemes', () => {
+    expect(sanitizeUri('javascript:alert(1)')).toBeNull()
+    expect(sanitizeUri('data:text/html,<script>')).toBeNull()
+    expect(sanitizeUri('vbscript:msgbox')).toBeNull()
+  })
+
+  it('rejects empty and non-string input', () => {
+    expect(sanitizeUri('')).toBeNull()
+    expect(sanitizeUri(null)).toBeNull()
+    expect(sanitizeUri(undefined)).toBeNull()
+    expect(sanitizeUri(42)).toBeNull()
+  })
+
+  it('rejects unparseable values', () => {
+    expect(sanitizeUri('not a url')).toBeNull()
+  })
+})
+
+describe('sanitizeHttpUrl', () => {
+  it('rejects non-http schemes', () => {
+    expect(sanitizeHttpUrl('postgresql://db.example.cloud/prod')).toBeNull()
+    expect(sanitizeHttpUrl('javascript:alert(1)')).toBeNull()
+  })
+
+  it('accepts http(s) URLs', () => {
+    expect(sanitizeHttpUrl('https://example.com/')).toBe('https://example.com/')
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,16 +53,13 @@ export function parseFilterFromBlueprint(
  * in user-supplied link values.
  */
 export function sanitizeHttpUrl(raw: unknown): null | string {
-  if (typeof raw !== 'string' || raw === '') return null
-  try {
-    const parsed = new URL(raw)
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return parsed.toString()
-    }
-  } catch {
-    // not a valid URL
-  }
-  return null
+  // Reuse sanitizeUri for input validation, parsing, canonicalization, and
+  // unsafe-scheme filtering, then narrow to the HTTP-only contract so the two
+  // helpers cannot drift.
+  const sanitized = sanitizeUri(raw)
+  if (sanitized === null) return null
+  const { protocol } = new URL(sanitized)
+  return protocol === 'http:' || protocol === 'https:' ? sanitized : null
 }
 
 // Schemes that are unsafe to expose as a clickable link ``href``.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -65,6 +65,27 @@ export function sanitizeHttpUrl(raw: unknown): null | string {
   return null
 }
 
+// Schemes that are unsafe to expose as a clickable link ``href``.
+const UNSAFE_URI_SCHEMES = new Set(['data:', 'javascript:', 'vbscript:'])
+
+/**
+ * Parse an arbitrary value as a URL of any scheme (http, postgresql, ssh,
+ * mailto, …). Returns the canonical URL string if valid, else null. Blocks
+ * the XSS-dangerous javascript:/data:/vbscript: schemes.
+ */
+export function sanitizeUri(raw: unknown): null | string {
+  if (typeof raw !== 'string' || raw === '') return null
+  try {
+    const parsed = new URL(raw)
+    if (!UNSAFE_URI_SCHEMES.has(parsed.protocol)) {
+      return parsed.toString()
+    }
+  } catch {
+    // not a valid URL
+  }
+  return null
+}
+
 /**
  * Generate a URL-safe slug from a display name.
  */


### PR DESCRIPTION
## Summary

Environment URIs with a non-http scheme (e.g. `postgresql://…`) were not displaying at all — the environment row showed only its name badge with no URL.

## Problem

`ProjectEnvironmentsCard` ran `env.url` through `sanitizeHttpUrl()`, which returns `null` for any scheme other than `http:`/`https:`. A `postgresql://…` URL became `null`, so `displayUrl` was `null` and `showUrlBlock` was false, suppressing the entire URL block. That guard exists to stop `javascript:`/`data:` schemes from becoming clickable links, but it was also suppressing *display* of legitimate non-http URIs.

## Solution

- Add `sanitizeUri()` to `lib/utils`: parses a URL of **any** scheme, rejecting only the XSS-dangerous `javascript:`/`data:`/`vbscript:` schemes.
- `ProjectEnvironmentsCard` now:
  - **displays** any URI as text (http(s) still gets its protocol/trailing-slash trimmed for brevity; other schemes shown in full), and
  - makes any **safe** scheme clickable, not just http(s).

The security intent is preserved: `javascript:`/`data:`/`vbscript:` URIs still never become a clickable `href`.

## Tests

Adds `src/lib/__tests__/sanitizeUri.test.ts` covering http(s), non-http schemes (postgresql/ssh/mailto), dangerous-scheme rejection, and invalid input. All pass locally (`vitest run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)