### PR TITLE
Add user type selector to webhook admin form

### DIFF
--- a/src/components/admin/webhooks/WebhookDetail.tsx
+++ b/src/components/admin/webhooks/WebhookDetail.tsx
@@ -122,6 +122,16 @@ export function WebhookDetail({ onBack, onEdit, webhook }: WebhookDetailProps) {
                 </div>
               </div>
             )}
+            {webhook.user_type_selector && (
+              <div>
+                <div className="text-secondary text-sm">User Type Selector</div>
+                <div className="mt-1">
+                  <code className="bg-secondary text-primary rounded px-2 py-1 text-sm">
+                    {webhook.user_type_selector}
+                  </code>
+                </div>
+              </div>
+            )}
             {webhook.identity_integration_slug && (
               <div>
                 <div className="text-secondary text-sm">

--- a/src/components/admin/webhooks/WebhookForm.tsx
+++ b/src/components/admin/webhooks/WebhookForm.tsx
@@ -72,6 +72,9 @@ export function WebhookForm({
   const [userSubjectSelector, setUserSubjectSelector] = useState(
     webhook?.user_subject_selector || '',
   )
+  const [userTypeSelector, setUserTypeSelector] = useState(
+    webhook?.user_type_selector || '',
+  )
   const [identityIntegrationSlug, setIdentityIntegrationSlug] = useState(
     webhook?.identity_integration_slug || '',
   )
@@ -115,6 +118,10 @@ export function WebhookForm({
       newErrors.user_subject_selector =
         'User subject selector requires an integration'
     }
+    if (userTypeSelector && !integrationSlug) {
+      newErrors.user_type_selector =
+        'User type selector requires an integration'
+    }
     if (identityIntegrationSlug && !integrationSlug) {
       newErrors.identity_integration_slug =
         'Identity integration slug requires an integration'
@@ -153,6 +160,7 @@ export function WebhookForm({
       })),
       secret: secret.trim() || null,
       user_subject_selector: userSubjectSelector.trim() || null,
+      user_type_selector: userTypeSelector.trim() || null,
       // Include slug only when editing so the PATCH can update it.
       ...(isEditing ? { slug: slug.trim() } : {}),
     }
@@ -177,6 +185,7 @@ export function WebhookForm({
     if (!newIntegration) {
       setIdentifierSelector('')
       setUserSubjectSelector('')
+      setUserTypeSelector('')
       setIdentityIntegrationSlug('')
       setEventTypeSelector('')
     }
@@ -523,6 +532,37 @@ export function WebhookForm({
                       JSON Pointer to the external identity subject in the
                       payload. Used to resolve the Imbi user attributed to
                       handler events.
+                    </p>
+                  </div>
+
+                  <div>
+                    <Label className="text-secondary mb-1.5 block text-sm">
+                      User Type Selector (JSON Pointer){' '}
+                      <span className="text-tertiary text-xs">(optional)</span>
+                    </Label>
+                    <Input
+                      className={`font-mono text-sm ${
+                        errors.user_type_selector ? 'border-red-500' : ''
+                      }`}
+                      disabled={isLoading}
+                      onChange={(e) => setUserTypeSelector(e.target.value)}
+                      placeholder="e.g., /sender/type"
+                      value={userTypeSelector}
+                    />
+                    {errors.user_type_selector && (
+                      <div
+                        className={
+                          'text-danger mt-1 flex items-center gap-1 text-xs'
+                        }
+                      >
+                        <AlertCircle className="size-3" />
+                        {errors.user_type_selector}
+                      </div>
+                    )}
+                    <p className="text-tertiary mt-1 text-xs">
+                      JSON Pointer to the sender account type. When it resolves
+                      to <code>Bot</code>, the identity lookup is skipped since
+                      bot senders are never Imbi users.
                     </p>
                   </div>
 

--- a/src/types/api-generated.ts
+++ b/src/types/api-generated.ts
@@ -11324,6 +11324,11 @@ export interface components {
              */
             user_subject_selector?: string | null;
             /**
+             * User Type Selector
+             * @description JSON Pointer that locates the sender account type (e.g. /sender/type). When it resolves to 'Bot' the identity lookup is skipped, since bot senders are never Imbi users.
+             */
+            user_type_selector?: string | null;
+            /**
              * Identity Integration Slug
              * @description Optional override for the identity integration slug used to resolve the Imbi user; falls back to identity integrations attached to the integration when unset.
              */
@@ -11361,6 +11366,8 @@ export interface components {
             identifier_selector?: string | null;
             /** User Subject Selector */
             user_subject_selector?: string | null;
+            /** User Type Selector */
+            user_type_selector?: string | null;
             /** Identity Integration Slug */
             identity_integration_slug?: string | null;
             /** Event Type Selector */


### PR DESCRIPTION
## Summary

Surfaces the new `user_type_selector` webhook edge field in the admin UI. Setting it to a JSON pointer that resolves to `"Bot"` (e.g. `/sender/type`) tells the gateway to skip the identity lookup for bot webhook senders, which otherwise produce a guaranteed `404` per delivery.

Companion to imbi-api `feature/webhook-user-type-selector` (adds the field to the API schema) and imbi-gateway #46 (the consumer).

## Changes

Mirrors the existing `user_subject_selector` field:
- **`WebhookForm.tsx`** — state hook, validation (`requires an integration`), submit payload, integration-cleared reset, and the JSON-pointer input with helper copy.
- **`WebhookDetail.tsx`** — read-only display row.
- **`api-generated.ts`** — added `user_type_selector` to `WebhookCreate` and `WebhookResponse`, hand-edited to match the imbi-api schema (`codegen:fetch` needs a running backend). `WebhookSaveData = WebhookCreate & {…}`, so the form payload type picks it up automatically.

## Testing

- `npm run build` (tsc + vite) — clean.
- `npm run lint` — 0 errors; `npm run format:check` — clean.
- `npx fallow audit --base origin/main` — no new findings in changed files (the pre-existing `validate` complexity is an inherited finding, unchanged in kind).

There are no existing tests for `WebhookForm`/`WebhookDetail` (the sibling selector fields are untested too), so this follows the surrounding convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)